### PR TITLE
Add project documentation (CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Fucktorio
+
+Automated Factorio factory blueprint generator. Takes a target item + production rate, solves recipe dependencies, generates a spatial layout, and exports a Factorio-importable blueprint string.
+
+## Quick start
+
+```bash
+# Requires: factorio-draftsman, pytest
+pip install factorio-draftsman pytest
+
+# Run tests
+pytest tests/
+
+# Generate a blueprint
+python -m src.pipeline
+```
+
+## Architecture
+
+Three-stage pipeline (`src/pipeline.py` orchestrates):
+
+1. **Solver** (`src/solver/`) — Recursively resolves recipes via `draftsman.data`, calculates machine counts and flow rates. Returns `SolverResult`.
+2. **Layout** (`src/layout/`) — Converts solver output to positioned entities: assembly rows (`placer.py`, `templates.py`), main bus routing (`router.py`), and power poles (`poles.py`). Returns `LayoutResult`.
+3. **Blueprint** (`src/blueprint/`) — Thin draftsman wrapper that converts `LayoutResult` to a base64 blueprint string.
+
+## Key models (`src/models.py`)
+
+- `ItemFlow` — item name, rate, fluid flag
+- `MachineSpec` — machine type, recipe, count, inputs/outputs
+- `SolverResult` — machines, external inputs/outputs, dependency order
+- `PlacedEntity` — entity name, position, direction, recipe
+- `LayoutResult` — entities, connections, dimensions
+
+## Layout conventions
+
+- Main bus runs vertically on the left (underground belts for solids, pipe-to-ground for fluids)
+- Assembly rows stack horizontally to the right
+- Templates: `single_input_row`, `dual_input_row`, `fluid_row`
+- Machines: assembling-machine-3 (default), chemical-plant (fluids), oil-refinery
+- Power: medium-electric-pole on a 7-tile grid
+
+## Verification
+
+`src/verify.py` — offline blueprint validation (overlap detection, unpaired undergrounds, ASCII map)


### PR DESCRIPTION
## Summary
Added comprehensive project documentation for Fucktorio, an automated Factorio factory blueprint generator.

## Changes
- Created `CLAUDE.md` with complete project overview including:
  - Quick start guide with installation and usage instructions
  - Three-stage pipeline architecture explanation (Solver → Layout → Blueprint)
  - Key data models and their responsibilities
  - Layout conventions and design patterns
  - Verification/validation approach

## Details
The documentation covers:
- **Architecture**: Clear explanation of the three-stage pipeline orchestrated by `src/pipeline.py`
- **Core modules**: Solver (recipe resolution), Layout (spatial positioning), and Blueprint (draftsman integration)
- **Data models**: ItemFlow, MachineSpec, SolverResult, PlacedEntity, LayoutResult
- **Layout strategy**: Main bus pattern with vertical routing and horizontal assembly rows
- **Verification**: Offline blueprint validation capabilities

This serves as the primary reference for understanding the codebase structure and design decisions.

https://claude.ai/code/session_01P8Haoo6bKub5vqv9ohay2E