### PR TITLE
Deploy test visualizations to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -37,3 +46,22 @@ jobs:
         with:
           name: test-results
           path: test-results.xml
+
+  deploy-viz:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: test-visualizations
+          path: site/
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Adds a `deploy-viz` job to CI that publishes test visualization HTML files to GitHub Pages on main branch pushes
- Visualizations will be viewable at `https://storkme.github.io/fucktorio/` instead of requiring artifact zip downloads
- Only deploys on main pushes (not PRs), keeping PR builds fast

## Setup
- Requires GitHub Pages enabled with Source set to **GitHub Actions** (already done)

## Test plan
- [ ] Merge to main and verify the `deploy-viz` job runs successfully
- [ ] Confirm HTML visualizations are accessible at `https://storkme.github.io/fucktorio/`

https://claude.ai/code/session_01FhBNwsPXZTAciVDLepoRSM