### PR TITLE
Update docs for spaghetti builder direction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,25 +20,54 @@ python -m src.pipeline
 Three-stage pipeline (`src/pipeline.py` orchestrates):
 
 1. **Solver** (`src/solver/`) — Recursively resolves recipes via `draftsman.data`, calculates machine counts and flow rates. Returns `SolverResult`.
-2. **Layout** (`src/layout/`) — Converts solver output to positioned entities: assembly rows (`placer.py`, `templates.py`), main bus routing (`router.py`), and power poles (`poles.py`). Returns `LayoutResult`.
+2. **Layout** — Converts solver output to positioned entities. Returns `LayoutResult`. Two layout engines:
+   - `src/layout/` — **Main bus** layout (template-based, human-like factory pattern). Legacy, not actively developed.
+   - `src/spaghetti/` — **Constraint-based** layout (planned). Place-and-route approach: position machines, then pathfind belt/pipe routes between them. No predefined pattern — produces novel, inhuman layouts.
 3. **Blueprint** (`src/blueprint/`) — Thin draftsman wrapper that converts `LayoutResult` to a base64 blueprint string.
+4. **Validation** (`src/validate.py`) — Functional checks run after layout: pipe isolation, fluid port connectivity, inserter chains, power coverage.
 
 ## Key models (`src/models.py`)
 
 - `ItemFlow` — item name, rate, fluid flag
 - `MachineSpec` — machine type, recipe, count, inputs/outputs
 - `SolverResult` — machines, external inputs/outputs, dependency order
-- `PlacedEntity` — entity name, position, direction, recipe
+- `PlacedEntity` — entity name, position, direction, recipe, carries (what item/fluid it transports)
 - `LayoutResult` — entities, connections, dimensions
 
-## Layout conventions
+## Factorio game rules (constraints for layout engines)
 
-- Main bus runs vertically on the left (underground belts for solids, pipe-to-ground for fluids)
-- Assembly rows stack horizontally to the right
-- Templates: `single_input_row`, `dual_input_row`, `fluid_row`
-- Machines: assembling-machine-3 (default), chemical-plant (fluids), oil-refinery
-- Power: medium-electric-pole on a 7-tile grid
+These are the physical rules any layout engine must satisfy:
 
-## Verification
+- **Machines** craft recipes, need ingredients delivered and products extracted
+- **Inserters** pick from one side, drop to the other. Regular inserters reach 1 tile; long-handed inserters reach 2 tiles
+- **Belts** move items in a direction, connect when adjacent. Different tiers have different throughput limits (yellow: 15/s, red: 30/s, blue: 45/s)
+- **Pipes** carry fluids, connect to any adjacent pipe (and merge — separate fluid networks must be physically isolated)
+- **Fluid ports** on machines are at specific tile positions (queryable from `draftsman.data.entities`)
+- **Entities** cannot overlap
+- **Power** — machines need electricity; medium-electric-pole covers a 7x7 area
 
-`src/verify.py` — offline blueprint validation (overlap detection, unpaired undergrounds, ASCII map)
+## Spaghetti builder approach (planned)
+
+Goal: given a production graph from the solver, produce a working factory layout without any predefined pattern (no bus, no rows, no templates). Analogous to PCB place-and-route.
+
+1. **Place** machines on the grid (e.g. force-directed, greedy, or random with retry)
+2. **Route** belts/pipes between connected machines using grid pathfinding (BFS/A*)
+3. **Validate** the result using `src/validate.py`
+4. **Retry/adjust** if routing fails or validation finds issues
+
+Key considerations:
+- Belt throughput limits must be respected (don't overload a single belt)
+- Inserter type selection (regular vs long-handed) based on layout geometry
+- Pipe isolation (parallel pipes carrying different fluids will merge)
+- Underground belts/pipes for crossing routes
+
+## Verification & validation
+
+- `src/verify.py` — structural blueprint validation (overlap detection, unpaired undergrounds, ASCII map)
+- `src/validate.py` — functional validation (pipe isolation, fluid connectivity, inserter chains, power coverage)
+- `tests/` — pytest suite with `--viz` flag for HTML visualizations, deployed to GitHub Pages via CI
+
+## Visualizations
+
+Test visualizations are deployed to GitHub Pages on main branch pushes:
+https://storkme.github.io/fucktorio/

--- a/README.md
+++ b/README.md
@@ -17,10 +17,21 @@ python -m src.pipeline
 ## Dependencies
 
 - **[factorio-draftsman](https://github.com/redruin1/factorio-draftsman)** — Provides the Factorio data layer and blueprint serialization. We use it for:
-  - **Recipe & entity database** (`draftsman.data.recipes`, `draftsman.data.entities`) — look up recipes, crafting speeds, machine types, and entity properties
+  - **Recipe & entity database** (`draftsman.data.recipes`, `draftsman.data.entities`) — look up recipes, crafting speeds, machine types, entity properties, and fluid port positions
   - **Blueprint construction** (`draftsman.blueprintable.Blueprint`, `draftsman.entity.new_entity`) — build blueprint objects and export the base64 strings that Factorio can import
   - **Blueprint parsing** (`draftsman.blueprintable.get_blueprintable_from_string`) — decode existing blueprints for visualization and verification
 
-- **[pytest](https://docs.pytest.org/)** — Test runner. The `--viz` flag generates HTML visualizations of blueprint layouts, which are deployed to GitHub Pages via CI.
+- **[pytest](https://docs.pytest.org/)** — Test runner. The `--viz` flag generates HTML visualizations of blueprint layouts, deployed to [GitHub Pages](https://storkme.github.io/fucktorio/).
 
-All layout logic (recipe solving, spatial placement, bus routing, power poles) and validation (overlap detection, underground belt pairing) is implemented in this project — draftsman provides the data and serialization, not the spatial reasoning.
+All layout logic (recipe solving, spatial placement, routing, validation) is implemented in this project — draftsman provides the data and serialization, not the spatial reasoning.
+
+## Architecture
+
+1. **Solver** — recursively resolves recipe dependencies, calculates machine counts and item flow rates
+2. **Layout** — positions machines and routes belts/pipes on a 2D tile grid
+3. **Validation** — checks the layout actually works (pipe isolation, fluid connectivity, inserter chains, power coverage)
+4. **Blueprint** — serializes the layout to a Factorio-importable base64 string
+
+## Direction
+
+We're building toward a **constraint-based layout engine** that doesn't use predefined patterns (no main bus, no templates). Given only Factorio's game rules, it places machines and pathfinds belt/pipe routes between them — a place-and-route approach analogous to PCB autorouting. The goal is to produce working but novel "spaghetti" factories.


### PR DESCRIPTION
## Summary
- Update CLAUDE.md and README.md to reflect the new project direction: constraint-based "spaghetti" layout engine using place-and-route, rather than extending the main bus builder
- Documents Factorio game rules as constraints (belt throughput, inserter types, pipe isolation, etc.)
- Describes the planned approach (place machines, pathfind routes, validate, retry)

https://claude.ai/code/session_01FhBNwsPXZTAciVDLepoRSM