### PR TITLE
Fix inserter placement in spaghetti engine

### DIFF
--- a/src/spaghetti/inserters.py
+++ b/src/spaghetti/inserters.py
@@ -6,8 +6,8 @@ from ..models import EntityDirection, PlacedEntity
 from .graph import ProductionGraph
 from .placer import machine_size
 
-# Direction from inserter to machine → inserter facing direction
-# Inserter faces the direction it DROPS toward
+# Inserter faces the direction it DROPS toward.
+# A SOUTH-facing inserter picks from the tile to its north and drops to the tile to its south.
 _FACING: dict[tuple[int, int], EntityDirection] = {
     (0, 1): EntityDirection.SOUTH,  # machine is below → drop south
     (0, -1): EntityDirection.NORTH,  # machine is above → drop north
@@ -23,12 +23,11 @@ def place_inserters(
 ) -> list[PlacedEntity]:
     """Place inserters between routed belts/pipes and machines.
 
-    For each machine, finds tiles that are:
-    - Adjacent to the machine border
-    - Occupied by a routed belt (in routed_tiles)
-    - Have a free tile for the inserter between belt and machine
+    The router places belts 2 tiles from the machine. The inserter goes on
+    the border tile (1 tile from machine), picking from the belt behind it
+    and dropping into the machine in front.
 
-    Places an inserter at the border tile between belt and machine.
+    Layout: ... [belt @ 2 tiles] [inserter @ 1 tile] [machine]
     """
     entities: list[PlacedEntity] = []
     used_tiles: set[tuple[int, int]] = set()
@@ -36,53 +35,33 @@ def place_inserters(
     for node in graph.nodes:
         mx, my = positions[node.id]
         size = machine_size(node.spec.entity)
-        machine_tiles = {(mx + dx, my + dy) for dx in range(size) for dy in range(size)}
 
-        # Check each border tile
-        _try_place_inserters_for_machine(mx, my, size, machine_tiles, routed_tiles, used_tiles, entities)
+        # Check each border tile around the machine
+        borders = [
+            *((mx + dx, my - 1, 0, 1) for dx in range(size)),  # top border
+            *((mx + dx, my + size, 0, -1) for dx in range(size)),  # bottom border
+            *((mx - 1, my + dy, 1, 0) for dy in range(size)),  # left border
+            *((mx + size, my + dy, -1, 0) for dy in range(size)),  # right border
+        ]
 
-    return entities
+        for bx, by, dx, dy in borders:
+            if (bx, by) in used_tiles:
+                continue
+            if (bx, by) in routed_tiles:
+                # Border tile is occupied by a belt — can't place inserter here
+                continue
 
+            # Check if there's a belt one tile further from the machine
+            belt_x, belt_y = bx - dx, by - dy
+            if (belt_x, belt_y) not in routed_tiles:
+                continue
 
-def _try_place_inserters_for_machine(
-    mx: int,
-    my: int,
-    size: int,
-    machine_tiles: set[tuple[int, int]],
-    routed_tiles: set[tuple[int, int]],
-    used_tiles: set[tuple[int, int]],
-    entities: list[PlacedEntity],
-) -> None:
-    """Try to place inserters around a single machine."""
-    # Border tiles with direction toward machine
-    borders = [
-        # (border_x, border_y, dx_to_machine, dy_to_machine)
-        *((mx + dx, my - 1, 0, 1) for dx in range(size)),  # top
-        *((mx + dx, my + size, 0, -1) for dx in range(size)),  # bottom
-        *((mx - 1, my + dy, 1, 0) for dy in range(size)),  # left
-        *((mx + size, my + dy, -1, 0) for dy in range(size)),  # right
-    ]
-
-    for bx, by, dx, dy in borders:
-        if (bx, by) in used_tiles:
-            continue
-
-        # Check if this border tile has a routed belt/pipe
-        if (bx, by) in routed_tiles:
-            # The belt IS on the border tile. Place inserter here —
-            # it picks from the belt at (bx, by) and drops into machine.
-            # But we can't place an inserter on top of a belt.
-            # Instead, check the tile one step further from the machine.
-            # If THAT tile has the belt, inserter goes on the border tile.
-            pass
-
-        # Check tile one step away from machine (belt position)
-        belt_x, belt_y = bx - dx, by - dy  # one tile further from machine
-        if (belt_x, belt_y) in routed_tiles and (bx, by) not in routed_tiles:
-            # Belt at (belt_x, belt_y), inserter at (bx, by), machine adjacent
+            # Belt is at (belt_x, belt_y), inserter goes at (bx, by)
+            # Inserter faces toward the machine (drops into machine)
             facing = _FACING.get((dx, dy))
             if facing is None:
                 continue
+
             entities.append(
                 PlacedEntity(
                     name="inserter",
@@ -92,17 +71,5 @@ def _try_place_inserters_for_machine(
                 )
             )
             used_tiles.add((bx, by))
-            continue
 
-        # Direct adjacency: belt on the border tile itself
-        if (bx, by) in routed_tiles:
-            # Belt right next to machine — inserter picks directly from adjacent belt
-            # In Factorio, inserter at (bx, by) facing (dx, dy) picks from behind
-            # and drops forward. So inserter should be between belt and machine.
-            # But belt IS at the border... the inserter needs its own tile.
-            # Try: inserter at border, picks from belt behind, drops into machine
-            facing = _FACING.get((dx, dy))
-            if facing is not None and (bx, by) not in used_tiles:
-                # This means the inserter and belt share a tile, which isn't valid.
-                # Skip — the router should have left a gap.
-                pass
+    return entities

--- a/src/spaghetti/placer.py
+++ b/src/spaghetti/placer.py
@@ -21,7 +21,7 @@ def machine_size(entity: str) -> int:
     return _MACHINE_SIZE.get(entity, _DEFAULT_SIZE)
 
 
-def place_machines(graph: ProductionGraph, spacing: int = 4) -> dict[int, tuple[int, int]]:
+def place_machines(graph: ProductionGraph, spacing: int = 5) -> dict[int, tuple[int, int]]:
     """Place machine nodes on the grid using simple grid layout.
 
     Arranges machines in rows with *spacing* tiles between them

--- a/src/spaghetti/router.py
+++ b/src/spaghetti/router.py
@@ -60,6 +60,28 @@ def _machine_border_tiles(x: int, y: int, size: int) -> list[tuple[int, int, int
     return borders
 
 
+def _machine_belt_tiles(x: int, y: int, size: int) -> list[tuple[int, int]]:
+    """Tiles 2 away from machine — where belts should end (inserter goes between).
+
+    The border tile (1 away) is reserved for the inserter.
+    The belt tile (2 away) is where the belt terminates.
+    """
+    tiles = []
+    # Top (y - 2)
+    for dx in range(size):
+        tiles.append((x + dx, y - 2))
+    # Bottom (y + size + 1)
+    for dx in range(size):
+        tiles.append((x + dx, y + size + 1))
+    # Left (x - 2)
+    for dy in range(size):
+        tiles.append((x - 2, y + dy))
+    # Right (x + size + 1)
+    for dy in range(size):
+        tiles.append((x + size + 1, y + dy))
+    return tiles
+
+
 def _bfs_path(
     start: tuple[int, int],
     goals: set[tuple[int, int]],
@@ -226,10 +248,10 @@ def _edge_endpoints(
 ) -> tuple[set[tuple[int, int]], set[tuple[int, int]]]:
     """Determine start and goal tile sets for routing an edge.
 
-    For internal edges: start = border tiles of source machine,
-    goal = border tiles of destination machine.
-    For external inputs: start = edge of grid, goal = machine border.
-    For external outputs: start = machine border, goal = edge of grid.
+    For internal edges: start/goal = belt tiles (2 tiles from machine),
+    leaving the border tile free for an inserter.
+    For external inputs: start = edge of grid, goal = belt tiles of dest.
+    For external outputs: start = belt tiles of source, goal = edge of grid.
     """
     start_tiles: set[tuple[int, int]] = set()
     goal_tiles: set[tuple[int, int]] = set()
@@ -238,7 +260,7 @@ def _edge_endpoints(
         fx, fy = positions[edge.from_node]
         src_node = next(n for n in graph.nodes if n.id == edge.from_node)
         size = machine_size(src_node.spec.entity)
-        for bx, by, _, _ in _machine_border_tiles(fx, fy, size):
+        for bx, by in _machine_belt_tiles(fx, fy, size):
             start_tiles.add((bx, by))
     else:
         # External input — start from left edge of grid
@@ -251,7 +273,7 @@ def _edge_endpoints(
         tx, ty = positions[edge.to_node]
         dst_node = next(n for n in graph.nodes if n.id == edge.to_node)
         size = machine_size(dst_node.spec.entity)
-        for bx, by, _, _ in _machine_border_tiles(tx, ty, size):
+        for bx, by in _machine_belt_tiles(tx, ty, size):
             goal_tiles.add((bx, by))
     else:
         # External output — route to right edge

--- a/tests/test_spaghetti.py
+++ b/tests/test_spaghetti.py
@@ -91,6 +91,17 @@ class TestSpaghettiPhase1:
         belts = [e for e in lr.entities if e.name in belt_types]
         assert len(belts) > 0, "Should have belts for item transport"
 
+    def test_has_inserters(self):
+        """Layout must contain inserters to move items between belts and machines."""
+        result = solve("iron-gear-wheel", target_rate=10, available_inputs={"iron-plate"})
+        lr = spaghetti_layout(result)
+
+        inserters = [e for e in lr.entities if "inserter" in e.name]
+        machines = [e for e in lr.entities if e.name == "assembling-machine-3"]
+        assert len(inserters) > 0, "Should have inserters"
+        # Each machine needs at least one inserter
+        assert len(inserters) >= len(machines), f"Should have at least {len(machines)} inserters, got {len(inserters)}"
+
     def test_no_overlaps(self):
         """No entities should overlap."""
         result = solve("iron-gear-wheel", target_rate=2, available_inputs={"iron-plate"})


### PR DESCRIPTION
The router now routes belts to 2 tiles from the machine (belt tiles), leaving the border tile (1 tile from machine) free for an inserter. The inserter picks from the belt behind it and drops into the machine.

Previously belts routed directly to the machine border, leaving no space for inserters — resulting in factories with no inserters at all.

Also increases machine spacing from 4 to 5 tiles and adds an explicit inserter count test.

https://claude.ai/code/session_01FhBNwsPXZTAciVDLepoRSM