### PR TITLE
Add 5 new validation checks and fix CI lint failures

### DIFF
--- a/src/validate.py
+++ b/src/validate.py
@@ -592,9 +592,7 @@ def check_belt_connectivity(
             continue
 
         size = _machine_size(e.name)
-        machine_tiles = {
-            (e.x + dx, e.y + dy) for dx in range(size) for dy in range(size)
-        }
+        machine_tiles = {(e.x + dx, e.y + dy) for dx in range(size) for dy in range(size)}
 
         # Find inserters adjacent to this machine
         adjacent_inserters: list[tuple[int, int]] = []
@@ -753,9 +751,7 @@ def check_belt_flow_path(
             continue
 
         size = _machine_size(e.name)
-        my_tiles = {
-            (e.x + dx, e.y + dy) for dx in range(size) for dy in range(size)
-        }
+        my_tiles = {(e.x + dx, e.y + dy) for dx in range(size) for dy in range(size)}
 
         # Find belt tiles adjacent to this machine's INPUT inserters
         start_belt_tiles: set[tuple[int, int]] = set()
@@ -796,10 +792,7 @@ def check_belt_flow_path(
                 break
 
         # Check if network reaches layout boundary (external input)
-        reaches_boundary = any(
-            bx == min_bx or bx == max_bx or by == min_by or by == max_by
-            for bx, by in belt_network
-        )
+        reaches_boundary = any(bx in (min_bx, max_bx) or by in (min_by, max_by) for bx, by in belt_network)
 
         if not reaches_source and not reaches_boundary:
             severity = "error" if layout_style == "spaghetti" else "warning"
@@ -859,25 +852,23 @@ def check_belt_direction_continuity(
             if nb_vec is None:
                 continue
 
-            # Check if they're 180-degree opposites
-            if nb_vec == opposite:
-                # Only flag if they're on the same axis as their flow
-                # (belts facing N/S adjacent vertically, or E/W adjacent horizontally)
-                # Side-by-side parallel belts going opposite ways is fine (common pattern)
-                if (dx, dy) == dir_vec or (dx, dy) == opposite:
-                    issues.append(
-                        ValidationIssue(
-                            severity="warning",
-                            category="belt-direction",
-                            message=(
-                                f"Adjacent belts at ({bx},{by}) and ({nb[0]},{nb[1]}) "
-                                f"face opposite directions ({direction.name} vs {nb_dir.name}), "
-                                f"creating a dead spot"
-                            ),
-                            x=bx,
-                            y=by,
-                        )
+            # Check if they're 180-degree opposites on the same axis as their flow
+            # (belts facing N/S adjacent vertically, or E/W adjacent horizontally)
+            # Side-by-side parallel belts going opposite ways is fine (common pattern)
+            if nb_vec == opposite and (dx, dy) in (dir_vec, opposite):
+                issues.append(
+                    ValidationIssue(
+                        severity="warning",
+                        category="belt-direction",
+                        message=(
+                            f"Adjacent belts at ({bx},{by}) and ({nb[0]},{nb[1]}) "
+                            f"face opposite directions ({direction.name} vs {nb_dir.name}), "
+                            f"creating a dead spot"
+                        ),
+                        x=bx,
+                        y=by,
                     )
+                )
 
     return issues
 
@@ -893,22 +884,9 @@ def check_belt_throughput(
     """
     issues: list[ValidationIssue] = []
 
-    # Build map of belt tile → (entity_name, total rate)
-    belt_entity_map: dict[tuple[int, int], str] = {}
-    belt_rate_map: dict[tuple[int, int], float] = defaultdict(float)
-
-    for e in layout_result.entities:
-        if e.name in _BELT_ENTITIES:
-            belt_entity_map[(e.x, e.y)] = e.name
-            # carries is the item name; we need the rate which isn't stored
-            # per-tile. However, if multiple entities occupy the same tile
-            # (shouldn't happen but indicates overlapping routes), count them.
-
     # Count overlapping belt entities at the same position.
     # Each belt entity placed at a tile represents a route using that tile.
-    # We track how many routes share each tile via entity duplication.
     tile_counts: dict[tuple[int, int], int] = defaultdict(int)
-    tile_rates: dict[tuple[int, int], float] = defaultdict(float)
     tile_names: dict[tuple[int, int], str] = {}
 
     for e in layout_result.entities:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,9 +1,8 @@
 """Tests for functional blueprint validation."""
 
 from src.layout import layout
-from src.models import LayoutResult, PlacedEntity
+from src.models import EntityDirection, LayoutResult, PlacedEntity
 from src.solver import solve
-from src.models import EntityDirection
 from src.validate import (
     ValidationError,
     check_belt_connectivity,
@@ -211,18 +210,26 @@ class TestBeltConnectivity:
                 PlacedEntity(name="assembling-machine-1", x=0, y=0, recipe="iron-gear-wheel"),
                 # Inserter on top border (center top = x=1, y=-1)
                 PlacedEntity(
-                    name="inserter", x=1, y=-1,
+                    name="inserter",
+                    x=1,
+                    y=-1,
                     direction=EntityDirection.SOUTH,
                 ),
                 # Belt above the inserter
                 PlacedEntity(
-                    name="transport-belt", x=1, y=-2,
-                    direction=EntityDirection.EAST, carries="iron-plate",
+                    name="transport-belt",
+                    x=1,
+                    y=-2,
+                    direction=EntityDirection.EAST,
+                    carries="iron-plate",
                 ),
                 # Extend belt so it's not isolated
                 PlacedEntity(
-                    name="transport-belt", x=2, y=-2,
-                    direction=EntityDirection.EAST, carries="iron-plate",
+                    name="transport-belt",
+                    x=2,
+                    y=-2,
+                    direction=EntityDirection.EAST,
+                    carries="iron-plate",
                 ),
             ]
         )
@@ -237,7 +244,9 @@ class TestBeltConnectivity:
                 PlacedEntity(name="assembling-machine-1", x=0, y=0, recipe="iron-gear-wheel"),
                 # Inserter on top border but no belt anywhere
                 PlacedEntity(
-                    name="inserter", x=1, y=-1,
+                    name="inserter",
+                    x=1,
+                    y=-1,
                     direction=EntityDirection.SOUTH,
                 ),
             ]
@@ -253,13 +262,18 @@ class TestBeltConnectivity:
             entities=[
                 PlacedEntity(name="assembling-machine-1", x=0, y=0, recipe="iron-gear-wheel"),
                 PlacedEntity(
-                    name="inserter", x=1, y=-1,
+                    name="inserter",
+                    x=1,
+                    y=-1,
                     direction=EntityDirection.SOUTH,
                 ),
                 # Single belt tile, not connected to anything
                 PlacedEntity(
-                    name="transport-belt", x=1, y=-2,
-                    direction=EntityDirection.EAST, carries="iron-plate",
+                    name="transport-belt",
+                    x=1,
+                    y=-2,
+                    direction=EntityDirection.EAST,
+                    carries="iron-plate",
                 ),
             ]
         )


### PR DESCRIPTION
## Summary

- Adds 5 new validation checks to catch broken layouts that previously passed silently
- Fixes ruff lint errors (`F821`, `I001`) from #22 that broke CI on main

### New checks

| Check | Severity | Catches |
|-------|----------|---------|
| `check_inserter_direction` | error | Inserters facing parallel to machine border (can't transfer items) |
| `check_belt_flow_path` | error (spaghetti) / warning (bus) | Input belt networks with no path to a source |
| `check_belt_direction_continuity` | warning | Head-on 180° belt reversals creating dead spots |
| `check_belt_throughput` | warning | Overlapping belt routes at the same tile |
| Inserter reach awareness | via direction check | `long-handed-inserter` (reach=2) vs regular (reach=1) handled correctly |

### Design decisions

- `check_belt_flow_path` only validates **input** belts — output belts are intentionally short dead-ends in both layout engines
- Bus layouts get warnings (not errors) for disconnected input spurs, since the bus engine has known gaps with underground belt connections
- Extracted shared helpers (`_build_machine_tile_set`, `_get_fluid_only_recipes`) to reduce duplication

## Test plan

- [x] 15 new unit tests covering all new checks (34 total in test_validate.py)
- [x] Full suite passes (108 tests)
- [x] `ruff check` and `ruff format --check` pass
- [x] Existing bus and spaghetti layout tests unaffected

https://claude.ai/code/session_01R4QWwXYATJqPTsyQ4rLt15