### PR TITLE
Improve external output routing and inserter placement strategy

### DIFF
--- a/src/spaghetti/inserters.py
+++ b/src/spaghetti/inserters.py
@@ -132,10 +132,18 @@ def assign_inserter_positions(
     strategy_pair = _STRATEGY_PAIRS.get(side_strategy, [(0, 1), (0, -1)])
 
     for _item, groups in edge_subgroups.items():
-        for group in groups:
-            for rank, edge_idx in enumerate(group):
-                # Alternate between the two sides in the strategy pair
-                edge_preferred[edge_idx] = strategy_pair[rank % 2]
+        for g_idx, group in enumerate(groups):
+            # All edges in the same sub-group go on the same side so the
+            # router can connect them into a single trunk network.
+            # Inputs use side 0, outputs use side 1 (so they don't conflict).
+            # Multiple sub-groups for the same direction alternate further.
+            sample_edge = graph.edges[group[0]]
+            is_output = sample_edge.to_node is None
+            base = 1 if is_output else 0
+            side_idx = (base + g_idx) % 2
+            side = strategy_pair[side_idx]
+            for edge_idx in group:
+                edge_preferred[edge_idx] = side
 
     # Now do per-machine assignment with preferred sides
     assignments: list[InserterAssignment] = []

--- a/src/spaghetti/layout.py
+++ b/src/spaghetti/layout.py
@@ -18,10 +18,12 @@ _MAX_RETRIES = 3
 _DEFAULT_SPACING = 4
 _SPACING_INCREMENT = 2
 
-# Retry strategies: vary spacing (left_right is incompatible with horizontal trunks)
+# Retry strategies: vary spacing and side strategy
 _RETRY_STRATEGIES = [
     ("top_bottom", _DEFAULT_SPACING),
+    ("left_right", _DEFAULT_SPACING),
     ("top_bottom", _DEFAULT_SPACING + _SPACING_INCREMENT),
+    ("left_right", _DEFAULT_SPACING + _SPACING_INCREMENT),
     ("top_bottom", _DEFAULT_SPACING + 2 * _SPACING_INCREMENT),
     ("top_bottom", _DEFAULT_SPACING + 3 * _SPACING_INCREMENT),
 ]

--- a/src/spaghetti/router.py
+++ b/src/spaghetti/router.py
@@ -503,6 +503,20 @@ def route_connections(
 
         indices.sort(key=_input_sort_key)
 
+    # Sort edges within each output group by spatial proximity
+    for _key, indices in output_routing_groups:
+        if len(indices) <= 1:
+            continue
+
+        def _output_sort_key(idx: int) -> float:
+            e = graph.edges[idx]
+            if e.from_node is None:
+                return 0
+            fx, fy = positions[e.from_node]
+            return fx + fy
+
+        indices.sort(key=_output_sort_key)
+
     # Build the routing order: internal edges, then input groups, then output groups
     routing_order: list[tuple[int, bool, tuple[str, int]]] = []
     for idx in internal_indices:
@@ -791,11 +805,41 @@ def _edge_endpoints(
         for bx, by in _machine_belt_tiles(tx, ty, size):
             goal_tiles.add((bx, by))
     else:
-        # External output — route to right edge
-        max_x = max(x for x, _ in positions.values()) + 10 if positions else 20
-        min_y = min(y for _, y in positions.values()) if positions else 0
-        max_y = max(y for _, y in positions.values()) + 5 if positions else 10
-        for y in range(min_y - 2, max_y + 3):
-            goal_tiles.add((max_x, y))
+        # External output — route to nearest grid edge (like inputs do)
+        if edge.from_node is not None and edge.from_node in {n.id for n in graph.nodes}:
+            fx, fy = positions[edge.from_node]
+            src_size = machine_size(next(n for n in graph.nodes if n.id == edge.from_node).spec.entity)
+            all_x = [x for x, _ in positions.values()]
+            all_y = [y for _, y in positions.values()]
+            min_gx, max_gx = min(all_x) - 3, max(all_x) + src_size + 3
+            min_gy, max_gy = min(all_y) - 3, max(all_y) + src_size + 3
+            cx, cy = fx + src_size // 2, fy + src_size // 2
+            edges_dist = [
+                (cx - min_gx, "left"),
+                (max_gx - cx, "right"),
+                (cy - min_gy, "top"),
+                (max_gy - cy, "bottom"),
+            ]
+            edges_dist.sort(key=lambda d: d[0])
+            _, nearest = edges_dist[0]
+            if nearest == "left":
+                for y in range(min_gy, max_gy + 1):
+                    goal_tiles.add((min_gx, y))
+            elif nearest == "right":
+                for y in range(min_gy, max_gy + 1):
+                    goal_tiles.add((max_gx, y))
+            elif nearest == "top":
+                for x in range(min_gx, max_gx + 1):
+                    goal_tiles.add((x, min_gy))
+            else:
+                for x in range(min_gx, max_gx + 1):
+                    goal_tiles.add((x, max_gy))
+        else:
+            # Fallback: right edge
+            max_x = max(x for x, _ in positions.values()) + 10 if positions else 20
+            min_y = min(y for _, y in positions.values()) if positions else 0
+            max_y = max(y for _, y in positions.values()) + 5 if positions else 10
+            for y in range(min_y - 2, max_y + 3):
+                goal_tiles.add((max_x, y))
 
     return start_tiles, goal_tiles


### PR DESCRIPTION
## Summary
This PR improves the routing and placement of external outputs in factory layouts by implementing spatial proximity-based sorting and dynamic edge selection, along with refinements to inserter placement strategies.

## Key Changes

- **Output edge sorting by spatial proximity**: Added sorting of edges within output routing groups based on the source node's position (sum of x and y coordinates), ensuring spatially close outputs are routed together for cleaner layouts.

- **Dynamic external output routing**: Changed external output routing from always using the right edge to intelligently selecting the nearest grid edge (left, right, top, or bottom) based on the source machine's position. This reduces routing distance and improves layout efficiency.

- **Improved inserter placement strategy**: Modified the inserter assignment logic to place all edges in the same sub-group on the same side, allowing the router to connect them into a single trunk network. Inputs and outputs now use different base sides (0 and 1 respectively) to prevent conflicts, with multiple sub-groups alternating further.

- **Expanded retry strategies**: Added "left_right" side strategy to the layout retry sequence alongside the existing "top_bottom" strategy, enabling more layout options when initial placement fails.

## Implementation Details

- The output sort key function mirrors the input sorting approach, using the source node's position to determine routing order.
- External output routing now calculates distances to all four grid edges and selects the nearest one, with proper handling of grid boundaries based on all node positions.
- The inserter placement now uses a `base + g_idx` calculation to ensure consistent side assignment within sub-groups while allowing alternation across multiple sub-groups.
- Retry strategies now interleave spacing increments with different side strategies for more comprehensive layout exploration.

https://claude.ai/code/session_011PM1jm2E3p3MQW7qhLNj36