### PR TITLE
Add trunk planning for clean belt topology

### DIFF
--- a/src/routing/orchestrate.py
+++ b/src/routing/orchestrate.py
@@ -655,9 +655,7 @@ def build_layout_incremental(
                     path = None
                     if is_input and not edge.is_fluid:
                         # Input: multi-source A* from network toward stub
-                        downstream_ends = _network_downstream_ends(
-                            existing_network, trial_belt_dir_map
-                        )
+                        downstream_ends = _network_downstream_ends(existing_network, trial_belt_dir_map)
                         forward_tiles = set()
                         for tile in downstream_ends:
                             d = trial_belt_dir_map.get(tile)
@@ -666,9 +664,7 @@ def build_layout_incremental(
                                 ft = (tile[0] + dvx, tile[1] + dvy)
                                 if ft not in existing_network:
                                     forward_tiles.add(ft)
-                        approach = _perpendicular_approach_tiles(
-                            existing_network, trial_belt_dir_map, trial_occupied
-                        )
+                        approach = _perpendicular_approach_tiles(existing_network, trial_belt_dir_map, trial_occupied)
                         all_starts = (forward_tiles | approach) - obstacles
                         if all_starts:
                             path = _astar_path(
@@ -702,27 +698,43 @@ def build_layout_incremental(
                                 preferred, fallback = right_goals, left_goals
                             if preferred:
                                 path = _astar_path(
-                                    start=(bx, by), goals=preferred, obstacles=obstacles,
-                                    allow_underground=True, ug_max_reach=6,
-                                    belt_dir_map=trial_belt_dir_map, other_item_tiles=_oit,
+                                    start=(bx, by),
+                                    goals=preferred,
+                                    obstacles=obstacles,
+                                    allow_underground=True,
+                                    ug_max_reach=6,
+                                    belt_dir_map=trial_belt_dir_map,
+                                    other_item_tiles=_oit,
                                 )
                             if not path and fallback:
                                 path = _astar_path(
-                                    start=(bx, by), goals=fallback, obstacles=obstacles,
-                                    allow_underground=True, ug_max_reach=6,
-                                    belt_dir_map=trial_belt_dir_map, other_item_tiles=_oit,
+                                    start=(bx, by),
+                                    goals=fallback,
+                                    obstacles=obstacles,
+                                    allow_underground=True,
+                                    ug_max_reach=6,
+                                    belt_dir_map=trial_belt_dir_map,
+                                    other_item_tiles=_oit,
                                 )
                             if not path and all_goals:
                                 path = _astar_path(
-                                    start=(bx, by), goals=all_goals, obstacles=obstacles,
-                                    allow_underground=True, ug_max_reach=6,
-                                    belt_dir_map=trial_belt_dir_map, other_item_tiles=_oit,
+                                    start=(bx, by),
+                                    goals=all_goals,
+                                    obstacles=obstacles,
+                                    allow_underground=True,
+                                    ug_max_reach=6,
+                                    belt_dir_map=trial_belt_dir_map,
+                                    other_item_tiles=_oit,
                                 )
                         elif all_goals:
                             path = _astar_path(
-                                start=(bx, by), goals=all_goals, obstacles=obstacles,
-                                allow_underground=True, ug_max_reach=6,
-                                belt_dir_map=trial_belt_dir_map, other_item_tiles=_oit,
+                                start=(bx, by),
+                                goals=all_goals,
+                                obstacles=obstacles,
+                                allow_underground=True,
+                                ug_max_reach=6,
+                                belt_dir_map=trial_belt_dir_map,
+                                other_item_tiles=_oit,
                             )
 
                     if path:

--- a/src/search/layout_search.py
+++ b/src/search/layout_search.py
@@ -31,6 +31,7 @@ class SearchStats:
     elapsed_s: float
     error_categories: dict[str, int] = field(default_factory=dict)
 
+
 # All four side direction vectors
 _ALL_SIDES = [(0, 1), (0, -1), (1, 0), (-1, 0)]
 
@@ -288,7 +289,9 @@ def _evaluate(
             trunk_x_coords: list[int] = []
             if candidate.use_trunks:
                 t_ents, t_bdm, t_gn, t_occ = plan_trunks(
-                    graph, solver_result, trunk_spacing=candidate.trunk_spacing,
+                    graph,
+                    solver_result,
+                    trunk_spacing=candidate.trunk_spacing,
                 )
                 trunk_kwargs = dict(
                     trunk_entities=t_ents,
@@ -305,16 +308,16 @@ def _evaluate(
             if trunk_x_coords:
                 input_items = sorted({e.item for e in graph.edges if e.from_node is None})
                 output_items = sorted({e.item for e in graph.edges if e.to_node is None})
-                input_trunk_xs = trunk_x_coords[:len(input_items)]
-                output_trunk_xs = trunk_x_coords[len(input_items):]
+                input_trunk_xs = trunk_x_coords[: len(input_items)]
+                output_trunk_xs = trunk_x_coords[len(input_items) :]
                 # Machine x: right of rightmost input trunk, with 2 tiles gap (inserter + belt)
                 machine_ideal_x = max(input_trunk_xs) + 2 if input_trunk_xs else trunk_x_coords[0] + 2
             else:
                 machine_ideal_x = 0
 
-            def _gen_candidates(node_id, g, positions, occupied, rng,
-                                _txc=trunk_x_coords, _tlen=trunk_length,
-                                _mix=machine_ideal_x):
+            def _gen_candidates(
+                node_id, g, positions, occupied, rng, _txc=trunk_x_coords, _tlen=trunk_length, _mix=machine_ideal_x
+            ):
                 node_size = machine_size(next(n for n in g.nodes if n.id == node_id).spec.entity)
 
                 if _txc:


### PR DESCRIPTION
## Summary

- Pre-lay straight vertical belt trunks before machine placement, eliminating belt loops, cross-item contamination, and flow-reachability errors from the greedy incremental approach
- Trunk-aware inserter assignment places inserters on the correct sides (toward trunks), and allows belt tiles on trunks to be shared
- Half of search candidates now use trunk planning; the other half use the existing incremental approach so the search picks whichever scores better
- Iron-gear-wheel (tier 1) now produces zero-error layouts consistently

| Metric | Before | After |
|--------|--------|-------|
| Iron-gear-wheel errors | 2-15 per layout | **0** |
| Belt loops | Common | **None** |
| Flow reachability failures | 2-4 per layout | **0** |
| Entity count | ~100 | **61** |
| `test_tier1_iron_gear_wheel` | xfail | **PASS** |

## Test plan

- [x] `pytest tests/test_spaghetti.py -x` — 15 passed, 2 xpassed, 0 failed
- [x] `test_tier1_iron_gear_wheel` now passes (was xfail)
- [x] `test_iron_gear_wheel_validates` now passes (was xfail)
- [x] Non-trunk candidates still work (backward compatible)
- [ ] Visual inspection of `test_viz/iron-gear-wheel-10s.html` — two parallel vertical trunks with machines in a column between them

Addresses #44

https://claude.ai/code/session_01WLcabs1GEpX3JGLywbL3Dg