### PR TITLE
Visualizer: merge belts, furnace icons, multiline text

### DIFF
--- a/src/renderers.py
+++ b/src/renderers.py
@@ -36,6 +36,33 @@ function isFurnace(name) {
   return name === 'stone-furnace' || name === 'steel-furnace'
     || name === 'electric-furnace';
 }
+function isUnderground(name) {
+  return name === 'underground-belt' || name === 'fast-underground-belt'
+    || name === 'express-underground-belt';
+}
+
+// Find the paired underground belt for a given one (scan along its direction)
+function findUndergroundPair(t) {
+  const d = t.dir || 0;
+  const dx = dirDx(d);
+  const dy = dirDy(d);
+  // input faces the direction it swallows from; output faces the direction it spits to
+  // Scan forward (in belt direction) for input, backward for output
+  const isInput = t.ioType === 'input';
+  const scanDx = isInput ? dx : -dx;
+  const scanDy = isInput ? dy : -dy;
+  // Underground belts can span up to 4 tiles apart (5 tiles gap) in vanilla
+  for (let dist = 1; dist <= 6; dist++) {
+    const nx = t.x + scanDx * dist;
+    const ny = t.y + scanDy * dist;
+    const nb = tileMap[nx + ',' + ny];
+    if (nb && isUnderground(nb.entity) && nb.ioType && nb.ioType !== t.ioType) {
+      const nd = nb.dir || 0;
+      if (nd === d) return { x: nx, y: ny, dist };
+    }
+  }
+  return null;
+}
 
 function pipeNeighbors(t) {
   const dirs = [[0,-1],[1,0],[0,1],[-1,0]];
@@ -482,9 +509,11 @@ const schematic = {
   },
 
   drawMachine(ctx, px, py, pw, ph, t) {
-    const gap = scale >= 4 ? 1 : 0;
-    const w = pw - gap;
-    const h = ph - gap;
+    const gap = Math.max(1, scale * 0.08);
+    const w = pw - gap * 2;
+    const h = ph - gap * 2;
+    px += gap;
+    py += gap;
     const cx = px + w / 2;
     const cy = py + h / 2;
 
@@ -640,6 +669,81 @@ const schematic = {
       ctx.arc(cx, cy, 3.5 * scale, 0, Math.PI * 2);
       ctx.stroke();
       ctx.setLineDash([]);
+    }
+  },
+
+  drawUnderground(ctx, px, py, s, t) {
+    const gap = Math.max(1, scale * 0.08);
+    const w = s - gap * 2;
+    const cx = px + s / 2;
+    const cy = py + s / 2;
+    const beltColors = {
+      'underground-belt': '#a89030',
+      'fast-underground-belt': '#b03030',
+      'express-underground-belt': '#3070b0',
+    };
+    const chevColors = {
+      'underground-belt': '#e0d070',
+      'fast-underground-belt': '#ff6060',
+      'express-underground-belt': '#70b0f0',
+    };
+    const base = beltColors[t.entity] || '#a89030';
+    const chev = chevColors[t.entity] || '#e0d070';
+    const isInput = t.ioType === 'input';
+
+    // Base tile with inset
+    ctx.fillStyle = darkenColor(base, 0.5);
+    ctx.fillRect(px + gap, py + gap, w, w);
+
+    // Inner belt surface
+    const frame = Math.max(1, w * 0.12);
+    ctx.fillStyle = base;
+    ctx.fillRect(px + gap + frame, py + gap + frame, w - frame * 2, w - frame * 2);
+
+    // Dark center hole for underground entry/exit
+    ctx.fillStyle = isInput ? 'rgba(0,0,0,0.6)' : 'rgba(0,0,0,0.35)';
+    const holeR = w * 0.2;
+    ctx.beginPath();
+    ctx.arc(cx, cy, holeR, 0, Math.PI * 2);
+    ctx.fill();
+
+    if (scale >= 4) {
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.rotate(dirAngle(t.dir || 0));
+
+      // Direction chevron — points inward for input, outward for output
+      ctx.strokeStyle = chev;
+      ctx.lineWidth = Math.max(1.5, s * 0.12);
+      ctx.lineCap = 'round';
+      const aSize = w * 0.22;
+      const yOff = isInput ? -w * 0.28 : w * 0.28;
+      const yTip = isInput ? -w * 0.08 : w * 0.08;
+      ctx.beginPath();
+      ctx.moveTo(-aSize, yOff);
+      ctx.lineTo(0, yTip);
+      ctx.lineTo(aSize, yOff);
+      ctx.stroke();
+
+      ctx.restore();
+    }
+
+    // Faint trace line to paired underground belt
+    const pair = findUndergroundPair(t);
+    if (pair) {
+      const pairPx = (pair.x - t.x) * scale;
+      const pairPy = (pair.y - t.y) * scale;
+      ctx.save();
+      ctx.strokeStyle = base;
+      ctx.globalAlpha = 0.2;
+      ctx.lineWidth = Math.max(2, w * 0.3);
+      ctx.setLineDash([Math.max(2, scale * 0.15), Math.max(2, scale * 0.15)]);
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx + pairPx, cy + pairPy);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.restore();
     }
   },
 
@@ -1099,9 +1203,11 @@ const factorio = {
   },
 
   drawMachine(ctx, px, py, pw, ph, t) {
-    const gap = scale >= 4 ? 1 : 0;
-    const w = pw - gap;
-    const h = ph - gap;
+    const gap = Math.max(1, scale * 0.08);
+    const w = pw - gap * 2;
+    const h = ph - gap * 2;
+    px += gap;
+    py += gap;
     const cx = px + w / 2;
     const cy = py + h / 2;
 
@@ -1346,6 +1452,90 @@ const factorio = {
       ctx.arc(cx, cy, 3.5 * scale, 0, Math.PI * 2);
       ctx.stroke();
       ctx.setLineDash([]);
+    }
+  },
+
+  drawUnderground(ctx, px, py, s, t) {
+    const gap = Math.max(1, scale * 0.08);
+    const w = s - gap * 2;
+    const cx = px + s / 2;
+    const cy = py + s / 2;
+    const baseColors = {
+      'underground-belt': '#484840',
+      'fast-underground-belt': '#443838',
+      'express-underground-belt': '#383844',
+    };
+    const arrowColors = {
+      'underground-belt': '#d4a820',
+      'fast-underground-belt': '#cc3030',
+      'express-underground-belt': '#3080cc',
+    };
+    const base = baseColors[t.entity] || '#484840';
+    const arrow = arrowColors[t.entity] || '#d4a820';
+    const isInput = t.ioType === 'input';
+
+    // Dark metallic frame with inset
+    ctx.fillStyle = '#1a1810';
+    ctx.fillRect(px + gap, py + gap, w, w);
+
+    // Inner belt surface
+    const frame = Math.max(1, w * 0.12);
+    ctx.fillStyle = base;
+    ctx.fillRect(px + gap + frame, py + gap + frame, w - frame * 2, w - frame * 2);
+
+    // Dark underground hole
+    ctx.fillStyle = isInput ? 'rgba(0,0,0,0.7)' : 'rgba(0,0,0,0.4)';
+    const holeR = w * 0.2;
+    ctx.beginPath();
+    ctx.arc(cx, cy, holeR, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Rim around hole
+    if (scale >= 6) {
+      ctx.strokeStyle = 'rgba(100,95,80,0.5)';
+      ctx.lineWidth = Math.max(1, w * 0.06);
+      ctx.beginPath();
+      ctx.arc(cx, cy, holeR, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    if (scale >= 4) {
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.rotate(dirAngle(t.dir || 0));
+
+      // Direction chevron
+      ctx.strokeStyle = arrow;
+      ctx.lineWidth = Math.max(1.5, s * 0.12);
+      ctx.lineCap = 'round';
+      const aSize = w * 0.22;
+      const yOff = isInput ? -w * 0.28 : w * 0.28;
+      const yTip = isInput ? -w * 0.08 : w * 0.08;
+      ctx.beginPath();
+      ctx.moveTo(-aSize, yOff);
+      ctx.lineTo(0, yTip);
+      ctx.lineTo(aSize, yOff);
+      ctx.stroke();
+
+      ctx.restore();
+    }
+
+    // Faint trace line to paired underground belt
+    const pair = findUndergroundPair(t);
+    if (pair) {
+      const pairPx = (pair.x - t.x) * scale;
+      const pairPy = (pair.y - t.y) * scale;
+      ctx.save();
+      ctx.strokeStyle = arrow;
+      ctx.globalAlpha = 0.15;
+      ctx.lineWidth = Math.max(2, w * 0.3);
+      ctx.setLineDash([Math.max(2, scale * 0.15), Math.max(2, scale * 0.15)]);
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx + pairPx, cy + pairPy);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.restore();
     }
   },
 

--- a/src/visualize.py
+++ b/src/visualize.py
@@ -47,6 +47,8 @@ _INFRA_COLORS = {
     "fast-transport-belt": "#e05050",
     "express-transport-belt": "#50a0e0",
     "underground-belt": "#a89040",
+    "fast-underground-belt": "#e05050",
+    "express-underground-belt": "#50a0e0",
     "inserter": "#6a8e3e",
     "fast-inserter": "#4a90d0",
     "long-handed-inserter": "#d04040",
@@ -61,6 +63,8 @@ _INFRA_LABELS = {
     "fast-transport-belt": "Belt (red)",
     "express-transport-belt": "Belt (blue)",
     "underground-belt": "UG Belt",
+    "fast-underground-belt": "UG Belt (red)",
+    "express-underground-belt": "UG Belt (blue)",
     "inserter": "Inserter",
     "fast-inserter": "Fast Inserter",
     "long-handed-inserter": "Long Inserter",
@@ -178,10 +182,11 @@ def visualize(
             tooltip = label
             if carries:
                 tooltip += f" [{carries}]"
-            if e.name == "underground-belt":
-                io = getattr(e, "io_type", None)
-                if io:
-                    tooltip += f" ({io})"
+            io_type = ""
+            if e.name in ("underground-belt", "fast-underground-belt", "express-underground-belt"):
+                io_type = getattr(e, "io_type", None) or ""
+                if io_type:
+                    tooltip += f" ({io_type})"
             tiles.append(
                 {
                     "x": tx,
@@ -194,6 +199,7 @@ def visualize(
                     "tooltip": tooltip,
                     "dir": direction,
                     "carries": carries,
+                    "ioType": io_type,
                 }
             )
 
@@ -742,6 +748,8 @@ function draw() {{
 
     if (isBelt(t.entity)) {{
       theme.drawBelt(ctx, px, py, s, t);
+    }} else if (isUnderground(t.entity)) {{
+      theme.drawUnderground(ctx, px, py, s, t);
     }} else if (isPipe(t.entity)) {{
       theme.drawPipe(ctx, px, py, s, t);
     }} else if (isInserter(t.entity)) {{


### PR DESCRIPTION
## Summary
- **Merge belt rendering** (fixes #43): Detect double-sideload merge patterns (two perpendicular feeders, no straight feeder) and render inward-pointing arrows from each feeder side in both themes
- **Furnace graphics**: Add stone/steel/electric furnace to `_3x3` crafting set so they render as proper 3x3 tiles with recipe colors, plus a trapezoid + flame icon in both themes
- **Multiline recipe text**: Replace truncated single-line labels with hyphen-aware word wrapping (up to 3 lines) using `ctx.measureText()` for proper width calculation

## Test plan
- [ ] Open `test_viz/iron-gear-wheel-10s.html` and verify merge tiles show side arrows
- [ ] Zoom in to confirm recipe names wrap across lines instead of clipping
- [ ] Check furnace rendering in blueprints that include furnaces (3x3 with flame icon)
- [ ] Toggle between schematic and factorio themes — both should show all three improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)