### PR TITLE
Add blueprint analysis pipeline for parsing blueprints into production graphs

### DIFF
--- a/src/analysis/batch.py
+++ b/src/analysis/batch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import statistics
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from . import analyze_blueprint
@@ -237,12 +237,12 @@ def aggregate_stats(results: list[tuple[str, BlueprintStats | None]]) -> Aggrega
 def print_summary(agg: AggregateStats) -> None:
     """Print a formatted summary of aggregate statistics."""
     print(f"\n{'=' * 60}")
-    print(f"BLUEPRINT ANALYSIS SUMMARY")
+    print("BLUEPRINT ANALYSIS SUMMARY")
     print(f"{'=' * 60}")
     print(f"  Analyzed: {agg.count} blueprints ({agg.success_count} ok, {agg.failure_count} failed)")
 
     if agg.by_product:
-        print(f"\n--- By Final Product ---")
+        print("\n--- By Final Product ---")
         for product, stats_list in sorted(agg.by_product.items(), key=lambda x: -len(x[1])):
             print(f"  {product}: {len(stats_list)} blueprints")
 
@@ -261,7 +261,7 @@ def print_summary(agg: AggregateStats) -> None:
             ("output_inserters_per_machine", "Output inserters/machine"),
         ]
 
-        print(f"\n--- Key Ratios (for tuning layout engine) ---")
+        print("\n--- Key Ratios (for tuning layout engine) ---")
         print(f"  {'Metric':<30} {'Mean':>8} {'Median':>8} {'Min':>8} {'Max':>8} {'StdDev':>8}")
         print(f"  {'-' * 78}")
         for field_name, label in key_metrics:
@@ -270,6 +270,6 @@ def print_summary(agg: AggregateStats) -> None:
                 continue
             print(f"  {label:<30} {d.mean:>8.2f} {d.median:>8.2f} {d.min:>8.2f} {d.max:>8.2f} {d.stdev:>8.2f}")
 
-        print(f"\n--- All Distributions ---")
+        print("\n--- All Distributions ---")
         for field_name, d in sorted(agg.distributions.items()):
             print(f"  {field_name}: mean={d.mean:.2f}, median={d.median:.2f}, range=[{d.min:.1f}, {d.max:.1f}]")

--- a/src/analysis/stats.py
+++ b/src/analysis/stats.py
@@ -6,7 +6,6 @@ import logging
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 
-from ..routing.common import _MACHINE_SIZE
 from ..solver.recipe_db import get_crafting_speed, get_recipe
 from .models import BlueprintGraph
 
@@ -109,11 +108,7 @@ def extract_stats(graph: BlueprintGraph) -> BlueprintStats:
         stats.bbox_height = max(ys) - min(ys) + 1
         stats.bbox_area = stats.bbox_width * stats.bbox_height
         total_entities = (
-            stats.machine_count
-            + stats.belt_tiles
-            + stats.pipe_tiles
-            + stats.inserter_count
-            + len(graph.unhandled)
+            stats.machine_count + stats.belt_tiles + stats.pipe_tiles + stats.inserter_count + len(graph.unhandled)
         )
         stats.density = total_entities / stats.bbox_area if stats.bbox_area > 0 else 0.0
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -3,9 +3,8 @@
 import pytest
 
 from src.analysis import analyze_blueprint
-from src.analysis.stats import BlueprintStats, detect_final_product, estimate_throughput, extract_stats
+from src.analysis.stats import detect_final_product, estimate_throughput, extract_stats
 from src.blueprint import build_blueprint
-
 
 # The processing-unit blueprint from earlier testing
 PROCESSING_UNIT_BP = (
@@ -83,7 +82,7 @@ class TestExtractStats:
         assert stats.machines_without_inserters == 0
         assert "iron-gear-wheel" in stats.throughput_estimates
 
-        print(f"\n--- Iron Gear Wheel Stats ---")
+        print("\n--- Iron Gear Wheel Stats ---")
         print(f"  Final product: {stats.final_product}")
         print(f"  Machines: {stats.machine_count}")
         print(f"  Belts/machine: {stats.belts_per_machine:.1f}")
@@ -110,7 +109,7 @@ class TestExtractStats:
         assert len(stats.machine_gaps) > 0
         assert 1 in stats.machine_gaps
 
-        print(f"\n--- Processing Unit Stats ---")
+        print("\n--- Processing Unit Stats ---")
         print(f"  Final product: {stats.final_product}")
         print(f"  Machines: {stats.machine_count}, Recipes: {stats.recipe_count}")
         print(f"  Belts/machine: {stats.belts_per_machine:.1f}")


### PR DESCRIPTION
Introduces src/analysis/ module that takes a Factorio blueprint string and
reconstructs the production graph: machines as nodes, belt/pipe networks as
edges, with item labels inferred from recipe constraints.

Five-step pipeline:
1. classify - sort entities into machines, belts, pipes, inserters
2. trace - BFS connected components for belt and pipe networks
3. inserters - resolve pickup/drop positions to link machines ↔ networks
4. infer - propagate item labels from recipes through networks
5. graph_builder - construct production edges

Round-trip tested: generate iron-gear-wheel → export → parse → analyze
correctly finds 4 machines, 2 networks (iron-plate + iron-gear-wheel),
8 inserter links, and 8 production edges.

https://claude.ai/code/session_01321R9wp46L2wrqwAZ7WREt