### PR TITLE
Add trace debug UI: overlays, stats panel, step-through debugger (Pha…

### DIFF
--- a/crates/core/src/bus/balancer_library.rs
+++ b/crates/core/src/bus/balancer_library.rs
@@ -1725,7 +1725,7 @@ static T_6_1_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "splitter", x: 0, y: 3, direction: 4, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 4, direction: 2, io_type: None },
 ];
-static T_6_1_INPUT: &[(i32, i32)] = &[(0, 1)];
+static T_6_1_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
 static T_6_1_OUTPUT: &[(i32, i32)] = &[(2, 5)];
 
 static T_6_2_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -1759,7 +1759,7 @@ static T_6_2_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 3, direction: 2, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 4, direction: 0, io_type: None },
 ];
-static T_6_2_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0)];
+static T_6_2_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
 static T_6_2_OUTPUT: &[(i32, i32)] = &[(4, 6), (5, 6)];
 
 static T_6_3_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -1798,7 +1798,7 @@ static T_6_3_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 4, direction: 0, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 5, direction: 0, io_type: None },
 ];
-static T_6_3_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0)];
+static T_6_3_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
 static T_6_3_OUTPUT: &[(i32, i32)] = &[(3, 7), (4, 7), (5, 7)];
 
 static T_6_4_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -1844,7 +1844,7 @@ static T_6_4_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 1, direction: 4, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 2, direction: 2, io_type: None },
 ];
-static T_6_4_INPUT: &[(i32, i32)] = &[(0, 1), (2, 1), (5, 1)];
+static T_6_4_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
 static T_6_4_OUTPUT: &[(i32, i32)] = &[(2, 9), (3, 9), (4, 9), (5, 9)];
 
 static T_6_5_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -2274,7 +2274,7 @@ static T_7_2_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 4, direction: 2, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 5, direction: 0, io_type: None },
 ];
-static T_7_2_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)];
+static T_7_2_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)];
 static T_7_2_OUTPUT: &[(i32, i32)] = &[(5, 6), (6, 6)];
 
 static T_7_3_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -2341,7 +2341,7 @@ static T_7_3_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 5, direction: 0, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 6, direction: 0, io_type: None },
 ];
-static T_7_3_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
+static T_7_3_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)];
 static T_7_3_OUTPUT: &[(i32, i32)] = &[(1, 11), (2, 11), (3, 11)];
 
 static T_7_4_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -2398,7 +2398,7 @@ static T_7_4_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 6, direction: 4, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 7, direction: 2, io_type: None },
 ];
-static T_7_4_INPUT: &[(i32, i32)] = &[(6, 0)];
+static T_7_4_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)];
 static T_7_4_OUTPUT: &[(i32, i32)] = &[(2, 9), (3, 9), (4, 9), (5, 9)];
 
 static T_7_5_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -2885,7 +2885,7 @@ static T_8_3_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 4, direction: 4, io_type: None },
     BalancerTemplateEntity { name: "splitter", x: 0, y: 5, direction: 4, io_type: None },
 ];
-static T_8_3_INPUT: &[(i32, i32)] = &[(0, 2), (7, 2)];
+static T_8_3_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0)];
 static T_8_3_OUTPUT: &[(i32, i32)] = &[(3, 8), (4, 8), (5, 8)];
 
 static T_8_4_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -3029,7 +3029,7 @@ static T_8_6_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 10, direction: 0, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 11, direction: 0, io_type: None },
 ];
-static T_8_6_INPUT: &[(i32, i32)] = &[(2, 2), (5, 2), (7, 2)];
+static T_8_6_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0)];
 static T_8_6_OUTPUT: &[(i32, i32)] = &[(1, 14), (2, 14), (3, 14), (4, 14), (5, 14), (6, 14)];
 
 static T_8_7_ENTITIES: &[BalancerTemplateEntity] = &[

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -48,6 +48,7 @@ pub fn build_bus_layout(
 
     // First pass: place rows with temp bus width
     let temp_bw = estimate_bus_width(solver_result);
+    #[cfg(not(target_arch = "wasm32"))]
     let t_place1 = std::time::Instant::now();
     let (row_entities, row_spans, row_width, total_height) = place_rows(
         &solver_result.machines,
@@ -59,9 +60,12 @@ pub fn build_bus_layout(
         None,
     );
 
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime { phase: "place_rows_1".to_string(), duration_ms: t_place1.elapsed().as_millis() as u64 });
+    #[cfg(not(target_arch = "wasm32"))]
     let t_plan1 = std::time::Instant::now();
     let (lanes, families) = plan_bus_lanes(solver_result, &row_spans, max_belt_tier)?;
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime { phase: "plan_bus_lanes_1".to_string(), duration_ms: t_plan1.elapsed().as_millis() as u64 });
     let actual_bw = bus_width_for_lanes(&lanes);
 
@@ -69,6 +73,7 @@ pub fn build_bus_layout(
     let extra_gaps = compute_extra_gaps(&families);
 
     // Re-place rows if bus width changed or balancers need extra space
+    #[cfg(not(target_arch = "wasm32"))]
     let t_place2 = std::time::Instant::now();
     let (row_entities, row_spans, row_width, total_height) = if actual_bw != temp_bw || !extra_gaps.is_empty()
     {
@@ -97,14 +102,17 @@ pub fn build_bus_layout(
         });
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime { phase: "place_rows_2".to_string(), duration_ms: t_place2.elapsed().as_millis() as u64 });
     // Re-plan lanes with final row positions
+    #[cfg(not(target_arch = "wasm32"))]
     let t_plan2 = std::time::Instant::now();
     let (lanes, families) = if actual_bw != temp_bw || !extra_gaps.is_empty() {
         plan_bus_lanes(solver_result, &row_spans, max_belt_tier)?
     } else {
         (lanes, families)
     };
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime { phase: "plan_bus_lanes_2".to_string(), duration_ms: t_plan2.elapsed().as_millis() as u64 });
     crate::trace::emit(crate::trace::TraceEvent::PhaseComplete {
         phase: "lanes_planned".into(),
@@ -120,6 +128,7 @@ pub fn build_bus_layout(
     }
 
     // Route bus lanes
+    #[cfg(not(target_arch = "wasm32"))]
     let t_route_bus = std::time::Instant::now();
     let (bus_entities, max_y, merge_max_x, regions) = route_bus(
         &lanes,
@@ -131,6 +140,7 @@ pub fn build_bus_layout(
         &families,
         &row_entities,
     )?;
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime { phase: "route_bus_total".to_string(), duration_ms: t_route_bus.elapsed().as_millis() as u64 });
     crate::trace::emit(crate::trace::TraceEvent::PhaseComplete {
         phase: "bus_routed".into(),
@@ -354,9 +364,11 @@ fn route_bus(
     // SAT crossing zones: trunk-only approach. SAT determines how trunks
     // handle crossings (UG bridges). The A* routes tap-offs normally (underground).
     // SAT zones have forced-empty tiles at tap_y so trunks bridge around them.
+    #[cfg(not(target_arch = "wasm32"))]
     let sat_start = std::time::Instant::now();
     let (solved_crossings, mut crossing_tiles, _sat_regions) =
         extract_and_solve_crossings(lanes, row_spans, max_belt_tier);
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime {
         phase: "sat_crossing_zones".to_string(),
         duration_ms: sat_start.elapsed().as_millis() as u64,
@@ -374,6 +386,7 @@ fn route_bus(
 
     // No spec splitting needed — A* runs normally, SAT only affects trunk rendering.
     let empty_regions: Vec<SatCrossingRegion> = Vec::new();
+    #[cfg(not(target_arch = "wasm32"))]
     let negotiate_start = std::time::Instant::now();
     let routed_paths = negotiate_and_route(
         lanes,
@@ -387,6 +400,7 @@ fn route_bus(
         &empty_regions,
         &FxHashSet::default(),
     );
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime {
         phase: "negotiate_astar".to_string(),
         duration_ms: negotiate_start.elapsed().as_millis() as u64,
@@ -483,6 +497,7 @@ fn route_bus(
 
     // Route each lane, skipping tiles owned by SAT crossing zones
     // and tiles claimed by A* tap-offs.
+    #[cfg(not(target_arch = "wasm32"))]
     let route_lanes_start = std::time::Instant::now();
     for lane in lanes {
         let entity_count_before = entities.len();
@@ -497,6 +512,7 @@ fn route_bus(
             tapoffs: if has_tapoffs { lane.tap_off_ys.len() } else { 0 },
         });
     }
+    #[cfg(not(target_arch = "wasm32"))]
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime {
         phase: "route_all_lanes".to_string(),
         duration_ms: route_lanes_start.elapsed().as_millis() as u64,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,8 @@ set -e
 # ---------------------------------------------------------------------------
 if [ -n "$GH_TOKEN" ]; then
     echo "gh: authenticated as $(gh api user --jq .login)"
+    git config --global --unset-all credential.https://github.com.helper 2>/dev/null || true
+    git config --global --unset-all credential.https://gist.github.com.helper 2>/dev/null || true
     gh auth setup-git
 else
     echo "Warning: GH_TOKEN not set — gh will be unauthenticated"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,7 @@ set -e
 # ---------------------------------------------------------------------------
 if [ -n "$GH_TOKEN" ]; then
     echo "gh: authenticated as $(gh api user --jq .login)"
+    gh auth setup-git
 else
     echo "Warning: GH_TOKEN not set — gh will be unauthenticated"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,9 +8,8 @@ set -e
 # ---------------------------------------------------------------------------
 if [ -n "$GH_TOKEN" ]; then
     echo "gh: authenticated as $(gh api user --jq .login)"
-    git config --global --unset-all credential.https://github.com.helper 2>/dev/null || true
-    git config --global --unset-all credential.https://gist.github.com.helper 2>/dev/null || true
-    gh auth setup-git
+    git config --global credential.https://github.com.helper \
+        '!f() { echo "username=oauth2"; echo "password=$GH_TOKEN"; }; f'
 else
     echo "Warning: GH_TOKEN not set — gh will be unauthenticated"
 fi

--- a/scripts/generate_balancer_library.py
+++ b/scripts/generate_balancer_library.py
@@ -691,7 +691,7 @@ def _maybe_sync() -> None:
     """Run sync_balancer_to_rust.py if it exists."""
     if not SYNC_SCRIPT.exists():
         return
-    print(f"\nSyncing to Rust...", flush=True)
+    print("\nSyncing to Rust...", flush=True)
     result = subprocess.run(
         [sys.executable, str(SYNC_SCRIPT)],
         cwd=str(SYNC_SCRIPT.parent.parent),

--- a/src/bus/balancer_library.py
+++ b/src/bus/balancer_library.py
@@ -6,6 +6,7 @@ DO NOT EDIT MANUALLY. Regenerate with:
 Shapes are oriented for vertical SOUTH flow: inputs at the top
 (facing SOUTH), outputs at the bottom (facing SOUTH).
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -1865,7 +1866,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="splitter", x=0, y=3, direction=4),
             BalancerTemplateEntity(name="transport-belt", x=0, y=4, direction=2),
         ),
-        input_tiles=((0, 1),),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)),
         output_tiles=((2, 5),),
         source_blueprint="0eNqtlNFugyAUhl+l4bprRAF1r7I0i7akIVEggMuM4d13apxrOsa6yZVwOPwfnvPDhNpu4NoI6dDzbkLipKSF0cuErLjIppujbtQcBkg43qP9Dsmmn+dWd8I5bpCHoJBn/g5R7I/7JRVSvuQh+MaNFUpCPK8wKUldshJnjDJY49IJJ/gCn2fjqxz6FuRBFDK0spAxb5/QlZQdKITH6/Ih86FzQewsDD8t23JI+q6dh7TzG216q+1MI61Wxj21vHP3BBIkFCFCkZJAQgTyPwILEmiIgFdCvqUDLFyfbNWmj2iHK1PGK3OnPYCJzcUo+K61+XS/GpweHApSqrg/iy3VqeP+LLa7B2dxg/4JEf4JjON9SIEIXmSaFFHEe0ESIH65yuRxwwr5o18xjRuWbjEsZvG3giaoUhlvRApEFb8U20pUx7scP78/ev8BGB9bWQ==",
     ),
@@ -1905,7 +1906,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=3, direction=2),
             BalancerTemplateEntity(name="transport-belt", x=0, y=4, direction=0),
         ),
-        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)),
         output_tiles=((4, 6), (5, 6)),
         source_blueprint="0eNqtlltuwjAQRbeC/E2R3yFspUIVDwtZCk7kOFVR5L13GlFKVTMJjb9iT5x7hplrm57sq8403rpANoue2EPtWhi99qS1J7erhmi4NAYGxAZzJssFcbvzMG+byoZgPIkQtO5oPiDK4nZ5XQpLfuQh+G58a2sHcb5mspBloQtGtdLwzrhggzVX+DC7vLnuvAd5EIUVTd3CiuHznnyR+EpB+AIjulLxLq/gd65tah9e9qYayEfrzeH6MYelfwk8RRA5CSJFkDkJMkXQOQkqRaA3AlvRmPLHJG2d0mZ32r+y78Bu/uRreKbzh/nNt67pAklCC9xYE6DfkLoLDylr3FwzfhpGLVNUladZjOJeY/O9xhhuNp4BwfH250AIvPc5EBI/WfisRivcRU/lL9MIjTdaZChRgR8uYlaJ1riLxPRDBDmpWIkbKUOVOMWNJOb3mjPcTjkQHLeTzFCoB5uaphH3/5MSYjJdkjGxacUYubFVhmKMXNxqzt7iIxc0nn9acuQ2/o9kiW+cp6qs4zbGT55VibI=",
     ),
@@ -1950,7 +1951,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=4, direction=0),
             BalancerTemplateEntity(name="transport-belt", x=0, y=5, direction=0),
         ),
-        input_tiles=((0, 0), (1, 0)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)),
         output_tiles=((3, 7), (4, 7), (5, 7)),
         source_blueprint="0eNq1lm1rwjAQgP+K5LOTvFf3V4YMX4IEalrSdExK//tuRZxjt+u6xk8mZ3pPenmapGP7snV19CGx50XH/KEKDbReOtb4U9iVQzRdagcN5pM7s+WChd156Dd16VNykfUQ9OHo3iEq+u3yOhSGfKWH4JuLja8CxOVa6EJvClsIbo2F/1xIPnl3hQ+9y2toz3tID0lhRF01MGJ4vGOfJLkyEL5Ai69MfzevFHehqauYnvauHMhHH93h+rCEoT8JEiOonASFEXROgsYINifBYIQiJ8FiBH4jiBXvMQP/lLvAcou73N9m34LQ8RQr+MXnD/3blxHqNjEUuqbVFWTJ0IwbWtUZr1G16df3EBzDmjwrIwStrpgvlpC0uzkQihZMPkQwoWnD5HTDhKEVkw9SzNJbpJylWEErJjOs/5pWLAdiQ++Pak6JJKdNUtNNkoI2SWU4uSVtTQ6Eove+eVUfObYnzV/jCENbozOUyOILzXHE/dURSVbQ9dYZSrKmqz4JYXHEyLdqMtwpOX3imDliqpFbt5m+HaiRa/Z/Uo7cq838hVSa1nEiYtv3Hx9XHAY=",
     ),
@@ -2002,7 +2003,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=1, direction=4),
             BalancerTemplateEntity(name="transport-belt", x=0, y=2, direction=2),
         ),
-        input_tiles=((0, 1), (2, 1), (5, 1)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)),
         output_tiles=((2, 9), (3, 9), (4, 9), (5, 9)),
         source_blueprint="0eNq1lttqwzAMhl+l+HorPifZq4wyejDFkDohccZKyLtPhNJtTNXW2L2qozr6bPn/5YxsVw+u7XyI7GU1Mr9vQg+j15H1/hi29RyN59bBgPnoTuxpxcL2ND/3be1jdB2bIOjDwX1AVEybp8tUmPKVHoLvrut9EyAuS6ELXRW2ENwaC/+5EH307gKfn85vYTjtID0khRlt08OM+fWRzaS1gfAZRnxtpm/rit029G3Txeedq2fywXduf3lZwtTfBIkRZE6CwghqGUGjBI0RdE6CwQhmGcGiBIsRbM5zKDBCkZNQYoQqJ6HCCPxKEGs+YT79V27BaSuIn8sfwPfdsWvgF98APF8bSGiHyHCqwMXLceqtLeGyFZLWrSBPBE+paKEuSalpZSYUvhni7cqjpi4zicnSXhDpXhAFfTnIpPWXtBnkY8xQ0XeFzHDfcdoS8n79SkFbYklKSVtCPsYSUtGqzVF/TbdwlaJaaWhLqAzrt7QxciAK+nsmrUQlLVa1QKwVLdYMJVGc7tVJJVGCVn2O9UtamPoh7VQpWqs6w8Y03bF10sEY2gj6MV1QWfqKSNtTQfsvx5mUtB/1/RZXf3x4m5SSaE6bw6SXRAvaCTRi2kzTJzZe8Bs=",
     ),
@@ -2462,7 +2463,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=4, direction=2),
             BalancerTemplateEntity(name="transport-belt", x=0, y=5, direction=0),
         ),
-        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)),
         output_tiles=((5, 6), (6, 6)),
         source_blueprint="0eNqtlttugzAMhl+lyvVW5UBCu1eZqqmHqIpEAwphWoV493mo6zrNdejIFYkJ/xfsn5ie7arONsH5yF4WPXP72rcweu1Z645+W43ReG4sDJiL9sSeFsxvT+O8bSoXow1sgKDzB/sBUTFsni5LYcmPPATfbWhd7SEuV6Ioi3VpSsGNNnDP+uiisxf4ODu/+e60A3kQhRVN3cKK8fGefZHkUkP4DCO+1MPNvmLY+rapQ3ze2WokH1yw+8vDEpb+JUiMoHISFEYochIKjGByEjRG4FeCWPIB88ckbYNpixvtX7vvwG7hGGq44vuH+dW3vukiQ6ElbawJ0G9I3cW7lBVtrhmvRlHXGFXnKZbgtNfEfK8JQZtNZkBIuvw5EIqufQ5EQZ8sclahNe2ih/Zf4AhDF1plSFFJHy5qVopWtIvU9EOEOKnEmjZShixJThtJza+1FLSdciAkbaciQ6LufNQcR9z+JyFiBZ6SlNi0ZCQ6ts6QjETj1nO+LZlo0PT+cckV7nKOSyaKl2iyer6fFadLaDL8mgq6hDkQiVabA5FoteZxr6hEa/2PZKKhPpQIM2yG4RMgtTMM",
     ),
@@ -2535,7 +2536,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=5, direction=0),
             BalancerTemplateEntity(name="transport-belt", x=0, y=6, direction=0),
         ),
-        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)),
         output_tiles=((1, 11), (2, 11), (3, 11)),
         source_blueprint="0eNq1mN1u2zAMhV+l8HU7mPqzs1cZiiJphUJAIhu2PCwI/O5TvWALMIZ0IuYqtiLriJQ+HlunareffD+EmKrvT6cqvHdxzFc/TtUYPuN2v7SmY+/zRRWSP1TPT1XcHpb7sd+HlPxQzbkxxA//K7fC/Pp87pq7/Bs+N/70wxi6mNtVC6Yxm8Y1UDvr8n8+ppCCP4svd8e3OB12efg8aO7Rd2PusTx+qr6U6m82Nx//XM0X85ryVIbPocu/Lzu/X7Q/wuDfz4+rfP83pthP6SuA/0UVJqquiaZhG8e+GxIuiSpoTEHfp2BQBYMpWInEdVO6mjmLqTrJuBym0EgqNJhCe5+CQxVaTGEjqbDBFKCWlICaRhPKKQGgQQR+E6/ZtKBoGiUi0TSO8JA6BobG8UZVs1LV0ohCOaLgaEbhMdUNGgYrOjR8zJbGSAlsPrwaXEjUM2buqwZXNQ2PwPwVWgaM0PwVTabE/DWNoSoHQhmaOYkoLO1aZavgGLIkctTQpGmBHLW0YemiHG1o0gTmr2saBv0Qm9JA86HL114rmg/9GMPQmvapov2gDQ2kRNosg6XEnsPRB1ENBn0jINHSJmuKlnpD1xWz/kWY4NAwVi6QJcNYeVGWDGPlRuCrmrFyiRQxVi4hYemyJJEoRxcniSgapnBIaDBv51ZA4oqt17jE5dEbcv5S03y5dXzhX/wWaL5s+aGCVTRf9v4vVvLYivFpgWW2jFtLSHBubUuqq+V8WiICxqedgATj064oR4xPu9vPBxxjyvcMyXDsyjl2DMc3SrzO829+14fc",
     ),
@@ -2598,7 +2599,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=6, direction=4),
             BalancerTemplateEntity(name="transport-belt", x=0, y=7, direction=2),
         ),
-        input_tiles=((6, 0),),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)),
         output_tiles=((2, 9), (3, 9), (4, 9), (5, 9)),
         source_blueprint="0eNq1V9tu4yAQ/ZWK57YyMGB7f2VVVUmLKqQEWzZebRT535f1RnvR0hMnjJ+CCZ4zl3OG8VnsD5PrBx+i+PJwFv6tC2NafT2L0X+E3WHZjafepYXw0R3F44MIu+PyPPYHH6MbxJw2fXh339OunF8eL0fTkT/m0+Y3N4y+C2lfNZJqamtby8oam/5zIfro3QV8eTq9hum4T+aT0XSi78Z0Ynn9LH4iVc8mbZ9+rea//IrDLox9N8SnvTssyO9+cG+Xl1U6+j+CyiFITgSdQ1D3IVAWgXIIxBmDySEYzhhsDsFyxlDnEGrOGBrMJfkvwpSEM3wMXfrNR5Gefysw9FMUWdAW0+tGUFoHKqscquYItZvi57ASM13CGuZNKkxtWU4LqTG3VyRrVXIIE1yWS0hm+0DLCmFxy1fP1Zy7itYZr7FC1SYKlQ2WqGKgWIv1eBOEzV+UFdaeXleYT4xLrEIO/xVWodqmZams+BsePivCelQM85HBktGbSEZZLBnNEFiNKacZKNdgyumNKNfii0CXUE5XmHIMldFXpn4q8l9hZhGD/xo34zL/CdOWbh+BtME0pfXzCZC0tpiVHImvca8tS3yDic/hf4t7rSnxnypMfHP/hwJqRiSxGEx52kjhyaQsbVeGd3O73ujKoH6PSYNbpi1KgcW0tJuMAFRjvloG4jSYm/aOQrSYi3abK99U+FYoqr+RWAIMlTAKS+JKJV7m+Qf/hlp8",
     ),
@@ -3121,7 +3122,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=4, direction=4),
             BalancerTemplateEntity(name="splitter", x=0, y=5, direction=4),
         ),
-        input_tiles=((0, 2), (7, 2)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0)),
         output_tiles=((3, 8), (4, 8), (5, 8)),
         source_blueprint="0eNq1l29vwiAQxr+K4bUz/KfdV1nMohtZSJQ2LV1mmn733Rrjlg1PHecrKdL7Ac9zBx3Zdjf4tgsxscfFyMJLE3toPY2sD29xs5t706H10GAh+T1bLljc7Ofnvt2FlHzHJugM8dV/QK+Y1svjUBjyHR46333XhyZCv6yEdrp21glujYX/fEwhBX+Ez0+H5zjstxAegsKItulhxPz6yL5IcmWg+wAtvjLTj3mlbhP7tunSw9bvZvJr6PzL8WUJQ/8SZI6gKAkqRzCUBJ0j2P8RdJZgcgR+IogVn3L+uGr2FtdYoLPPRnS4pqJ8x6scQdPsR437RZSrKThuGApENnPFCSFLdkhI3DKSYP4K95C83ZVC46ZR122JzQc3uGtu2pIzCIu7RpanlchmbkWKqPBSpoqMWePGVOXGlBw3JgVC4F5S5V6SEveSIjjYsxnsaISWGjcqxfwN7iVNILTFvaQJVuHwovcLMcBlsnvrGvjNQ+D5dCuN7XCm1Moqby+ep/68z2aC1biRCpbQDOnsGhTHLUYgjhJ4LTQlKaIkfgMwd1FeKTxrTHnWKI1njbmTHy6c8Ob2G4m6cKL/J6TDVbf3Ub3CVbcEqte46vY+qmuO109bkqJa4Prb2/XXEi8prmi+F5LbEXxKX0huCoTBJaVAWLxWXK3Cepo+AVXWigg=",
     ),
@@ -3277,7 +3278,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=10, direction=0),
             BalancerTemplateEntity(name="transport-belt", x=0, y=11, direction=0),
         ),
-        input_tiles=((2, 2), (5, 2), (7, 2)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0)),
         output_tiles=((1, 14), (2, 14), (3, 14), (4, 14), (5, 14), (6, 14)),
         source_blueprint="0eNq1muFq2zAUhV+l+HdXLOnqSt6rjDKS1hRD6gTHGQsh7z4tlLUw5dw4uvoVW3F0JF2dr8eip2a9OfS7aRjn5vvDqRletuM+Xf04NfvhbVxtLq3zcdeni2aY+/fm8aEZV++X+/1uM8xzPzXn1DiMr/3v1GrOz48fj6ZHPrtPjb/6aT9sx9Ruo6FAXeBgWvacvuvHeZiH/kP8cnf8OR7e16n71Gl6YrfdpycuPz81F6Unn5qP6ap98ucv4zqkoUxv0zZ9flv3m4v26zD1Lx8/t+n+35zG3WH+O4H/RW1O1F4TnafVuN9tpzkvmVVwOQV3nwJlFSinQBoLtz3MV1fO51R95XJxTpQ1yxVyCkFTIeYUoqZCl1PoNLecabNmbWtvOpOHhFGdW5YJn1MzT+05B8ibSmMcBo6R1+2mdSJMHVO+yYzH2NGQEOyOJfJdCv7WGLVgcFOFjEYwvcLErGR6U24+Kxl84erRjTEg63ljNYqGfGqzODCqLrKEg5Ut4Zn1mGdWYfyMWaYhEXCYKVuiiClm6wTbDoPOLmenazHYFArhDKaYLSeMswLFNDScQDFbByeOBIxplCjreON0zOJYAKLGDAIOeK5oAhHT1lVxu+swht3tsRKoUItJ7OrsajI4aRbViyymc516kcujtM2rfj2EyXRGV4gm9Xbb6YIXWFar6ixwxpWTgIJAGw0NAQhUZ4MJQCCd90wvEIEqnT0ZnNeohAheIAKV5wPvcDij5eHMEw5n93TpcRhbtBCcl2AhjFG5AX0QQlHZbokCpjRm0AmYUtDgFociX7JIbDCNvML4LSaRhoTDOaRsiQgjzZdThz0Gm4YEY7D55RTigMHmyynEEYNOY+90AugUNEIrJLWiDRqMgFGNGVgBdBoaDucxLlokwqBjlfewIBy9c7mRA2MccbnrQsA4YoVaR4wjrpK9w5Wj+Davil/uomRqvv9AHEXsKNmd60T7aIU8VeTPKJ23K2y6SDhJhaIJeEyvUGVHR8ZYC8v/rMeA81ooB0yMGJMaEh1mWKhjkq7FXAsK/0NgcOy6o+SdxTHrni6dEKsUatyRQOCFGs/n8x8tcXTj",
     ),

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -149,6 +149,11 @@ async function main(): Promise<void> {
   let traceOverlayLayer: Container | null = null;
   let tracePhaseIndex = -1; // -1 = show all phases
   let snapshotActive = false; // true when entities are from a PhaseSnapshot
+  let prevSnapshotEntities: Set<string> | null = null;
+
+  function entityKey(e: PlacedEntity): string {
+    return `${e.x},${e.y},${e.name},${e.recipe ?? ""}`;
+  }
 
   function getSnapshotForPhase(
     events: TraceEvent[],
@@ -178,29 +183,60 @@ async function main(): Promise<void> {
   const nextBtn = document.createElement("button");
   nextBtn.textContent = "\u25B6";
   nextBtn.style.cssText = "background:none;border:1px solid #555;color:#ccc;cursor:pointer;padding:0 4px;border-radius:2px;font-size:10px";
+  const failBtn = document.createElement("button");
+  failBtn.style.cssText = "background:#442;color:#f66;border:1px solid #833;cursor:pointer;padding:0 6px;border-radius:2px;font-size:10px;display:none";
   stepBar.appendChild(prevBtn);
   stepBar.appendChild(phaseLabel);
   stepBar.appendChild(nextBtn);
+  stepBar.appendChild(failBtn);
   container.appendChild(stepBar);
 
   function updateStepControls(): void {
     if (!debugCb.checked || !lastLayout?.trace?.length) {
       stepBar.style.display = "none";
+      failBtn.style.display = "none";
       return;
     }
-    const phases = getTracePhases(lastLayout.trace as TraceEvent[]);
+    const trace = lastLayout.trace as TraceEvent[];
+    const phases = getTracePhases(trace);
     if (phases.length === 0) {
       stepBar.style.display = "none";
+      failBtn.style.display = "none";
       return;
     }
     stepBar.style.display = "flex";
+
+    // Compute cumulative PhaseTime durations
+    const timeEvents = trace.filter(e => e.phase === "PhaseTime") as Extract<TraceEvent, { phase: "PhaseTime" }>[];
+    // PhaseComplete events carry entity_count
+    const completeEvents = trace.filter(e => e.phase === "PhaseComplete") as Extract<TraceEvent, { phase: "PhaseComplete" }>[];
+
     if (tracePhaseIndex < 0) {
-      phaseLabel.textContent = `all (${phases.length})`;
+      const totalMs = timeEvents.reduce((s, t) => s + t.data.duration_ms, 0);
+      const totalEntities = completeEvents.length > 0 ? completeEvents[completeEvents.length - 1].data.entity_count : 0;
+      phaseLabel.textContent = `all (${phases.length}) — ${totalEntities} entities, ${totalMs}ms`;
     } else {
-      phaseLabel.textContent = phases[tracePhaseIndex].name;
+      // Sum PhaseTime events up to and including the current phase's PhaseComplete index
+      const phaseEndIdx = phases[tracePhaseIndex].eventIndex;
+      let elapsedMs = 0;
+      for (const t of timeEvents) {
+        const tIdx = trace.indexOf(t as TraceEvent);
+        if (tIdx <= phaseEndIdx) elapsedMs += t.data.duration_ms;
+      }
+      const entityCount = completeEvents.find(c => c.data.phase === phases[tracePhaseIndex].name)?.data.entity_count ?? 0;
+      phaseLabel.textContent = `${phases[tracePhaseIndex].name} — ${entityCount} entities, ${elapsedMs}ms`;
     }
     prevBtn.disabled = tracePhaseIndex <= 0 && tracePhaseIndex !== -1;
     nextBtn.disabled = tracePhaseIndex >= phases.length - 1;
+
+    // Failure badge
+    const failCount = trace.filter(e => e.phase === "RouteFailure").length;
+    if (failCount > 0) {
+      failBtn.textContent = `\u26A0 ${failCount}`;
+      failBtn.style.display = "inline-block";
+    } else {
+      failBtn.style.display = "none";
+    }
   }
 
   function updateTraceOverlay(): void {
@@ -222,9 +258,32 @@ async function main(): Promise<void> {
         { ...lastLayout!, entities: snapshot.entities, width: snapshot.width, height: snapshot.height },
         entityLayer, onHover, onSelect,
       );
+      // Entity delta highlight: tint newly added entities green for 1 second
+      const newKeys = new Set(snapshot.entities.map(entityKey));
+      const prev = prevSnapshotEntities;
+      if (prev) {
+        const added = snapshot.entities.filter(e => !prev.has(entityKey(e)));
+        const addedPositions = new Set(added.map(e => `${e.x},${e.y}`));
+        for (const child of entityLayer.children) {
+          if ("tint" in child && addedPositions.size > 0) {
+            // Check if this graphic corresponds to an added entity by position
+            const cx = (child as any).x;
+            const cy = (child as any).y;
+            // Match by tile center position
+            const tx = Math.floor((cx ?? -1) / TILE_PX);
+            const ty = Math.floor((cy ?? -1) / TILE_PX);
+            if (added.some(e => e.x === tx && e.y === ty)) {
+              (child as any).tint = 0x44ff88;
+              setTimeout(() => { if ("tint" in child) (child as any).tint = 0xffffff; }, 1000);
+            }
+          }
+        }
+      }
+      prevSnapshotEntities = newKeys;
     } else if (snapshotActive) {
       // Was showing a snapshot — restore full entity rendering.
       snapshotActive = false;
+      prevSnapshotEntities = null;
       if (lastLayout) {
         highlightCtrl = renderLayout(lastLayout, entityLayer, onHover, onSelect);
       }
@@ -271,7 +330,53 @@ async function main(): Promise<void> {
     updateTraceOverlay();
   });
 
-  debugCb.addEventListener("change", updateTraceOverlay);
+  // --- Jump to first route failure ---
+  function jumpToFirstFailure(): void {
+    if (!lastLayout?.trace) return;
+    const failures = (lastLayout.trace as TraceEvent[]).filter(e => e.phase === "RouteFailure") as Extract<TraceEvent, { phase: "RouteFailure" }>[];
+    if (failures.length === 0) return;
+    const first = failures[0].data;
+    const targetX = first.from_x * TILE_PX + TILE_PX / 2;
+    const targetY = first.from_y * TILE_PX + TILE_PX / 2;
+    viewport.moveCenter(targetX, targetY);
+    // Pulse the first RouteFailure marker in the overlay
+    if (traceOverlayLayer) {
+      const marker = traceOverlayLayer.children.find(c => c.label === "RouteFailure");
+      if (marker) {
+        let pulses = 0;
+        const interval = setInterval(() => {
+          marker.alpha = marker.alpha < 0.5 ? 1.0 : 0.3;
+          pulses++;
+          if (pulses >= 6) {
+            marker.alpha = 1.0;
+            clearInterval(interval);
+          }
+        }, 100);
+      }
+    }
+  }
+
+  failBtn.addEventListener("click", jumpToFirstFailure);
+
+  // --- Keyboard shortcuts for step-through ---
+  document.addEventListener("keydown", (e) => {
+    // Don't fire when typing in inputs
+    const tag = (e.target as HTMLElement)?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+    // Only when step bar is visible
+    if (stepBar.style.display === "none") return;
+
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      prevBtn.click();
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      nextBtn.click();
+    } else if (e.key === "f") {
+      e.preventDefault();
+      jumpToFirstFailure();
+    }
+  });
 
   // --- Validation overlay toggle ---
   const valToggle = document.createElement("label");
@@ -423,6 +528,7 @@ async function main(): Promise<void> {
     lastLayout = layout;
     tracePhaseIndex = -1;
     snapshotActive = false;
+    prevSnapshotEntities = null;
     // Destroy previous selection controller (new layout = new tile map)
     if (selectionCtrl) { selectionCtrl.destroy(); selectionCtrl = null; }
     annotationBar.style.display = "none";

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -265,17 +265,14 @@ async function main(): Promise<void> {
         const added = snapshot.entities.filter(e => !prev.has(entityKey(e)));
         const addedPositions = new Set(added.map(e => `${e.x},${e.y}`));
         for (const child of entityLayer.children) {
-          if ("tint" in child && addedPositions.size > 0) {
-            // Check if this graphic corresponds to an added entity by position
-            const cx = (child as any).x;
-            const cy = (child as any).y;
-            // Match by tile center position
-            const tx = Math.floor((cx ?? -1) / TILE_PX);
-            const ty = Math.floor((cy ?? -1) / TILE_PX);
-            if (added.some(e => e.x === tx && e.y === ty)) {
-              (child as any).tint = 0x44ff88;
-              setTimeout(() => { if ("tint" in child) (child as any).tint = 0xffffff; }, 1000);
-            }
+          // Skip overlay containers and non-graphics children
+          if (!("tint" in child) || addedPositions.size === 0) continue;
+          const g = child as { x: number; y: number; tint: number };
+          const tx = Math.round(g.x / TILE_PX);
+          const ty = Math.round(g.y / TILE_PX);
+          if (addedPositions.has(`${tx},${ty}`)) {
+            g.tint = 0x44ff88;
+            setTimeout(() => { g.tint = 0xffffff; }, 1000);
           }
         }
       }
@@ -341,7 +338,10 @@ async function main(): Promise<void> {
     viewport.moveCenter(targetX, targetY);
     // Pulse the first RouteFailure marker in the overlay
     if (traceOverlayLayer) {
-      const marker = traceOverlayLayer.children.find(c => c.label === "RouteFailure");
+      const marker = traceOverlayLayer.children.find(c =>
+        c.label === "RouteFailure" &&
+        Math.abs(c.x - targetX) < 1 && Math.abs(c.y - targetY) < 1,
+      );
       if (marker) {
         let pulses = 0;
         const interval = setInterval(() => {

--- a/web/src/renderer/traceOverlay.ts
+++ b/web/src/renderer/traceOverlay.ts
@@ -9,6 +9,34 @@ type RowsPlaced   = Extract<TraceEvent, { phase: "RowsPlaced" }>;
 type LanesPlanned = Extract<TraceEvent, { phase: "LanesPlanned" }>;
 export type PhaseSnapshot = Extract<TraceEvent, { phase: "PhaseSnapshot" }>;
 export type PhaseComplete = Extract<TraceEvent, { phase: "PhaseComplete" }>;
+type RouteFailureEvent = Extract<TraceEvent, { phase: "RouteFailure" }>;
+type CrossingZoneConflictEvent = Extract<TraceEvent, { phase: "CrossingZoneConflict" }>;
+type LaneConsolidatedEvent = Extract<TraceEvent, { phase: "LaneConsolidated" }>;
+type RowSplitEvent = Extract<TraceEvent, { phase: "RowSplit" }>;
+type LaneOrderOptimizedEvent = Extract<TraceEvent, { phase: "LaneOrderOptimized" }>;
+
+/** Draw a dashed line segment on a Graphics context. */
+function drawDashedLine(
+  g: Graphics,
+  x0: number, y0: number, x1: number, y1: number,
+  dashLen: number, gapLen: number,
+  opts: { width?: number; color?: number; alpha?: number },
+): void {
+  const dx = x1 - x0;
+  const dy = y1 - y0;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  if (dist === 0) return;
+  const ux = dx / dist;
+  const uy = dy / dist;
+  let drawn = 0;
+  while (drawn < dist) {
+    const segEnd = Math.min(drawn + dashLen, dist);
+    g.moveTo(x0 + ux * drawn, y0 + uy * drawn)
+      .lineTo(x0 + ux * segEnd, y0 + uy * segEnd)
+      .stroke(opts);
+    drawn = segEnd + gapLen;
+  }
+}
 
 export function renderTraceOverlay(
   events: TraceEvent[],
@@ -122,11 +150,101 @@ export function renderTraceOverlay(
     layer.addChild(g);
   }
 
+  // --- Route failures (from RouteFailure) ---
+  for (const evt of events) {
+    if (evt.phase !== "RouteFailure") continue;
+    const d = (evt as RouteFailureEvent).data;
+    const cx = d.from_x * TILE_PX + TILE_PX / 2;
+    const cy = d.from_y * TILE_PX + TILE_PX / 2;
+    const halfSpan = 3;
+    const g = new Graphics();
+    g.label = "RouteFailure";
+    // Red ✕ cross at source tile
+    g.moveTo(cx - halfSpan, cy - halfSpan)
+      .lineTo(cx + halfSpan, cy + halfSpan)
+      .stroke({ width: 2, color: 0xff3333 });
+    g.moveTo(cx + halfSpan, cy - halfSpan)
+      .lineTo(cx - halfSpan, cy + halfSpan)
+      .stroke({ width: 2, color: 0xff3333 });
+    // Dashed red line from source to target
+    drawDashedLine(g, cx, cy, d.to_x * TILE_PX + TILE_PX / 2, d.to_y * TILE_PX + TILE_PX / 2,
+      6, 4, { width: 1, color: 0xff3333, alpha: 0.6 });
+    g.eventMode = "static";
+    g.on("pointerenter", () => onHover(`Route failed: ${d.item} (${d.from_x},${d.from_y})\u2192(${d.to_x},${d.to_y}) [${d.spec_key}]`));
+    g.on("pointerleave", () => onHover(null));
+    layer.addChild(g);
+  }
+
+  // --- Crossing zone conflicts (from CrossingZoneConflict) ---
+  const conflictTextStyle = new TextStyle({ fontSize: 14, fill: "#ff44ff", fontFamily: "monospace", fontWeight: "bold" });
+  for (const evt of events) {
+    if (evt.phase !== "CrossingZoneConflict") continue;
+    const d = (evt as CrossingZoneConflictEvent).data;
+    const tx = d.conflict_x * TILE_PX;
+    const ty = d.conflict_y * TILE_PX;
+    const g = new Graphics();
+    g.rect(tx, ty, TILE_PX, TILE_PX)
+      .stroke({ width: 1.5, color: 0xff44ff });
+    const excl = new Text({ text: "!", style: conflictTextStyle });
+    excl.x = tx + TILE_PX / 2 - excl.width / 2;
+    excl.y = ty + TILE_PX / 2 - excl.height / 2;
+    excl.eventMode = "none";
+    g.eventMode = "static";
+    g.on("pointerenter", () => onHover(`Crossing conflict: segment ${d.segment_id} at (${d.conflict_x},${d.conflict_y})`));
+    g.on("pointerleave", () => onHover(null));
+    layer.addChild(g);
+    layer.addChild(excl);
+  }
+
+  // --- Lane consolidation badges (from LaneConsolidated) ---
+  const badgeStyle = new TextStyle({ fontSize: 10, fill: "#ffaa44", fontFamily: "monospace", fontWeight: "bold" });
+  for (const evt of events) {
+    if (evt.phase !== "LaneConsolidated") continue;
+    const d = (evt as LaneConsolidatedEvent).data;
+    let laneX = -1;
+    if (lanesEvent) {
+      const match = lanesEvent.data.lanes.find(l => l.item === d.item);
+      if (match) laneX = match.x;
+    }
+    if (laneX < 0) continue;
+    const badge = new Text({ text: `\u00F7${d.n_trunk_lanes}`, style: badgeStyle });
+    badge.x = laneX * TILE_PX + TILE_PX / 2 - badge.width / 2;
+    badge.y = 2;
+    badge.eventMode = "static";
+    badge.on("pointerenter", () => onHover(`${d.item}: ${d.consumer_count} consumers share ${d.n_trunk_lanes} lane(s) @ ${d.rate_per_lane.toFixed(1)}/s each`));
+    badge.on("pointerleave", () => onHover(null));
+    layer.addChild(badge);
+  }
+
+  // --- Row split indicators (from RowSplit) ---
+  const splitStyle = new TextStyle({ fontSize: 10, fill: "#ffcc44", fontFamily: "monospace", fontWeight: "bold" });
+  for (const evt of events) {
+    if (evt.phase !== "RowSplit") continue;
+    const d = (evt as RowSplitEvent).data;
+    let splitY = -1;
+    if (rowsEvent) {
+      const matching = rowsEvent.data.rows.filter(r => r.recipe === d.recipe);
+      if (matching.length > 0) {
+        splitY = matching.reduce((a, b) => a.y_end > b.y_end ? a : b).y_end;
+      }
+    }
+    if (splitY < 0) continue;
+    const label = new Text({ text: `\u2295${d.split_into}`, style: splitStyle });
+    label.x = 4;
+    label.y = splitY * TILE_PX - label.height - 1;
+    label.eventMode = "static";
+    label.on("pointerenter", () => onHover(`${d.recipe}: split ${d.original_count}\u2192${d.split_into} rows \u2014 ${d.reason}`));
+    label.on("pointerleave", () => onHover(null));
+    layer.addChild(label);
+  }
+
   // --- Phase summary label (top-left, above layout) ---
   const phaseNames = events.map(e => e.phase);
   const uniquePhases = [...new Set(phaseNames)];
   const summaryStyle = new TextStyle({ fontSize: 10, fill: "#aaa", fontFamily: "monospace" });
-  const summaryText = new Text({ text: `Trace: ${uniquePhases.join(" → ")}`, style: summaryStyle });
+  const laneOrder = events.find((e): e is LaneOrderOptimizedEvent => e.phase === "LaneOrderOptimized");
+  const crossingSuffix = laneOrder ? ` | lane order: ${laneOrder.data.crossing_score} crossings` : "";
+  const summaryText = new Text({ text: `Trace: ${uniquePhases.join(" → ")}${crossingSuffix}`, style: summaryStyle });
   summaryText.x = 4;
   summaryText.y = -16;
   layer.addChild(summaryText);

--- a/web/src/ui/debugPanel.ts
+++ b/web/src/ui/debugPanel.ts
@@ -16,7 +16,7 @@ const STYLE = `
 .debug-panel .timeline-seg { min-width: 2px; }
 .debug-panel .timeline-total { font-size: 11px; color: #aaa; margin-bottom: 4px; }
 .debug-panel .machine-line { font-size: 11px; color: #ccc; padding: 1px 0 1px 12px; }
-.debug-panel .lane-chip { display: inline-block; padding: 1px 4px; border-radius: 3px; background: #333; font-size: 10px; margin: 1px; color: #e0e0e0; }
+.debug-panel .lane-chip { display: inline-block; padding: 1px 4px; border-radius: 3px; background: #252526; font-size: 10px; margin: 1px; color: #e0e0e0; }
 .debug-panel .failure-item { color: #ff6666; font-size: 11px; padding: 1px 0 1px 12px; }
 .debug-panel .skip-item { font-size: 11px; color: #aaa; padding: 1px 0 1px 12px; }
 .debug-panel .cons-table { width: 100%; font-size: 11px; border-collapse: collapse; margin-top: 4px; }
@@ -121,11 +121,11 @@ function renderTimeline(body: HTMLDivElement, events: TraceEvent[]): void {
     return;
   }
 
-  const total = times.reduce((s, t) => s + (t.data as { duration_ms: number }).duration_ms, 0);
+  const total = times.reduce((s, t) => s + t.data.duration_ms, 0);
   const bar = el("div", "timeline-bar");
 
   for (const t of times) {
-    const d = t.data as { phase: string; duration_ms: number };
+    const d = t.data;
     const pct = total > 0 ? (d.duration_ms / total) * 100 : 0;
     const seg = el("div", "timeline-seg");
     seg.style.width = `${pct}%`;
@@ -147,11 +147,7 @@ function renderTimeline(body: HTMLDivElement, events: TraceEvent[]): void {
 function renderSolver(body: HTMLDivElement, events: TraceEvent[]): void {
   const evt = findEvent(events, "SolverCompleted");
   if (!evt) { body.textContent = "No solver data"; return; }
-  const d = evt.data as {
-    recipe_count: number; machine_count: number;
-    external_input_count: number; external_output_count: number;
-    machines: { recipe: string; machine: string; count: number; rate: number }[];
-  };
+  const d = evt.data;
 
   body.appendChild(statRow("Recipes", String(d.recipe_count)));
   body.appendChild(statRow("Machines", String(d.machine_count)));
@@ -179,7 +175,7 @@ function renderLayoutStats(body: HTMLDivElement, events: TraceEvent[]): void {
   if (!lanes && !rows) { body.textContent = "No layout data"; return; }
 
   if (lanes) {
-    const d = lanes.data as { lanes: { is_fluid: boolean }[]; families: unknown[]; bus_width: number };
+    const d = lanes.data;
     const solids = d.lanes.filter(l => !l.is_fluid).length;
     const fluids = d.lanes.filter(l => l.is_fluid).length;
     body.appendChild(statRow("Bus width", `${d.bus_width} tiles`));
@@ -188,15 +184,13 @@ function renderLayoutStats(body: HTMLDivElement, events: TraceEvent[]): void {
   }
 
   if (rows) {
-    const d = rows.data as { rows: unknown[] };
-    body.appendChild(statRow("Rows", String(d.rows.length)));
+    body.appendChild(statRow("Rows", String(rows.data.rows.length)));
   }
 
   if (splits.length > 0) {
     for (const s of splits) {
-      const d = s.data as { item: string; rate: number; n_splits: number };
       const line = el("div", "machine-line");
-      line.textContent = `${d.item} ${d.rate.toFixed(1)}/s \u2192 ${d.n_splits} lanes`;
+      line.textContent = `${s.data.item} ${s.data.rate.toFixed(1)}/s \u2192 ${s.data.n_splits} lanes`;
       body.appendChild(line);
     }
   }
@@ -209,7 +203,7 @@ function renderLayoutStats(body: HTMLDivElement, events: TraceEvent[]): void {
 function renderLaneOrder(body: HTMLDivElement, events: TraceEvent[]): void {
   const evt = findEvent(events, "LaneOrderOptimized");
   if (!evt) { body.textContent = "No lane order data"; return; }
-  const d = evt.data as { ordering: string[]; crossing_score: number };
+  const d = evt.data;
 
   body.appendChild(statRow("Crossing score", `${d.crossing_score} (lower = fewer UG hops)`));
 
@@ -231,7 +225,7 @@ function renderRouting(body: HTMLDivElement, events: TraceEvent[]): void {
   const failures = filterEvents(events, "RouteFailure");
 
   if (neg) {
-    const d = neg.data as { specs: number; iterations: number; duration_ms: number };
+    const d = neg.data;
     body.appendChild(statRow("Specs", String(d.specs)));
     body.appendChild(statRow("Iterations", String(d.iterations)));
     body.appendChild(statRow("Duration", `${d.duration_ms}ms`));
@@ -246,7 +240,7 @@ function renderRouting(body: HTMLDivElement, events: TraceEvent[]): void {
     hdr.textContent = `\u26A0 ${failures.length} route failure${failures.length > 1 ? "s" : ""}:`;
     body.appendChild(hdr);
     for (const f of failures) {
-      const d = f.data as { item: string; from_x: number; from_y: number; to_x: number; to_y: number; spec_key: string };
+      const d = f.data;
       const line = el("div", "failure-item");
       line.textContent = `  ${d.item}: (${d.from_x},${d.from_y})\u2192(${d.to_x},${d.to_y}) [${d.spec_key}]`;
       body.appendChild(line);
@@ -268,7 +262,7 @@ function renderSatZones(body: HTMLDivElement, events: TraceEvent[]): void {
     return;
   }
 
-  const totalUs = solved.reduce((s, z) => s + (z.data as { solve_time_us: number }).solve_time_us, 0);
+  const totalUs = solved.reduce((s, z) => s + z.data.solve_time_us, 0);
 
   body.appendChild(statRow("Zones solved", String(solved.length)));
   body.appendChild(statRow("Zones skipped", String(skipped.length)));
@@ -276,7 +270,7 @@ function renderSatZones(body: HTMLDivElement, events: TraceEvent[]): void {
   body.appendChild(statRow("Total solve time", `${totalUs.toLocaleString()}\u00B5s`));
 
   for (const s of skipped) {
-    const d = s.data as { tap_item: string; tap_x: number; tap_y: number; reason: string };
+    const d = s.data;
     const line = el("div", "skip-item");
     line.textContent = `${d.tap_item} @ (${d.tap_x},${d.tap_y}): ${d.reason}`;
     body.appendChild(line);
@@ -301,7 +295,7 @@ function renderConsolidation(body: HTMLDivElement, events: TraceEvent[]): void {
   table.appendChild(thead);
 
   for (const c of conss) {
-    const d = c.data as { item: string; consumer_count: number; n_trunk_lanes: number; rate_per_lane: number };
+    const d = c.data;
     const tr = el("tr");
     const tdItem = el("td"); tdItem.textContent = d.item;
     const tdCons = el("td"); tdCons.textContent = String(d.consumer_count);
@@ -326,9 +320,8 @@ function renderConsolidation(body: HTMLDivElement, events: TraceEvent[]): void {
 function renderPower(body: HTMLDivElement, events: TraceEvent[]): void {
   const evt = findEvent(events, "PolesPlaced");
   if (!evt) { body.textContent = "No power data"; return; }
-  const d = evt.data as { count: number; strategy: string };
-  body.appendChild(statRow("Poles", String(d.count)));
-  body.appendChild(statRow("Strategy", d.strategy));
+  body.appendChild(statRow("Poles", String(evt.data.count)));
+  body.appendChild(statRow("Strategy", evt.data.strategy));
 }
 
 // ---------------------------------------------------------------------------
@@ -338,7 +331,7 @@ function renderPower(body: HTMLDivElement, events: TraceEvent[]): void {
 function renderValidation(body: HTMLDivElement, events: TraceEvent[]): void {
   const evt = findEvent(events, "ValidationCompleted");
   if (!evt) { body.textContent = "No validation data"; return; }
-  const d = evt.data as { error_count: number; warning_count: number; issues: { severity: string; category: string; message: string }[] };
+  const d = evt.data;
 
   body.appendChild(statRow("Errors", String(d.error_count)));
   body.appendChild(statRow("Warnings", String(d.warning_count)));

--- a/web/src/ui/debugPanel.ts
+++ b/web/src/ui/debugPanel.ts
@@ -1,0 +1,411 @@
+import type { TraceEvent } from "../engine";
+
+// ---------------------------------------------------------------------------
+// Style injection (same pattern as sidebar.ts)
+// ---------------------------------------------------------------------------
+const STYLE_ID = "fucktorio-debug-panel-style";
+const STYLE = `
+.debug-panel { margin-top: 8px; font-family: monospace; }
+.debug-panel details { margin-bottom: 6px; }
+.debug-panel summary { cursor: pointer; color: #9cdcfe; font-size: 12px; padding: 3px 0; user-select: none; }
+.debug-panel summary:hover { color: #b0dfff; }
+.debug-panel .stat-row { display: flex; justify-content: space-between; padding: 2px 0; font-size: 11px; color: #ccc; }
+.debug-panel .stat-label { color: #aaa; }
+.debug-panel .stat-value { color: #e0e0e0; }
+.debug-panel .timeline-bar { display: flex; height: 16px; border-radius: 3px; overflow: hidden; margin: 4px 0; }
+.debug-panel .timeline-seg { min-width: 2px; }
+.debug-panel .timeline-total { font-size: 11px; color: #aaa; margin-bottom: 4px; }
+.debug-panel .machine-line { font-size: 11px; color: #ccc; padding: 1px 0 1px 12px; }
+.debug-panel .lane-chip { display: inline-block; padding: 1px 4px; border-radius: 3px; background: #333; font-size: 10px; margin: 1px; color: #e0e0e0; }
+.debug-panel .failure-item { color: #ff6666; font-size: 11px; padding: 1px 0 1px 12px; }
+.debug-panel .skip-item { font-size: 11px; color: #aaa; padding: 1px 0 1px 12px; }
+.debug-panel .cons-table { width: 100%; font-size: 11px; border-collapse: collapse; margin-top: 4px; }
+.debug-panel .cons-table th { text-align: left; color: #9cdcfe; font-weight: normal; padding: 2px 4px; }
+.debug-panel .cons-table td { padding: 2px 4px; color: #ccc; }
+.debug-panel .amber { color: #ffaa44; }
+.debug-panel .issue-line { font-size: 11px; padding: 1px 0 1px 12px; }
+.debug-panel .issue-error { color: #f44; }
+.debug-panel .issue-warn { color: #ffaa00; }
+.debug-panel .ok { color: #6a6; }
+`;
+
+function injectStyle(): void {
+  if (!document.getElementById(STYLE_ID)) {
+    const el = document.createElement("style");
+    el.id = STYLE_ID;
+    el.textContent = STYLE;
+    document.head.appendChild(el);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event helpers
+// ---------------------------------------------------------------------------
+
+type EventOf<T extends string> = Extract<TraceEvent, { phase: T }>;
+
+function findEvent<T extends string>(events: TraceEvent[], phase: T): EventOf<T> | undefined {
+  return events.find(e => e.phase === phase) as EventOf<T> | undefined;
+}
+
+function filterEvents<T extends string>(events: TraceEvent[], phase: T): EventOf<T>[] {
+  return events.filter(e => e.phase === phase) as EventOf<T>[];
+}
+
+// ---------------------------------------------------------------------------
+// Section builders
+// ---------------------------------------------------------------------------
+
+function el(tag: string, cls?: string): HTMLElement {
+  const e = document.createElement(tag) as HTMLElement;
+  if (cls) e.className = cls;
+  return e;
+}
+
+function div(cls?: string): HTMLDivElement {
+  const e = document.createElement("div");
+  if (cls) e.className = cls;
+  return e;
+}
+
+function statRow(label: string, value: string): HTMLElement {
+  const row = el("div", "stat-row");
+  const lbl = el("span", "stat-label");
+  lbl.textContent = label;
+  const val = el("span", "stat-value");
+  val.textContent = value;
+  row.appendChild(lbl);
+  row.appendChild(val);
+  return row;
+}
+
+function section(title: string, open = false): { details: HTMLDetailsElement; body: HTMLDivElement } {
+  const details = document.createElement("details");
+  if (open) details.open = true;
+  const summary = document.createElement("summary");
+  summary.textContent = title;
+  details.appendChild(summary);
+  const body = div();
+  details.appendChild(body);
+  return { details, body };
+}
+
+// ---------------------------------------------------------------------------
+// Phase color map for timeline
+// ---------------------------------------------------------------------------
+const PHASE_COLORS: Record<string, string> = {
+  rows: "#4a9",
+  lanes: "#49c",
+  route: "#c84",
+  validate: "#888",
+  poles: "#cc4",
+  solve: "#96a",
+  merge: "#a86",
+};
+
+function phaseColor(name: string): string {
+  for (const [key, color] of Object.entries(PHASE_COLORS)) {
+    if (name.includes(key)) return color;
+  }
+  return "#69c";
+}
+
+// ---------------------------------------------------------------------------
+// Section: Performance Timeline
+// ---------------------------------------------------------------------------
+
+function renderTimeline(body: HTMLDivElement, events: TraceEvent[]): void {
+  const times = filterEvents(events, "PhaseTime");
+  if (times.length === 0) {
+    body.textContent = "No timing data";
+    return;
+  }
+
+  const total = times.reduce((s, t) => s + (t.data as { duration_ms: number }).duration_ms, 0);
+  const bar = el("div", "timeline-bar");
+
+  for (const t of times) {
+    const d = t.data as { phase: string; duration_ms: number };
+    const pct = total > 0 ? (d.duration_ms / total) * 100 : 0;
+    const seg = el("div", "timeline-seg");
+    seg.style.width = `${pct}%`;
+    seg.style.background = phaseColor(d.phase);
+    seg.title = `${d.phase}: ${d.duration_ms}ms (${pct.toFixed(1)}%)`;
+    bar.appendChild(seg);
+  }
+  body.appendChild(bar);
+
+  const totalLine = el("div", "timeline-total");
+  totalLine.textContent = `Total: ${total}ms`;
+  body.appendChild(totalLine);
+}
+
+// ---------------------------------------------------------------------------
+// Section: Solver Summary
+// ---------------------------------------------------------------------------
+
+function renderSolver(body: HTMLDivElement, events: TraceEvent[]): void {
+  const evt = findEvent(events, "SolverCompleted");
+  if (!evt) { body.textContent = "No solver data"; return; }
+  const d = evt.data as {
+    recipe_count: number; machine_count: number;
+    external_input_count: number; external_output_count: number;
+    machines: { recipe: string; machine: string; count: number; rate: number }[];
+  };
+
+  body.appendChild(statRow("Recipes", String(d.recipe_count)));
+  body.appendChild(statRow("Machines", String(d.machine_count)));
+  body.appendChild(statRow("External inputs", String(d.external_input_count)));
+  body.appendChild(statRow("External outputs", String(d.external_output_count)));
+
+  if (d.machines?.length) {
+    for (const m of d.machines) {
+      const line = el("div", "machine-line");
+      line.textContent = `${m.count}\u00D7 \u2192 ${m.recipe} @ ${m.rate.toFixed(1)}/s`;
+      body.appendChild(line);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section: Layout Stats
+// ---------------------------------------------------------------------------
+
+function renderLayoutStats(body: HTMLDivElement, events: TraceEvent[]): void {
+  const lanes = findEvent(events, "LanesPlanned");
+  const rows = findEvent(events, "RowsPlaced");
+  const splits = filterEvents(events, "LaneSplit");
+
+  if (!lanes && !rows) { body.textContent = "No layout data"; return; }
+
+  if (lanes) {
+    const d = lanes.data as { lanes: { is_fluid: boolean }[]; families: unknown[]; bus_width: number };
+    const solids = d.lanes.filter(l => !l.is_fluid).length;
+    const fluids = d.lanes.filter(l => l.is_fluid).length;
+    body.appendChild(statRow("Bus width", `${d.bus_width} tiles`));
+    body.appendChild(statRow("Lanes", `${solids} solid \u00B7 ${fluids} fluid`));
+    body.appendChild(statRow("Balancer families", String(d.families.length)));
+  }
+
+  if (rows) {
+    const d = rows.data as { rows: unknown[] };
+    body.appendChild(statRow("Rows", String(d.rows.length)));
+  }
+
+  if (splits.length > 0) {
+    for (const s of splits) {
+      const d = s.data as { item: string; rate: number; n_splits: number };
+      const line = el("div", "machine-line");
+      line.textContent = `${d.item} ${d.rate.toFixed(1)}/s \u2192 ${d.n_splits} lanes`;
+      body.appendChild(line);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section: Lane Ordering
+// ---------------------------------------------------------------------------
+
+function renderLaneOrder(body: HTMLDivElement, events: TraceEvent[]): void {
+  const evt = findEvent(events, "LaneOrderOptimized");
+  if (!evt) { body.textContent = "No lane order data"; return; }
+  const d = evt.data as { ordering: string[]; crossing_score: number };
+
+  body.appendChild(statRow("Crossing score", `${d.crossing_score} (lower = fewer UG hops)`));
+
+  const chips = el("div");
+  for (const item of d.ordering) {
+    const chip = el("span", "lane-chip");
+    chip.textContent = item;
+    chips.appendChild(chip);
+  }
+  body.appendChild(chips);
+}
+
+// ---------------------------------------------------------------------------
+// Section: A* Routing
+// ---------------------------------------------------------------------------
+
+function renderRouting(body: HTMLDivElement, events: TraceEvent[]): void {
+  const neg = findEvent(events, "NegotiateComplete");
+  const failures = filterEvents(events, "RouteFailure");
+
+  if (neg) {
+    const d = neg.data as { specs: number; iterations: number; duration_ms: number };
+    body.appendChild(statRow("Specs", String(d.specs)));
+    body.appendChild(statRow("Iterations", String(d.iterations)));
+    body.appendChild(statRow("Duration", `${d.duration_ms}ms`));
+  }
+
+  if (failures.length === 0) {
+    const ok = el("div", "ok");
+    ok.textContent = "\u2713 all routes resolved";
+    body.appendChild(ok);
+  } else {
+    const hdr = el("div", "failure-item");
+    hdr.textContent = `\u26A0 ${failures.length} route failure${failures.length > 1 ? "s" : ""}:`;
+    body.appendChild(hdr);
+    for (const f of failures) {
+      const d = f.data as { item: string; from_x: number; from_y: number; to_x: number; to_y: number; spec_key: string };
+      const line = el("div", "failure-item");
+      line.textContent = `  ${d.item}: (${d.from_x},${d.from_y})\u2192(${d.to_x},${d.to_y}) [${d.spec_key}]`;
+      body.appendChild(line);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section: SAT Zones
+// ---------------------------------------------------------------------------
+
+function renderSatZones(body: HTMLDivElement, events: TraceEvent[]): void {
+  const solved = filterEvents(events, "CrossingZoneSolved");
+  const skipped = filterEvents(events, "CrossingZoneSkipped");
+  const conflicts = filterEvents(events, "CrossingZoneConflict");
+
+  if (solved.length === 0 && skipped.length === 0 && conflicts.length === 0) {
+    body.textContent = "No SAT zone data";
+    return;
+  }
+
+  const totalUs = solved.reduce((s, z) => s + (z.data as { solve_time_us: number }).solve_time_us, 0);
+
+  body.appendChild(statRow("Zones solved", String(solved.length)));
+  body.appendChild(statRow("Zones skipped", String(skipped.length)));
+  body.appendChild(statRow("Conflicts", String(conflicts.length)));
+  body.appendChild(statRow("Total solve time", `${totalUs.toLocaleString()}\u00B5s`));
+
+  for (const s of skipped) {
+    const d = s.data as { tap_item: string; tap_x: number; tap_y: number; reason: string };
+    const line = el("div", "skip-item");
+    line.textContent = `${d.tap_item} @ (${d.tap_x},${d.tap_y}): ${d.reason}`;
+    body.appendChild(line);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section: Lane Consolidation
+// ---------------------------------------------------------------------------
+
+function renderConsolidation(body: HTMLDivElement, events: TraceEvent[]): void {
+  const conss = filterEvents(events, "LaneConsolidated");
+  if (conss.length === 0) return;
+
+  const table = el("table", "cons-table");
+  const thead = el("tr");
+  for (const h of ["Item", "Consumers", "Lanes", "Rate/lane"]) {
+    const th = el("th");
+    th.textContent = h;
+    thead.appendChild(th);
+  }
+  table.appendChild(thead);
+
+  for (const c of conss) {
+    const d = c.data as { item: string; consumer_count: number; n_trunk_lanes: number; rate_per_lane: number };
+    const tr = el("tr");
+    const tdItem = el("td"); tdItem.textContent = d.item;
+    const tdCons = el("td"); tdCons.textContent = String(d.consumer_count);
+    const tdLanes = el("td"); tdLanes.textContent = String(d.n_trunk_lanes);
+    const tdRate = el("td");
+    const nearCapacity = d.rate_per_lane >= 13.5;
+    tdRate.textContent = `${d.rate_per_lane.toFixed(1)}/s`;
+    if (nearCapacity) tdRate.className = "amber";
+    tr.appendChild(tdItem);
+    tr.appendChild(tdCons);
+    tr.appendChild(tdLanes);
+    tr.appendChild(tdRate);
+    table.appendChild(tr);
+  }
+  body.appendChild(table);
+}
+
+// ---------------------------------------------------------------------------
+// Section: Power
+// ---------------------------------------------------------------------------
+
+function renderPower(body: HTMLDivElement, events: TraceEvent[]): void {
+  const evt = findEvent(events, "PolesPlaced");
+  if (!evt) { body.textContent = "No power data"; return; }
+  const d = evt.data as { count: number; strategy: string };
+  body.appendChild(statRow("Poles", String(d.count)));
+  body.appendChild(statRow("Strategy", d.strategy));
+}
+
+// ---------------------------------------------------------------------------
+// Section: Validation Summary
+// ---------------------------------------------------------------------------
+
+function renderValidation(body: HTMLDivElement, events: TraceEvent[]): void {
+  const evt = findEvent(events, "ValidationCompleted");
+  if (!evt) { body.textContent = "No validation data"; return; }
+  const d = evt.data as { error_count: number; warning_count: number; issues: { severity: string; category: string; message: string }[] };
+
+  body.appendChild(statRow("Errors", String(d.error_count)));
+  body.appendChild(statRow("Warnings", String(d.warning_count)));
+
+  for (const issue of d.issues) {
+    const line = el("div", "issue-line");
+    const cls = issue.severity === "Error" ? "issue-error" : "issue-warn";
+    line.classList.add(cls);
+    line.textContent = `[${issue.severity.toLowerCase()}] ${issue.category}: ${issue.message}`;
+    body.appendChild(line);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function renderDebugPanel(events: TraceEvent[]): HTMLElement {
+  injectStyle();
+  const root = div("debug-panel");
+
+  // Performance Timeline
+  const timeline = section("Performance", true);
+  renderTimeline(timeline.body, events);
+  root.appendChild(timeline.details);
+
+  // Solver Summary
+  const solver = section("Solver");
+  renderSolver(solver.body, events);
+  root.appendChild(solver.details);
+
+  // Layout Stats
+  const layoutStats = section("Layout Stats");
+  renderLayoutStats(layoutStats.body, events);
+  root.appendChild(layoutStats.details);
+
+  // Lane Ordering
+  const laneOrder = section("Lane Ordering");
+  renderLaneOrder(laneOrder.body, events);
+  root.appendChild(laneOrder.details);
+
+  // A* Routing
+  const routing = section("A* Routing", true);
+  renderRouting(routing.body, events);
+  root.appendChild(routing.details);
+
+  // SAT Zones
+  const satZones = section("SAT Zones");
+  renderSatZones(satZones.body, events);
+  root.appendChild(satZones.details);
+
+  // Lane Consolidation (only if events exist)
+  const consolidation = section("Lane Consolidation");
+  renderConsolidation(consolidation.body, events);
+  if (consolidation.body.hasChildNodes()) {
+    root.appendChild(consolidation.details);
+  }
+
+  // Power
+  const power = section("Power");
+  renderPower(power.body, events);
+  root.appendChild(power.details);
+
+  // Validation Summary
+  const validation = section("Validation");
+  renderValidation(validation.body, events);
+  root.appendChild(validation.details);
+
+  return root;
+}

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -2,6 +2,7 @@ import type { Engine, SolverResult, LayoutResult, ItemFlow } from "../engine.js"
 import { readUrlState, writeUrlState, DEFAULT_INPUTS } from "../state.js";
 import { beltTierForRate, hexToCss } from "../renderer/colors.js";
 import { niceName, setRecipeFlows } from "../renderer/entities.js";
+import { renderDebugPanel } from "./debugPanel.js";
 
 const STYLE = `
   .sidebar-inner {
@@ -455,6 +456,10 @@ export function renderSidebar(
         const total_us = currentLayout.regions.reduce((s, r) => s + (r.solve_time_us ?? 0), 0);
         zoneDiv.textContent = `SAT: ${currentLayout.regions.length} crossing zone${currentLayout.regions.length > 1 ? "s" : ""} solved (${total_us}\u00B5s total)`;
         resultContainer.appendChild(zoneDiv);
+      }
+      // Debug stats panel (only when trace events are present)
+      if (currentLayout.trace?.length) {
+        resultContainer.appendChild(renderDebugPanel(currentLayout.trace));
       }
     } catch (err) {
       const errDiv = document.createElement("div");

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -458,7 +458,7 @@ export function renderSidebar(
         resultContainer.appendChild(zoneDiv);
       }
       // Debug stats panel (only when trace events are present)
-      if (currentLayout.trace?.length) {
+      if (currentLayout.trace?.length && options?.getDebugMode?.()) {
         resultContainer.appendChild(renderDebugPanel(currentLayout.trace));
       }
     } catch (err) {


### PR DESCRIPTION
…ses 1-3)

Surface the Rust bus layout pipeline's 22 trace events as interactive visuals in the web app:

Phase 1 — 5 new grid overlays in traceOverlay.ts:
- RouteFailure: red ✕ cross + dashed line for failed A* paths
- CrossingZoneConflict: magenta "!" tile for SAT zone conflicts
- LaneConsolidated: sharing badge on lane columns
- RowSplit: split indicator on row boundaries
- LaneOrderOptimized: crossing score in phase summary label

Phase 2 — debug stats panel (new debugPanel.ts):
- 9 collapsible sections: Performance Timeline, Solver Summary, Layout Stats, Lane Ordering, A* Routing, SAT Zones, Lane Consolidation, Power, Validation Summary
- Wired into sidebar, shown only when Debug mode is on

Phase 3 — enhanced step-through debugger:
- Phase stats (entity count + elapsed ms) in step label
- Entity delta highlight (green tint on newly added entities)
- Jump-to-failure shortcut (⚠ badge + 'f' key)
- Keyboard shortcuts (Arrow keys for stepping)
- Fixed double debugCb change handler bug