### PR TITLE
Fix T_5_1 input_tiles and identify_ports splitter handling

### DIFF
--- a/crates/core/src/bus/balancer_library.rs
+++ b/crates/core/src/bus/balancer_library.rs
@@ -1269,7 +1269,7 @@ static T_5_1_ENTITIES: &[BalancerTemplateEntity] = &[
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 6, direction: 4, io_type: None },
     BalancerTemplateEntity { name: "transport-belt", x: 0, y: 7, direction: 2, io_type: None },
 ];
-static T_5_1_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (4, 0)];
+static T_5_1_INPUT: &[(i32, i32)] = &[(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)];
 static T_5_1_OUTPUT: &[(i32, i32)] = &[(4, 8)];
 
 static T_5_2_ENTITIES: &[BalancerTemplateEntity] = &[
@@ -3754,10 +3754,6 @@ mod tests {
         for ((n, m), t) in templates {
             assert_eq!(t.n_inputs, *n, "n_inputs mismatch for ({n},{m})");
             assert_eq!(t.n_outputs, *m, "n_outputs mismatch for ({n},{m})");
-            // (5,1) SAT solution has non-standard port topology — skip tile count check
-            if (*n, *m) == (5, 1) {
-                continue;
-            }
             assert_eq!(
                 t.input_tiles.len() as u32, *n,
                 "input_tiles.len mismatch for ({n},{m})"

--- a/scripts/generate_balancer_library.py
+++ b/scripts/generate_balancer_library.py
@@ -261,22 +261,29 @@ def entity_tile(e: RawEntity) -> tuple[int, int]:
 def identify_ports(
     entities: list[RawEntity],
 ) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
-    """Find input (top-edge SOUTH belts) and output (bottom-edge SOUTH belts).
+    """Find input (top-edge SOUTH belts/splitters) and output (bottom-edge SOUTH belts).
 
     Post-rotation, the bus's flow convention is SOUTH:
-      - inputs are belts facing SOUTH at the topmost y (items enter here)
+      - inputs are belts/splitters facing SOUTH at the topmost y (items enter here)
       - outputs are belts facing SOUTH at the bottommost y (items exit here)
-    """
-    belts = [e for e in entities if e.name == "transport-belt"]
-    if not belts:
-        return [], []
-    belt_tiles = [(entity_tile(e), e) for e in belts]
-    min_y = min(ty for (_, ty), _ in belt_tiles)
-    max_y = max(ty for (_, ty), _ in belt_tiles)
 
-    inputs = sorted((tx, ty) for (tx, ty), e in belt_tiles if ty == min_y and e.direction == FACTORIO_SOUTH)
-    outputs = sorted((tx, ty) for (tx, ty), e in belt_tiles if ty == max_y and e.direction == FACTORIO_SOUTH)
-    return inputs, outputs
+    Splitters at the top row each accept 2 input lanes (x and x+1).
+    """
+    conveyors = [e for e in entities if e.name in ("transport-belt", "splitter")]
+    if not conveyors:
+        return [], []
+    conveyor_tiles = [(entity_tile(e), e) for e in conveyors]
+    min_y = min(ty for (_, ty), _ in conveyor_tiles)
+    max_y = max(ty for (_, ty), _ in conveyor_tiles)
+
+    inputs: list[tuple[int, int]] = []
+    for (tx, ty), e in conveyor_tiles:
+        if ty == min_y and e.direction == FACTORIO_SOUTH:
+            inputs.append((tx, ty))
+            if e.name == "splitter":
+                inputs.append((tx + 1, ty))
+    outputs = sorted((tx, ty) for (tx, ty), e in conveyor_tiles if ty == max_y and e.direction == FACTORIO_SOUTH)
+    return sorted(inputs), outputs
 
 
 def derive_reverse(n: int, m: int, template: dict) -> dict:

--- a/src/bus/balancer_library.py
+++ b/src/bus/balancer_library.py
@@ -1374,7 +1374,7 @@ BALANCER_TEMPLATES: dict[tuple[int, int], BalancerTemplate] = {
             BalancerTemplateEntity(name="transport-belt", x=0, y=6, direction=4),
             BalancerTemplateEntity(name="transport-belt", x=0, y=7, direction=2),
         ),
-        input_tiles=((0, 0), (1, 0), (4, 0)),
+        input_tiles=((0, 0), (1, 0), (2, 0), (3, 0), (4, 0)),
         output_tiles=((4, 8),),
         source_blueprint="0eNq1ldtugzAMhl+lynVX5USAvcpUTT1EVSQaUAjTKsS7z2NVt2muaUt2RWKMPwf/dnq2rTrbBOcje170zO1q38LqpWetO/hNNVrjqbGwYC7aI1sumN8cx33bVC5GG9gARuf39h2sYlgvz67g8h0ejG82tK72YJeF0Lkuc5MLbjID76yPLjp7ho+706vvjlsID0HBo6lb8Bg/79knia8yMJ++VsOPvGLY+LapQ3za2mok712wu/PHElz/EiRGEI8RNEpQGEGmJGiMoB4jGJSQYQR9IYgVHzB93BTbYLGzlNnnGMGkJBQYIU+p0xIjFCkJguNC5ZciZ7cUGZeoELRGxfwuEBIvwlT+eDBFTx55m+Kv/GlNDx35O9MOJmw4hBqeeDlhfxnVvunilSNleAk4Tr2zvoaeEDOOVHfx+pkmWluSssJDTvTyIyFLWkwqwTXG6VtG/Yuk5ERXq/ldLSUtLPU/wpKKvpXUnP6XmpaYul9iMqMlphNIzNBTS8/6JTmtpBT5F7SSUiBKWjUJEIrTEy8FQtDypBHDehg+ALNaxjk=",
     ),


### PR DESCRIPTION
## Summary
- Fix T_5_1 balancer template `input_tiles` from 3 to 5 entries (was missing splitter at (2,0) spanning columns 2-3)
- Fix `identify_ports` in `generate_balancer_library.py` to include SOUTH-facing splitters, not just transport-belts
- Remove test skip for (5,1) template — now passes the IO count assertion

## Context
PR #99 fixed 9 templates with the same truncated `input_tiles` issue but missed T_5_1. Root cause was the generation script only examining `transport-belt` entities when finding input ports — templates with splitters at their top row got wrong counts and wrong y-values.

## Test plan
- [x] `cargo test -p fucktorio_core test_all_templates_have_correct_io_counts` passes (no more skips)
- [x] `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)