### PR TITLE
Fix blueprint export offset for multi-tile entities

### DIFF
--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -1,12 +1,6 @@
 //! LayoutResult → Factorio blueprint string.
 //!
 //! Format: `"0" + base64(zlib(JSON))`. The `"0"` is Factorio's version byte.
-//!
-//! NOTE: position is emitted as `{x: ent.x + 0.5, y: ent.y + 0.5}` for every
-//! entity. This is correct for 1x1 entities (belts, pipes, inserters). For
-//! multi-tile entities (3x3 assemblers, chemical plants, etc.) the center
-//! should instead be `{x: ent.x + w/2, y: ent.y + h/2}`. Fixing this requires
-//! an entity footprint lookup which is a follow-up.
 
 use std::io::Write;
 
@@ -15,6 +9,7 @@ use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use serde::Serialize;
 
+use crate::common::{is_machine_entity, machine_size};
 use crate::models::LayoutResult;
 
 #[derive(Serialize)]
@@ -60,9 +55,16 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
         .map(|(i, ent)| BlueprintEntity {
             entity_number: i + 1,
             name: &ent.name,
-            position: Position {
-                x: ent.x as f64 + 0.5,
-                y: ent.y as f64 + 0.5,
+            position: {
+                let size = if is_machine_entity(&ent.name) {
+                    machine_size(&ent.name) as f64
+                } else {
+                    1.0
+                };
+                Position {
+                    x: ent.x as f64 + size / 2.0,
+                    y: ent.y as f64 + size / 2.0,
+                }
             },
             direction: ent.direction as u8,
             recipe: ent.recipe.as_deref(),
@@ -151,6 +153,10 @@ mod tests {
         assert_eq!(ents[0]["direction"], 0);
         assert_eq!(ents[1]["entity_number"], 2);
         assert_eq!(ents[1]["direction"], 4);
+        // 3x3 assembler at (0,0) → center at (1.5, 1.5)
+        assert_eq!(ents[0]["position"]["x"], 1.5);
+        assert_eq!(ents[0]["position"]["y"], 1.5);
+        // 1x1 belt at (3,0) → center at (3.5, 0.5)
         assert_eq!(ents[1]["position"]["x"], 3.5);
         // mirror should be absent when false
         assert!(ents[0].get("mirror").is_none());

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -100,10 +100,9 @@ fn assert_produces(result: &E2EResult, item: &str, min_rate: f64) {
 }
 
 fn assert_round_trip(result: &E2EResult) {
-    // Intentionally weak check: entity count only. A dropped entity + duplicated
-    // entity would not be caught. This is acceptable because the blueprint export
-    // has a known offset bug for multi-tile entities that prevents a stronger
-    // positional comparison. See follow-up issue for the offset bug.
+    // Check entity count and per-entity position/direction/name.
+    // Metadata like carries, segment_id, and rate are lost in the blueprint
+    // format, so we only compare structural fields.
     assert_eq!(
         result.layout.entities.len(),
         result.parsed.entities.len(),
@@ -111,6 +110,29 @@ fn assert_round_trip(result: &E2EResult) {
         result.layout.entities.len(),
         result.parsed.entities.len(),
     );
+
+    // Normalize both to (0,0) origin before comparing — the parser always
+    // normalizes but the layout engine may use a different origin.
+    let l_min_x = result.layout.entities.iter().map(|e| e.x).min().unwrap_or(0);
+    let l_min_y = result.layout.entities.iter().map(|e| e.y).min().unwrap_or(0);
+    let p_min_x = result.parsed.entities.iter().map(|e| e.x).min().unwrap_or(0);
+    let p_min_y = result.parsed.entities.iter().map(|e| e.y).min().unwrap_or(0);
+
+    // Sort both lists by (name, x-lmin, y-lmin, direction) and compare pairwise.
+    let mut layout_sorted: Vec<_> = result.layout.entities.iter().collect();
+    layout_sorted.sort_by_key(|e| (e.name.clone(), e.x - l_min_x, e.y - l_min_y, e.direction as u8));
+    let mut parsed_sorted: Vec<_> = result.parsed.entities.iter().collect();
+    parsed_sorted.sort_by_key(|e| (e.name.clone(), e.x - p_min_x, e.y - p_min_y, e.direction as u8));
+
+    for (i, (orig, parsed)) in layout_sorted.iter().zip(parsed_sorted.iter()).enumerate() {
+        assert_eq!(
+            (orig.name.clone(), orig.x - l_min_x, orig.y - l_min_y, orig.direction as u8),
+            (parsed.name.clone(), parsed.x - p_min_x, parsed.y - p_min_y, parsed.direction as u8),
+            "Entity {i} mismatch: layout has {} at ({},{}) dir {:?}, parsed has {} at ({},{}) dir {:?}",
+            orig.name, orig.x, orig.y, orig.direction,
+            parsed.name, parsed.x, parsed.y, parsed.direction
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Blueprint exporter used hardcoded `+0.5` for all entity center positions, which is only correct for 1×1 entities. Multi-tile machines (3×3 assemblers, chemical plants, 5×5 refineries) exported at the wrong tile.
- Fix uses `machine_size()` to compute the correct center (`top_left + size/2`) for machines, while keeping `+0.5` for 1×1 entities (belts, inserters, pipes).
- Strengthens the e2e round-trip test from entity-count-only to full per-entity position/direction comparison (with normalization to handle parser origin offset).

## Test plan
- [x] Unit test in `blueprint.rs` verifies 3×3 assembler center at (1.5, 1.5) and 1×1 belt center at (3.5, 0.5)
- [x] All 4 non-ignored e2e tests pass with stronger round-trip assertions (`cargo test -p fucktorio_core --test e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)