### PR TITLE
Add layout snapshot debugger for test failure visualization

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod common;
 pub mod models;
 pub mod recipe_db;
 pub mod sat;
+pub mod snapshot;
 pub mod solver;
 pub mod trace;
 pub mod validate;

--- a/crates/core/src/snapshot.rs
+++ b/crates/core/src/snapshot.rs
@@ -1,0 +1,301 @@
+//! Layout snapshot format — self-describing debug artifact.
+//!
+//! Format: `"fls1" + base64(gzip(JSON))`. Captures everything needed to
+//! reproduce a view of a layout without re-running the pipeline.
+
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+
+use base64::Engine;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use serde::{Deserialize, Serialize};
+
+use crate::models::{LayoutResult, SolverResult};
+use crate::trace::TraceEvent;
+use crate::validate::ValidationIssue;
+
+/// Magic prefix for v1 snapshots.
+const MAGIC: &str = "fls1";
+
+// ---------------------------------------------------------------------------
+// Snapshot types
+// ---------------------------------------------------------------------------
+
+/// Origin of a snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SnapshotSource {
+    Test,
+    Manual,
+    Ci,
+}
+
+/// Parameters that produced the snapshot — enough to re-run the pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotParams {
+    pub item: String,
+    pub rate: f64,
+    pub machine: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub belt_tier: Option<String>,
+    pub inputs: Vec<String>,
+}
+
+/// Human-readable provenance metadata.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SnapshotContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+}
+
+/// Validation results captured in the snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotValidation {
+    pub issues: Vec<ValidationIssue>,
+    /// True if the validator panicked or timed out.
+    #[serde(default)]
+    pub truncated: bool,
+}
+
+/// Trace data captured in the snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotTrace {
+    pub events: Vec<TraceEvent>,
+    /// False if the snapshot was captured mid-pipeline (e.g. at timeout).
+    #[serde(default = "default_true")]
+    pub complete: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Complete layout snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayoutSnapshot {
+    pub version: u32,
+    pub created_at: String,
+    pub source: SnapshotSource,
+    pub params: SnapshotParams,
+    #[serde(default)]
+    pub context: SnapshotContext,
+    pub layout: LayoutResult,
+    pub validation: SnapshotValidation,
+    pub trace: SnapshotTrace,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub solver: Option<SolverResult>,
+}
+
+impl LayoutSnapshot {
+    /// Create a snapshot from a completed pipeline run.
+    pub fn from_run(
+        source: SnapshotSource,
+        params: SnapshotParams,
+        context: SnapshotContext,
+        layout: LayoutResult,
+        issues: Vec<ValidationIssue>,
+        truncated: bool,
+        trace_events: Vec<TraceEvent>,
+        trace_complete: bool,
+        solver: Option<SolverResult>,
+    ) -> Self {
+        Self {
+            version: 1,
+            created_at: chrono_now(),
+            source,
+            params,
+            context,
+            layout,
+            validation: SnapshotValidation {
+                issues,
+                truncated,
+            },
+            trace: SnapshotTrace {
+                events: trace_events,
+                complete: trace_complete,
+            },
+            solver,
+        }
+    }
+
+    /// Encode to the wire format: `"fls1" + base64(gzip(json))`.
+    pub fn encode(&self) -> Result<String, SnapshotError> {
+        let json = serde_json::to_vec(self).map_err(SnapshotError::Json)?;
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder
+            .write_all(&json)
+            .map_err(SnapshotError::Io)?;
+        let compressed = encoder.finish().map_err(SnapshotError::Io)?;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&compressed);
+        Ok(format!("{MAGIC}{b64}"))
+    }
+
+    /// Decode from the wire format.
+    pub fn decode(input: &str) -> Result<Self, SnapshotError> {
+        if !input.starts_with(MAGIC) {
+            return Err(SnapshotError::BadMagic {
+                expected: MAGIC.to_string(),
+                found: input.chars().take(4).collect(),
+            });
+        }
+        let b64 = &input[MAGIC.len()..];
+        let compressed = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .map_err(SnapshotError::Base64)?;
+        let mut json_bytes = Vec::new();
+        GzDecoder::new(&compressed[..])
+            .read_to_end(&mut json_bytes)
+            .map_err(SnapshotError::Io)?;
+        let snapshot: Self =
+            serde_json::from_slice(&json_bytes).map_err(SnapshotError::Json)?;
+        Ok(snapshot)
+    }
+
+    /// Write the encoded snapshot to a file.
+    pub fn write_to_file(&self, path: &Path) -> std::io::Result<()> {
+        let encoded = self
+            .encode()
+            .map_err(std::io::Error::other)?;
+        std::fs::write(path, encoded)
+    }
+
+    /// Read and decode a snapshot from a file.
+    pub fn read_from_file(path: &Path) -> Result<Self, SnapshotError> {
+        let contents = std::fs::read_to_string(path).map_err(SnapshotError::Io)?;
+        Self::decode(&contents)
+    }
+}
+
+/// Errors that can occur during snapshot encode/decode.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("bad magic prefix: expected {expected:?}, found {found:?}")]
+    BadMagic { expected: String, found: String },
+    #[error("base64 decode: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// ISO 8601 timestamp without external dependencies.
+fn chrono_now() -> String {
+    // Use std::time and format manually — good enough for timestamps.
+    // Format: YYYY-MM-DDTHH:MM:SSZ (UTC, no subseconds)
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+
+    // Calculate date components from unix timestamp
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+
+    // Calculate year/month/day from days since epoch
+    let (year, month, day) = days_to_date(days);
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hours, minutes, seconds
+    )
+}
+
+/// Convert days since Unix epoch to (year, month, day).
+fn days_to_date(days_since_epoch: u64) -> (u64, u64, u64) {
+    // Algorithm from http://howardhinnant.github.io/date_algorithms.html
+    let z = days_since_epoch + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::PlacedEntity;
+
+    fn test_snapshot() -> LayoutSnapshot {
+        LayoutSnapshot::from_run(
+            SnapshotSource::Test,
+            SnapshotParams {
+                item: "iron-gear-wheel".into(),
+                rate: 10.0,
+                machine: "assembling-machine-1".into(),
+                belt_tier: None,
+                inputs: vec!["iron-plate".into()],
+            },
+            SnapshotContext {
+                test_name: Some("tier1_iron_gear_wheel".into()),
+                label: None,
+                git_sha: None,
+            },
+            LayoutResult {
+                entities: vec![PlacedEntity {
+                    name: "assembling-machine-1".into(),
+                    x: 0,
+                    y: 0,
+                    ..Default::default()
+                }],
+                width: 1,
+                height: 1,
+                ..Default::default()
+            },
+            vec![],
+            false,
+            vec![],
+            true,
+            None,
+        )
+    }
+
+    #[test]
+    fn round_trip() {
+        let snap = test_snapshot();
+        let encoded = snap.encode().unwrap();
+        assert!(encoded.starts_with("fls1"), "should have magic prefix");
+        let decoded = LayoutSnapshot::decode(&encoded).unwrap();
+        assert_eq!(decoded.version, 1);
+        assert_eq!(decoded.params.item, "iron-gear-wheel");
+        assert_eq!(decoded.layout.entities.len(), 1);
+        assert!(decoded.trace.complete);
+        assert!(decoded.solver.is_none());
+    }
+
+    #[test]
+    fn bad_magic_rejected() {
+        let err = LayoutSnapshot::decode("abcdpayload").unwrap_err();
+        assert!(
+            matches!(err, SnapshotError::BadMagic { .. }),
+            "expected BadMagic, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn truncated_flag_preserved() {
+        let mut snap = test_snapshot();
+        snap.validation.truncated = true;
+        snap.trace.complete = false;
+        let encoded = snap.encode().unwrap();
+        let decoded = LayoutSnapshot::decode(&encoded).unwrap();
+        assert!(decoded.validation.truncated);
+        assert!(!decoded.trace.complete);
+    }
+}

--- a/crates/core/src/snapshot.rs
+++ b/crates/core/src/snapshot.rs
@@ -159,6 +159,7 @@ impl LayoutSnapshot {
     }
 
     /// Write the encoded snapshot to a file.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn write_to_file(&self, path: &Path) -> std::io::Result<()> {
         let encoded = self
             .encode()
@@ -167,6 +168,7 @@ impl LayoutSnapshot {
     }
 
     /// Read and decode a snapshot from a file.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn read_from_file(path: &Path) -> Result<Self, SnapshotError> {
         let contents = std::fs::read_to_string(path).map_err(SnapshotError::Io)?;
         Self::decode(&contents)

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -7,16 +7,25 @@
 //! Run with:  cargo test --test e2e
 //! Filter:    cargo test --test e2e -- tier1
 //! All (incl. known-failing): cargo test --test e2e -- --ignored
+//!
+//! Snapshot dumping:
+//!   FUCKTORIO_DUMP_SNAPSHOTS=1  — dump .fls files for ALL tests (passing too)
+//!   Automatic on failure — any test with validation errors dumps a snapshot.
 
 use fucktorio_core::analysis::{self, BlueprintAnalysis};
 use fucktorio_core::blueprint;
 use fucktorio_core::blueprint_parser;
 use fucktorio_core::bus::layout;
 use fucktorio_core::models::{LayoutResult, SolverResult};
+use fucktorio_core::snapshot::{
+    LayoutSnapshot, SnapshotContext, SnapshotParams, SnapshotSource,
+};
 use fucktorio_core::solver;
+use fucktorio_core::trace;
 use fucktorio_core::validate::{self, LayoutStyle, Severity, ValidationIssue};
 use fucktorio_core::validate::{belt_flow, belt_structural, power, inserters};
 use rustc_hash::FxHashSet;
+use std::path::PathBuf;
 use std::time::Instant;
 
 struct E2EResult {
@@ -30,13 +39,86 @@ struct E2EResult {
     analysis: BlueprintAnalysis,
 }
 
+/// Whether to dump snapshots for all tests or only failing ones.
+fn should_dump_snapshots() -> bool {
+    std::env::var("FUCKTORIO_DUMP_SNAPSHOTS").is_ok()
+}
+
+/// Dump a snapshot file for a test. Called on failure or when env var is set.
+fn dump_snapshot(
+    test_name: &str,
+    params: &RunParams,
+    result: &E2EResult,
+) {
+    let dir = snapshot_dir();
+    std::fs::create_dir_all(&dir).ok();
+
+    let snapshot = LayoutSnapshot::from_run(
+        SnapshotSource::Test,
+        SnapshotParams {
+            item: params.item.to_string(),
+            rate: params.rate,
+            machine: params.machine.to_string(),
+            belt_tier: params.belt_tier.map(|s| s.to_string()),
+            inputs: params.available_inputs.iter().cloned().collect(),
+        },
+        SnapshotContext {
+            test_name: Some(test_name.to_string()),
+            label: None,
+            git_sha: git_sha(),
+        },
+        result.layout.clone(),
+        result.issues.clone(),
+        false, // not truncated
+        trace::drain_events(),
+        true, // trace complete
+        Some(result.solver_result.clone()),
+    );
+
+    let path = dir.join(format!("snapshot-{test_name}.fls"));
+    match snapshot.write_to_file(&path) {
+        Ok(()) => eprintln!("  snapshot: {}", path.display()),
+        Err(e) => eprintln!("  snapshot write failed: {e}"),
+    }
+}
+
+/// Directory for snapshot files. Uses `CARGO_TARGET_TMPDIR` if available,
+/// otherwise `target/tmp/`.
+fn snapshot_dir() -> PathBuf {
+    std::env::var("CARGO_TARGET_TMPDIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("target/tmp"))
+}
+
+/// Best-effort git SHA.
+fn git_sha() -> Option<String> {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}
+
+/// Parameters for a test run (borrowed from the test function's arguments).
+struct RunParams<'a> {
+    item: &'a str,
+    rate: f64,
+    machine: &'a str,
+    belt_tier: Option<&'a str>,
+    available_inputs: &'a FxHashSet<String>,
+}
+
 fn run_e2e(
+    test_name: &str,
     item: &str,
     rate: f64,
     machine: &str,
     belt_tier: Option<&str>,
     available_inputs: &FxHashSet<String>,
 ) -> Result<E2EResult, String> {
+    let _guard = trace::start_trace();
+
     let solver_result = solver::solve(item, rate, available_inputs, machine)
         .map_err(|e| format!("solver: {e}"))?;
 
@@ -56,14 +138,23 @@ fn run_e2e(
     let parsed = blueprint_parser::parse_blueprint_string(&bp_string)
         .map_err(|e| format!("parse: {e}"))?;
 
-    Ok(E2EResult {
+    let result = E2EResult {
         solver_result,
         layout,
         bp_string,
         parsed,
         issues,
         analysis,
-    })
+    };
+
+    // Dump snapshot if there are errors or if env var is set.
+    let has_errors = result.issues.iter().any(|i| i.severity == Severity::Error);
+    if has_errors || should_dump_snapshots() {
+        let params = RunParams { item, rate, machine, belt_tier, available_inputs };
+        dump_snapshot(test_name, &params, &result);
+    }
+
+    Ok(result)
 }
 
 fn assert_no_errors(result: &E2EResult) {
@@ -141,7 +232,7 @@ fn assert_round_trip(result: &E2EResult) {
 #[ntest::timeout(10000)]
 fn tier1_iron_gear_wheel() {
     let inputs: FxHashSet<String> = ["iron-plate"].iter().map(|s| s.to_string()).collect();
-    let result = run_e2e("iron-gear-wheel", 10.0, "assembling-machine-1", None, &inputs)
+    let result = run_e2e("tier1_iron_gear_wheel", "iron-gear-wheel", 10.0, "assembling-machine-1", None, &inputs)
         .expect("e2e pipeline");
 
     assert_no_errors(&result);
@@ -154,6 +245,7 @@ fn tier1_iron_gear_wheel() {
 fn tier1_iron_gear_wheel_from_ore() {
     let inputs: FxHashSet<String> = ["iron-ore"].iter().map(|s| s.to_string()).collect();
     let result = run_e2e(
+        "tier1_iron_gear_wheel_from_ore",
         "iron-gear-wheel",
         10.0,
         "assembling-machine-2",
@@ -171,7 +263,7 @@ fn tier1_iron_gear_wheel_from_ore() {
 #[ntest::timeout(10000)]
 fn tier1_iron_gear_wheel_20s() {
     let inputs: FxHashSet<String> = ["iron-plate"].iter().map(|s| s.to_string()).collect();
-    let result = run_e2e("iron-gear-wheel", 20.0, "assembling-machine-2", None, &inputs)
+    let result = run_e2e("tier1_iron_gear_wheel_20s", "iron-gear-wheel", 20.0, "assembling-machine-2", None, &inputs)
         .expect("e2e pipeline");
 
     assert_no_errors(&result);
@@ -192,6 +284,7 @@ fn tier2_electronic_circuit() {
         .map(|s| s.to_string())
         .collect();
     let result = run_e2e(
+        "tier2_electronic_circuit",
         "electronic-circuit",
         10.0,
         "assembling-machine-2",
@@ -214,6 +307,7 @@ fn tier2_electronic_circuit_from_ore() {
         .map(|s| s.to_string())
         .collect();
     let result = run_e2e(
+        "tier2_electronic_circuit_from_ore",
         "electronic-circuit",
         10.0,
         "assembling-machine-1",
@@ -236,6 +330,7 @@ fn tier2_electronic_circuit_20s_from_ore() {
         .map(|s| s.to_string())
         .collect();
     let result = run_e2e(
+        "tier2_electronic_circuit_20s_from_ore",
         "electronic-circuit",
         20.0,
         "assembling-machine-2",
@@ -261,7 +356,7 @@ fn tier3_plastic_bar() {
         .map(|s| s.to_string())
         .collect();
     let result =
-        run_e2e("plastic-bar", 10.0, "chemical-plant", None, &inputs).expect("e2e pipeline");
+        run_e2e("tier3_plastic_bar", "plastic-bar", 10.0, "chemical-plant", None, &inputs).expect("e2e pipeline");
 
     assert_no_errors(&result);
     assert_produces(&result, "plastic-bar", 10.0);
@@ -276,7 +371,7 @@ fn tier3_plastic_bar_from_crude() {
         .map(|s| s.to_string())
         .collect();
     let result =
-        run_e2e("plastic-bar", 10.0, "chemical-plant", None, &inputs).expect("e2e pipeline");
+        run_e2e("tier3_plastic_bar_from_crude", "plastic-bar", 10.0, "chemical-plant", None, &inputs).expect("e2e pipeline");
 
     assert_no_errors(&result);
     assert_produces(&result, "plastic-bar", 10.0);
@@ -291,7 +386,7 @@ fn tier3_sulfuric_acid() {
         .map(|s| s.to_string())
         .collect();
     let result =
-        run_e2e("sulfuric-acid", 5.0, "chemical-plant", None, &inputs).expect("e2e pipeline");
+        run_e2e("tier3_sulfuric_acid", "sulfuric-acid", 5.0, "chemical-plant", None, &inputs).expect("e2e pipeline");
 
     assert_no_errors(&result);
     assert_produces(&result, "sulfuric-acid", 5.0);
@@ -312,6 +407,7 @@ fn tier4_advanced_circuit_from_plates() {
         .map(|s| s.to_string())
         .collect();
     let result = run_e2e(
+        "tier4_advanced_circuit_from_plates",
         "advanced-circuit",
         10.0,
         "assembling-machine-2",

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -82,6 +82,54 @@ fn dump_snapshot(
     }
 }
 
+/// Dump a partial snapshot when the pipeline fails early (solver/layout error).
+/// Uses whatever data is available — may have no layout entities.
+fn dump_partial_snapshot(
+    test_name: &str,
+    params: &RunParams,
+    solver_result: Option<&SolverResult>,
+    error_msg: &str,
+) {
+    let dir = snapshot_dir();
+    std::fs::create_dir_all(&dir).ok();
+
+    let error_issue = ValidationIssue {
+        severity: Severity::Error,
+        category: "pipeline".into(),
+        message: error_msg.into(),
+        x: None,
+        y: None,
+    };
+
+    let snapshot = LayoutSnapshot::from_run(
+        SnapshotSource::Test,
+        SnapshotParams {
+            item: params.item.to_string(),
+            rate: params.rate,
+            machine: params.machine.to_string(),
+            belt_tier: params.belt_tier.map(|s| s.to_string()),
+            inputs: params.available_inputs.iter().cloned().collect(),
+        },
+        SnapshotContext {
+            test_name: Some(test_name.to_string()),
+            label: None,
+            git_sha: git_sha(),
+        },
+        LayoutResult::default(),
+        vec![error_issue],
+        true, // truncated — pipeline didn't finish
+        trace::drain_events(),
+        false, // trace incomplete
+        solver_result.cloned(),
+    );
+
+    let path = dir.join(format!("snapshot-{test_name}-partial.fls"));
+    match snapshot.write_to_file(&path) {
+        Ok(()) => eprintln!("  partial snapshot: {}", path.display()),
+        Err(e) => eprintln!("  partial snapshot write failed: {e}"),
+    }
+}
+
 /// Directory for snapshot files. Uses `CARGO_TARGET_TMPDIR` if available,
 /// otherwise `target/tmp/`.
 fn snapshot_dir() -> PathBuf {
@@ -118,12 +166,21 @@ fn run_e2e(
     available_inputs: &FxHashSet<String>,
 ) -> Result<E2EResult, String> {
     let _guard = trace::start_trace();
+    let run_params = RunParams { item, rate, machine, belt_tier, available_inputs };
 
     let solver_result = solver::solve(item, rate, available_inputs, machine)
-        .map_err(|e| format!("solver: {e}"))?;
+        .map_err(|e| {
+            let msg = format!("solver: {e}");
+            dump_partial_snapshot(test_name, &run_params, None, &msg);
+            msg
+        })?;
 
     let layout = layout::build_bus_layout(&solver_result, belt_tier)
-        .map_err(|e| format!("layout: {e}"))?;
+        .map_err(|e| {
+            let msg = format!("layout: {e}");
+            dump_partial_snapshot(test_name, &run_params, Some(&solver_result), &msg);
+            msg
+        })?;
 
     // Validate the original layout (correct top-left positions).
     let issues = match validate::validate(&layout, Some(&solver_result), LayoutStyle::Bus) {
@@ -136,7 +193,11 @@ fn run_e2e(
     // Round-trip through blueprint export → parse as a smoke test.
     let bp_string = blueprint::export(&layout, item);
     let parsed = blueprint_parser::parse_blueprint_string(&bp_string)
-        .map_err(|e| format!("parse: {e}"))?;
+        .map_err(|e| {
+            let msg = format!("parse: {e}");
+            dump_partial_snapshot(test_name, &run_params, Some(&solver_result), &msg);
+            msg
+        })?;
 
     let result = E2EResult {
         solver_result,
@@ -150,8 +211,7 @@ fn run_e2e(
     // Dump snapshot if there are errors or if env var is set.
     let has_errors = result.issues.iter().any(|i| i.severity == Severity::Error);
     if has_errors || should_dump_snapshots() {
-        let params = RunParams { item, rate, machine, belt_tier, available_inputs };
-        dump_snapshot(test_name, &params, &result);
+        dump_snapshot(test_name, &run_params, &result);
     }
 
     Ok(result)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fucktorio-web",
       "version": "0.0.0",
       "dependencies": {
+        "fflate": "^0.8.2",
         "pixi-viewport": "^6.0.3",
         "pixi.js": "^8.6.0"
       },
@@ -1213,6 +1214,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -9,8 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "pixi.js": "^8.6.0",
-    "pixi-viewport": "^6.0.3"
+    "fflate": "^0.8.2",
+    "pixi-viewport": "^6.0.3",
+    "pixi.js": "^8.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -504,15 +504,6 @@ async function main(): Promise<void> {
     // Show banner
     clearSnapshotBanner();
     const bannerCallbacks: BannerCallbacks = {
-      onReSolve: (params) => {
-        // Switch to generate tab and re-solve
-        const sidebarEl = document.getElementById("sidebar");
-        const genBtn = sidebarEl?.querySelector("button") as HTMLButtonElement | null;
-        genBtn?.click();
-        clearSnapshotBanner();
-        // TODO: populate sidebar from params and trigger solve
-        console.log("Re-solve requested with params:", params);
-      },
       onClear: () => {
         clearSnapshotBanner();
         entityLayer.removeChildren();

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -6,6 +6,13 @@ import { initEntityIcons, renderLayout, setItemColoring, setRateOverlay, itemCol
 import { createSelectionController, type SelectionController } from "./renderer/selection";
 import { renderSidebar } from "./ui/sidebar";
 import { initCorpusPanel } from "./ui/corpus";
+import {
+  setupSnapshotDropZone,
+  showSnapshotBanner,
+  decodeSnapshot,
+  type LayoutSnapshot,
+  type BannerCallbacks,
+} from "./ui/snapshotLoader";
 import { initEngine, getEngine } from "./engine";
 import type { SolverResult, LayoutResult, PlacedEntity, ValidationIssue } from "./engine";
 import { renderTraceOverlay, getTracePhases, eventsUpToPhase, type TraceEvent, type PhaseSnapshot } from "./renderer/traceOverlay";
@@ -30,6 +37,9 @@ async function main(): Promise<void> {
   const { app, viewport } = await createApp(container);
   drawGrid(viewport);
   drawGraph(viewport, null);
+
+  // --- Snapshot drag-drop ---
+  setupSnapshotDropZone(container, (snap) => loadSnapshot(snap));
 
   const entityLayer = new Container();
   viewport.addChild(entityLayer);
@@ -455,6 +465,74 @@ async function main(): Promise<void> {
 
   let lastLayout: LayoutResult | null = null;
   let selectionCtrl: SelectionController | null = null;
+  let activeBanner: HTMLDivElement | null = null;
+
+  function clearSnapshotBanner(): void {
+    if (activeBanner) {
+      activeBanner.remove();
+      activeBanner = null;
+    }
+    // Re-enable sidebar
+    const sidebarEl = document.getElementById("sidebar");
+    if (sidebarEl) sidebarEl.style.opacity = "1";
+    sidebarEl?.querySelectorAll("input,select,button").forEach((el) => {
+      (el as HTMLInputElement).disabled = false;
+    });
+  }
+
+  function loadSnapshot(snapshot: LayoutSnapshot): void {
+    cachedValidationIssues = snapshot.validation.issues.length > 0
+      ? snapshot.validation.issues as unknown as ValidationIssue[]
+      : null;
+
+    // Build a LayoutResult from snapshot data (inject trace events)
+    const layout: LayoutResult = {
+      ...snapshot.layout,
+      trace: snapshot.trace.events as LayoutResult["trace"],
+    } as LayoutResult;
+
+    // Auto-enable debug + validation if there are issues or trace events
+    if (snapshot.trace.events.length > 0) {
+      debugCb.checked = true;
+    }
+    if (snapshot.validation.issues.length > 0) {
+      valCb.checked = true;
+    }
+
+    renderLayoutOnCanvas(layout);
+
+    // Show banner
+    clearSnapshotBanner();
+    const bannerCallbacks: BannerCallbacks = {
+      onReSolve: (params) => {
+        // Switch to generate tab and re-solve
+        const sidebarEl = document.getElementById("sidebar");
+        const genBtn = sidebarEl?.querySelector("button") as HTMLButtonElement | null;
+        genBtn?.click();
+        clearSnapshotBanner();
+        // TODO: populate sidebar from params and trigger solve
+        console.log("Re-solve requested with params:", params);
+      },
+      onClear: () => {
+        clearSnapshotBanner();
+        entityLayer.removeChildren();
+        lastLayout = null;
+        drawGraph(viewport, null);
+        viewport.moveCenter(WORLD_SIZE / 2, WORLD_SIZE / 2);
+        legendEl.style.display = "none";
+        infoPanel.style.display = "none";
+      },
+    };
+    const sidebarEl = document.getElementById("sidebar");
+    if (sidebarEl) {
+      activeBanner = showSnapshotBanner(sidebarEl, snapshot, bannerCallbacks);
+      // Dim sidebar to indicate snapshot mode
+      sidebarEl.style.opacity = "0.5";
+      sidebarEl.querySelectorAll("input,select,button").forEach((el) => {
+        (el as HTMLInputElement).disabled = true;
+      });
+    }
+  }
 
   function onSelectionChange(entities: PlacedEntity[]): void {
     if (entities.length === 0) {
@@ -554,14 +632,34 @@ async function main(): Promise<void> {
 
   // Ctrl+C: copy selection JSON when entities are selected
   document.addEventListener("keydown", (e) => {
-    if (!e.ctrlKey || e.key !== "c") return;
-    if (!selectionCtrl || selectionCtrl.getSelected().length === 0) return;
-    e.preventDefault();
-    const params = sidebarCtrl?.getParams() ?? null;
-    const json = selectionCtrl.buildJson(params, annotationNote.value.trim());
-    navigator.clipboard.writeText(json).catch(() => undefined);
-    annotationHint.textContent = "Copied!";
-    setTimeout(() => { annotationHint.textContent = "Ctrl+C to copy JSON"; }, 2000);
+    if (!e.ctrlKey) return;
+    if (e.key === "c") {
+      if (!selectionCtrl || selectionCtrl.getSelected().length === 0) return;
+      e.preventDefault();
+      const params = sidebarCtrl?.getParams() ?? null;
+      const json = selectionCtrl.buildJson(params, annotationNote.value.trim());
+      navigator.clipboard.writeText(json).catch(() => undefined);
+      annotationHint.textContent = "Copied!";
+      setTimeout(() => { annotationHint.textContent = "Ctrl+C to copy JSON"; }, 2000);
+    } else if (e.key === "o") {
+      // Ctrl+O: open snapshot file picker
+      e.preventDefault();
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = ".fls";
+      input.addEventListener("change", async () => {
+        const file = input.files?.[0];
+        if (!file) return;
+        try {
+          const text = await file.text();
+          const snapshot = await decodeSnapshot(text);
+          loadSnapshot(snapshot);
+        } catch (err) {
+          alert(`Failed to load snapshot: ${err}`);
+        }
+      });
+      input.click();
+    }
   });
 
   const sidebarEl = document.getElementById("sidebar");

--- a/web/src/ui/snapshotLoader.ts
+++ b/web/src/ui/snapshotLoader.ts
@@ -136,7 +136,6 @@ export function setupSnapshotDropZone(
 // ---------------------------------------------------------------------------
 
 export interface BannerCallbacks {
-  onReSolve: (params: SnapshotParams) => void;
   onClear: () => void;
 }
 
@@ -201,9 +200,10 @@ export function showSnapshotBanner(
 
   const reSolveBtn = document.createElement("button");
   reSolveBtn.textContent = "Re-solve";
+  reSolveBtn.title = "Not yet implemented";
+  reSolveBtn.disabled = true;
   reSolveBtn.style.cssText =
-    "background:#335;border:1px solid #569cd6;color:#e0e0e0;padding:2px 8px;border-radius:3px;cursor:pointer;font:11px monospace";
-  reSolveBtn.addEventListener("click", () => callbacks.onReSolve(params));
+    "background:#222;border:1px solid #444;color:#666;padding:2px 8px;border-radius:3px;font:11px monospace;cursor:not-allowed";
   banner.appendChild(reSolveBtn);
 
   const clearBtn = document.createElement("button");

--- a/web/src/ui/snapshotLoader.ts
+++ b/web/src/ui/snapshotLoader.ts
@@ -1,0 +1,218 @@
+/**
+ * Snapshot loader — decode .fls layout snapshots and hydrate the web app.
+ *
+ * Wire format: "fls1" + base64(gzip(JSON))
+ */
+
+import { gunzipSync } from "fflate";
+
+// ---------------------------------------------------------------------------
+// Types (mirror crates/core/src/snapshot.rs)
+// ---------------------------------------------------------------------------
+
+export interface SnapshotParams {
+  item: string;
+  rate: number;
+  machine: string;
+  belt_tier: string | null;
+  inputs: string[];
+}
+
+export interface SnapshotContext {
+  test_name?: string;
+  label?: string;
+  git_sha?: string;
+}
+
+export interface SnapshotValidation {
+  issues: SnapshotValidationIssue[];
+  truncated: boolean;
+}
+
+export interface SnapshotValidationIssue {
+  severity: "Error" | "Warning";
+  category: string;
+  message: string;
+  x?: number;
+  y?: number;
+}
+
+export interface SnapshotTrace {
+  events: unknown[];
+  complete: boolean;
+}
+
+export interface LayoutSnapshot {
+  version: number;
+  created_at: string;
+  source: "test" | "manual" | "ci";
+  params: SnapshotParams;
+  context: SnapshotContext;
+  layout: {
+    entities: unknown[];
+    width?: number;
+    height?: number;
+    warnings?: string[];
+    regions?: unknown[];
+    trace?: unknown[];
+  };
+  validation: SnapshotValidation;
+  trace: SnapshotTrace;
+  solver?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Decoder
+// ---------------------------------------------------------------------------
+
+const MAGIC = "fls1";
+
+export async function decodeSnapshot(input: string | ArrayBuffer): Promise<LayoutSnapshot> {
+  const text = typeof input === "string" ? input : new TextDecoder().decode(input);
+  if (!text.startsWith(MAGIC)) {
+    throw new Error(`Not a layout snapshot: expected "${MAGIC}" prefix, got "${text.slice(0, 4)}"`);
+  }
+  const b64 = text.slice(MAGIC.length);
+  const gz = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  const jsonBytes = gunzipSync(gz);
+  const json = new TextDecoder().decode(jsonBytes);
+  return JSON.parse(json) as LayoutSnapshot;
+}
+
+// ---------------------------------------------------------------------------
+// File loader helpers
+// ---------------------------------------------------------------------------
+
+export function readSnapshotFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsText(file);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Drag-drop setup
+// ---------------------------------------------------------------------------
+
+export function setupSnapshotDropZone(
+  element: HTMLElement,
+  onLoad: (snapshot: LayoutSnapshot) => void,
+): void {
+  element.addEventListener("dragover", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    element.style.outline = "2px dashed #569cd6";
+  });
+
+  element.addEventListener("dragleave", () => {
+    element.style.outline = "none";
+  });
+
+  element.addEventListener("drop", async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    element.style.outline = "none";
+
+    const file = e.dataTransfer?.files[0];
+    if (!file) return;
+    if (!file.name.endsWith(".fls")) {
+      alert("Expected a .fls snapshot file");
+      return;
+    }
+    try {
+      const text = await readSnapshotFile(file);
+      const snapshot = await decodeSnapshot(text);
+      onLoad(snapshot);
+    } catch (err) {
+      alert(`Failed to load snapshot: ${err}`);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Banner UI
+// ---------------------------------------------------------------------------
+
+export interface BannerCallbacks {
+  onReSolve: (params: SnapshotParams) => void;
+  onClear: () => void;
+}
+
+export function showSnapshotBanner(
+  parent: HTMLElement,
+  snapshot: LayoutSnapshot,
+  callbacks: BannerCallbacks,
+): HTMLDivElement {
+  const banner = document.createElement("div");
+  banner.style.cssText =
+    "background:rgba(0,40,80,0.85);color:#e0e0e0;font:11px monospace;padding:6px 10px;border-bottom:1px solid #569cd6;display:flex;align-items:center;gap:8px;flex-wrap:wrap;z-index:20";
+
+  const { params, context, trace, validation } = snapshot;
+  const label = context.test_name ?? context.label ?? "snapshot";
+
+  let info = `<span style="color:#569cd6;font-weight:bold">${label}</span>`;
+  if (context.git_sha) info += ` <span style="color:#888">(git: ${context.git_sha})</span>`;
+  info += ` <span style="color:#aaa">${snapshot.created_at}</span>`;
+
+  let detail = `${params.item} @ ${params.rate}/s`;
+  detail += ` · ${params.machine}`;
+  if (params.belt_tier) detail += ` · ${params.belt_tier}`;
+  if (params.inputs.length) detail += ` · from ${params.inputs.join(", ")}`;
+
+  const infoSpan = document.createElement("span");
+  infoSpan.innerHTML = info;
+  banner.appendChild(infoSpan);
+
+  const detailSpan = document.createElement("span");
+  detailSpan.style.cssText = "color:#888;margin-left:8px";
+  detailSpan.textContent = detail;
+  banner.appendChild(detailSpan);
+
+  // Incomplete trace warning
+  if (!trace.complete) {
+    const warn = document.createElement("span");
+    warn.style.cssText = "color:#ff6b6b;margin-left:8px";
+    warn.textContent = "⚠ Incomplete trace";
+    banner.appendChild(warn);
+  }
+  if (validation.truncated) {
+    const warn = document.createElement("span");
+    warn.style.cssText = "color:#ff6b6b;margin-left:4px";
+    warn.textContent = "⚠ Validation truncated";
+    banner.appendChild(warn);
+  }
+
+  // Validation summary
+  const errors = validation.issues.filter((i) => i.severity === "Error").length;
+  const warnings = validation.issues.length - errors;
+  if (validation.issues.length > 0) {
+    const badge = document.createElement("span");
+    badge.style.cssText = "margin-left:8px";
+    badge.innerHTML = `<span style="color:#f66">${errors} errors</span> <span style="color:#fa0">${warnings} warnings</span>`;
+    banner.appendChild(badge);
+  }
+
+  // Buttons
+  const spacer = document.createElement("span");
+  spacer.style.cssText = "flex:1";
+  banner.appendChild(spacer);
+
+  const reSolveBtn = document.createElement("button");
+  reSolveBtn.textContent = "Re-solve";
+  reSolveBtn.style.cssText =
+    "background:#335;border:1px solid #569cd6;color:#e0e0e0;padding:2px 8px;border-radius:3px;cursor:pointer;font:11px monospace";
+  reSolveBtn.addEventListener("click", () => callbacks.onReSolve(params));
+  banner.appendChild(reSolveBtn);
+
+  const clearBtn = document.createElement("button");
+  clearBtn.textContent = "Clear";
+  clearBtn.style.cssText =
+    "background:#333;border:1px solid #666;color:#ccc;padding:2px 8px;border-radius:3px;cursor:pointer;font:11px monospace";
+  clearBtn.addEventListener("click", () => callbacks.onClear());
+  banner.appendChild(clearBtn);
+
+  parent.insertBefore(banner, parent.firstChild);
+  return banner;
+}


### PR DESCRIPTION
## Summary

- **Rust snapshot format** (`crates/core/src/snapshot.rs`): `LayoutSnapshot` struct with encode/decode in `"fls1" + base64(gzip(json))` wire format. Captures params, context (test name, git SHA), layout, validation issues, trace events, and solver output. 3 unit tests.
- **E2E test integration** (`crates/core/tests/e2e.rs`): `run_e2e()` now dumps `.fls` snapshots automatically on validation errors, or for all tests with `FUCKTORIO_DUMP_SNAPSHOTS=1`. Includes trace events via `start_trace()` guard.
- **Web app snapshot loader** (`web/src/ui/snapshotLoader.ts`): Decode with `fflate`, drag-drop on canvas, banner UI showing metadata/validation summary/incomplete trace warnings. Ctrl+O opens file picker. Sidebar dims when snapshot is loaded.

Implements Phases 1–3 from `docs/layout-snapshot-debugger.md`.

## Test plan

- [x] `cargo test -p fucktorio_core` — 356 passed, 0 failed
- [x] `cargo clippy -p fucktorio_core -- -D warnings` — clean
- [x] `npm run build` — clean (tsc + vite)
- [x] `FUCKTORIO_DUMP_SNAPSHOTS=1 cargo test --test e2e -- tier1 --nocapture` — snapshots dumped to `target/tmp/`, valid `fls1` prefix
- [ ] Manual: drag a `.fls` file into the web app, verify layout renders with banner
- [ ] Manual: Ctrl+O opens file picker, loads snapshot correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)