### PR TITLE
Change viewport controls: left-click pan, Shift+drag select

### DIFF
--- a/web/src/renderer/app.ts
+++ b/web/src/renderer/app.ts
@@ -28,7 +28,7 @@ export async function createApp(container: HTMLElement): Promise<AppContext> {
     events: app.renderer.events,
   });
 
-  viewport.drag({ mouseButtons: "middle-right" }).pinch().wheel().decelerate();
+  viewport.drag({ mouseButtons: "left" }).pinch().wheel().decelerate();
 
   app.stage.addChild(viewport);
 

--- a/web/src/renderer/selection.ts
+++ b/web/src/renderer/selection.ts
@@ -91,7 +91,7 @@ export function createSelectionController(
   }
 
   const onDown = (e: PointerEvent) => {
-    if (e.button !== 0) return;
+    if (e.button !== 0 || !e.shiftKey) return;
     dragStart = { sx: e.clientX, sy: e.clientY };
     isDragging = false;
   };


### PR DESCRIPTION
## Summary
- Left-click now pans the viewport (changed from middle/right-click)
- Box selection requires Shift+left-drag (was plain left-drag)
- Right-click does nothing (reserved for future use)

## Test plan
- [ ] Verify left-click drag pans the viewport
- [ ] Verify Shift+left-drag draws a selection rectangle
- [ ] Verify plain click (no Shift) clears selection
- [ ] Verify right-click does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)