### PR TITLE
Skip CI jobs based on changed paths + Rust caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      rust: ${{ steps.filter.outputs.rust }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.python-version'
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            web:
+              - 'web/**'
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +52,8 @@ jobs:
           args: format --check
 
   test:
+    needs: changes
+    if: always() && (needs.changes.outputs.python == 'true' || needs.changes.outputs.rust == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +61,7 @@ jobs:
         with:
           python-version: "3.13"
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: pip install factorio-draftsman pytest pytest-timeout maturin
       - run: maturin build --release
       - run: pip install target/wheels/*.whl --no-deps
@@ -51,12 +78,15 @@ jobs:
           path: test-results.xml
 
   rust:
+    needs: changes
+    if: always() && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
@@ -102,12 +132,15 @@ jobs:
           path: target/nextest/ci/junit.xml
 
   web:
+    needs: changes
+    if: always() && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build WASM


### PR DESCRIPTION
## Summary
- Add `changes` job with `dorny/paths-filter` to detect python/rust/web changes
- Skip `test`, `rust`, `web` jobs when their inputs haven't changed (e.g. web-only PR skips Rust tests)
- Add `Swatinem/rust-cache@v2` to all three Rust-compiling jobs to share compiled artifacts across runs

## Path → job mapping

| Job | Runs when |
|-----|-----------|
| `lint` | Always (fast) |
| `test` | python or rust changed |
| `rust` | rust changed |
| `web` | rust or web changed |
| `deploy` | main only (unchanged) |

## Test plan
- [ ] Merge this PR and verify all jobs run (CI config itself changed)
- [ ] Push a web-only change to a test branch — `test` and `rust` should skip
- [ ] Second run on same branch should show Rust cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)