### PR TITLE
Pre-fill sidebar form from snapshot params

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -638,6 +638,9 @@ async function main(): Promise<void> {
 
     renderLayoutOnCanvas(layout);
 
+    // Pre-fill sidebar form with snapshot params
+    sidebarCtrl?.setParams(snapshot.params);
+
     // Show banner
     clearSnapshotBanner();
     const bannerCallbacks: BannerCallbacks = {

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -229,6 +229,9 @@ export interface SidebarCallbacks {
 export interface SidebarParams {
   item: string;
   rate: number;
+  machine?: string;
+  inputs?: string[];
+  belt?: string | null;
 }
 
 export function renderSidebar(
@@ -236,7 +239,7 @@ export function renderSidebar(
   engine: Engine,
   callbacks: SidebarCallbacks,
   options?: { getDebugMode?: () => boolean },
-): { getParams(): SidebarParams | null } {
+): { getParams(): SidebarParams | null; setParams(params: SidebarParams): void } {
   el.innerHTML = "";
 
   if (!document.getElementById("fucktorio-sidebar-style")) {
@@ -490,6 +493,28 @@ export function renderSidebar(
       const rate = parseFloat(rateInput.value);
       if (!item || isNaN(rate) || rate <= 0) return null;
       return { item, rate };
+    },
+    setParams(params) {
+      itemInput.value = params.item;
+      rateInput.value = String(params.rate);
+      if (params.machine) {
+        machineSelect.value = params.machine;
+      } else {
+        machineSelect.value = engine.defaultMachineForItem(params.item, "assembling-machine-3");
+      }
+      if (params.inputs) {
+        checkboxes.forEach((cb, name) => {
+          cb.checked = params.inputs!.includes(name);
+        });
+      }
+      if (params.belt) {
+        beltSelect.value = params.belt;
+      } else {
+        beltSelect.value = "";
+      }
+      // Update internal state and re-solve
+      previousItem = params.item;
+      scheduleAutoSolve();
     },
   };
 }


### PR DESCRIPTION
## Summary
- When a `.fls` snapshot file is opened, the sidebar form now pre-fills with the snapshot's stored params (item, rate, machine, inputs, belt tier)
- Added `setParams()` method to the sidebar controller alongside existing `getParams()`
- After clearing a snapshot, the form retains the params so the user can re-solve or tweak settings

## Test plan
- [ ] Drag-drop a `.fls` snapshot file onto the canvas
- [ ] Verify the sidebar form shows the correct item, rate, machine, inputs, and belt tier
- [ ] Clear the snapshot — verify form values remain
- [ ] Verify the form is still disabled while the snapshot banner is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)