### PR TITLE
Retire belt-direction validator check (false positives on sideload patterns)

### DIFF
--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -1160,7 +1160,6 @@ mod tests {
         all_issues.extend(belt_flow::check_underground_belt_pairs(&layout));
         all_issues.extend(belt_flow::check_belt_connectivity(&layout, Some(&sr)));
         all_issues.extend(belt_flow::check_belt_flow_path(&layout, Some(&sr), crate::validate::LayoutStyle::Bus));
-        all_issues.extend(belt_flow::check_belt_direction_continuity(&layout));
 
         let errors: Vec<_> = all_issues.iter()
             .filter(|i| i.severity == Severity::Error)
@@ -1456,7 +1455,7 @@ mod tests {
         use crate::validate::underground::check_underground_belt_pairs;
         use crate::validate::belt_flow::{
             check_belt_dead_ends, check_belt_item_isolation, check_belt_loops,
-            check_belt_junctions, check_belt_direction_continuity,
+            check_belt_junctions,
         };
         use crate::validate::Severity;
 
@@ -1502,9 +1501,6 @@ mod tests {
                 if issue.severity == Severity::Error { all_errors.push(issue.message); }
             }
             for issue in check_belt_junctions(&layout) {
-                if issue.severity == Severity::Error { all_errors.push(issue.message); }
-            }
-            for issue in check_belt_direction_continuity(&layout) {
                 if issue.severity == Severity::Error { all_errors.push(issue.message); }
             }
 
@@ -1554,7 +1550,7 @@ mod tests {
         // Full validation — dead-ends, loops, isolation, etc.
         use crate::validate::belt_flow::{
             check_belt_dead_ends, check_belt_item_isolation, check_belt_loops,
-            check_belt_junctions, check_belt_direction_continuity,
+            check_belt_junctions,
         };
         use crate::validate::underground::check_underground_belt_pairs;
         use crate::validate::Severity;
@@ -1572,9 +1568,6 @@ mod tests {
             if issue.severity == Severity::Error { all_errors.push(issue.message.clone()); }
         }
         for issue in check_belt_junctions(&layout) {
-            if issue.severity == Severity::Error { all_errors.push(issue.message.clone()); }
-        }
-        for issue in check_belt_direction_continuity(&layout) {
             if issue.severity == Severity::Error { all_errors.push(issue.message.clone()); }
         }
         if !all_errors.is_empty() {

--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -1,9 +1,8 @@
-//! Belt connectivity, flow paths, direction continuity, reachability, network topology, junctions.
+//! Belt connectivity, flow paths, reachability, network topology, junctions.
 //!
 //! Port of the belt-check functions from `src/validate.py`:
 //! - `check_belt_connectivity`
 //! - `check_belt_flow_path`
-//! - `check_belt_direction_continuity`
 //! - `check_belt_network_topology`
 //! - `check_belt_junctions`
 //! - `check_belt_flow_reachability`
@@ -386,13 +385,6 @@ fn get_fluid_only_recipes(solver: Option<&SolverResult>) -> FxHashSet<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Opposite direction vector
-// ---------------------------------------------------------------------------
-
-fn opposite_vec((dx, dy): (i32, i32)) -> (i32, i32) {
-    (-dx, -dy)
-}
-
 // ---------------------------------------------------------------------------
 // 1. check_belt_connectivity
 // ---------------------------------------------------------------------------
@@ -723,57 +715,7 @@ pub fn check_belt_flow_path(
 }
 
 // ---------------------------------------------------------------------------
-// 3. check_belt_direction_continuity
-// ---------------------------------------------------------------------------
-
-pub fn check_belt_direction_continuity(layout: &LayoutResult) -> Vec<ValidationIssue> {
-    let mut issues = Vec::new();
-
-    let belt_dir_map = belt_dir_map_from(&layout.entities);
-    let mut checked: FxHashSet<((i32, i32), (i32, i32))> = FxHashSet::default();
-
-    for (&(bx, by), &direction) in &belt_dir_map {
-        let dir_vec = dir_to_vec(direction);
-        let opposite = opposite_vec(dir_vec);
-
-        for (dx, dy) in [(1, 0), (-1, 0), (0, 1), (0, -1)] {
-            let nb = (bx + dx, by + dy);
-            if !belt_dir_map.contains_key(&nb) {
-                continue;
-            }
-            let pair = if (bx, by) <= nb {
-                ((bx, by), nb)
-            } else {
-                (nb, (bx, by))
-            };
-            if !checked.insert(pair) {
-                continue;
-            }
-            let nb_dir = belt_dir_map[&nb];
-            let nb_vec = dir_to_vec(nb_dir);
-
-            // Only flag if 180° opposite AND the adjacency is along the flow axis
-            if nb_vec == opposite && ((dx, dy) == dir_vec || (dx, dy) == opposite) {
-                issues.push(ValidationIssue::with_pos(
-                    Severity::Warning,
-                    "belt-direction",
-                    format!(
-                        "Adjacent belts at ({},{}) and ({},{}) face opposite directions ({:?} vs {:?}), creating a dead spot",
-                        bx, by, nb.0, nb.1,
-                        direction, nb_dir
-                    ),
-                    bx,
-                    by,
-                ));
-            }
-        }
-    }
-
-    issues
-}
-
-// ---------------------------------------------------------------------------
-// 4. check_belt_network_topology
+// 3. check_belt_network_topology
 // ---------------------------------------------------------------------------
 
 pub fn check_belt_network_topology(
@@ -2866,69 +2808,6 @@ mod tests {
             .filter(|i| i.severity == Severity::Error && i.category == "belt-flow-path")
             .collect();
         assert_eq!(errors.len(), 1);
-    }
-
-    // --- check_belt_direction_continuity ---
-
-    #[test]
-    fn direction_continuity_same_direction_ok() {
-        let lr = LayoutResult {
-            entities: vec![
-                belt(0, 0, EntityDirection::East),
-                belt(1, 0, EntityDirection::East),
-            ],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        assert!(check_belt_direction_continuity(&lr).is_empty());
-    }
-
-    #[test]
-    fn direction_continuity_turn_ok() {
-        let lr = LayoutResult {
-            entities: vec![
-                belt(0, 0, EntityDirection::East),
-                belt(1, 0, EntityDirection::South),
-            ],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        assert!(check_belt_direction_continuity(&lr).is_empty());
-    }
-
-    #[test]
-    fn direction_continuity_head_on_warning() {
-        let lr = LayoutResult {
-            entities: vec![
-                belt(0, 0, EntityDirection::East),
-                belt(1, 0, EntityDirection::West),
-            ],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        let issues = check_belt_direction_continuity(&lr);
-        let warnings: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Warning).collect();
-        assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].category, "belt-direction");
-    }
-
-    #[test]
-    fn direction_continuity_parallel_opposite_ok() {
-        let lr = LayoutResult {
-            entities: vec![
-                belt(0, 0, EntityDirection::East),
-                belt(0, 1, EntityDirection::West),
-            ],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        let issues = check_belt_direction_continuity(&lr);
-        let warnings: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Warning).collect();
-        assert!(warnings.is_empty());
     }
 
     // --- check_belt_throughput ---

--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -19,7 +19,7 @@ use crate::models::{LayoutResult, SolverResult};
 use power::{check_pole_network_connectivity, check_power_coverage};
 
 use belt_flow::{
-    check_belt_connectivity, check_belt_direction_continuity, check_belt_flow_path,
+    check_belt_connectivity, check_belt_flow_path,
     check_belt_flow_reachability, check_belt_junctions, check_belt_network_topology,
     check_input_rate_delivery, check_underground_belt_entry_sideload,
     check_underground_belt_pairs, check_underground_belt_sideloading,
@@ -141,7 +141,6 @@ pub fn validate(
     issues.extend(check_fluid_port_connectivity(layout_result, layout_style));
     issues.extend(check_belt_connectivity(layout_result, solver_result));
     issues.extend(check_belt_flow_path(layout_result, solver_result, layout_style));
-    issues.extend(check_belt_direction_continuity(layout_result));
     issues.extend(belt_structural::check_entity_overlaps(layout_result));
     issues.extend(belt_structural::check_belt_throughput(layout_result));
     issues.extend(belt_structural::check_output_belt_coverage(layout_result, solver_result));

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -614,7 +614,6 @@ fn run_timed_validators(lr: &LayoutResult, sr: &SolverResult) {
         ("fluid_port_connectivity", Box::new(|| validate::check_fluid_port_connectivity(lr, LayoutStyle::Bus))),
         ("belt_connectivity", Box::new(|| belt_flow::check_belt_connectivity(lr, Some(sr)))),
         ("belt_flow_path", Box::new(|| belt_flow::check_belt_flow_path(lr, Some(sr), LayoutStyle::Bus))),
-        ("belt_direction_continuity", Box::new(|| belt_flow::check_belt_direction_continuity(lr))),
         ("entity_overlaps", Box::new(|| belt_structural::check_entity_overlaps(lr))),
         ("belt_throughput", Box::new(|| belt_structural::check_belt_throughput(lr))),
         ("output_belt_coverage", Box::new(|| belt_structural::check_output_belt_coverage(lr, Some(sr)))),


### PR DESCRIPTION
## Summary

- Removes `check_belt_direction_continuity` and its `opposite_vec` helper entirely from `crates/core/src/validate/belt_flow.rs`
- Drops the registration from the top-level `validate()` dispatcher in `validate/mod.rs`
- Removes all call sites in `bus/layout.rs` tests and `tests/e2e.rs`
- Deletes the four unit tests that specifically exercised the removed check

## Motivation

The check flagged any two adjacent belts facing opposite directions as a potential dead spot. This is correct for head-on collisions on a straight trunk, but the bus router's sideload-bridge templates and merger south columns routinely produce exactly this pattern as an intentional and legal Factorio layout. Because the check cannot distinguish a genuine dead spot from a sideload, it generated persistent false-positive warnings on template-stamped entities.

The `belt_flow_reachability` and `belt_flow_path` checks already catch real flow problems (items that genuinely cannot reach a sink). The signal-to-noise ratio for `belt-direction` was too low to justify keeping it.

## Test plan

- `cargo test --manifest-path crates/core/Cargo.toml` — 354 pass, 3 ignored (unchanged), 0 fail
- `cargo check` — clean
- Pre-existing clippy failures in `tapoff_search.rs` and `e2e.rs` are unrelated to this change and were already present on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)