### PR TITLE
fix(rust): pipe-to-ground output direction must face input

### DIFF
--- a/crates/core/src/bus/bus_router.rs
+++ b/crates/core/src/bus/bus_router.rs
@@ -2633,7 +2633,7 @@ fn chain_ptg_pairs_vertical(
             name: "pipe-to-ground".to_string(),
             x,
             y: out_pos,
-            direction: EntityDirection::South,
+            direction: EntityDirection::North,
             io_type: Some("output".to_string()),
             carries: Some(item.to_string()),
             ..Default::default()
@@ -2678,7 +2678,7 @@ fn chain_ptg_pairs_horizontal(
             name: "pipe-to-ground".to_string(),
             x: out_pos,
             y,
-            direction: EntityDirection::East,
+            direction: EntityDirection::West,
             io_type: Some("output".to_string()),
             carries: Some(item.to_string()),
             ..Default::default()

--- a/crates/core/src/bus/templates.rs
+++ b/crates/core/src/bus/templates.rs
@@ -755,12 +755,12 @@ pub fn fluid_input_row(
                 });
             }
 
-            // y+3: UG pipe OUT adjacent to machine fluid port + inserter for solid
+            // y+3: UG pipe OUT facing north (back toward input) adjacent to machine fluid port
             entities.push(PlacedEntity {
                 name: "pipe-to-ground".to_string(),
                 x: mx + port_dx,
                 y: interface_y,
-                direction: EntityDirection::South,
+                direction: EntityDirection::North,
                 io_type: Some("output".to_string()),
                 carries: Some(fluid_item.to_string()),
                 segment_id: fluid_in_seg.clone(),
@@ -929,7 +929,7 @@ pub fn fluid_input_row(
 ///   y+2 : solid input belt 1 (EAST) -- far belt
 ///   y+3 : solid input belt 2 (EAST) -- close belt
 ///   y+4 : long-handed-inserter at mx+1 + inserter at mx+2 +
-///           pipe-to-ground output at mx+port_dx (direction SOUTH)
+///           pipe-to-ground output at mx+port_dx (direction NORTH, faces input)
 ///   y+5..y+5+msz-1 : machine (msz×msz)
 ///   y+5+msz : fluid output pipes (if output_is_fluid) OR output inserter
 ///   y+5+msz+1 : output belt (solid output only)
@@ -1013,7 +1013,7 @@ pub fn fluid_dual_input_row(
             name: "pipe-to-ground".to_string(),
             x: mx + port_dx,
             y: inserter_y,
-            direction: EntityDirection::South,
+            direction: EntityDirection::North,
             io_type: Some("output".to_string()),
             carries: Some(fluid_item.to_string()),
             segment_id: fluid_in_seg.clone(),
@@ -1639,9 +1639,9 @@ mod tests {
             assert_eq!(b.carries.as_deref(), Some("coal"));
         }
 
-        // Machine 1: UG pipe OUT at (0, 3) facing South, io=output
+        // Machine 1: UG pipe OUT at (0, 3) facing North (back toward input), io=output
         let ptg_out = assert_entity(&entities, 0, 3, "pipe-to-ground");
-        assert_eq!(ptg_out.direction, EntityDirection::South);
+        assert_eq!(ptg_out.direction, EntityDirection::North);
         assert_eq!(ptg_out.io_type.as_deref(), Some("output"));
         assert_eq!(ptg_out.carries.as_deref(), Some("petroleum-gas"));
 
@@ -1662,9 +1662,9 @@ mod tests {
         assert_eq!(ptg2_in.direction, EntityDirection::South);
         assert_eq!(ptg2_in.io_type.as_deref(), Some("input"));
 
-        // Machine 2: UG pipe OUT at (3, 3) facing South
+        // Machine 2: UG pipe OUT at (3, 3) facing North (back toward input)
         let ptg2_out = assert_entity(&entities, 3, 3, "pipe-to-ground");
-        assert_eq!(ptg2_out.direction, EntityDirection::South);
+        assert_eq!(ptg2_out.direction, EntityDirection::North);
         assert_eq!(ptg2_out.io_type.as_deref(), Some("output"));
 
         // Machine 2 at (3, 4)
@@ -1802,9 +1802,9 @@ mod tests {
         assert_eq!(ptg_in.direction, EntityDirection::South);
         assert_eq!(ptg_in.io_type.as_deref(), Some("input"));
 
-        // PTG output at (0+0, 4) = (0, 4) direction SOUTH
+        // PTG output at (0+0, 4) = (0, 4) direction NORTH (faces input)
         let ptg_out = assert_entity(&entities, 0, 4, "pipe-to-ground");
-        assert_eq!(ptg_out.direction, EntityDirection::South);
+        assert_eq!(ptg_out.direction, EntityDirection::North);
         assert_eq!(ptg_out.io_type.as_deref(), Some("output"));
 
         // Solid input belt 1 at y=2

--- a/crates/core/src/validate/fluids.rs
+++ b/crates/core/src/validate/fluids.rs
@@ -99,6 +99,15 @@ fn fluid_ports(entity_name: &str, mirror: bool) -> &'static [(i32, i32, &'static
 // check_pipe_isolation
 // ---------------------------------------------------------------------------
 
+fn opposite_direction(dir: EntityDirection) -> EntityDirection {
+    match dir {
+        EntityDirection::North => EntityDirection::South,
+        EntityDirection::South => EntityDirection::North,
+        EntityDirection::East => EntityDirection::West,
+        EntityDirection::West => EntityDirection::East,
+    }
+}
+
 /// For a pipe-to-ground entity, return the single surface-side neighbour tile.
 ///
 /// Input PTGs expose their surface on the side *opposite* their flow direction
@@ -216,64 +225,49 @@ pub fn check_pipe_isolation(layout_result: &LayoutResult) -> Vec<ValidationIssue
 
 /// Find pipe-to-ground pairs: returns a bidirectional map `pos_a ↔ pos_b`.
 ///
-/// PTGs travelling in the same direction along the same axis are paired:
-/// each input is matched with the nearest downstream output.
+/// PTG pairs must face each other along the same axis:
+/// input faces East ↔ output faces West (same y), or
+/// input faces South ↔ output faces North (same x).
 fn find_ptg_pairs(layout_result: &LayoutResult) -> FxHashMap<(i32, i32), (i32, i32)> {
-    // Group PTGs by (direction, axis_value).
-    // EAST/WEST flow → axis is y; NORTH/SOUTH flow → axis is x.
-    type GroupKey = (u8, i32); // (direction as u8, axis)
-    let mut groups: FxHashMap<GroupKey, Vec<&PlacedEntity>> = FxHashMap::default();
+    // Collect inputs and outputs separately
+    let mut inputs: Vec<&PlacedEntity> = Vec::new();
+    let mut outputs: Vec<&PlacedEntity> = Vec::new();
 
     for e in &layout_result.entities {
         if e.name != "pipe-to-ground" {
             continue;
         }
-        let axis = match e.direction {
-            EntityDirection::East | EntityDirection::West => e.y,
-            EntityDirection::North | EntityDirection::South => e.x,
-        };
-        groups
-            .entry((e.direction as u8, axis))
-            .or_default()
-            .push(e);
+        match e.io_type.as_deref() {
+            Some("input") => inputs.push(e),
+            Some("output") => outputs.push(e),
+            _ => {}
+        }
     }
 
     let mut pairs: FxHashMap<(i32, i32), (i32, i32)> = FxHashMap::default();
 
-    for group in groups.values() {
-        let mut inputs: Vec<&PlacedEntity> = group
-            .iter()
-            .copied()
-            .filter(|e| e.io_type.as_deref() == Some("input"))
-            .collect();
-        let mut outputs: Vec<&PlacedEntity> = group
-            .iter()
-            .copied()
-            .filter(|e| e.io_type.as_deref() == Some("output"))
-            .collect();
+    // For each input, find the nearest output that faces back toward it on the same axis.
+    let mut remaining: Vec<&PlacedEntity> = outputs;
 
-        inputs.sort_by_key(|e| (e.x, e.y));
-        outputs.sort_by_key(|e| (e.x, e.y));
-
-        let mut remaining = outputs;
-
-        for inp in &inputs {
-            let dir = inp.direction;
-            let matched_idx = remaining.iter().position(|out| {
-                match dir {
-                    EntityDirection::East => out.x > inp.x,
-                    EntityDirection::West => out.x < inp.x,
-                    EntityDirection::South => out.y > inp.y,
-                    EntityDirection::North => out.y < inp.y,
-                }
-            });
-            if let Some(idx) = matched_idx {
-                let out = remaining.remove(idx);
-                let a = (inp.x, inp.y);
-                let b = (out.x, out.y);
-                pairs.insert(a, b);
-                pairs.insert(b, a);
+    for inp in &inputs {
+        let expected_dir = opposite_direction(inp.direction);
+        let matched_idx = remaining.iter().position(|out| {
+            if out.direction != expected_dir {
+                return false;
             }
+            match inp.direction {
+                EntityDirection::East => out.y == inp.y && out.x > inp.x,
+                EntityDirection::West => out.y == inp.y && out.x < inp.x,
+                EntityDirection::South => out.x == inp.x && out.y > inp.y,
+                EntityDirection::North => out.x == inp.x && out.y < inp.y,
+            }
+        });
+        if let Some(idx) = matched_idx {
+            let out = remaining.remove(idx);
+            let a = (inp.x, inp.y);
+            let b = (out.x, out.y);
+            pairs.insert(a, b);
+            pairs.insert(b, a);
         }
     }
 
@@ -738,7 +732,7 @@ mod tests {
     fn ptg_pairs_east_direction() {
         let lr = layout(vec![
             ptg(0, 0, EntityDirection::East, "input", None),
-            ptg(3, 0, EntityDirection::East, "output", None),
+            ptg(3, 0, EntityDirection::West, "output", None),
         ]);
         let pairs = find_ptg_pairs(&lr);
         assert_eq!(pairs.get(&(0, 0)), Some(&(3, 0)));
@@ -749,7 +743,7 @@ mod tests {
     fn ptg_pairs_north_direction() {
         let lr = layout(vec![
             ptg(0, 3, EntityDirection::North, "input", None),
-            ptg(0, 0, EntityDirection::North, "output", None),
+            ptg(0, 0, EntityDirection::South, "output", None),
         ]);
         let pairs = find_ptg_pairs(&lr);
         assert_eq!(pairs.get(&(0, 3)), Some(&(0, 0)));
@@ -758,7 +752,7 @@ mod tests {
 
     #[test]
     fn ptg_pairs_wrong_direction_not_paired() {
-        // Output is behind the input (EAST flow) → no pairing
+        // Output faces same direction as input instead of opposite → no pairing
         let lr = layout(vec![
             ptg(3, 0, EntityDirection::East, "input", None),
             ptg(0, 0, EntityDirection::East, "output", None),


### PR DESCRIPTION
## Summary

Pipe-to-ground entities in Factorio must face **each other** to connect underground. The layout engine was giving both entities in a pair the **same** direction (e.g. both East), making the pair impossible to connect in-game.

**Placement fixes** (`bus_router.rs`, `templates.rs`):
- Vertical PTG pairs: output now faces North (was South)
- Horizontal PTG pairs: output now faces West (was East)
- Two row-template PTG outputs: now face North (was South)

**Validator fix** (`validate/fluids.rs`):
- `find_ptg_pairs` grouped PTGs by same direction — it happily paired two East-facing PTGs and never flagged the impossible layout
- Rewritten to require opposite-facing pairs on the same axis
- Updated tests to encode correct behavior
- Added `opposite_direction` helper

## Test plan
- [x] `cargo test -p fucktorio_core --lib` — 354 passed, 0 failed
- [x] `cargo clippy -p fucktorio_core -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)