### PR TITLE
Fix solo-regions alpha reset, add ghost path visualization

### DIFF
--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -421,6 +421,8 @@ pub fn route_bus_ghost(
                     path_len: path.len(),
                     crossings: crossings.len(),
                     turns,
+                    tiles: path.clone(),
+                    crossing_tiles: crossings.clone(),
                 });
 
                 // Emit entities via render_path

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -271,6 +271,8 @@ pub enum TraceEvent {
         path_len: usize,
         crossings: usize,
         turns: usize,
+        tiles: Vec<(i32, i32)>,
+        crossing_tiles: Vec<(i32, i32)>,
     },
     GhostSpecFailed {
         spec_key: String,

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -172,6 +172,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   let regionsCb: HTMLInputElement;
   let soloRegionsCb: HTMLInputElement;
 
+  // Solo-regions flag: true whenever solo mode is active (persists across re-renders)
+  let soloRegionsActive = false;
   // Solo-regions state: saved toggle states before solo mode was enabled
   let soloSavedState: {
     colorChecked: boolean;
@@ -841,6 +843,10 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       viewport.fit(true, pxW * 1.1, pxH * 1.2);
       viewport.moveCenter(pxW / 2, pxH / 2);
     }
+    // Re-apply solo-regions dimming after entity layer rebuild
+    if (soloRegionsActive) {
+      entityLayer.alpha = 0.12;
+    }
   }
 
   // Ctrl+C: copy selection JSON when entities are selected
@@ -952,6 +958,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
         soloRegionsCb.addEventListener("change", () => {
           if (soloRegionsCb.checked) {
+            soloRegionsActive = true;
             // Entering solo mode: save current state
             soloSavedState = {
               colorChecked: colorCb.checked,
@@ -993,6 +1000,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
             // Ensure region overlay is on top after re-render
             updateRegionOverlay();
           } else {
+            soloRegionsActive = false;
             // Exiting solo mode: restore previous state
             if (soloSavedState) {
               entityLayer.alpha = soloSavedState.entityAlpha;

--- a/web/src/renderer/traceOverlay.ts
+++ b/web/src/renderer/traceOverlay.ts
@@ -13,6 +13,9 @@ type RouteFailureEvent = Extract<TraceEvent, { phase: "RouteFailure" }>;
 type LaneConsolidatedEvent = Extract<TraceEvent, { phase: "LaneConsolidated" }>;
 type RowSplitEvent = Extract<TraceEvent, { phase: "RowSplit" }>;
 type LaneOrderOptimizedEvent = Extract<TraceEvent, { phase: "LaneOrderOptimized" }>;
+type GhostSpecRoutedEvent = Extract<TraceEvent, { phase: "GhostSpecRouted" }>;
+type GhostSpecFailedEvent = Extract<TraceEvent, { phase: "GhostSpecFailed" }>;
+type GhostRoutingCompleteEvent = Extract<TraceEvent, { phase: "GhostRoutingComplete" }>;
 
 /** Draw a dashed line segment on a Graphics context. */
 function drawDashedLine(
@@ -188,10 +191,95 @@ export function renderTraceOverlay(
     layer.addChild(label);
   }
 
-  // --- Phase summary label (top-left, above layout) ---
+  const summaryStyle = new TextStyle({ fontSize: 10, fill: "#aaa", fontFamily: "monospace" });
+
+  // --- Ghost routing paths (from GhostSpecRouted) ---
+  const ghostPalette = [
+    0x569cd6, 0xd0a040, 0x6ac080, 0xc06090, 0x70b0e0,
+    0xb080d0, 0xe07050, 0x60c0c0, 0xd0d060, 0x80b060,
+  ];
+  let ghostPathIdx = 0;
+  for (const evt of events) {
+    if (evt.phase !== "GhostSpecRouted") continue;
+    const d = (evt as GhostSpecRoutedEvent).data;
+    const color = ghostPalette[ghostPathIdx % ghostPalette.length];
+    ghostPathIdx++;
+    const g = new Graphics();
+    // Draw path polyline through tile centers
+    if (d.tiles && d.tiles.length > 1) {
+      g.setStrokeStyle({ width: 3, color, alpha: 0.7 });
+      g.moveTo(d.tiles[0][0] * TILE_PX + TILE_PX / 2, d.tiles[0][1] * TILE_PX + TILE_PX / 2);
+      for (let i = 1; i < d.tiles.length; i++) {
+        g.lineTo(d.tiles[i][0] * TILE_PX + TILE_PX / 2, d.tiles[i][1] * TILE_PX + TILE_PX / 2);
+      }
+      g.stroke();
+    }
+    // Crossing tiles as yellow diamonds
+    if (d.crossing_tiles) {
+      for (const [cx, cy] of d.crossing_tiles) {
+        const px = cx * TILE_PX + TILE_PX / 2;
+        const py = cy * TILE_PX + TILE_PX / 2;
+        const ds = TILE_PX * 0.25;
+        g.moveTo(px, py - ds).lineTo(px + ds, py).lineTo(px, py + ds).lineTo(px - ds, py).closePath()
+          .fill({ color: 0xffdd00, alpha: 0.85 });
+      }
+    }
+    g.eventMode = "static";
+    g.on("pointerenter", () => onHover(`Ghost path: ${d.spec_key} len=${d.path_len} crossings=${d.crossings} turns=${d.turns}`));
+    g.on("pointerleave", () => onHover(null));
+    layer.addChild(g);
+  }
+
+  // --- Ghost spec failures (from GhostSpecFailed) ---
+  for (const evt of events) {
+    if (evt.phase !== "GhostSpecFailed") continue;
+    const d = (evt as GhostSpecFailedEvent).data;
+    const cx = d.from_x * TILE_PX + TILE_PX / 2;
+    const cy = d.from_y * TILE_PX + TILE_PX / 2;
+    const halfSpan = 4;
+    const g = new Graphics();
+    g.label = "RouteFailure";
+    g.moveTo(cx - halfSpan, cy - halfSpan).lineTo(cx + halfSpan, cy + halfSpan).stroke({ width: 2, color: 0xff3333 });
+    g.moveTo(cx + halfSpan, cy - halfSpan).lineTo(cx - halfSpan, cy + halfSpan).stroke({ width: 2, color: 0xff3333 });
+    drawDashedLine(g, cx, cy, d.to_x * TILE_PX + TILE_PX / 2, d.to_y * TILE_PX + TILE_PX / 2,
+      6, 4, { width: 1, color: 0xff3333, alpha: 0.6 });
+    g.eventMode = "static";
+    g.on("pointerenter", () => onHover(`Ghost failed: ${d.spec_key} (${d.from_x},${d.from_y})→(${d.to_x},${d.to_y})`));
+    g.on("pointerleave", () => onHover(null));
+    layer.addChild(g);
+  }
+
+  // --- Ghost cluster zones (from GhostClusterSolved / GhostClusterFailed) ---
+  for (const evt of events) {
+    if (evt.phase !== "GhostClusterSolved" && evt.phase !== "GhostClusterFailed") continue;
+    const isFailed = evt.phase === "GhostClusterFailed";
+    const solved = isFailed ? null : (evt as Extract<TraceEvent, { phase: "GhostClusterSolved" }>).data;
+    const failed = isFailed ? (evt as Extract<TraceEvent, { phase: "GhostClusterFailed" }>).data : null;
+    const base = solved ?? failed!;
+    const color = isFailed ? 0xff4444 : 0x44aaff;
+    const g = new Graphics();
+    g.rect(base.zone_x * TILE_PX, base.zone_y * TILE_PX, base.zone_w * TILE_PX, base.zone_h * TILE_PX)
+      .fill({ color, alpha: isFailed ? 0.15 : 0.08 })
+      .stroke({ width: isFailed ? 2 : 1, color, alpha: isFailed ? 0.9 : 0.6 });
+    g.eventMode = "static";
+    const solveInfo = solved ? ` vars=${solved.variables} clauses=${solved.clauses} ${(solved.solve_time_us / 1000).toFixed(1)}ms` : "";
+    g.on("pointerenter", () => onHover(`Cluster #${base.cluster_id}: ${base.zone_w}x${base.zone_h} @ (${base.zone_x},${base.zone_y}) ${base.boundary_count} ports${solveInfo}${isFailed ? " FAILED" : ""}`));
+    g.on("pointerleave", () => onHover(null));
+    layer.addChild(g);
+  }
+
+  // --- Ghost routing summary (from GhostRoutingComplete) ---
+  const ghostComplete = events.find((e): e is GhostRoutingCompleteEvent => e.phase === "GhostRoutingComplete");
+  if (ghostComplete) {
+    const d = ghostComplete.data;
+    const info = `Ghost: ${d.entity_count} entities, ${d.cluster_count} clusters (max ${d.max_cluster_tiles} tiles), ${d.unroutable_count} unroutable`;
+    const summaryGhost = new Text({ text: info, style: summaryStyle });
+    summaryGhost.x = 4;
+    summaryGhost.y = -28;
+    layer.addChild(summaryGhost);
+  }
   const phaseNames = events.map(e => e.phase);
   const uniquePhases = [...new Set(phaseNames)];
-  const summaryStyle = new TextStyle({ fontSize: 10, fill: "#aaa", fontFamily: "monospace" });
   const laneOrder = events.find((e): e is LaneOrderOptimizedEvent => e.phase === "LaneOrderOptimized");
   const crossingSuffix = laneOrder ? ` | lane order: ${laneOrder.data.crossing_score} crossings` : "";
   const summaryText = new Text({ text: `Trace: ${uniquePhases.join(" → ")}${crossingSuffix}`, style: summaryStyle });


### PR DESCRIPTION
## Summary

- **Fixes #141**: Entity layer alpha no longer resets to 1.0 when loading a new layout or snapshot while solo-regions mode is active. A persistent `soloRegionsActive` flag re-applies `entityLayer.alpha = 0.12` after re-renders.
- **Ghost path visualization**: The trace overlay now renders ghost A* routing data — colored polylines for each routed spec, yellow diamond markers at crossing tiles, blue/red rectangles for solved/failed SAT clusters, and red cross markers for failed specs with dashed lines to their targets.
- **Trace event enrichment**: `GhostSpecRouted` now carries actual `tiles` and `crossing_tiles` coordinates from the Rust side so the frontend can draw paths instead of just metadata.

## Test plan

- [ ] Enable Solo regions toggle → generate a new layout → entity layer stays dimmed at 12%
- [ ] Load a snapshot while solo mode is active → entity layer stays dimmed
- [ ] Disable solo mode → entity layer restores to previous alpha
- [ ] Run with `FUCKTORIO_GHOST_ROUTING=1`, enable Debug overlay → ghost paths visible as colored lines
- [ ] Hover ghost path → tooltip shows spec_key, crossings, turns
- [ ] Yellow diamonds mark crossing tiles; cluster zones show as colored rectangles
- [ ] `cargo test --manifest-path crates/core/Cargo.toml` passes
- [ ] WASM rebuild + `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)