### PR TITLE
UI cleanup: overlay panel, default colours off, remove placeholder

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -41,7 +41,7 @@
   </head>
   <body>
     <div id="app">
-      <div id="sidebar" style="display:none">Solver output will appear here</div>
+      <div id="sidebar" style="display:none"></div>
       <div id="canvas-container" style="display:none"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -157,21 +157,40 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   }
 
   // --- Cursor tile position overlay ---
-  const coordsEl = document.createElement("div");
-  coordsEl.style.cssText = "position:absolute;bottom:8px;right:8px;background:rgba(0,0,0,0.6);color:#aaa;font:11px monospace;padding:3px 7px;border-radius:3px;pointer-events:none;z-index:10";
-  coordsEl.textContent = "x:\u2013 y:\u2013";
+  // --- Canvas overlay controls (bottom-right, pinned) ---
+  const overlayPanel = document.createElement("div");
+  overlayPanel.style.cssText = "position:absolute;bottom:8px;right:8px;background:rgba(0,0,0,0.6);color:#aaa;font:11px monospace;padding:4px 8px;border-radius:3px;z-index:10;display:flex;flex-direction:column;gap:2px;user-select:none";
   container.style.position = "relative";
-  container.appendChild(coordsEl);
 
-  // Display toggles are created by the sidebar and wired via onDisplayToggles callback.
-  // Forward-declare checkbox references — they get populated by onDisplayToggles.
+  const coordsEl = document.createElement("div");
+  coordsEl.style.cssText = "color:#aaa;font:11px monospace;pointer-events:none";
+  coordsEl.textContent = "x:\u2013 y:\u2013";
+  overlayPanel.appendChild(coordsEl);
+
+  function makeOverlayToggle(label: string, checked = false): HTMLInputElement {
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = checked;
+    cb.style.cssText = "accent-color:#569cd6;width:12px;height:12px;margin:0;vertical-align:middle";
+    const lbl = document.createElement("label");
+    lbl.style.cssText = "display:flex;align-items:center;gap:4px;cursor:pointer;font-size:10px;color:#888";
+    lbl.appendChild(cb);
+    lbl.appendChild(document.createTextNode(label));
+    overlayPanel.appendChild(lbl);
+    return cb;
+  }
+
+  const debugCb = makeOverlayToggle("Debug");
+  const valCb = makeOverlayToggle("Validation");
+  const regionsCb = makeOverlayToggle("SAT Zones");
+  const soloRegionsCb = makeOverlayToggle("Solo regions");
+  const ghostCb = makeOverlayToggle("Ghost routes");
+
+  container.appendChild(overlayPanel);
+
+  // Sidebar toggles — populated via onDisplayToggles callback.
   let colorCb: HTMLInputElement;
   let rateCb: HTMLInputElement;
-  let debugCb: HTMLInputElement;
-  let valCb: HTMLInputElement;
-  let regionsCb: HTMLInputElement;
-  let soloRegionsCb: HTMLInputElement;
-  let ghostCb: HTMLInputElement;
 
   // Solo-regions flag: true whenever solo mode is active (persists across re-renders)
   let soloRegionsActive = false;
@@ -847,7 +866,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     for (const e of layout.entities) {
       if (e.carries) items.add(e.carries);
     }
-    if (items.size === 0) {
+    if (items.size === 0 || !colorCb.checked) {
       legendEl.style.display = "none";
       return;
     }
@@ -990,109 +1009,109 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       onDisplayToggles: (toggles: DisplayToggles) => {
         colorCb = toggles.colorCb;
         rateCb = toggles.rateCb;
-        debugCb = toggles.debugCb;
-        valCb = toggles.valCb;
-        regionsCb = toggles.regionsCb;
-        soloRegionsCb = toggles.soloRegionsCb;
-        ghostCb = toggles.ghostCb;
 
-        // Wire up the same listeners that used to be on the canvas toggles.
         colorCb.addEventListener("change", () => {
           setItemColoring(colorCb.checked);
-          if (lastLayout) renderLayoutOnCanvas(lastLayout);
+          if (!colorCb.checked) {
+            legendEl.style.display = "none";
+          } else if (lastLayout) {
+            renderLayoutOnCanvas(lastLayout);
+          }
         });
         rateCb.addEventListener("change", () => {
           setRateOverlay(rateCb.checked);
           if (lastLayout) renderLayoutOnCanvas(lastLayout);
         });
-        debugCb.addEventListener("change", () => {
-          tracePhaseIndex = -1;
-          updateTraceOverlay();
-        });
-        valCb.addEventListener("change", updateValidationOverlay);
-        regionsCb.addEventListener("change", updateRegionOverlay);
-        ghostCb.addEventListener("change", updateGhostOverlay);
-
-        soloRegionsCb.addEventListener("change", () => {
-          if (soloRegionsCb.checked) {
-            soloRegionsActive = true;
-            // Entering solo mode: save current state
-            soloSavedState = {
-              colorChecked: colorCb.checked,
-              rateChecked: rateCb.checked,
-              valChecked: valCb.checked,
-              regionsChecked: regionsCb.checked,
-              entityAlpha: entityLayer.alpha,
-            };
-
-            // Turn on SAT zones
-            if (!regionsCb.checked) {
-              regionsCb.checked = true;
-              updateRegionOverlay();
-            }
-
-            // Hide item colours
-            if (colorCb.checked) {
-              colorCb.checked = false;
-              setItemColoring(false);
-              if (lastLayout) renderLayoutOnCanvas(lastLayout);
-            }
-
-            // Hide rate labels
-            if (rateCb.checked) {
-              rateCb.checked = false;
-              setRateOverlay(false);
-              if (lastLayout) renderLayoutOnCanvas(lastLayout);
-            }
-
-            // Hide validation overlay
-            if (valCb.checked) {
-              valCb.checked = false;
-              updateValidationOverlay();
-            }
-
-            // Dim entity layer
-            entityLayer.alpha = 0.12;
-
-            // Ensure region overlay is on top after re-render
-            updateRegionOverlay();
-          } else {
-            soloRegionsActive = false;
-            // Exiting solo mode: restore previous state
-            if (soloSavedState) {
-              entityLayer.alpha = soloSavedState.entityAlpha;
-
-              // Restore regions checkbox
-              if (regionsCb.checked !== soloSavedState.regionsChecked) {
-                regionsCb.checked = soloSavedState.regionsChecked;
-                updateRegionOverlay();
-              }
-
-              // Restore validation
-              if (valCb.checked !== soloSavedState.valChecked) {
-                valCb.checked = soloSavedState.valChecked;
-                updateValidationOverlay();
-              }
-
-              // Restore item colours
-              if (colorCb.checked !== soloSavedState.colorChecked) {
-                colorCb.checked = soloSavedState.colorChecked;
-                setItemColoring(colorCb.checked);
-                if (lastLayout) renderLayoutOnCanvas(lastLayout);
-              }
-
-              // Restore rate labels
-              if (rateCb.checked !== soloSavedState.rateChecked) {
-                rateCb.checked = soloSavedState.rateChecked;
-                setRateOverlay(rateCb.checked);
-                if (lastLayout) renderLayoutOnCanvas(lastLayout);
-              }
-
-              soloSavedState = null;
-            }
-          }
-        });
       },
+    });
+
+    // Wire overlay panel toggles (created above, independent of sidebar)
+    debugCb.addEventListener("change", () => {
+      tracePhaseIndex = -1;
+      updateTraceOverlay();
+    });
+    valCb.addEventListener("change", updateValidationOverlay);
+    regionsCb.addEventListener("change", updateRegionOverlay);
+    ghostCb.addEventListener("change", updateGhostOverlay);
+
+    soloRegionsCb.addEventListener("change", () => {
+      if (soloRegionsCb.checked) {
+        soloRegionsActive = true;
+        // Entering solo mode: save current state
+        soloSavedState = {
+          colorChecked: colorCb.checked,
+          rateChecked: rateCb.checked,
+          valChecked: valCb.checked,
+          regionsChecked: regionsCb.checked,
+          entityAlpha: entityLayer.alpha,
+        };
+
+        // Turn on SAT zones
+        if (!regionsCb.checked) {
+          regionsCb.checked = true;
+          updateRegionOverlay();
+        }
+
+        // Hide item colours
+        if (colorCb.checked) {
+          colorCb.checked = false;
+          setItemColoring(false);
+          if (lastLayout) renderLayoutOnCanvas(lastLayout);
+        }
+
+        // Hide rate labels
+        if (rateCb.checked) {
+          rateCb.checked = false;
+          setRateOverlay(false);
+          if (lastLayout) renderLayoutOnCanvas(lastLayout);
+        }
+
+        // Hide validation overlay
+        if (valCb.checked) {
+          valCb.checked = false;
+          updateValidationOverlay();
+        }
+
+        // Dim entity layer
+        entityLayer.alpha = 0.12;
+
+        // Ensure region overlay is on top after re-render
+        updateRegionOverlay();
+      } else {
+        soloRegionsActive = false;
+        // Exiting solo mode: restore previous state
+        if (soloSavedState) {
+          entityLayer.alpha = soloSavedState.entityAlpha;
+
+          // Restore regions checkbox
+          if (regionsCb.checked !== soloSavedState.regionsChecked) {
+            regionsCb.checked = soloSavedState.regionsChecked;
+            updateRegionOverlay();
+          }
+
+          // Restore validation
+          if (valCb.checked !== soloSavedState.valChecked) {
+            valCb.checked = soloSavedState.valChecked;
+            updateValidationOverlay();
+          }
+
+          // Restore item colours
+          if (colorCb.checked !== soloSavedState.colorChecked) {
+            colorCb.checked = soloSavedState.colorChecked;
+            setItemColoring(colorCb.checked);
+            if (lastLayout) renderLayoutOnCanvas(lastLayout);
+          }
+
+          // Restore rate labels
+          if (rateCb.checked !== soloSavedState.rateChecked) {
+            rateCb.checked = soloSavedState.rateChecked;
+            setRateOverlay(rateCb.checked);
+            if (lastLayout) renderLayoutOnCanvas(lastLayout);
+          }
+
+          soloSavedState = null;
+        }
+      }
     });
 
     initCorpusPanel(corpusPanel, renderLayoutOnCanvas);

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -513,11 +513,6 @@ export interface SidebarOptions {
 export interface DisplayToggles {
   colorCb: HTMLInputElement;
   rateCb: HTMLInputElement;
-  debugCb: HTMLInputElement;
-  valCb: HTMLInputElement;
-  regionsCb: HTMLInputElement;
-  soloRegionsCb: HTMLInputElement;
-  ghostCb: HTMLInputElement;
 }
 
 export function renderSidebar(
@@ -713,7 +708,7 @@ export function renderSidebar(
 
   const colorCb = document.createElement("input");
   colorCb.type = "checkbox";
-  colorCb.checked = true;
+  colorCb.checked = false;
   const colorToggle = document.createElement("label");
   colorToggle.className = "sb-toggle";
   colorToggle.appendChild(colorCb);
@@ -729,58 +724,13 @@ export function renderSidebar(
   rateToggle.appendChild(document.createTextNode("Rates"));
   togglesWrap.appendChild(rateToggle);
 
-  const debugCb = document.createElement("input");
-  debugCb.type = "checkbox";
-  debugCb.checked = false;
-  const debugToggle = document.createElement("label");
-  debugToggle.className = "sb-toggle";
-  debugToggle.appendChild(debugCb);
-  debugToggle.appendChild(document.createTextNode("Debug"));
-  togglesWrap.appendChild(debugToggle);
-
-  const valCb = document.createElement("input");
-  valCb.type = "checkbox";
-  valCb.checked = false;
-  const valToggle = document.createElement("label");
-  valToggle.className = "sb-toggle";
-  valToggle.appendChild(valCb);
-  valToggle.appendChild(document.createTextNode("Validation"));
-  togglesWrap.appendChild(valToggle);
-
-  const regionsCb = document.createElement("input");
-  regionsCb.type = "checkbox";
-  regionsCb.checked = false;
-  const regionsToggle = document.createElement("label");
-  regionsToggle.className = "sb-toggle";
-  regionsToggle.appendChild(regionsCb);
-  regionsToggle.appendChild(document.createTextNode("SAT Zones"));
-  togglesWrap.appendChild(regionsToggle);
-
-  const soloRegionsCb = document.createElement("input");
-  soloRegionsCb.type = "checkbox";
-  soloRegionsCb.checked = false;
-  const soloRegionsToggle = document.createElement("label");
-  soloRegionsToggle.className = "sb-toggle";
-  soloRegionsToggle.appendChild(soloRegionsCb);
-  soloRegionsToggle.appendChild(document.createTextNode("Solo regions"));
-  togglesWrap.appendChild(soloRegionsToggle);
-
-  const ghostCb = document.createElement("input");
-  ghostCb.type = "checkbox";
-  ghostCb.checked = false;
-  const ghostToggle = document.createElement("label");
-  ghostToggle.className = "sb-toggle";
-  ghostToggle.appendChild(ghostCb);
-  ghostToggle.appendChild(document.createTextNode("Ghost routes"));
-  togglesWrap.appendChild(ghostToggle);
-
   displayBody.appendChild(togglesWrap);
   // Mark display section so snapshot mode doesn't disable its controls
   displaySection.setAttribute("data-snapshot-keep", "");
   inner.appendChild(displaySection);
 
   // Expose toggles to main.ts
-  options?.onDisplayToggles?.({ colorCb, rateCb, debugCb, valCb, regionsCb, soloRegionsCb, ghostCb });
+  options?.onDisplayToggles?.({ colorCb, rateCb });
 
   el.appendChild(inner);
 


### PR DESCRIPTION
## Summary
- Remove stale "Solver output will appear here" placeholder text from `#sidebar` div
- Default "Item colours" toggle to off; hide the legend when colours are disabled (all entities same colour = no legend needed)
- Move layout-affecting toggles (Debug, Validation, SAT Zones, Solo regions, Ghost routes) from sidebar Display section to a pinned bottom-right panel on the canvas, always visible and independent of sidebar scroll

## Test plan
- [ ] Load page → no placeholder text flash
- [ ] Generate layout → entities are all default colour, no legend shown
- [ ] Enable "Item colours" in sidebar → colours apply, legend appears
- [ ] Disable "Item colours" → legend disappears
- [ ] Bottom-right overlay panel shows 5 toggles, always pinned
- [ ] All toggles work identically to before (debug trace, validation overlay, SAT zones, solo regions, ghost routes)
- [ ] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)