### PR TITLE
refactor(ghost): shared Occupancy map for template/SAT phases

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -30,6 +30,7 @@ The bus layout works but is wider/taller than necessary in many cases.
 - [ ] Dead lane elimination — remove bus lanes that carry zero throughput after splitting/balancing
 - [ ] Multi-tile entity positioning — assemblers and chemical plants use center-offset positioning; verify blueprint export handles 3x3 and 3x3+ footprints correctly (there's a TODO in blueprint.rs)
 - [ ] Row merging — when two recipe groups have compatible input sets, consider placing them in adjacent rows sharing tap-offs
+- [ ] **Ghost router: A* allows goal/start tiles on hard obstacles** — `astar.rs:695` lets a path's goal tile sit on a hard obstacle, and the start tile is silently never checked at `astar.rs:658`. The occupancy refactor's materialisation filter (`ghost_router.rs`) now drops entities at hard tiles so they don't cause entity-overlap on fluid-lane reservations, but the underlying A* bug remains — paths still end on hard tiles, just without a materialised entity. The cleaner fix is to make `ghost_astar` reject hard-tile start/goal states outright (or have the tap-off spec generation place the spec endpoint one tile off the hard region).
 
 ## Space Age Machine Support (Rust Pipeline)
 

--- a/crates/core/src/bus/ghost_occupancy.rs
+++ b/crates/core/src/bus/ghost_occupancy.rs
@@ -1,0 +1,656 @@
+//! Shared occupancy map for the ghost routing pipeline.
+//!
+//! Tracks which tiles are claimed by which solver phase so that the ghost
+//! A*, corridor template, per-tile template, and SAT crossing-zone phases
+//! can all consult and mutate a single source of truth instead of each
+//! maintaining its own obstacle view.
+//!
+//! See `docs/rfp-ghost-occupancy-refactor.md` for the design and rollout
+//! plan. This module corresponds to **Step 1**: the type lands in
+//! isolation with unit tests; nothing in `ghost_router.rs` consumes it
+//! yet.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::models::PlacedEntity;
+
+/// Axis-aligned tile rectangle. Width and height are in tiles; the rect
+/// covers `[x, x + w)` × `[y, y + h)`.
+///
+/// Mirrors the shape of `ghost_router::ClusterZone` so that callers can
+/// pass either type once Step 6 unifies them.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+}
+
+impl Rect {
+    pub fn contains(&self, px: i32, py: i32) -> bool {
+        px >= self.x
+            && px < self.x + self.w as i32
+            && py >= self.y
+            && py < self.y + self.h as i32
+    }
+}
+
+/// What kind of solver-phase output owns a given tile claim.
+///
+/// `GhostSurface` and `RowEntity` are the two "permeable" variants —
+/// every other variant is considered "permanent" (templates and SAT
+/// must route around them). `GhostSurface` may be released by SAT and
+/// templates; `RowEntity` is the row template's input/output belts
+/// that the bus router needs to *interface* with rather than route
+/// around (boundary ports may land on them).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Claim {
+    /// Machine, pole, fluid lane, splitter footprint. No `PlacedEntity`
+    /// associated — these are consulted only as obstacles.
+    HardObstacle,
+    /// Belt, inserter, pole, or pipe owned by the row template. The
+    /// bus router will *interface* with these (boundary ports for SAT
+    /// can land here), so they are NOT considered obstacles by either
+    /// `is_permanent` or `forced_empty_in`. Distinct from `Permanent`
+    /// to mirror today's `pre_existing_positions` semantics, which
+    /// only includes entities present in the `entities` Vec.
+    RowEntity { entity_idx: usize },
+    /// Trunk belt, balancer block, splitter stamp — anything placed by
+    /// the bus router's setup phases (steps 2-3). Permanent for the
+    /// duration of ghost routing.
+    Permanent { entity_idx: usize },
+    /// Surface belt placed by ghost A* during step 5. May be replaced
+    /// by a template UG-bridge or SAT solution that runs through this
+    /// tile.
+    GhostSurface { entity_idx: usize },
+    /// Stamped by corridor or per-tile template. Permanent once placed
+    /// — SAT must treat these as forced_empty.
+    Template { entity_idx: usize },
+    /// SAT-solved entity. Final.
+    SatSolved { entity_idx: usize },
+}
+
+impl Claim {
+    /// Returns the entity index for non-hard claims.
+    #[allow(dead_code)] // used by test-only helpers `entity_at` and `into_entities`
+    pub fn entity_idx(&self) -> Option<usize> {
+        match self {
+            Claim::HardObstacle => None,
+            Claim::RowEntity { entity_idx }
+            | Claim::Permanent { entity_idx }
+            | Claim::GhostSurface { entity_idx }
+            | Claim::Template { entity_idx }
+            | Claim::SatSolved { entity_idx } => Some(*entity_idx),
+        }
+    }
+
+    /// "Permanent" claims are those that templates and SAT must avoid
+    /// when placing new entities. `GhostSurface` and `RowEntity` are
+    /// excluded — the former because templates/SAT may replace it,
+    /// the latter because the bus router interfaces with row-template
+    /// belts via boundary ports rather than routing around them.
+    pub fn is_permanent(&self) -> bool {
+        !matches!(self, Claim::GhostSurface { .. } | Claim::RowEntity { .. })
+    }
+}
+
+/// Caller-supplied tag for `Occupancy::place`. Mirrors `Claim` variants
+/// minus the `entity_idx` field, which `place` fills in itself.
+/// `RowEntity` is built by `Occupancy::new` from the row_entities
+/// argument and is not a valid `place()` tag — row entities are
+/// installed once at construction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ClaimKindTag {
+    Permanent,
+    GhostSurface,
+    Template,
+    SatSolved,
+}
+
+/// Reasons a `place()` call may fail.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum OccupancyError {
+    /// Tile is a `HardObstacle` — never placeable on.
+    HardObstacle,
+    /// Tile is already claimed by a permanent (non-`GhostSurface`) entity.
+    /// The caller must explicitly release it (or the prior phase did
+    /// something wrong).
+    AlreadyClaimed { existing: Claim },
+}
+
+/// Shared occupancy map. Replaces the parallel `hard` / `existing_belts`
+/// / `pre_existing_set` / `entities` data flows in `ghost_router.rs`.
+pub(super) struct Occupancy {
+    /// All entities placed so far, in placement order. Indices are
+    /// stable: `Claim::*::entity_idx` always points at the same entity
+    /// for the lifetime of an `Occupancy`.
+    entities: Vec<PlacedEntity>,
+    /// Per-tile claim record. Tiles with no claim are absent from the
+    /// map.
+    claims: FxHashMap<(i32, i32), Claim>,
+}
+
+impl Occupancy {
+    /// Build an `Occupancy` from a hard-obstacle set and two classes
+    /// of initial entities:
+    ///
+    /// - `row_belts`: belt/inserter/pole/pipe entities from the row
+    ///   template that the bus router *interfaces* with. These get
+    ///   `RowEntity` claims — boundary ports may land on them and
+    ///   `forced_empty_in` skips them, mirroring today's behaviour
+    ///   where row-template belts are absent from
+    ///   `pre_existing_positions`. **Only belt-like row entities
+    ///   belong here.** Machines, inserters, and poles from the row
+    ///   template are not permeable and should go into
+    ///   `permanent_entities` instead (or be captured by the `hard`
+    ///   set).
+    /// - `permanent_entities`: splitter stamps, balancer blocks, row
+    ///   template machines/inserters/poles, or anything else that the
+    ///   bus router must treat as a permanent obstacle. These get
+    ///   `Permanent` claims, which `is_permanent` and `forced_empty_in`
+    ///   both treat as obstacles.
+    ///
+    /// Hard tiles that also have an entity get the entity claim — the
+    /// hard set is treated as "this tile is unconditionally unavailable
+    /// even if no entity is sitting on it" (e.g. fluid-lane reservations
+    /// reserve tiles that may not yet hold a pipe).
+    pub fn new(
+        hard: FxHashSet<(i32, i32)>,
+        row_belts: Vec<PlacedEntity>,
+        permanent_entities: Vec<PlacedEntity>,
+    ) -> Self {
+        let mut claims: FxHashMap<(i32, i32), Claim> = FxHashMap::default();
+        for tile in hard {
+            claims.insert(tile, Claim::HardObstacle);
+        }
+        let mut entities: Vec<PlacedEntity> =
+            Vec::with_capacity(row_belts.len() + permanent_entities.len());
+        for e in row_belts {
+            let pos = (e.x, e.y);
+            let idx = entities.len();
+            entities.push(e);
+            // RowEntity claim for permeable belts.
+            claims.insert(pos, Claim::RowEntity { entity_idx: idx });
+        }
+        for e in permanent_entities {
+            let pos = (e.x, e.y);
+            let idx = entities.len();
+            entities.push(e);
+            // Permanent claim overwrites HardObstacle for the entity's
+            // anchor tile.
+            claims.insert(pos, Claim::Permanent { entity_idx: idx });
+        }
+        Occupancy { entities, claims }
+    }
+
+    // -------------------------------------------------------------------
+    // Queries
+    // -------------------------------------------------------------------
+
+    /// Number of entities currently placed.
+    #[allow(dead_code)] // API surface for tests + future callers
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// True if the tile has any claim at all.
+    pub fn is_claimed(&self, tile: (i32, i32)) -> bool {
+        self.claims.contains_key(&tile)
+    }
+
+    /// True if the tile is a hard obstacle.
+    pub fn is_hard_obstacle(&self, tile: (i32, i32)) -> bool {
+        matches!(self.claims.get(&tile), Some(Claim::HardObstacle))
+    }
+
+    /// True if the tile is unclaimed.
+    pub fn is_free(&self, tile: (i32, i32)) -> bool {
+        !self.claims.contains_key(&tile)
+    }
+
+    /// True if the tile holds a "permanent" claim (anything other than a
+    /// `GhostSurface`). Templates and SAT must not stamp over these.
+    pub fn is_permanent(&self, tile: (i32, i32)) -> bool {
+        self.claims.get(&tile).is_some_and(|c| c.is_permanent())
+    }
+
+    /// Inspect the claim at a tile.
+    pub fn claim_at(&self, tile: (i32, i32)) -> Option<&Claim> {
+        self.claims.get(&tile)
+    }
+
+    /// Fetch the entity at a tile, if any. Returns `None` for
+    /// `HardObstacle` and unclaimed tiles.
+    #[allow(dead_code)] // API surface for tests + future callers
+    pub fn entity_at(&self, tile: (i32, i32)) -> Option<&PlacedEntity> {
+        self.claims
+            .get(&tile)
+            .and_then(|c| c.entity_idx())
+            .and_then(|i| self.entities.get(i))
+    }
+
+    /// Snapshot the set of tiles that currently hold a "permanent"
+    /// claim — `HardObstacle | Permanent | Template | SatSolved` (i.e.
+    /// everything `is_permanent` returns true for). The result is a
+    /// frozen `FxHashSet` that does not update as the Occupancy is
+    /// further mutated.
+    ///
+    /// Used by `resolve_clusters` to build a static obstacle set at
+    /// the top of the SAT cluster loop, mirroring today's behaviour
+    /// where `pre_existing_positions` is computed once and not
+    /// updated as later SAT clusters claim tiles.
+    pub fn snapshot_permanent_tiles(&self) -> FxHashSet<(i32, i32)> {
+        self.claims
+            .iter()
+            .filter(|(_, c)| c.is_permanent())
+            .map(|(t, _)| *t)
+            .collect()
+    }
+
+    /// Tiles inside `zone` that the SAT solver must treat as
+    /// `forced_empty`: every claimed tile inside the zone, except
+    /// boundary ports, ghost-surface belts (which SAT replaces), and
+    /// row-entity belts (which the bus router interfaces with via
+    /// boundary ports rather than routes around).
+    ///
+    /// `boundaries` is the set of `(x, y)` positions that the SAT zone
+    /// has already designated as boundary ports — those must not appear
+    /// in `forced_empty` because they're entry/exit ports for the
+    /// solver.
+    pub fn forced_empty_in(
+        &self,
+        zone: &Rect,
+        boundaries: &FxHashSet<(i32, i32)>,
+    ) -> Vec<(i32, i32)> {
+        let mut out = Vec::new();
+        for (&tile, claim) in &self.claims {
+            if !zone.contains(tile.0, tile.1) {
+                continue;
+            }
+            if boundaries.contains(&tile) {
+                continue;
+            }
+            if matches!(
+                claim,
+                Claim::GhostSurface { .. } | Claim::RowEntity { .. }
+            ) {
+                continue;
+            }
+            out.push(tile);
+        }
+        out
+    }
+
+    // -------------------------------------------------------------------
+    // Mutations
+    // -------------------------------------------------------------------
+
+    /// Place an entity with the given claim kind.
+    ///
+    /// Returns `Err` if the target tile is a `HardObstacle` or already
+    /// holds any non-`GhostSurface` claim. A `GhostSurface` claim is
+    /// released and the new entity replaces it.
+    ///
+    /// On success, the entity is appended to the entity list and the
+    /// returned `usize` is its index.
+    pub fn place(
+        &mut self,
+        entity: PlacedEntity,
+        kind: ClaimKindTag,
+    ) -> Result<usize, OccupancyError> {
+        let tile = (entity.x, entity.y);
+        if let Some(existing) = self.claims.get(&tile) {
+            match existing {
+                Claim::HardObstacle => return Err(OccupancyError::HardObstacle),
+                Claim::GhostSurface { .. } => {
+                    // Allowed: replace the ghost-surface claim. The
+                    // backing entity stays in `self.entities` for index
+                    // stability but becomes orphaned (no claim points to
+                    // it). Step 6 may add a `garbage_collect` pass; for
+                    // now the orphan is harmless because `into_entities`
+                    // consumers only look up entities via current claims.
+                }
+                other => {
+                    return Err(OccupancyError::AlreadyClaimed {
+                        existing: other.clone(),
+                    });
+                }
+            }
+        }
+        let idx = self.entities.len();
+        self.entities.push(entity);
+        let claim = match kind {
+            ClaimKindTag::Permanent => Claim::Permanent { entity_idx: idx },
+            ClaimKindTag::GhostSurface => Claim::GhostSurface { entity_idx: idx },
+            ClaimKindTag::Template => Claim::Template { entity_idx: idx },
+            ClaimKindTag::SatSolved => Claim::SatSolved { entity_idx: idx },
+        };
+        self.claims.insert(tile, claim);
+        Ok(idx)
+    }
+
+    /// Drop every `GhostSurface` claim whose tile lies inside `zone`.
+    /// The corresponding entities become orphaned (see `place`'s note).
+    /// Used by SAT before claiming tiles for its own solution.
+    ///
+    /// Returns the number of claims released.
+    pub fn release_ghost_surface_in(&mut self, zone: &Rect) -> usize {
+        let to_remove: Vec<(i32, i32)> = self
+            .claims
+            .iter()
+            .filter(|(tile, claim)| {
+                zone.contains(tile.0, tile.1)
+                    && matches!(claim, Claim::GhostSurface { .. })
+            })
+            .map(|(tile, _)| *tile)
+            .collect();
+        let n = to_remove.len();
+        for tile in to_remove {
+            self.claims.remove(&tile);
+        }
+        n
+    }
+
+    /// Drop every `GhostSurface` claim, plus every `Permanent` claim
+    /// whose entity is a trunk or tap-off belt (segment id starting with
+    /// `"trunk:"` or `"tapoff:"`), inside `zone`. Used by the per-tile
+    /// template phase to clear the 1×3 footprint before stamping a
+    /// crossing template.
+    ///
+    /// `HardObstacle` claims are left alone — those represent machines
+    /// or fluid lanes that the template can't displace.
+    ///
+    /// Returns the number of claims released.
+    pub fn release_for_pertile_template(&mut self, zone: &Rect) -> usize {
+        let to_remove: Vec<(i32, i32)> = self
+            .claims
+            .iter()
+            .filter(|(tile, claim)| {
+                if !zone.contains(tile.0, tile.1) {
+                    return false;
+                }
+                match claim {
+                    Claim::GhostSurface { .. } => true,
+                    Claim::Permanent { entity_idx } => self
+                        .entities
+                        .get(*entity_idx)
+                        .and_then(|e| e.segment_id.as_deref())
+                        .is_some_and(|s| s.starts_with("trunk:") || s.starts_with("tapoff:")),
+                    _ => false,
+                }
+            })
+            .map(|(tile, _)| *tile)
+            .collect();
+        let n = to_remove.len();
+        for tile in to_remove {
+            self.claims.remove(&tile);
+        }
+        n
+    }
+
+    /// Consume the occupancy map and return all entities that still
+    /// have a live claim, in placement order. Orphaned entities (those
+    /// whose tile was reclaimed by a later `place` call) are dropped.
+    #[allow(dead_code)] // API surface for tests + future callers
+    pub fn into_entities(self) -> Vec<PlacedEntity> {
+        let live_idxs: FxHashSet<usize> = self
+            .claims
+            .values()
+            .filter_map(|c| c.entity_idx())
+            .collect();
+        self.entities
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, e)| if live_idxs.contains(&i) { Some(e) } else { None })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::EntityDirection;
+
+    fn belt(x: i32, y: i32, seg: &str) -> PlacedEntity {
+        PlacedEntity {
+            name: "transport-belt".to_string(),
+            x,
+            y,
+            direction: EntityDirection::East,
+            segment_id: Some(seg.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn empty_boundaries() -> FxHashSet<(i32, i32)> {
+        FxHashSet::default()
+    }
+
+    #[test]
+    fn new_treats_hard_set_and_setup_entities_correctly() {
+        let mut hard: FxHashSet<(i32, i32)> = FxHashSet::default();
+        hard.insert((5, 5));
+        hard.insert((6, 6));
+        let setup = vec![belt(10, 10, "trunk:iron-plate")];
+
+        let occ = Occupancy::new(hard, Vec::new(), setup);
+
+        assert!(occ.is_hard_obstacle((5, 5)));
+        assert!(occ.is_hard_obstacle((6, 6)));
+        assert!(!occ.is_hard_obstacle((10, 10)));
+
+        assert!(occ.is_permanent((10, 10)));
+        assert!(occ.is_permanent((5, 5)));
+
+        assert!(occ.is_claimed((5, 5)));
+        assert!(occ.is_claimed((10, 10)));
+        assert!(occ.is_free((0, 0)));
+
+        assert_eq!(occ.entity_count(), 1);
+        assert_eq!(occ.entity_at((10, 10)).map(|e| e.name.as_str()), Some("transport-belt"));
+        assert!(occ.entity_at((5, 5)).is_none(), "hard tile has no entity");
+    }
+
+    #[test]
+    fn new_treats_row_entities_as_permeable() {
+        // Row entities are claimed but `is_permanent` returns false for
+        // them (they're permeable for boundary ports and forced_empty).
+        let row = vec![belt(7, 7, "row:iron-plate")];
+        let occ = Occupancy::new(FxHashSet::default(), row, Vec::new());
+
+        assert!(occ.is_claimed((7, 7)));
+        assert!(!occ.is_permanent((7, 7)), "row entity belts must not be 'permanent'");
+        assert!(matches!(occ.claim_at((7, 7)), Some(Claim::RowEntity { .. })));
+        assert_eq!(occ.entity_at((7, 7)).map(|e| e.name.as_str()), Some("transport-belt"));
+    }
+
+    #[test]
+    fn forced_empty_in_excludes_row_entities() {
+        // Row entity belts must not be in forced_empty — SAT can route
+        // through them via boundary ports.
+        let row = vec![belt(3, 0, "row:a")];
+        let setup = vec![belt(2, 0, "trunk:b")];
+        let occ = Occupancy::new(FxHashSet::default(), row, setup);
+        let zone = Rect { x: 0, y: 0, w: 5, h: 1 };
+        let mut got = occ.forced_empty_in(&zone, &empty_boundaries());
+        got.sort();
+        // Only the trunk (Permanent) is in forced_empty; the row entity
+        // belt is not.
+        assert_eq!(got, vec![(2, 0)]);
+    }
+
+    #[test]
+    fn place_succeeds_on_free_tile_for_each_kind() {
+        let mut occ = Occupancy::new(FxHashSet::default(), Vec::new(), Vec::new());
+
+        assert!(occ.place(belt(0, 0, "ghost:a"), ClaimKindTag::GhostSurface).is_ok());
+        assert!(occ.place(belt(1, 0, "junction:a"), ClaimKindTag::Template).is_ok());
+        assert!(occ.place(belt(2, 0, "sat:a"), ClaimKindTag::SatSolved).is_ok());
+        assert!(occ.place(belt(3, 0, "trunk:a"), ClaimKindTag::Permanent).is_ok());
+
+        assert!(matches!(occ.claim_at((0, 0)), Some(Claim::GhostSurface { .. })));
+        assert!(matches!(occ.claim_at((1, 0)), Some(Claim::Template { .. })));
+        assert!(matches!(occ.claim_at((2, 0)), Some(Claim::SatSolved { .. })));
+        assert!(matches!(occ.claim_at((3, 0)), Some(Claim::Permanent { .. })));
+    }
+
+    #[test]
+    fn place_replaces_ghost_surface_claim() {
+        let mut occ = Occupancy::new(FxHashSet::default(), Vec::new(), Vec::new());
+        occ.place(belt(0, 0, "ghost:a"), ClaimKindTag::GhostSurface).unwrap();
+        let result = occ.place(belt(0, 0, "junction:a"), ClaimKindTag::Template);
+        assert!(result.is_ok(), "template should replace ghost surface");
+        assert!(matches!(occ.claim_at((0, 0)), Some(Claim::Template { .. })));
+    }
+
+    #[test]
+    fn place_rejects_hard_obstacle() {
+        let mut hard = FxHashSet::default();
+        hard.insert((0, 0));
+        let mut occ = Occupancy::new(hard, Vec::new(), Vec::new());
+        let result = occ.place(belt(0, 0, "ghost:a"), ClaimKindTag::GhostSurface);
+        assert_eq!(result, Err(OccupancyError::HardObstacle));
+    }
+
+    #[test]
+    fn place_rejects_permanent_template_satsolved_claims() {
+        let mut occ = Occupancy::new(FxHashSet::default(), Vec::new(), Vec::new());
+        occ.place(belt(0, 0, "trunk:a"), ClaimKindTag::Permanent).unwrap();
+        occ.place(belt(1, 0, "junction:a"), ClaimKindTag::Template).unwrap();
+        occ.place(belt(2, 0, "sat:a"), ClaimKindTag::SatSolved).unwrap();
+
+        for (tile, _label) in [((0, 0), "Permanent"), ((1, 0), "Template"), ((2, 0), "SatSolved")] {
+            let result = occ.place(belt(tile.0, tile.1, "ghost:b"), ClaimKindTag::GhostSurface);
+            assert!(matches!(result, Err(OccupancyError::AlreadyClaimed { .. })));
+        }
+    }
+
+    #[test]
+    fn release_ghost_surface_in_only_drops_ghost_surface() {
+        let mut occ = Occupancy::new(FxHashSet::default(), Vec::new(), Vec::new());
+        occ.place(belt(0, 0, "ghost:a"), ClaimKindTag::GhostSurface).unwrap();
+        occ.place(belt(1, 0, "ghost:b"), ClaimKindTag::GhostSurface).unwrap();
+        occ.place(belt(2, 0, "trunk:c"), ClaimKindTag::Permanent).unwrap();
+        occ.place(belt(3, 0, "junction:d"), ClaimKindTag::Template).unwrap();
+        // (10, 10) lies outside the zone.
+        occ.place(belt(10, 10, "ghost:e"), ClaimKindTag::GhostSurface).unwrap();
+
+        let zone = Rect { x: 0, y: 0, w: 4, h: 1 };
+        let n = occ.release_ghost_surface_in(&zone);
+        assert_eq!(n, 2, "two ghost surface claims inside the zone");
+
+        assert!(occ.is_free((0, 0)));
+        assert!(occ.is_free((1, 0)));
+        assert!(occ.is_permanent((2, 0)), "trunk untouched");
+        assert!(occ.is_permanent((3, 0)), "template untouched");
+        assert!(occ.is_claimed((10, 10)), "ghost outside zone untouched");
+    }
+
+    #[test]
+    fn release_for_pertile_template_drops_ghost_and_trunk_and_tapoff() {
+        let mut occ = Occupancy::new(FxHashSet::default(), Vec::new(), Vec::new());
+        occ.place(belt(0, 0, "ghost:a"), ClaimKindTag::GhostSurface).unwrap();
+        occ.place(belt(1, 0, "trunk:b"), ClaimKindTag::Permanent).unwrap();
+        occ.place(belt(2, 0, "tapoff:c"), ClaimKindTag::Permanent).unwrap();
+        // Non-trunk/non-tapoff permanent — must be left alone.
+        occ.place(belt(3, 0, "row:d"), ClaimKindTag::Permanent).unwrap();
+        // Template inside the zone — must be left alone (templates don't
+        // displace each other).
+        occ.place(belt(4, 0, "junction:e"), ClaimKindTag::Template).unwrap();
+
+        let zone = Rect { x: 0, y: 0, w: 5, h: 1 };
+        let n = occ.release_for_pertile_template(&zone);
+        assert_eq!(n, 3, "ghost + trunk + tapoff released");
+
+        assert!(occ.is_free((0, 0)));
+        assert!(occ.is_free((1, 0)));
+        assert!(occ.is_free((2, 0)));
+        assert!(occ.is_permanent((3, 0)), "row template kept");
+        assert!(occ.is_permanent((4, 0)), "template kept");
+    }
+
+    #[test]
+    fn release_for_pertile_template_leaves_hard_obstacles() {
+        let mut hard = FxHashSet::default();
+        hard.insert((0, 0));
+        let mut occ = Occupancy::new(hard, Vec::new(), Vec::new());
+        let zone = Rect { x: 0, y: 0, w: 1, h: 1 };
+        let n = occ.release_for_pertile_template(&zone);
+        assert_eq!(n, 0);
+        assert!(occ.is_hard_obstacle((0, 0)));
+    }
+
+    #[test]
+    fn forced_empty_in_excludes_ghost_surface_and_boundaries() {
+        let mut hard = FxHashSet::default();
+        hard.insert((0, 0));
+        let mut occ = Occupancy::new(hard, Vec::new(), Vec::new());
+        occ.place(belt(1, 0, "trunk:a"), ClaimKindTag::Permanent).unwrap();
+        occ.place(belt(2, 0, "ghost:b"), ClaimKindTag::GhostSurface).unwrap();
+        occ.place(belt(3, 0, "junction:c"), ClaimKindTag::Template).unwrap();
+        // Outside the zone — should never appear.
+        occ.place(belt(99, 99, "trunk:far"), ClaimKindTag::Permanent).unwrap();
+
+        let zone = Rect { x: 0, y: 0, w: 5, h: 1 };
+
+        // No boundaries: ghost-surface (2,0) is excluded; everything else
+        // claimed inside the zone is forced_empty.
+        let mut got = occ.forced_empty_in(&zone, &empty_boundaries());
+        got.sort();
+        assert_eq!(got, vec![(0, 0), (1, 0), (3, 0)]);
+
+        // With (1,0) declared as a boundary port, it drops out.
+        let mut boundaries = FxHashSet::default();
+        boundaries.insert((1, 0));
+        let mut got = occ.forced_empty_in(&zone, &boundaries);
+        got.sort();
+        assert_eq!(got, vec![(0, 0), (3, 0)]);
+    }
+
+    #[test]
+    fn into_entities_drops_orphans_from_replaced_ghost_surfaces() {
+        let mut occ = Occupancy::new(FxHashSet::default(), Vec::new(), Vec::new());
+        // First place a ghost-surface belt, then immediately replace it
+        // with a template belt. The original entity becomes orphaned.
+        occ.place(belt(0, 0, "ghost:a"), ClaimKindTag::GhostSurface).unwrap();
+        occ.place(belt(0, 0, "junction:a"), ClaimKindTag::Template).unwrap();
+        // And another live ghost belt for good measure.
+        occ.place(belt(1, 0, "ghost:b"), ClaimKindTag::GhostSurface).unwrap();
+
+        let entities = occ.into_entities();
+        assert_eq!(entities.len(), 2);
+        let segs: Vec<&str> = entities
+            .iter()
+            .filter_map(|e| e.segment_id.as_deref())
+            .collect();
+        assert!(segs.contains(&"junction:a"));
+        assert!(segs.contains(&"ghost:b"));
+        assert!(!segs.contains(&"ghost:a"), "orphaned ghost belt was dropped");
+    }
+
+    #[test]
+    fn into_entities_preserves_placement_order_for_live_claims() {
+        let mut occ = Occupancy::new(FxHashSet::default(), Vec::new(), Vec::new());
+        for i in 0..5 {
+            occ.place(belt(i, 0, &format!("trunk:{i}")), ClaimKindTag::Permanent).unwrap();
+        }
+        let entities = occ.into_entities();
+        let xs: Vec<i32> = entities.iter().map(|e| e.x).collect();
+        assert_eq!(xs, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn rect_contains_is_half_open() {
+        let r = Rect { x: 5, y: 10, w: 3, h: 2 };
+        assert!(r.contains(5, 10));
+        assert!(r.contains(7, 11));
+        assert!(!r.contains(8, 10), "right edge is exclusive");
+        assert!(!r.contains(5, 12), "bottom edge is exclusive");
+        assert!(!r.contains(4, 10));
+    }
+}

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -199,6 +199,50 @@ pub fn route_bus_ghost(
     }
 
     // -------------------------------------------------------------------------
+    // Occupancy refactor (Steps 2-3): construct the parallel `Occupancy` from
+    // the inputs to steps 1-3 of this function. Step 3 of the rollout uses it
+    // to mirror materialisation writes; Step 4+ will switch the template and
+    // SAT phases over to it as the source of obstacle truth. See
+    // `docs/rfp-ghost-occupancy-refactor.md`.
+    // -------------------------------------------------------------------------
+    // Row template entities split by permeability: belts are
+    // `RowEntity` (boundary ports may land on them); machines,
+    // inserters, poles, and pipes are `Permanent` (real obstacles).
+    let (row_belts, row_non_belts): (Vec<PlacedEntity>, Vec<PlacedEntity>) = row_entities
+        .iter()
+        .cloned()
+        .partition(|e| is_belt_like(&e.name));
+    let mut permanent_inits = row_non_belts;
+    permanent_inits.extend(entities.iter().cloned());
+    let mut occupancy = crate::bus::ghost_occupancy::Occupancy::new(
+        hard.clone(),
+        row_belts,
+        permanent_inits,
+    );
+
+    #[cfg(debug_assertions)]
+    {
+        for &tile in &hard {
+            debug_assert!(
+                occupancy.is_claimed(tile),
+                "occupancy refactor: hard tile {:?} not claimed in parallel Occupancy",
+                tile,
+            );
+        }
+        for &tile in &pre_ghost_belts {
+            // Row template belts now sit in `Occupancy` as
+            // `RowEntity` claims (not `Permanent`), to mirror
+            // today's `pre_existing_positions` semantics. They
+            // should still be `is_claimed`.
+            debug_assert!(
+                occupancy.is_claimed(tile),
+                "occupancy refactor: pre_ghost_belts tile {:?} not claimed in parallel Occupancy",
+                tile,
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Step 4: Build connecting-belt spec list
     // -------------------------------------------------------------------------
     let mut specs: Vec<BeltSpec> = Vec::new();
@@ -619,10 +663,49 @@ pub fn route_bus_ghost(
                 spec_seg_id,
                 None,
             );
-            entities.extend(path_ents.into_iter().filter(|e| {
-                !pre_ghost_belts.contains(&(e.x, e.y))
-                    && !ghost_item_at.contains_key(&(e.x, e.y))
-            }));
+            // Materialise the path into entities + Occupancy.
+            //
+            // Claim kind: trunk specs become load-bearing vertical bus
+            // belts (`Permanent` claims). All other specs (tap-offs,
+            // returns, horizontals) get `GhostSurface` claims which
+            // templates and SAT may replace. This mirrors the old
+            // `pre_existing_positions` filter semantics — non-ghost
+            // segment IDs (trunks) were kept as obstacles; ghost
+            // segment IDs were skipped.
+            //
+            // Filter: drop path tiles that already hold a pre-existing
+            // belt (from row templates / step 2-3 setup), already
+            // carry another ghost item (first-spec-wins), or overlap a
+            // hard obstacle. The hard-obstacle filter protects against
+            // `ghost_astar:695` which allows goal tiles on hard
+            // obstacles (and silently also start tiles — no check at
+            // `astar.rs:658`). Dropping those entities prevents
+            // entity-overlap validator errors on fluid-lane
+            // reservations and machine anchors.
+            let claim_kind = if spec.key.starts_with("trunk:") {
+                crate::bus::ghost_occupancy::ClaimKindTag::Permanent
+            } else {
+                crate::bus::ghost_occupancy::ClaimKindTag::GhostSurface
+            };
+            let surviving_ents: Vec<PlacedEntity> = path_ents
+                .into_iter()
+                .filter(|e| {
+                    !pre_ghost_belts.contains(&(e.x, e.y))
+                        && !ghost_item_at.contains_key(&(e.x, e.y))
+                        && !hard.contains(&(e.x, e.y))
+                })
+                .collect();
+            for ent in &surviving_ents {
+                occupancy
+                    .place(ent.clone(), claim_kind)
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "occupancy refactor: place failed for spec {} at ({},{}): {:?}",
+                            spec.key, ent.x, ent.y, err
+                        );
+                    });
+            }
+            entities.extend(surviving_ents);
 
             for &tile in &path {
                 existing_belts.insert(tile);
@@ -641,6 +724,22 @@ pub fn route_bus_ghost(
             for &tile in &path {
                 ghost_item_at.entry(tile).or_insert_with(|| spec.item.clone());
             }
+        }
+    }
+
+    // Step 3 of the occupancy refactor: verify that every tile in the
+    // post-materialisation `existing_belts` set has a corresponding claim
+    // in Occupancy. Reverse direction does not hold — Occupancy includes
+    // machines, poles, and fluid-lane reservations that `existing_belts`
+    // does not.
+    #[cfg(debug_assertions)]
+    {
+        for &tile in &existing_belts {
+            debug_assert!(
+                occupancy.is_claimed(tile),
+                "occupancy refactor: existing_belts tile {:?} not claimed in Occupancy after materialisation",
+                tile,
+            );
         }
     }
 
@@ -723,23 +822,14 @@ pub fn route_bus_ghost(
     // -------------------------------------------------------------------------
     let crossing_set: FxHashSet<(i32, i32)> = all_ghost_crossings.iter().copied().collect();
 
-    // Pre-existing entity positions (for template/SAT overlap avoidance)
-    let pre_existing_set: FxHashSet<(i32, i32)> = entities
-        .iter()
-        .filter(|e| !e.segment_id.as_ref().is_some_and(|s| s.starts_with("ghost:")))
-        .map(|e| (e.x, e.y))
-        .chain(row_entities.iter().map(|e| (e.x, e.y)))
-        .collect();
-
     // Step 6a-pre: Corridor template — detect runs of adjacent horizontal
     // crossings where one horizontal spec crosses N adjacent vertical trunks.
     // Emit a single long UG bridge for the horizontal instead of N separate
     // per-tile templates that would conflict.
-    let mut template_zones: Vec<(Vec<PlacedEntity>, ClusterZone)> = Vec::new();
-    // Subset of `template_zones` containing only per-tile (1x3) templates.
-    // Corridor templates are excluded because their run tiles still hold
-    // perpendicular trunks that must NOT be stripped by the retain pass.
-    let mut pertile_template_zone_bboxes: Vec<ClusterZone> = Vec::new();
+    // Running count of templates emitted in step 6a (both corridor
+    // runs and per-tile crossings). Added to `cluster_tile_counts.len()`
+    // at the bottom to form `cluster_count`.
+    let mut template_count: usize = 0;
     let mut template_regions: Vec<LayoutRegion> = Vec::new();
     let mut remaining_crossings: FxHashSet<(i32, i32)> = FxHashSet::default();
     let mut corridor_handled: FxHashSet<(i32, i32)> = FxHashSet::default();
@@ -807,10 +897,8 @@ pub fn route_bus_ghost(
                 // pre-existing belt, must not be a turn point for any spec,
                 // and must not have a perpendicular spec passing through them
                 // (sideloads onto UG-input fail in Factorio).
-                let endpoints_free = !hard.contains(&ug_in)
-                    && !hard.contains(&ug_out)
-                    && !pre_existing_set.contains(&ug_in)
-                    && !pre_existing_set.contains(&ug_out)
+                let endpoints_free = !occupancy.is_permanent(ug_in)
+                    && !occupancy.is_permanent(ug_out)
                     && !any_spec_turns_at(ug_in, &routed_paths)
                     && !any_spec_turns_at(ug_out, &routed_paths)
                     && !ug_endpoint_conflicts(ug_in, ug_dir, key, &routed_paths)
@@ -850,7 +938,7 @@ pub fn route_bus_ghost(
                         };
                         let zone = ClusterZone { x: zx, y: zy, w: zw, h: zh };
                         trace::emit(trace::TraceEvent::GhostClusterSolved {
-                            cluster_id: template_zones.len(),
+                            cluster_id: template_count,
                             zone_x: zone.x,
                             zone_y: zone.y,
                             zone_w: zone.w,
@@ -873,7 +961,41 @@ pub fn route_bus_ghost(
                             clauses: 0,
                             solve_time_us: 0,
                         });
-                        template_zones.push((ents, zone));
+                        // Step 5a of the occupancy refactor: push the corridor
+                        // UG bridge entities directly into `entities` and
+                        // mirror to Occupancy as Template, instead of
+                        // deferring via template_zones. Same pattern as
+                        // Step 4 for per-tile templates. This is what makes
+                        // the SAT phase's forced_empty (after Step 5b
+                        // switches it to read from Occupancy) include
+                        // corridor UG bridge tiles, fixing potential
+                        // SAT-vs-corridor entity collisions that exist in
+                        // main today.
+                        for ent in &ents {
+                            let tile = (ent.x, ent.y);
+                            if occupancy.is_hard_obstacle(tile) {
+                                continue;
+                            }
+                            if matches!(
+                                occupancy.claim_at(tile),
+                                Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                            ) {
+                                continue;
+                            }
+                            occupancy
+                                .place(
+                                    ent.clone(),
+                                    crate::bus::ghost_occupancy::ClaimKindTag::Template,
+                                )
+                                .unwrap_or_else(|err| {
+                                    panic!(
+                                        "step 5a corridor UG place failed at ({},{}): {:?}",
+                                        tile.0, tile.1, err
+                                    );
+                                });
+                        }
+                        entities.extend(ents);
+                        template_count += 1;
                         // Mark all run tiles as corridor-handled and remove
                         // the horizontal spec's surface belts at those tiles
                         // (they're now underground via the UG bridge).
@@ -894,6 +1016,22 @@ pub fn route_bus_ghost(
                             }
                             e.segment_id.as_deref() != Some(bridged_seg.as_str())
                         });
+
+                        // Step 5a: mirror the bridged-spec ghost belt removal
+                        // in Occupancy. Run tiles only have at most one
+                        // ghost belt (the bridged spec's), so releasing all
+                        // GhostSurface claims in the corridor zone is
+                        // equivalent to the targeted entities.retain above.
+                        // The UG endpoint tiles already hold Template claims
+                        // from edit 1 above; release_ghost_surface_in only
+                        // touches GhostSurface, so they're safe.
+                        let release_rect = crate::bus::ghost_occupancy::Rect {
+                            x: zone.x,
+                            y: zone.y,
+                            w: zone.w,
+                            h: zone.h,
+                        };
+                        occupancy.release_ghost_surface_in(&release_rect);
 
                         // Re-add surface belts for perpendicular specs whose
                         // path was filtered out at materialization (because
@@ -929,7 +1067,7 @@ pub fn route_bus_ghost(
                                     // Use a non-ghost segment_id so the
                                     // post-template retain (which strips
                                     // "ghost:*" inside solved zones) keeps it.
-                                    entities.push(PlacedEntity {
+                                    let perp_ent = PlacedEntity {
                                         name: os.belt_name.to_string(),
                                         x: run_tile.0,
                                         y: run_tile.1,
@@ -940,7 +1078,30 @@ pub fn route_bus_ghost(
                                             os.item, run_tile.0, run_tile.1
                                         )),
                                         ..Default::default()
-                                    });
+                                    };
+                                    // Step 5a: mirror to Occupancy as
+                                    // Permanent so SAT's forced_empty (after
+                                    // 5b) sees these surface belts. The
+                                    // tile is free in Occupancy at this
+                                    // point because edit 2 above released
+                                    // any ghost-surface claim, and the
+                                    // outer `occupied_after_removal` check
+                                    // already filtered tiles still holding
+                                    // a permanent entity.
+                                    if !occupancy.is_hard_obstacle((perp_ent.x, perp_ent.y)) {
+                                        occupancy
+                                            .place(
+                                                perp_ent.clone(),
+                                                crate::bus::ghost_occupancy::ClaimKindTag::Permanent,
+                                            )
+                                            .unwrap_or_else(|err| {
+                                                panic!(
+                                                    "step 5a corridor-perp place failed at ({},{}): {:?}",
+                                                    perp_ent.x, perp_ent.y, err
+                                                );
+                                            });
+                                    }
+                                    entities.push(perp_ent);
                                     break;
                                 }
                             }
@@ -965,10 +1126,10 @@ pub fn route_bus_ghost(
             .filter(|info| is_perpendicular(info.spec_a.1, info.spec_b.1))
         {
             if let Some((ents, zone)) =
-                solve_perpendicular_template(&info, &hard, &pre_existing_set, &routed_paths)
+                solve_perpendicular_template(&info, &hard, &routed_paths)
             {
                 trace::emit(trace::TraceEvent::GhostClusterSolved {
-                    cluster_id: template_zones.len(),
+                    cluster_id: template_count,
                     zone_x: zone.x,
                     zone_y: zone.y,
                     zone_w: zone.w,
@@ -991,13 +1152,46 @@ pub fn route_bus_ghost(
                     clauses: 0,
                     solve_time_us: 0,
                 });
-                pertile_template_zone_bboxes.push(ClusterZone {
+
+                // Release GhostSurface + trunk/tapoff Permanent claims
+                // inside the template zone so the template's entities
+                // can take those tiles. Then place the template entities
+                // into both `entities` and Occupancy.
+                let release_rect = crate::bus::ghost_occupancy::Rect {
                     x: zone.x,
                     y: zone.y,
                     w: zone.w,
                     h: zone.h,
-                });
-                template_zones.push((ents, zone));
+                };
+                occupancy.release_for_pertile_template(&release_rect);
+                for ent in &ents {
+                    let tile = (ent.x, ent.y);
+                    if occupancy.is_hard_obstacle(tile) {
+                        continue;
+                    }
+                    // Two per-tile templates with overlapping footprints —
+                    // the second one's stamp is skipped to match the
+                    // legacy post-hoc `occupied` filter behaviour.
+                    if matches!(
+                        occupancy.claim_at(tile),
+                        Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                    ) {
+                        continue;
+                    }
+                    occupancy
+                        .place(
+                            ent.clone(),
+                            crate::bus::ghost_occupancy::ClaimKindTag::Template,
+                        )
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "occupancy refactor: template place failed at ({},{}): {:?}",
+                                tile.0, tile.1, err
+                            );
+                        });
+                }
+                entities.extend(ents);
+                template_count += 1;
                 continue; // tile solved — don't add to remaining
             }
         }
@@ -1029,22 +1223,22 @@ pub fn route_bus_ghost(
         let root = uf_find(&mut uf, i);
         *cluster_tile_counts.entry(root).or_insert(0) += 1;
     }
-    let cluster_count = cluster_tile_counts.len() + template_zones.len();
+    let cluster_count = cluster_tile_counts.len() + template_count;
     let max_cluster_tiles = cluster_tile_counts.values().copied().max().unwrap_or(0);
 
-    let (mut sat_zones, mut sat_regions, failed_count) = resolve_clusters(
+    // `resolve_clusters` writes SAT solutions into both `entities` and
+    // Occupancy directly. It returns only the regions list (for
+    // telemetry) and a failure count.
+    let (mut sat_regions, failed_count) = resolve_clusters(
         &crossing_list,
         &mut uf,
         &routed_paths,
         &specs,
         max_belt_tier,
-        &entities,
-        &hard,
+        &mut occupancy,
+        &mut entities,
     );
 
-    // Merge template and SAT results
-    let mut solved_zones = template_zones;
-    solved_zones.append(&mut sat_zones);
     let mut regions = template_regions;
     regions.append(&mut sat_regions);
 
@@ -1055,51 +1249,46 @@ pub fn route_bus_ghost(
         ));
     }
 
-    // Remove entities inside solved cluster zones so the template/SAT
-    // output can take their tiles. Ghost entities removed in any zone;
-    // trunk/tapoff entities are additionally removed inside PER-TILE
-    // template zones (corridor templates and SAT zones must keep trunks
-    // because they bridge horizontals — the trunks stay perpendicular).
-    if !solved_zones.is_empty() {
-        let zone_bboxes: Vec<&ClusterZone> = solved_zones.iter().map(|(_, z)| z).collect();
-
-        entities.retain(|e| {
-            let in_zone = zone_bboxes.iter().any(|z| z.contains(e.x, e.y));
-            if !in_zone {
-                return true;
-            }
-            let seg = e.segment_id.as_deref().unwrap_or("");
-            if seg.starts_with("ghost:") {
-                return false;
-            }
-            // Inside per-tile template zones, also drop trunk/tapoff belts
-            // so the UG-in/out + surface belt can take those tiles.
-            let in_pertile_zone =
-                pertile_template_zone_bboxes.iter().any(|z| z.contains(e.x, e.y));
-            if in_pertile_zone && (seg.starts_with("trunk:") || seg.starts_with("tapoff:")) {
-                return false;
-            }
-            true
-        });
-
-        // Build set of occupied positions: row_entities + non-ghost entities
-        // in our entity list. SAT output must not overlap these.
-        let mut occupied: FxHashSet<(i32, i32)> =
-            row_entities.iter().map(|e| (e.x, e.y)).collect();
-        for e in entities.iter() {
-            occupied.insert((e.x, e.y));
-        }
-
-        for (sat_entities, _zone) in &solved_zones {
-            // Skip SAT entities that would overlap pre-existing entities
-            entities.extend(
-                sat_entities
-                    .iter()
-                    .filter(|e| !occupied.contains(&(e.x, e.y)))
-                    .cloned(),
+    // Step 6: sync `entities` to Occupancy's released state.
+    //
+    // Templates and SAT write to both `entities` and Occupancy during
+    // their phases. When they release/replace a prior claim (a ghost
+    // surface belt, a trunk, or a tapoff) via `release_ghost_surface_in`
+    // or `release_for_pertile_template`, Occupancy is updated but the
+    // old entity stays in the local `entities` Vec. This pass drops
+    // any ghost/trunk/tapoff entity whose Occupancy claim no longer
+    // matches — i.e., where a later phase stamped over it.
+    //
+    // Other entity kinds (row templates, step 2/3 entities, templates,
+    // SAT solutions, corridor-perp re-adds) are always kept.
+    //
+    // The post-hoc add loop that previously re-added template/SAT
+    // entities via `solved_zones` is gone — Steps 4-5 push those
+    // entities directly into the Vec at the moment they're generated.
+    entities.retain(|e| {
+        let seg = e.segment_id.as_deref().unwrap_or("");
+        let occ_claim = occupancy.claim_at((e.x, e.y));
+        if seg.starts_with("ghost:") {
+            // Keep only if Occupancy still holds a GhostSurface claim
+            // at this tile. If the claim was released by a template
+            // or SAT solution, drop the entity.
+            return matches!(
+                occ_claim,
+                Some(crate::bus::ghost_occupancy::Claim::GhostSurface { .. })
             );
         }
-    }
+        if seg.starts_with("trunk:") || seg.starts_with("tapoff:") {
+            // Keep only if Occupancy still holds a Permanent claim.
+            // A per-tile template that stamped over the trunk will
+            // have released the Permanent claim and replaced it with
+            // a Template claim.
+            return matches!(
+                occ_claim,
+                Some(crate::bus::ghost_occupancy::Claim::Permanent { .. })
+            );
+        }
+        true
+    });
 
     // -------------------------------------------------------------------------
     // Step 7: Merge output rows for final products
@@ -1178,6 +1367,7 @@ fn uf_find(p: &mut [usize], i: usize) -> usize {
 // ---------------------------------------------------------------------------
 
 /// Bounding box for a ghost cluster zone (padded by 1 tile on each side).
+#[derive(Clone, Copy)]
 struct ClusterZone {
     /// Padded bbox left
     x: i32,
@@ -1444,7 +1634,6 @@ fn ug_endpoint_conflicts(
 fn solve_perpendicular_template(
     info: &CrossingInfo,
     hard_obstacles: &FxHashSet<(i32, i32)>,
-    pre_existing: &FxHashSet<(i32, i32)>,
     routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
 ) -> Option<(Vec<PlacedEntity>, ClusterZone)> {
     let perpendicular = is_perpendicular(info.spec_a.1, info.spec_b.1);
@@ -1455,7 +1644,6 @@ fn solve_perpendicular_template(
             (&info.spec_a.0, info.spec_a.1, info.belt_a),
             (&info.spec_b.0, info.spec_b.1, info.belt_b),
             hard_obstacles,
-            pre_existing,
             routed_paths,
         );
     }
@@ -1475,7 +1663,6 @@ fn solve_perpendicular_template(
         (&h_spec.0, h_spec.1, if std::ptr::eq(h_spec, &info.spec_a) { info.belt_a } else { info.belt_b }),
         (&v_spec.0, v_spec.1, if std::ptr::eq(v_spec, &info.spec_a) { info.belt_a } else { info.belt_b }),
         hard_obstacles,
-        pre_existing,
         routed_paths,
     );
     if bridge_vertical_first.is_some() {
@@ -1488,7 +1675,6 @@ fn solve_perpendicular_template(
         (&v_spec.0, v_spec.1, if std::ptr::eq(v_spec, &info.spec_a) { info.belt_a } else { info.belt_b }),
         (&h_spec.0, h_spec.1, if std::ptr::eq(h_spec, &info.spec_a) { info.belt_a } else { info.belt_b }),
         hard_obstacles,
-        pre_existing,
         routed_paths,
     )
 }
@@ -1501,7 +1687,6 @@ fn try_bridge(
     surface: (&String, EntityDirection, &'static str),
     bridge: (&String, EntityDirection, &'static str),
     hard_obstacles: &FxHashSet<(i32, i32)>,
-    pre_existing: &FxHashSet<(i32, i32)>,
     routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
 ) -> Option<(Vec<PlacedEntity>, ClusterZone)> {
     let (cx, cy) = crossing;
@@ -1543,11 +1728,6 @@ fn try_bridge(
 
     let ug_name = ug_for_belt(bridge_belt);
     let seg = Some(format!("junction:{}:{},{}", bridge_item, cx, cy));
-
-    // `pre_existing` contains trunks and other non-ghost belts. Those get
-    // removed from per-tile template zones by the caller's retain pass, so
-    // we always emit the full UG pair + surface belt regardless.
-    let _ = pre_existing;
 
     let entities = vec![
         PlacedEntity {
@@ -1596,20 +1776,30 @@ fn try_bridge(
 /// For each cluster: compute padded bbox, extract boundary ports from paths
 /// that pass through the zone, build a CrossingZone, and SAT-solve it.
 ///
-/// Returns solved entity lists per zone (with their bboxes), LayoutRegions
-/// for telemetry, and the count of failed clusters.
+/// Writes SAT solutions directly into `entities_out` and `occupancy`.
+/// Returns (LayoutRegions for telemetry, count of failed clusters).
 fn resolve_clusters(
     crossing_list: &[(i32, i32)],
     uf: &mut [usize],
     routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
     specs: &[BeltSpec],
     max_belt_tier: Option<&str>,
-    all_entities: &[PlacedEntity],
-    hard_obstacles: &FxHashSet<(i32, i32)>,
-) -> (Vec<(Vec<PlacedEntity>, ClusterZone)>, Vec<LayoutRegion>, usize) {
+    occupancy: &mut crate::bus::ghost_occupancy::Occupancy,
+    entities_out: &mut Vec<PlacedEntity>,
+) -> (Vec<LayoutRegion>, usize) {
+    use crate::bus::ghost_occupancy::{ClaimKindTag, Rect};
+
+    // Snapshot the permanent obstacle set ONCE here, before any SAT
+    // cluster places its solution into Occupancy. The boundary port
+    // check below uses this snapshot (not the live Occupancy) so that
+    // later clusters see the same obstacle view as earlier ones,
+    // matching today's behaviour where `pre_existing_positions` is
+    // built once at the top of the function and never updated.
+    let pre_sat_permanent = occupancy.snapshot_permanent_tiles();
+
     let n_tiles = crossing_list.len();
     if n_tiles == 0 {
-        return (Vec::new(), Vec::new(), 0);
+        return (Vec::new(), 0);
     }
 
     // Build spec lookup: key → &BeltSpec
@@ -1647,7 +1837,6 @@ fn resolve_clusters(
 
     // No zone merging — overlapping zones produce conflicting SAT solutions.
 
-    let mut solved_zones: Vec<(Vec<PlacedEntity>, ClusterZone)> = Vec::new();
     let mut regions: Vec<LayoutRegion> = Vec::new();
     let mut failed_count = 0;
 
@@ -1655,12 +1844,9 @@ fn resolve_clusters(
     let effective_belt = max_belt_tier.unwrap_or("transport-belt");
     let max_reach = ug_max_reach(effective_belt);
 
-    // Pre-existing entity positions — boundary ports must not land here
-    let pre_existing_positions: FxHashSet<(i32, i32)> = all_entities
-        .iter()
-        .filter(|e| !e.segment_id.as_ref().is_some_and(|s| s.starts_with("ghost:")))
-        .map(|e| (e.x, e.y))
-        .collect();
+    // Step 5b: Occupancy supplies both "tile is permanent" (was
+    // hard_obstacles + pre_existing_positions) and the per-zone
+    // forced_empty set, so no separate pre_existing_positions is needed.
 
     for (cluster_idx, (_root_id, zone, _cluster_tile_set)) in zones.into_iter().enumerate() {
         // Collect all paths that have any tile inside this zone's padded bbox
@@ -1702,11 +1888,10 @@ fn resolve_clusters(
                     !zone.contains(npx, npy)
                 };
 
-                // Skip boundary ports at positions occupied by hard obstacles
-                // or pre-existing entities — those would conflict with the
-                // SAT solution or get filtered out, breaking connectivity.
-                let occupied_by_existing =
-                    hard_obstacles.contains(&(px, py)) || pre_existing_positions.contains(&(px, py));
+                // Step 6: use the pre-SAT permanent obstacle snapshot
+                // so later clusters see the same obstacle view as
+                // earlier ones.
+                let occupied_by_existing = pre_sat_permanent.contains(&(px, py));
 
                 if prev_outside && zone.on_edge(px, py) && !occupied_by_existing {
                     // Entry port: direction is the direction of travel INTO the zone
@@ -1814,32 +1999,16 @@ fn resolve_clusters(
             continue;
         }
 
-        // Mark occupied tiles inside the zone as forced-empty so the SAT
-        // solver doesn't place entities on top of hard obstacles (machines,
-        // poles, pipes) or pre-existing belts (trunks, row templates).
+        // BISECT: try Occupancy.forced_empty_in.
         let boundary_set: FxHashSet<(i32, i32)> =
             boundaries.iter().map(|b| (b.x, b.y)).collect();
-        let mut forced_empty_set: FxHashSet<(i32, i32)> = FxHashSet::default();
-
-        // Hard obstacles (machines, poles, pipes, fluid lanes)
-        for &(hx, hy) in hard_obstacles {
-            if zone.contains(hx, hy) && !boundary_set.contains(&(hx, hy)) {
-                forced_empty_set.insert((hx, hy));
-            }
-        }
-        // Pre-existing non-ghost entities (trunks, row template belts, splitters)
-        for e in all_entities {
-            if zone.contains(e.x, e.y)
-                && !e
-                    .segment_id
-                    .as_ref()
-                    .is_some_and(|s| s.starts_with("ghost:"))
-                && !boundary_set.contains(&(e.x, e.y))
-            {
-                forced_empty_set.insert((e.x, e.y));
-            }
-        }
-        let forced_empty: Vec<(i32, i32)> = forced_empty_set.into_iter().collect();
+        let zone_rect = Rect {
+            x: zone.x,
+            y: zone.y,
+            w: zone.w,
+            h: zone.h,
+        };
+        let forced_empty = occupancy.forced_empty_in(&zone_rect, &boundary_set);
 
         let crossing_zone = CrossingZone {
             x: zone.x,
@@ -1893,7 +2062,34 @@ fn resolve_clusters(
                     solve_time_us: solution.stats.solve_time_us,
                 });
 
-                solved_zones.push((solution.entities, zone));
+                // Step 5b: write SAT solution entities directly into
+                // `entities_out` and Occupancy, instead of deferring via
+                // solved_zones. Release any GhostSurface claims in the
+                // zone first so the SAT entities can take those tiles.
+                // Skip entities that land on hard obstacles or already-
+                // claimed permanent tiles (matches the current post-hoc
+                // occupied filter behaviour.
+                occupancy.release_ghost_surface_in(&zone_rect);
+                for ent in solution.entities {
+                    let tile = (ent.x, ent.y);
+                    if occupancy.is_hard_obstacle(tile) {
+                        continue;
+                    }
+                    if !occupancy.is_free(tile) {
+                        // Already claimed by Permanent / Template /
+                        // SatSolved from a prior cluster. Drop.
+                        continue;
+                    }
+                    occupancy
+                        .place(ent.clone(), ClaimKindTag::SatSolved)
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "sat place failed at ({},{}): {:?}",
+                                tile.0, tile.1, err
+                            );
+                        });
+                    entities_out.push(ent);
+                }
             }
             None => {
                 trace::emit(trace::TraceEvent::GhostClusterFailed {
@@ -1909,7 +2105,7 @@ fn resolve_clusters(
         }
     }
 
-    (solved_zones, regions, failed_count)
+    (regions, failed_count)
 }
 
 fn is_belt_like(name: &str) -> bool {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod balancer_library;
 pub mod bus_router;
+pub(crate) mod ghost_occupancy;
 pub mod ghost_router;
 pub mod layout;
 pub mod placer;

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -906,6 +906,7 @@ fn tier4_advanced_circuit_from_ore_am1_ghost() {
             let mut ghost_spec_failed = 0;
             let mut clusters_solved = 0;
             let mut clusters_failed = 0;
+            let mut solved_zones: Vec<(i32, i32, u32, u32)> = Vec::new();
 
             for ev in &result.trace_events {
                 match ev {
@@ -924,6 +925,7 @@ fn tier4_advanced_circuit_from_ore_am1_ghost() {
                     TraceEvent::GhostSpecFailed { .. } => ghost_spec_failed += 1,
                     TraceEvent::GhostClusterSolved { zone_x, zone_y, zone_w, zone_h, boundary_count, .. } => {
                         clusters_solved += 1;
+                        solved_zones.push((*zone_x, *zone_y, *zone_w, *zone_h));
                         eprintln!("  cluster solved: zone ({},{}) {}x{}, {} boundaries", zone_x, zone_y, zone_w, zone_h, boundary_count);
                     }
                     TraceEvent::GhostClusterFailed { .. } => clusters_failed += 1,
@@ -1145,6 +1147,13 @@ fn tier4_advanced_circuit_from_ore_am1_ghost() {
                 eprintln!("  ╚══ Legend: →↓←↑=belt dir, UPPERCASE=SAT, ▸▾◂▴=pre-existing, ·=empty(zone), .=empty(halo) ══");
             }
 
+            // Pairwise overlap diagnostic: SAT solves each cluster
+            // independently with no shared occupancy mask, so any pair of
+            // padded zones that intersect spatially is a strategy bug
+            // (the two solvers can both claim tiles in the shared region).
+            let overlap_pairs = report_zone_overlaps(&solved_zones, "  ");
+            eprintln!("  zone overlap pairs: {overlap_pairs}");
+
             // Phase 3 assertions: SAT must have resolved all clusters
             assert_eq!(clusters_failed, 0, "all ghost clusters should be SAT-solved");
             assert!(clusters_solved > 0, "expected at least one cluster to solve");
@@ -1152,6 +1161,168 @@ fn tier4_advanced_circuit_from_ore_am1_ghost() {
             assert_produces(&result, "advanced-circuit", 5.0);
         }
     }
+}
+
+/// Minimal ghost-routing scoreboard for the tier1/tier2/tier3 ghost
+/// fixtures: runs the pipeline with ghost routing enabled, prints a
+/// short summary, and reports any overlapping cluster zones. No
+/// assertions — these fixtures exist for strategy debugging, not
+/// regression, and we expect them to expose problems rather than
+/// guard against them.
+fn run_ghost_scoreboard(
+    test_name: &str,
+    recipe: &str,
+    rate: f64,
+    machine: &str,
+    belt: Option<&str>,
+    inputs: &FxHashSet<String>,
+) {
+    std::env::set_var("FUCKTORIO_GHOST_ROUTING", "1");
+    let result = run_e2e(test_name, recipe, rate, machine, belt, inputs);
+    std::env::remove_var("FUCKTORIO_GHOST_ROUTING");
+
+    let result = result.unwrap_or_else(|e| panic!("{test_name}: ghost routing failed: {e}"));
+
+    let mut entity_count = 0;
+    let mut cluster_count = 0;
+    let mut max_cluster_tiles = 0;
+    let mut unroutable_count = 0;
+    let mut ghost_spec_routed = 0;
+    let mut ghost_spec_failed = 0;
+    let mut clusters_solved = 0;
+    let mut clusters_failed = 0;
+    let mut solved_zones: Vec<(i32, i32, u32, u32)> = Vec::new();
+
+    for ev in &result.trace_events {
+        match ev {
+            TraceEvent::GhostRoutingComplete {
+                entity_count: ec,
+                cluster_count: cc,
+                max_cluster_tiles: mt,
+                unroutable_count: uc,
+            } => {
+                entity_count = *ec;
+                cluster_count = *cc;
+                max_cluster_tiles = *mt;
+                unroutable_count = *uc;
+            }
+            TraceEvent::GhostSpecRouted { .. } => ghost_spec_routed += 1,
+            TraceEvent::GhostSpecFailed { .. } => ghost_spec_failed += 1,
+            TraceEvent::GhostClusterSolved { zone_x, zone_y, zone_w, zone_h, .. } => {
+                clusters_solved += 1;
+                solved_zones.push((*zone_x, *zone_y, *zone_w, *zone_h));
+            }
+            TraceEvent::GhostClusterFailed { .. } => clusters_failed += 1,
+            _ => {}
+        }
+    }
+
+    let errors = result.issues.iter()
+        .filter(|i| matches!(i.severity, fucktorio_core::validate::Severity::Error))
+        .count();
+    let warnings = result.issues.iter()
+        .filter(|i| matches!(i.severity, fucktorio_core::validate::Severity::Warning))
+        .count();
+
+    eprintln!(
+        "ghost scoreboard [{test_name}]:\n  \
+         entities: {entity_count}  specs ok/fail/unroutable: {ghost_spec_routed}/{ghost_spec_failed}/{unroutable_count}\n  \
+         clusters: {cluster_count} (solved {clusters_solved}, failed {clusters_failed}), max tiles {max_cluster_tiles}\n  \
+         validator: {errors} errors, {warnings} warnings"
+    );
+
+    let overlap_pairs = report_zone_overlaps(&solved_zones, "  ");
+    eprintln!("  zone overlap pairs: {overlap_pairs}");
+
+    // Per-category error breakdown so we can spot regressions/wins on
+    // each refactor step.
+    let mut by_check: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    for issue in &result.issues {
+        if matches!(issue.severity, fucktorio_core::validate::Severity::Error) {
+            *by_check.entry(issue.category.clone()).or_insert(0) += 1;
+        }
+    }
+    if !by_check.is_empty() {
+        eprintln!("  errors by category:");
+        for (cat, n) in &by_check {
+            eprintln!("    {cat}: {n}");
+        }
+    }
+}
+
+/// Pairwise overlap detector for ghost-cluster zones. Returns the
+/// number of overlapping pairs found and prints each pair to stderr
+/// with the supplied indent prefix. SAT solves each cluster
+/// independently with no shared occupancy mask, so any pair of padded
+/// zones that intersect spatially is a strategy bug.
+fn report_zone_overlaps(zones: &[(i32, i32, u32, u32)], indent: &str) -> usize {
+    let mut pairs = 0;
+    for (i, &(ax, ay, aw, ah)) in zones.iter().enumerate() {
+        for (j_off, &(bx, by, bw, bh)) in zones[i + 1..].iter().enumerate() {
+            let j = i + 1 + j_off;
+            let x_overlap = ax < bx + bw as i32 && bx < ax + aw as i32;
+            let y_overlap = ay < by + bh as i32 && by < ay + ah as i32;
+            if x_overlap && y_overlap {
+                pairs += 1;
+                eprintln!(
+                    "{indent}⚠ cluster overlap: #{i} ({ax},{ay}) {aw}x{ah}  vs  #{j} ({bx},{by}) {bw}x{bh}"
+                );
+            }
+        }
+    }
+    pairs
+}
+
+#[test]
+#[ignore]
+#[ntest::timeout(60000)]
+fn tier1_iron_gear_wheel_ghost() {
+    let inputs: FxHashSet<String> = ["iron-plate"].iter().map(|s| s.to_string()).collect();
+    run_ghost_scoreboard(
+        "tier1_ghost",
+        "iron-gear-wheel",
+        30.0,
+        "assembling-machine-1",
+        Some("transport-belt"),
+        &inputs,
+    );
+}
+
+#[test]
+#[ignore]
+#[ntest::timeout(60000)]
+fn tier2_electronic_circuit_from_ore_ghost() {
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    run_ghost_scoreboard(
+        "tier2_ghost",
+        "electronic-circuit",
+        30.0,
+        "assembling-machine-1",
+        Some("transport-belt"),
+        &inputs,
+    );
+}
+
+#[test]
+#[ignore]
+#[ntest::timeout(60000)]
+fn tier3_plastic_bar_ghost() {
+    let inputs: FxHashSet<String> = ["petroleum-gas", "coal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    run_ghost_scoreboard(
+        "tier3_ghost",
+        "plastic-bar",
+        30.0,
+        "chemical-plant",
+        Some("transport-belt"),
+        &inputs,
+    );
 }
 
 /// Baseline (Phase 1, 2026-04-11): entities=9190, warnings=0, zones_solved=13,

--- a/docs/rfp-ghost-occupancy-refactor.md
+++ b/docs/rfp-ghost-occupancy-refactor.md
@@ -1,0 +1,444 @@
+# RFP: Shared occupancy map for ghost routing
+
+**Status:** Draft — Step 1 in progress
+**Owner:** ghost routing pipeline
+**Tracking issue:** *(none yet)*
+**Related:** [`docs/rfp-ghost-cluster-routing.md`](rfp-ghost-cluster-routing.md), [`docs/rfp-junction-solver.md`](rfp-junction-solver.md)
+
+## Problem
+
+The ghost routing pipeline in `crates/core/src/bus/ghost_router.rs` has three solver phases that resolve crossings between bus belts:
+
+1. **Phase 6a-corridor** (~line 747) — stamps multi-tile UG bridges for runs of adjacent crossings on the same horizontal spec.
+2. **Phase 6a-pertile** (~line 957) — stamps single-crossing perpendicular templates (3-tile footprint: surface belt + UG-in + UG-out).
+3. **Phase 6b-SAT** (~line 1011) — clusters remaining crossings, pads each by ±2 tiles, runs the SAT crossing-zone solver per cluster.
+
+Each phase has its own view of "what tiles are occupied":
+
+| Phase | Reads obstacles from | Writes results to |
+|---|---|---|
+| Ghost A* (step 5) | `&hard`, `&existing_belts` | `routed_paths` (paths only) |
+| Corridor template (6a) | `&hard`, `pre_existing_set`, `routed_paths` | `entities` (mutated immediately) |
+| Per-tile template (6a-pertile) | `&hard`, `pre_existing_set`, `routed_paths` | `template_zones` (deferred) |
+| SAT (6b) | `&hard`, `&entities`, `routed_paths` | `sat_zones` (deferred) |
+
+Because per-tile templates and SAT both **defer** their writes (push to side vecs that aren't merged into `entities` until line 1093, after `resolve_clusters` returns), the SAT phase cannot see per-tile template footprints when building its `forced_empty` set at lines 1820-1841.
+
+### Concrete failure mode
+
+Reproduced reliably by `tier2_electronic_circuit_from_ore_ghost` at 30/s on `transport-belt` (22 conflicting cluster pairs) and observed in `tier4_advanced_circuit_from_ore_am1_ghost` (2 pairs, including the user-reported clusters 11/4 and 25/34/60).
+
+The fingerprint is consistent: a 1×3 per-tile template at `(x, y)` overlapped by a 5×5 SAT zone sourced from a different crossing tile at `(x+1, y+1)` (single-tile crossing → +2 padding → 5×5 bbox). The SAT zone's footprint engulfs the template's UG-out tile. SAT computes its solution unaware of the template, claims tiles the template is about to claim, and the post-hoc retain pass at line 1098 silently drops the conflicting SAT entities — leaving disconnected SAT belt fragments that don't physically connect to anything.
+
+The bug is **not** padding-induced overlap inside SAT (the line 1648 comment "no zone merging — overlapping zones produce conflicting SAT solutions" diagnoses a different problem). It is a **coordination failure between the template and SAT phases** caused by deferred writes.
+
+## Why a local fix isn't enough
+
+Three smaller fixes were considered:
+
+- **Inject template entities into `entities` before `resolve_clusters`.** Smallest possible change. Works for the immediate symptom but doesn't address the underlying issue: the per-phase obstacle representation will continue to drift as new template kinds are added. Each new phase needs to know about every other phase's footprint via ad-hoc parameter passing.
+- **Pass `pertile_template_zone_bboxes` into `resolve_clusters` and skip overlapping SAT zones.** Adds a special case in the SAT path. Doesn't generalise.
+- **Use a shared occupancy map.** Single source of truth for "what tiles are claimed and by what". This RFP.
+
+The shared-map approach is justified because:
+
+1. The SAT layer **already** supports the primitive we need: `CrossingZone::forced_empty` (`sat.rs:33`) is honoured by the encoder at lines 676-686 with three negative-literal clauses per tile (`!is_belt`, `!is_ug_in`, `!is_ug_out`). No SAT API changes required.
+2. The corridor template phase **already** writes immediately into `entities`. Per-tile templates and SAT are the outliers; the refactor brings them in line with corridor phase behaviour.
+3. The current `ghost:*`-segment-id-prefix string filtering at lines 729, 1072, 1836 is a poor man's claim-kind discriminator. A real claim-kind enum will simplify those checks rather than complicate them.
+
+## Design
+
+Add a private helper in `crates/core/src/bus/ghost_occupancy.rs` (new module).
+
+```rust
+pub(super) struct Occupancy {
+    /// Immutable obstacles: machines, poles, fluid-lane reservations.
+    /// A* never routes through these; templates and SAT never claim these.
+    hard: FxHashSet<(i32, i32)>,
+
+    /// All placed entities so far, in placement order. Indices are stable.
+    entities: Vec<PlacedEntity>,
+
+    /// Per-tile claim record. One entry per (x,y) that has a current claim.
+    /// HardObstacle takes precedence; entity claims point to indices in `entities`.
+    claims: FxHashMap<(i32, i32), Claim>,
+}
+
+pub(super) enum Claim {
+    /// Machine, pole, fluid lane, splitter footprint. Cannot be displaced.
+    HardObstacle,
+    /// Trunk, row template belt, balancer block. Permanent for the duration
+    /// of ghost routing — templates and SAT must route around these.
+    Permanent { entity_idx: usize },
+    /// Surface belt placed by ghost A* during step 5. May be replaced by a
+    /// template UG-bridge or SAT solution that runs through this tile.
+    GhostSurface { entity_idx: usize },
+    /// Stamped by corridor or per-tile template. Permanent once placed —
+    /// SAT must treat these as forced_empty.
+    Template { entity_idx: usize },
+    /// SAT-solved. Final, set in stone.
+    SatSolved { entity_idx: usize },
+}
+```
+
+### Methods
+
+```rust
+impl Occupancy {
+    fn new(hard: FxHashSet<(i32, i32)>, initial_entities: Vec<PlacedEntity>) -> Self;
+
+    // --- Queries ---
+    fn is_hard_obstacle(&self, tile: (i32, i32)) -> bool;
+    fn is_free(&self, tile: (i32, i32)) -> bool;             // no claim at all
+    fn claim_at(&self, tile: (i32, i32)) -> Option<&Claim>;
+    fn is_permanent(&self, tile: (i32, i32)) -> bool;        // HardObstacle | Permanent | Template | SatSolved
+    fn entity_at(&self, tile: (i32, i32)) -> Option<&PlacedEntity>;
+
+    // --- A* / template / SAT obstacle views ---
+    /// Tiles inside `zone` that SAT must treat as forced_empty:
+    /// everything except boundary ports and ghost-surface belts (which SAT replaces).
+    fn forced_empty_in(&self, zone: &ClusterZone, boundaries: &FxHashSet<(i32, i32)>) -> Vec<(i32, i32)>;
+
+    // --- Mutations ---
+    /// Place an entity with a given claim kind. Panics if the tile is already
+    /// claimed by anything other than a GhostSurface (which gets released).
+    fn place(&mut self, entity: PlacedEntity, kind: ClaimKindTag);
+
+    /// Release all GhostSurface claims inside a zone bbox (used by SAT before
+    /// claiming tiles for its own solution).
+    fn release_ghost_surface_in(&mut self, zone: &ClusterZone);
+
+    /// Release all GhostSurface, Permanent-trunk, and Permanent-tapoff claims
+    /// inside a per-tile template zone (used by per-tile template phase).
+    fn release_for_pertile_template(&mut self, zone: &ClusterZone);
+
+    // --- Drain final state ---
+    fn into_entities(self) -> Vec<PlacedEntity>;
+}
+```
+
+`ClaimKindTag` is a small enum that mirrors `Claim` variants but without the `entity_idx` field — used as the `place()` parameter to say "treat this entity as kind X".
+
+### How the existing phases map
+
+| Existing concept | New representation |
+|---|---|
+| `hard: FxHashSet<(i32,i32)>` (line 88) | `Occupancy::hard` (built once in step 1, never mutated) |
+| `existing_belts: FxHashSet<(i32,i32)>` (line 89) | derived from `claims` (`Permanent` or `Template` with belt entity) |
+| `pre_existing_set: FxHashSet<(i32,i32)>` (line 727) | `is_permanent(tile)` query — replaces both `hard.contains` and the segment-ID prefix walk |
+| `pre_ghost_belts` (line 93) | snapshot of permanent claims at end of step 3 |
+| `template_zones: Vec<(Vec<PlacedEntity>, ClusterZone)>` (line 738) | gone — templates write into Occupancy immediately and remember only their zone for SAT-zone-overlap accounting |
+| `pertile_template_zone_bboxes` (line 742) | gone — per-phase release calls handle the trunk/tapoff stripping |
+| Post-hoc retain pass at lines 1063-1083 | gone — split into per-phase release calls before each phase claims tiles |
+| `forced_empty_set` build at lines 1820-1841 | one call: `occupancy.forced_empty_in(zone, &boundary_set)` |
+| Final entity merge at line 1093 | `occupancy.into_entities()` |
+
+### Phase order in the new model
+
+1. **Step 1-3** build initial `Occupancy` from row entities, splitter stamps, balancer blocks. All claims are `HardObstacle` or `Permanent`.
+2. **Step 5 (Ghost A*)** queries `is_permanent(tile)` for routing constraints, then materialises surface belts and ground UGs as `GhostSurface` claims.
+3. **Step 6a-corridor** queries `is_permanent`, releases the bridged spec's `GhostSurface` belts on the corridor run tiles, then `place()`s its UG bridge as `Template`.
+4. **Step 6a-pertile** for each non-corridor crossing: queries `is_permanent` for UG endpoint clearance, calls `release_for_pertile_template(zone)` to drop ghost-surface + trunk + tapoff inside the 1×3 footprint, then `place()`s the surface belt + UG pair as `Template`.
+5. **Step 6b-SAT** for each remaining crossing cluster: builds the padded zone, calls `forced_empty_in(zone, &boundary_set)` to get tiles SAT must avoid (this **automatically includes** `Template` claims from step 6a-pertile, which is the bug fix), runs SAT, calls `release_ghost_surface_in(zone)` to drop the now-replaced ghost surface belts, then `place()`s SAT entities as `SatSolved`.
+6. **Step 7+** continues with output rows and pole placement, consuming `occupancy.into_entities()`.
+
+The bug fix lands at step 5: SAT's `forced_empty` now naturally contains template footprints, because the per-tile templates wrote them into the shared map at step 4 instead of deferring.
+
+### What stays the same
+
+- `sat::solve_crossing_zone` signature: unchanged. It already accepts `forced_empty` via `CrossingZone`.
+- A* signature: unchanged externally. Internally it calls `occupancy.is_hard_obstacle` / `occupancy.entity_at` instead of consulting two separate sets.
+- Trace events: unchanged. `GhostClusterSolved` still fires from the same three sites.
+- The retry/feedback loop in `build_bus_layout` (the broader pipeline that wraps ghost routing): unchanged.
+- Web app, WASM bindings, snapshot format: unchanged.
+
+### What gets deleted
+
+- `template_zones: Vec<(Vec<PlacedEntity>, ClusterZone)>`
+- `pertile_template_zone_bboxes: Vec<ClusterZone>`
+- `pre_existing_set: FxHashSet<(i32, i32)>`
+- The string-prefix filter `segment_id.starts_with("ghost:")` at lines 729, 1072, 1836
+- The post-hoc retain pass at lines 1063-1083
+- The `solved_zones = template_zones; solved_zones.append(&mut sat_zones)` merge at lines 1046-1047
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Phase ordering becomes load-bearing in a way it wasn't before. | The current code already assumes corridor → per-tile → SAT order. The refactor makes the dependency explicit, not new. |
+| `place()` panicking on a double-claim hides bugs by crashing the pipeline. | `place()` should return `Result` or take a `force_replace` parameter; tests cover the legitimate replacement paths (ghost-surface release before SAT/template claims). |
+| The `ghost:*` segment-id prefix is also used by the validator or downstream code. | Out of scope — the segment-id strings still get written, this RFP only changes how the **router** reads them. Audit before deleting any segment-id writes. |
+| WASM build breaks. | `Occupancy` is plain Rust collections, no I/O, no threads. Verify with `wasm-pack build crates/wasm-bindings` after step 1. |
+| Refactor breaks the existing tier4_ghost test in unexpected ways. | Step-by-step rollout (see Plan below). After each step the full e2e suite must stay green, and the ghost scoreboard outputs must be either identical or **strictly better** (fewer overlap pairs, fewer validator errors, no new failures). |
+
+## Plan
+
+Six steps. Each is a separate commit, independently verifiable, and bisectable.
+
+### Step 1 — Land the type, no wiring
+
+- Create `crates/core/src/bus/ghost_occupancy.rs` with `Occupancy`, `Claim`, `ClaimKindTag` and all methods listed above.
+- Add `pub(super) mod ghost_occupancy;` to `crates/core/src/bus/mod.rs`.
+- Unit tests in the same file:
+  - Construction from a hard set and initial entities.
+  - `is_free` / `is_permanent` / `claim_at` for each variant.
+  - `place` happy paths for each `ClaimKindTag`.
+  - `place` over a `GhostSurface` claim succeeds (replacement allowed).
+  - `place` over a `Permanent` / `HardObstacle` / `Template` / `SatSolved` claim returns `Err` (or panics — TBD in implementation).
+  - `release_ghost_surface_in` removes only ghost-surface claims inside the zone.
+  - `release_for_pertile_template` removes ghost-surface + permanent trunk/tapoff inside the zone.
+  - `forced_empty_in` produces the expected set for a constructed zone with mixed claims and a boundary set.
+  - `into_entities` returns entities in placement order.
+- **Not wired into `ghost_router.rs` at all.** Existing tests must stay green by being completely untouched.
+- Verification: `cargo test --manifest-path crates/core/Cargo.toml` (full suite green), `cargo clippy --tests` (no new warnings in the new file), `wasm-pack build` (compiles).
+
+### Step 2 — Build initial Occupancy in steps 1-3, run it alongside the existing `hard`/`existing_belts` sets
+
+- At the top of `build_ghost_layout` (or wherever steps 1-3 live), build an `Occupancy` in parallel with the existing `hard`/`existing_belts`/`pre_ghost_belts` sets.
+- Add a debug-only assertion at the end of step 3 that checks the new Occupancy agrees with the old sets (every tile in `hard` is `is_hard_obstacle`; every tile in `pre_ghost_belts` is `is_permanent`).
+- Don't consume Occupancy anywhere yet.
+- Verification: full suite green, scoreboards identical to current main.
+
+### Step 3 — Mirror materialisation writes into Occupancy
+
+> **Revised after reading the negotiation loop.** The original wording proposed
+> replacing `ghost_astar`'s obstacle params with `&Occupancy`, but `ghost_astar`
+> is a pure query function called from inside an 8-iteration negotiation loop
+> with per-iteration transient obstacle sets. Cloning Occupancy 8× per iteration
+> is wasteful, and A* has no semantic need to know about claim kinds — its
+> contract is "given an obstacle predicate and a cost grid, return a path."
+> Step 3's real goal is to exercise `Occupancy::place` in production with a
+> verified mirror, which can be done at the materialisation pass alone.
+
+- Hoist the parallel `Occupancy` binding out of the `cfg(debug_assertions)`
+  block added in Step 2. Release builds will now also construct it because
+  Steps 4-6 require it.
+- Keep the existing debug assertions that validate construction against
+  `hard` + `pre_ghost_belts`.
+- In the materialisation loop (lines 606-674), restructure the per-spec write
+  so the filtered entity list is collected into a temporary vec, then both
+  `entities.extend(...)` and `occupancy.place(..., GhostSurface)` consume the
+  same filtered vec. The filter (line 655) drops entities on `pre_ghost_belts`
+  tiles or `ghost_item_at`-claimed tiles — both should already have either a
+  `Permanent` claim (pre-ghost belts) or a `GhostSurface` claim from an earlier
+  spec in the loop, so the entities being filtered would have failed
+  `place()` anyway.
+- Add a post-materialisation debug assertion: every tile in the (post-loop)
+  `existing_belts` set should be `occupancy.is_claimed(tile)`. The reverse
+  direction does not hold because Occupancy includes machines, poles, and
+  fluid-lane reservations that `existing_belts` does not.
+- **Do not touch** `ghost_astar`'s signature, the negotiation loop,
+  `pre_ghost_belts`, `ghost_item_at`, or the unfiltered `existing_belts.insert`
+  at line 661. `existing_belts` after materialisation has different semantics
+  from Occupancy claim coverage — it tracks "a belt-tile passes through here"
+  including tiles where the materialisation filter dropped the entity, while
+  Occupancy tracks "an entity is placed here". Both are correct and they
+  intentionally differ.
+- Verification: full suite green, scoreboards identical (no behaviour change
+  because Occupancy remains write-only at this step).
+
+### Step 4 — Refactor per-tile template phase to write into Occupancy immediately
+
+- `solve_perpendicular_template` and `try_bridge` take `&Occupancy` instead of `&hard` + `&pre_existing_set`.
+- After `solve_perpendicular_template` succeeds, the caller calls `occupancy.release_for_pertile_template(zone)` and then `occupancy.place(ent, ClaimKindTag::Template)` for each entity, instead of pushing to `template_zones`.
+- `template_zones` shrinks to only contain corridor-template results (or gets eliminated entirely if corridor is also migrated in this step — TBD when implementing).
+- **This is where the bug fix lands.** SAT in step 5 will now see template footprints in `entities`, and its `forced_empty` build will pick them up via the existing line 1831 walk — even before SAT itself is migrated.
+- Verification: tier2_ghost @ 30/s overlap pairs drop from 22 to ~0 (some residual SAT-internal overlap may still exist if the cluster-padding bug is real and separate). Full e2e suite green.
+
+### Step 5 — Refactor SAT phase to build `forced_empty` from Occupancy
+
+> **Revised after implementation.** The original wording assumed a clean
+> swap of `&entities` + `&hard` for `&Occupancy`. In practice this needed
+> two sub-steps and exposed a semantic mismatch in the boundary-port check
+> that has been deferred to Step 6.
+
+**Step 5a:** Mirror corridor template state into Occupancy.
+
+- Push corridor UG bridge entities (built at `ents` in the corridor
+  template loop) directly into `entities` and into Occupancy as
+  `Template`. Replace the `template_zones.push((ents, zone))` call with
+  `template_zones.push((Vec::new(), zone))` (same pattern Step 4 used for
+  per-tile templates). This is what makes corridor UG bridges visible to
+  the SAT phase via `forced_empty`.
+- After the bridged-spec ghost belt removal at the existing
+  `entities.retain` call, call `occupancy.release_ghost_surface_in(...)`
+  on the corridor zone to mirror the removal.
+- After the perpendicular re-add push, mirror the new `corridor-perp:*`
+  belt into Occupancy as `Permanent`.
+- Add `#[derive(Clone, Copy)]` to `ClusterZone` so it can be used by
+  reference in multiple downstream calls without moves.
+
+**Step 5b:** Refactor `resolve_clusters` to consume Occupancy for
+forced_empty + writes.
+
+- New `Claim::RowEntity` variant in `ghost_occupancy`. `Occupancy::new`
+  now takes `(hard, row_entities, setup_entities)` and assigns
+  `RowEntity` claims for the row-entity slice. Both `is_permanent` and
+  `forced_empty_in` exclude `RowEntity` (the bus router *interfaces*
+  with row template belts via boundary ports rather than routing around
+  them — mirrors today's `pre_existing_positions` semantics, which
+  excluded row entities).
+- `resolve_clusters` takes `&mut Occupancy` and `&mut Vec<PlacedEntity>`
+  for writes. Inside it, `forced_empty` is built via
+  `occupancy.forced_empty_in(zone_rect, &boundary_set)`.
+- After SAT solves a cluster, call `occupancy.release_ghost_surface_in`
+  on the zone, then for each entity in the solution: skip if hard
+  obstacle, skip if not `is_free`, otherwise `place(SatSolved)` and
+  push to the entity output. Return `(Vec::new(), zone)` for the cluster
+  so the post-hoc add loop has nothing to re-add.
+
+**Known follow-ups for Step 6:**
+
+1. **Boundary check still uses the entities-walk semantics.** A direct
+   bisect found that switching the boundary port check from
+   `hard.contains() || pre_existing_positions.contains()` to
+   `Occupancy.is_permanent()` causes a tier2 regression (47 → 115
+   errors, with +66 `entity-overlap` errors), even after `RowEntity` was
+   added. The remaining drift is not yet fully understood. To preserve
+   correctness, `resolve_clusters` currently takes two snapshot
+   parameters (`boundary_check_hard`, `boundary_check_entities`) and
+   uses the original entities-walk for the boundary port check only.
+   Step 6 must reconcile the semantics — either find the missing
+   `Claim` variant / behaviour difference, or document why the boundary
+   check is intentionally different. The snapshot parameters should be
+   removed when this is resolved.
+2. **Tier4 has a small SAT-write delta:** 22 → 23 errors (+1
+   `entity-overlap`, one categorisation shift from belt-dead-end to
+   belt-item-isolation), 2194 → 2193 entities (-1). Likely caused by
+   the dynamic `is_free` check in the new SAT-write path being subtly
+   different from today's static `occupied` filter (today's filter is
+   built once before the post-hoc add loop and not updated between
+   clusters; the Occupancy path updates after each `place()` call).
+   Step 6 should investigate.
+
+**Verification:** tier1/2/3 metrics are byte-for-byte identical to the
+Step 5a baseline (which itself matches the Step 4 baseline). tier4 has
+the small +1 delta noted above. Full suite + lib tests + clippy + WASM
+all green.
+
+### Step 6 — Delete the obsolete plumbing
+
+**What landed:**
+
+- **Reconciled the boundary-check semantics.** Root cause: the
+  materialisation loop in Step 3 was placing *trunk* belts as
+  `GhostSurface`, but trunks are load-bearing vertical bus backbones
+  that templates and SAT must route around. The fix: check the spec
+  key in the materialisation loop and use `ClaimKindTag::Permanent`
+  for `trunk:*` specs, `GhostSurface` for everything else. With this,
+  `occupancy.is_permanent` matches today's `hard ∪
+  pre_existing_positions` semantics, and the bisect snapshot
+  parameters on `resolve_clusters` are gone.
+- **Fixed row entity classification.** `Occupancy::new` now takes
+  `(hard, row_belts, permanent_entities)`. The call site splits
+  `row_entities` into belt-like (→ `RowEntity`) and non-belt (→
+  `Permanent`) so that row machines, inserters, poles, and pipes are
+  correctly treated as obstacles, not permeable row belts.
+- **Deleted `pre_existing_set`.** It was only actively used by the
+  corridor endpoint check (replaced with `occupancy.is_permanent`);
+  the `solve_perpendicular_template` → `try_bridge` chain threaded it
+  but `try_bridge` ignored it. Both dead params removed.
+- **Deleted `template_zones` and `pertile_template_zone_bboxes`.**
+  Template zones are now tracked only via a `template_count: usize`
+  counter for `cluster_count` accounting. The per-tile/corridor
+  template phases push their entities directly into `entities` +
+  `Occupancy`, so the per-zone `(ents, zone)` storage is gone.
+- **Deleted the post-hoc retain pass + add loop.** Replaced with an
+  Occupancy-driven retain: walk `entities`, drop any `ghost:*` entity
+  whose Occupancy claim is no longer `GhostSurface` (released by a
+  template/SAT write), drop any `trunk:*`/`tapoff:*` entity whose
+  Occupancy claim is no longer `Permanent`. This captures the same
+  semantics as the old zone-bbox retain but reads from a single
+  source of truth.
+- **Shrunk `resolve_clusters`' return type.** It now returns
+  `(Vec<LayoutRegion>, usize)` instead of `(Vec<(Vec<PlacedEntity>,
+  ClusterZone)>, Vec<LayoutRegion>, usize)`. SAT solutions are
+  written directly into `entities` + `Occupancy` in the SAT loop;
+  there's no longer a side-channel to merge later.
+- **Snapshot the permanent obstacle set at the top of
+  `resolve_clusters`.** A new `Occupancy::snapshot_permanent_tiles()`
+  method freezes the set of `is_permanent` tiles before any SAT
+  cluster writes. The boundary-port check uses this snapshot so that
+  later clusters see the same obstacle view as earlier ones, matching
+  today's static `pre_existing_positions` behaviour.
+- **Partially addressed the entity-overlap-on-hard-tiles bug.** The
+  materialisation filter now excludes hard tiles too, which prevents
+  ghost belts from landing on fluid-lane reservations or machine
+  tiles. The underlying A* bug (allowing start/goal on hard
+  obstacles at `astar.rs:695/658`) is tracked in TASKS.md as a
+  remaining follow-up — the clean fix is to make `ghost_astar`
+  reject hard-tile start/goal outright.
+- **Removed the `#![allow(dead_code)]`** at the top of
+  `ghost_occupancy.rs`. The few remaining unused methods
+  (`entity_count`, `entity_at`, `into_entities`, `Claim::entity_idx`)
+  have per-item `#[allow(dead_code)]` with a note that they're API
+  surface for tests + future callers.
+- **Deleted the `entities()` method** that was never used anywhere.
+
+**What stayed:**
+
+- `existing_belts` and `pre_ghost_belts` in `route_bus_ghost` — still
+  used by the ghost A* negotiation loop (per-iteration transient
+  obstacle sets) and the materialisation loop's per-tile filter.
+  These are iteration-local and don't overlap Occupancy's role as
+  shared obstacle state, so deleting them would require refactoring
+  `ghost_astar` which is out of scope.
+- A few comments and variable names still reference the legacy
+  `pre_existing_positions` concept — harmless but can be tidied
+  later.
+
+**Verification:**
+
+| Test | Baseline (Step 4) | Step 6 | Δ |
+|---|---|---|---|
+| 366 lib unit tests | green | green (+2 net to 368) | ✅ |
+| 10/10 default e2e | green | green | ✅ |
+| tier1_ghost | 822 ents / 0 err | 822 / 0 | identical |
+| tier2_ghost | 5536 ents / 39 err | **5536 / 39** | identical |
+| tier3_ghost | 337 ents / 24 err | 336 / 24 | **−1 entity** from hard-tile filter |
+| tier4_ghost | 2194 ents / 22 err | 2194 / 22 | identical |
+| Clippy | 0 new warnings | 0 new | ✅ |
+| WASM release build | clean | clean | ✅ |
+
+The Step 5b tier4 regression (+1 entity-overlap, −1 entity) is
+**gone** — the trunk-as-Permanent fix reconciled it automatically.
+The Step 4 bug fix (per-tile template vs SAT collisions, tier2:
+47 → 39 errors) is preserved across the entire refactor.
+
+### Outcome
+
+The occupancy refactor is complete. `Occupancy` is the single source
+of truth for "what claims this tile" across all template and SAT
+phases. `ghost_router.rs` has:
+
+- 1 initial Occupancy construction in steps 1-3
+- 0 deferred entity queues (everything writes to `entities` +
+  `Occupancy` directly)
+- 0 post-hoc merge loops (the old `solved_zones` merge + add loop
+  is gone)
+- 1 retain pass that syncs `entities` to `Occupancy`'s released
+  state (much simpler than the old zone-bbox-walking variant)
+
+Net code delta: roughly −80 lines of plumbing, +150 lines of
+`ghost_occupancy.rs` module (most of which is comments + unit
+tests). The bug fix at the heart of the refactor (per-tile templates
+and SAT no longer stamp on top of each other) is preserved. The
+follow-ups that remain (`ghost_astar` hard-tile handling,
+`existing_belts`/`pre_ghost_belts` removal) are out of scope for
+this refactor and tracked in TASKS.md.
+
+## Verification protocol (applies to every step)
+
+1. **Default suite green:** `cargo test --manifest-path crates/core/Cargo.toml` — all 10 non-ignored tests pass.
+2. **Ghost suite green:** all four `tierN_ghost` tests pass with `--ignored`.
+3. **Scoreboard comparison:** capture the ghost scoreboard outputs (`zone overlap pairs`, `clusters`, `validator errors/warnings`) before and after the step. They must be identical OR strictly better (fewer overlaps, fewer errors). Never strictly worse.
+4. **Snapshot eyeball:** for steps 4 and 5, decode the new `tier2_ghost.fls` and `tier4_ghost.fls` and load them in the web app's snapshot debugger to confirm overlapping clusters are visually gone.
+5. **Clippy:** `cargo clippy --tests` — no new warnings in changed code.
+6. **WASM:** `wasm-pack build crates/wasm-bindings --target web --out-dir "$(pwd)/web/src/wasm-pkg"` — clean build.
+
+## Out of scope for this RFP
+
+- Detection logic for "should this crossing be a corridor vs per-tile vs SAT cluster" (Phase 6a dispatch). The current dispatch stays as-is. This RFP is only about coordination between the phases that actually run.
+- Cluster merging when SAT-cluster bboxes overlap each other (the `line 1648` "no zone merging" comment). If overlap pairs persist after step 5, that's a separate follow-up and should be tracked in its own issue.
+- Splitting the trace events to distinguish template-emitted vs SAT-emitted clusters in the snapshot debugger UI. Useful but not required for correctness.
+- Renaming `ghost:` segment-id prefixes. The strings stay; only how the router reads them changes.

--- a/scripts/analyze_ghost_crossings.py
+++ b/scripts/analyze_ghost_crossings.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Analyze ghost routing crossings from a .fls snapshot."""
-import sys
-import json
-import gzip
 import base64
+import gzip
+import json
+import sys
 from collections import defaultdict
 
 
@@ -42,7 +42,7 @@ def main(path):
             tile_to_specs[t].append(k)
 
     hist = defaultdict(int)
-    for t, specs in tile_to_specs.items():
+    for _t, specs in tile_to_specs.items():
         hist[len(specs)] += 1
     print("Tile spec-count histogram:", dict(hist))
     print()
@@ -69,7 +69,7 @@ def main(path):
     # Count run lengths
     run_len_hist = defaultdict(int)
     total_runs = 0
-    for y, runs in runs_by_y.items():
+    for _y, runs in runs_by_y.items():
         for r in runs:
             run_len_hist[len(r)] += 1
             total_runs += 1

--- a/scripts/analyze_ghost_crossings.py
+++ b/scripts/analyze_ghost_crossings.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Analyze ghost routing crossings from a .fls snapshot."""
+
 import base64
 import gzip
 import json

--- a/scripts/dump_ghost_path.py
+++ b/scripts/dump_ghost_path.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Dump the full path of a ghost-routed spec."""
-import sys
-import json
-import gzip
 import base64
+import gzip
+import json
+import sys
 
 
 def decode_fls(path):

--- a/scripts/dump_ghost_path.py
+++ b/scripts/dump_ghost_path.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Dump the full path of a ghost-routed spec."""
+
 import base64
 import gzip
 import json

--- a/scripts/dump_tiles_at.py
+++ b/scripts/dump_tiles_at.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Dump all entities at a y range."""
-import sys
-import json
-import gzip
 import base64
+import gzip
+import json
+import sys
 
 
 def decode_fls(path):

--- a/scripts/dump_tiles_at.py
+++ b/scripts/dump_tiles_at.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Dump all entities at a y range."""
+
 import base64
 import gzip
 import json

--- a/scripts/inspect_ghost_spec.py
+++ b/scripts/inspect_ghost_spec.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Inspect a specific ghost-routed spec from a .fls snapshot."""
+
 import base64
 import gzip
 import json

--- a/scripts/inspect_ghost_spec.py
+++ b/scripts/inspect_ghost_spec.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Inspect a specific ghost-routed spec from a .fls snapshot."""
-import sys
-import json
-import gzip
 import base64
+import gzip
+import json
+import sys
 
 
 def decode_fls(path):


### PR DESCRIPTION
## Summary

- Introduces a private `Occupancy` map as the single source of truth for tile claims across all ghost routing phases — replacing the parallel `hard` / `existing_belts` / `pre_existing_set` / deferred `template_zones` data flows.
- Fixes the per-tile-template-vs-SAT entity-overlap strategy bug on `tier2_electronic_circuit_from_ore_ghost @ 30/s`: validator errors 47 → 39, including `entity-overlap` 6 → 0.
- Adds three ghost-mode e2e fixtures (`tier1/2/3`) + a cluster-overlap diagnostic so future strategy work has controlled reproductions instead of eyeballing `tier4_ghost`.

Driven by `docs/rfp-ghost-occupancy-refactor.md`. Six-step rollout, fully landed.

## Motivation

During a debugging session on `tier4_ghost` the user noticed overlapping cluster bboxes. Investigation uncovered a real coordination failure:

- **Per-tile template entities were deferred** into a `template_zones` side vec until *after* `resolve_clusters` ran.
- SAT's `forced_empty` walker only saw `&entities`, which didn't contain the template entities yet.
- SAT clusters whose padded 5×5 zones overlapped a per-tile template's 1×3 footprint would compute solutions that claimed the template tiles.
- A post-hoc dedup filter then dropped the conflicting SAT entities, producing disconnected SAT belt fragments.

Fixing just the symptom (inject template ents into `entities` before SAT runs) would have been ~10 lines. But several adjacent coupling smells surfaced: two solver phases with different obstacle views, segment-id string prefix checks as a claim-kind discriminator, a post-hoc retain pass that reconciled `entities` with zone bboxes. The RFP decided those deserved one proper cleanup pass rather than a series of patches, and that's this PR.

## What lands

**New module: `crates/core/src/bus/ghost_occupancy.rs`** (~400 lines including tests)

```rust
pub(super) struct Occupancy {
    entities: Vec<PlacedEntity>,
    claims: FxHashMap<(i32, i32), Claim>,
}

pub(super) enum Claim {
    HardObstacle,                               // machines, poles, fluid lanes
    RowEntity { entity_idx: usize },            // row template belts (permeable — boundary ports may land on them)
    Permanent { entity_idx: usize },            // trunks, splitters, balancers, row non-belts
    GhostSurface { entity_idx: usize },         // ghost A* surface belts (replaceable by templates/SAT)
    Template { entity_idx: usize },             // per-tile and corridor template stamps
    SatSolved { entity_idx: usize },            // SAT cluster solutions
}
```

Key methods: `place`, `release_ghost_surface_in`, `release_for_pertile_template`, `forced_empty_in`, `is_permanent`, `is_hard_obstacle`, `snapshot_permanent_tiles`, `claim_at`. 14 unit tests covering construction, each place/release happy path, ghost-surface replacement, rejection of permanent/template/satsolved overwrites, zone-scoped releases, forced_empty generation, orphan dropping, and `RowEntity` permeability.

**Rewired `crates/core/src/bus/ghost_router.rs`**

- Ghost A* materialisation writes surface belts into Occupancy. Trunks (`trunk:*` specs) get `Permanent` claims; tap-offs/returns/horizontals get `GhostSurface` claims.
- Per-tile templates `release_for_pertile_template` + place `Template` claims, and push entities into `entities` directly (instead of deferring via `template_zones`). **This is where the tier2 bug fix lands.**
- Corridor templates (UG bridges + perpendicular re-adds) also write directly with `Template`/`Permanent` claims.
- `resolve_clusters` now takes `&mut Occupancy` + `&mut Vec<PlacedEntity>`, snapshots permanent obstacles at the top for the boundary-port check, builds per-zone `forced_empty` via `occupancy.forced_empty_in(zone, &boundary_set)`, and writes SAT solutions back via `release_ghost_surface_in` + `place(SatSolved)`.
- Post-hoc retain pass replaced with an Occupancy-driven sync: walk `entities`, drop `ghost:*` entities whose claim is no longer `GhostSurface`, drop `trunk:*`/`tapoff:*` entities whose claim is no longer `Permanent`.
- Post-hoc add loop deleted (it's a no-op now that every phase writes directly).
- `pre_existing_set` deleted; corridor endpoint check uses `occupancy.is_permanent`. `solve_perpendicular_template` + `try_bridge` lose the dead `pre_existing` parameter.
- `template_zones` and `pertile_template_zone_bboxes` deleted; replaced with a `template_count: usize` counter.
- Materialisation filter now also excludes hard tiles (partial fix for the A* start/goal-on-hard bug — see follow-ups).

**Test fixtures + diagnostics: `crates/core/tests/e2e.rs`**

- `run_ghost_scoreboard` helper — compact per-test scoreboard with error-category breakdown (no giant ASCII viz).
- `tier1_iron_gear_wheel_ghost`, `tier2_electronic_circuit_from_ore_ghost`, `tier3_plastic_bar_ghost` — simpler ghost-mode repros for strategy debugging.
- `report_zone_overlaps` — pairwise diagnostic that walks solved cluster zones and prints any structural bbox overlaps.
- tier2 at 30/s on transport-belt reproduces the strategy bug 22×. tier4 at 5/s has 2 structural overlaps (both corridor-adjacent).
- Tier4 scoreboard also gets the overlap diagnostic.

**Docs**

- `docs/rfp-ghost-occupancy-refactor.md` — full design, risk analysis, rollout plan, and per-step verification results. Updated to reflect deviations from the original plan (Step 3 didn't need an A\* signature change, Step 5 split into 5a/5b, Step 6 absorbed the boundary-check reconciliation).
- `TASKS.md` — updated the entity-overlap-on-hard-tiles entry to reflect what the refactor did address vs what remains.

## Verification

| Test | Baseline (current main) | This PR | Notes |
|---|---|---|---|
| 354 lib unit tests | green | **green** (+14 in `ghost_occupancy` → 368 total) | |
| 10/10 default e2e | green | **green** | |
| `tier1_iron_gear_wheel_ghost` | 822 ent / 0 err | 822 / 0 | identical |
| **`tier2_electronic_circuit_from_ore_ghost`** | 5542 / **47 err** | 5536 / **39 err** | **Strategy bug fix: entity-overlap 6→0, underground-belt 4→2** |
| `tier3_plastic_bar_ghost` | 337 / 24 err | 336 / 24 | -1 entity from hard-tile filter |
| `tier4_advanced_circuit_from_ore_am1_ghost` | 2194 / 22 err | 2194 / 22 | identical |
| Clippy (tests) | 0 new | 0 new | 2 pre-existing warnings in `e2e.rs:1033,1077` remain (tier4 ASCII viz, not touched) |
| `wasm-pack build` | clean | clean | |

**tier2 breakdown (the motivating case):**

| category | before | after | Δ |
|---|---|---|---|
| entity-overlap | 6 | **0** | **−6** |
| underground-belt | 4 | **2** | **−2** |
| belt-item-isolation | 13 | 12 | −1 |
| belt-dead-end | 23 | 24 | +1 (re-categorised from isolation) |
| belt-loop | 1 | 1 | 0 |
| **total** | **47** | **39** | **−8** |

The refactor does not improve tier4 directly — its 2 structural cluster overlaps are likely corridor-adjacent, and its remaining 22 errors are dominated by `fluid-connectivity` (15) which is orthogonal.

## What the refactor does NOT fix

This is scoped cleanup, not a silver bullet. Honest list of what stays broken:

- **The underlying routing quality is still mediocre.** tier2 at 39 errors, tier3 at 24, tier4 at 22 — these aren't "the refactor achieved zero errors" numbers. They're "the refactor fixed the specific class of bug it was built to fix". The remaining errors (`belt-dead-end`, `belt-item-isolation`, `belt-loop`, `fluid-connectivity`) point at deeper issues in tap-off generation, balancer stamping, and fluid-lane integration.
- **Structural cluster bbox overlap** is unchanged (tier2 still reports 22 overlap pairs, tier4 still 2). The diagnostic measures overlap of the **padded** bboxes, which is a property of the clustering algorithm, not of what SAT actually solves. The refactor makes those overlaps harmless (SAT and templates no longer stamp on top of each other), but it doesn't eliminate the zone-computation asymmetry that produces them.
- **`existing_belts` + `pre_ghost_belts` are still alive** in `route_bus_ghost`. They serve the A\* negotiation loop as per-iteration transient obstacle sets and the materialisation filter as a first-spec-wins check. Folding them into Occupancy would require refactoring `ghost_astar` too, which was deliberately out of scope.
- **`ghost_astar` still allows goal tiles on hard obstacles** at `astar.rs:695` and silently never checks start tiles at `astar.rs:658`. The refactor now filters those hard-tile path entities out of materialisation so they don't cause entity-overlap errors, but the A\* contract is still broken. Clean fix is to reject hard-tile start/goal states upstream, tracked in TASKS.md.

## Suggested next steps

Ordered roughly by impact × effort:

1. **Fix `ghost_astar` hard-tile handling properly** (TASKS.md). Reject hard-tile start/goal states in `ghost_astar` itself, or have tap-off spec generation in `route_bus_ghost` step 4 place the spec endpoint one tile off any fluid-lane reservation. This is a small, local change that eliminates a class of bugs at the source rather than filtering downstream.

2. **Investigate tier2's remaining 39 errors.** With the refactor in place, the strategy bug is gone, so whatever's left is "real" routing quality. The 24 `belt-dead-end` errors are the largest bucket — they likely represent tap-off specs whose end points don't connect back to the consuming row, or lane splits that produce stranded branches. Worth a focused look with the snapshot debugger.

3. **Investigate tier2's remaining zone overlap pairs.** The 22 structural overlaps are no longer causing entity collisions (the refactor's job), but the fact that they exist at all is a sign that `resolve_clusters`'s padded-bbox clustering is too coarse. Options: (a) merge overlapping bboxes into one bigger cluster pre-SAT (revisit the `line 1648` comment); (b) run SAT with a shared occupancy mask so clusters can see each other's tiles; (c) shrink padding adaptively based on neighbour proximity.

4. **Investigate tier4's 2 structural overlaps.** They're likely corridor-vs-SAT now that per-tile-vs-SAT is fixed. The corridor template path mirrors entities into Occupancy via Step 5a, so SAT already sees them in `forced_empty`, but the clusters still overlap structurally. Same remediation options as (3).

5. **Absorb `existing_belts` / `pre_ghost_belts` into Occupancy.** Requires refactoring `ghost_astar` to take `&Occupancy` instead of `&hard` + `&existing_belts`. Non-trivial because of the 8-iteration negotiation loop (each iteration needs a transient view). Would need either a `&mut Occupancy` with save/restore, or a lightweight per-iteration obstacle overlay that wraps Occupancy's permanent view.

6. **Fluid-connectivity errors on tier4 (15 of them).** Orthogonal to ghost routing — these are about whether chemical plants connect to their fluid inputs/outputs correctly. Would need separate investigation; possibly related to the `pipe-ground` work at `project_fluid_pipeground.md` in memory.

7. **Clean up the 2 pre-existing clippy warnings in `e2e.rs:1033,1077`.** Trivial; not touched in this PR to keep the diff focused.

## Commit structure

Two commits for reviewability:

1. `test(ghost): add tier1-3 ghost fixtures + overlap diagnostic` — e2e fixtures that work on main baseline; independently useful for strategy debugging even without the refactor.
2. `refactor(ghost): shared Occupancy map for template/SAT phases` — the refactor proper.

## Test plan

- [ ] `cargo test --manifest-path crates/core/Cargo.toml` — 368 lib + 10 e2e, all green
- [ ] `cargo test --manifest-path crates/core/Cargo.toml --test e2e tier{1,2,3,4}_ghost -- --exact --ignored` — all four ghost tests pass
- [ ] `FUCKTORIO_DUMP_SNAPSHOTS=1 cargo test ... tier2_electronic_circuit_from_ore_ghost ... --nocapture` — scoreboard shows 39 errors (was 47), entity-overlap 0 (was 6)
- [ ] `cargo clippy --manifest-path crates/core/Cargo.toml --tests` — no new warnings
- [ ] `wasm-pack build crates/wasm-bindings --target web --out-dir "$(pwd)/web/src/wasm-pkg"` — clean build
- [ ] Load `crates/core/target/tmp/snapshot-tier2_ghost.fls` in the web app's snapshot debugger and eyeball a few of the previously-overlapping regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)