### PR TITLE
Pass explicit exit directions through junction solving pipeline

### DIFF
--- a/crates/core/src/bus/ghost_occupancy.rs
+++ b/crates/core/src/bus/ghost_occupancy.rs
@@ -384,7 +384,25 @@ impl Occupancy {
     /// or fluid lanes that the template can't displace.
     ///
     /// Returns the number of claims released.
-    pub fn release_for_pertile_template(&mut self, zone: &Rect) -> usize {
+    ///
+    /// Releases ghost surface and trunk/tapoff permanent entities in `zone`.
+    ///
+    /// `preserve_trunk_tiles`: when `Some`, tiles in this set are kept even
+    /// if they carry a trunk/tapoff Permanent claim — use this to preserve
+    /// 1-tile trunk stubs that the crossing zone solution routes around
+    /// underground rather than replacing. `None` releases all trunk entities
+    /// in the zone (original behaviour).
+    ///
+    /// GhostSurface entities are always fully released within the zone.
+    ///
+    /// Note: trunk entities share a coarse segment_id (`"trunk:{item}"`),
+    /// so the preserve set is keyed by tile position, not segment_id.
+    pub fn release_for_pertile_template(
+        &mut self,
+        zone: &Rect,
+        releasable_ghost_tiles: Option<&rustc_hash::FxHashSet<(i32, i32)>>,
+        preserve_trunk_tiles: Option<&rustc_hash::FxHashSet<(i32, i32)>>,
+    ) -> usize {
         let to_remove: Vec<(i32, i32)> = self
             .claims
             .iter()
@@ -393,12 +411,21 @@ impl Occupancy {
                     return false;
                 }
                 match claim {
-                    Claim::GhostSurface { .. } => true,
-                    Claim::Permanent { entity_idx } => self
-                        .entities
-                        .get(*entity_idx)
-                        .and_then(|e| e.segment_id.as_deref())
-                        .is_some_and(|s| s.starts_with("trunk:") || s.starts_with("tapoff:")),
+                    Claim::GhostSurface { .. } => {
+                        releasable_ghost_tiles.is_none_or(|set| set.contains(*tile))
+                    }
+                    Claim::Permanent { entity_idx } => {
+                        let seg = self
+                            .entities
+                            .get(*entity_idx)
+                            .and_then(|e| e.segment_id.as_deref());
+                        let Some(seg) = seg else { return false; };
+                        if !seg.starts_with("trunk:") && !seg.starts_with("tapoff:") {
+                            return false;
+                        }
+                        // Release UNLESS this tile is in the preserve set.
+                        preserve_trunk_tiles.is_none_or(|set| !set.contains(*tile))
+                    }
                     _ => false,
                 }
             })
@@ -586,7 +613,7 @@ mod tests {
         occ.place(belt(4, 0, "junction:e"), ClaimKindTag::Template).unwrap();
 
         let zone = Rect { x: 0, y: 0, w: 5, h: 1 };
-        let n = occ.release_for_pertile_template(&zone);
+        let n = occ.release_for_pertile_template(&zone, None, None);
         assert_eq!(n, 3, "ghost + trunk + tapoff released");
 
         assert!(occ.is_free((0, 0)));
@@ -602,7 +629,7 @@ mod tests {
         hard.insert((0, 0));
         let mut occ = Occupancy::new(hard, Vec::new(), Vec::new());
         let zone = Rect { x: 0, y: 0, w: 1, h: 1 };
-        let n = occ.release_for_pertile_template(&zone);
+        let n = occ.release_for_pertile_template(&zone, None, None);
         assert_eq!(n, 0);
         assert!(occ.is_hard_obstacle((0, 0)));
     }

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -1368,31 +1368,28 @@ pub fn route_bus_ghost(
             w: footprint.w,
             h: footprint.h,
         };
-        // Only release trunk Permanent entities for specs that are actually
-        // participating in this crossing zone. Non-participating trunk stubs
-        // (e.g. 1-tile balancer output columns whose path sits inside the
-        // zone bbox but weren't an initial crossing spec) are left in place
-        // so the zone solution routes the participating specs around them
-        // underground without orphaning the stub.
+        // Preserve every tile in the footprint that the strategy is
+        // NOT explicitly stamping a new entity at. The strategy's
+        // solution is authoritative *exactly* over its proposed
+        // tiles; every other tile's existing claim (trunk belt,
+        // balancer splitter, non-participating tap, whatever) must
+        // remain intact so the chain around the crossing stays
+        // connected.
         //
-        // Note: trunk entities share a coarse segment_id ("trunk:{item}"),
-        // so we key the allowlist by tile position derived from each
-        // participating spec's routed path.
-        // Only preserve 1-tile trunk stubs that are NOT participating in this
-        // zone. These balancer output column stubs sit inside the crossing
-        // zone bbox but the SAT routes the participating specs underground past
-        // them — the stub entity must stay so the belt chain above it is not
-        // broken. All other trunks in the footprint are releasable as normal.
-        let preserve_trunk_tiles: rustc_hash::FxHashSet<(i32, i32)> = routed_paths
-            .iter()
-            .filter(|(key, path)| {
-                path.len() == 1
-                    && !keys_at_tile.contains(&key.as_str())
-                    && (key.starts_with("trunk:") || key.starts_with("tapoff:"))
-            })
-            .flat_map(|(_, path)| path.iter().copied())
-            .filter(|t| release_rect.contains(t.0, t.1))
-            .collect();
+        // This is the minimum-authority rule: we only touch what
+        // the solver explicitly promises to replace. Without it,
+        // uniformly-grown bboxes wipe out unrelated trunk/splitter
+        // entities just because they sit inside the rectangle.
+        let proposed_tiles: rustc_hash::FxHashSet<(i32, i32)> =
+            sol.entities.iter().map(|e| (e.x, e.y)).collect();
+        let preserve_trunk_tiles: rustc_hash::FxHashSet<(i32, i32)> =
+            (0..release_rect.h as i32)
+                .flat_map(|dy| {
+                    (0..release_rect.w as i32)
+                        .map(move |dx| (release_rect.x + dx, release_rect.y + dy))
+                })
+                .filter(|t| !proposed_tiles.contains(t))
+                .collect();
         // Only release ghost surface entities that lie on a participating
         // spec path. Ghost entities belonging to non-participating specs
         // (e.g. a copper-cable tap whose path runs through the zone bbox

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -1243,6 +1243,10 @@ pub fn route_bus_ghost(
         .iter()
         .map(|s| (s.key.clone(), s.item.clone()))
         .collect();
+    let spec_exit_dirs: FxHashMap<String, EntityDirection> = specs
+        .iter()
+        .filter_map(|s| s.exit_dir.map(|d| (s.key.clone(), d)))
+        .collect();
     // Build the obstacle set seen by junction strategies. The narrow
     // `hard` set only covers row-template machines and fluid lanes;
     // SAT (and any future strategy) needs the full picture so it
@@ -1314,6 +1318,7 @@ pub fn route_bus_ghost(
             &unreleasable_obstacles,
             &spec_belt_tiers,
             &spec_items,
+            &spec_exit_dirs,
             &entities,
             &strategies,
         ) else {
@@ -1588,6 +1593,10 @@ fn classify_crossing(
                 } else if i > 0 {
                     let (px2, py2) = path[i - 1];
                     step_direction(px - px2, py - py2)
+                } else if let Some(d) = spec.exit_dir {
+                    // 1-tile path: no neighbour to derive direction from.
+                    // Use the explicit exit_dir set at emission time.
+                    d
                 } else {
                     continue;
                 };

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -1321,12 +1321,27 @@ pub fn route_bus_ghost(
             &spec_exit_dirs,
             &entities,
             &strategies,
+            &crossing_set,
         ) else {
             remaining_crossings.insert(tile);
             continue;
         };
 
         let footprint = sol.footprint;
+        // Mark any other crossing tiles inside this zone's footprint as
+        // handled. A grown zone (e.g. a 4-tile wide SAT solution) may span
+        // several original crossing tiles; if we let the loop visit them
+        // independently the solver produces a second, broken solution that
+        // only partially overlaps the first (e.g. a UG output with no input).
+        for &ct in &crossing_set {
+            if ct.0 >= footprint.x
+                && ct.0 < footprint.x + footprint.w as i32
+                && ct.1 >= footprint.y
+                && ct.1 < footprint.y + footprint.h as i32
+            {
+                corridor_handled.insert(ct);
+            }
+        }
         trace::emit(trace::TraceEvent::GhostClusterSolved {
             cluster_id: template_count,
             zone_x: footprint.x,
@@ -1353,7 +1368,47 @@ pub fn route_bus_ghost(
             w: footprint.w,
             h: footprint.h,
         };
-        occupancy.release_for_pertile_template(&release_rect);
+        // Only release trunk Permanent entities for specs that are actually
+        // participating in this crossing zone. Non-participating trunk stubs
+        // (e.g. 1-tile balancer output columns whose path sits inside the
+        // zone bbox but weren't an initial crossing spec) are left in place
+        // so the zone solution routes the participating specs around them
+        // underground without orphaning the stub.
+        //
+        // Note: trunk entities share a coarse segment_id ("trunk:{item}"),
+        // so we key the allowlist by tile position derived from each
+        // participating spec's routed path.
+        // Only preserve 1-tile trunk stubs that are NOT participating in this
+        // zone. These balancer output column stubs sit inside the crossing
+        // zone bbox but the SAT routes the participating specs underground past
+        // them — the stub entity must stay so the belt chain above it is not
+        // broken. All other trunks in the footprint are releasable as normal.
+        let preserve_trunk_tiles: rustc_hash::FxHashSet<(i32, i32)> = routed_paths
+            .iter()
+            .filter(|(key, path)| {
+                path.len() == 1
+                    && !keys_at_tile.contains(&key.as_str())
+                    && (key.starts_with("trunk:") || key.starts_with("tapoff:"))
+            })
+            .flat_map(|(_, path)| path.iter().copied())
+            .filter(|t| release_rect.contains(t.0, t.1))
+            .collect();
+        // Only release ghost surface entities that lie on a participating
+        // spec path. Ghost entities belonging to non-participating specs
+        // (e.g. a copper-cable tap whose path runs through the zone bbox
+        // but is NOT being rerouted) must stay so the belt chain is intact.
+        let releasable_ghost_tiles: rustc_hash::FxHashSet<(i32, i32)> = keys_at_tile
+            .iter()
+            .filter_map(|k| routed_paths.get(*k))
+            .flatten()
+            .filter(|&&t| release_rect.contains(t.0, t.1))
+            .copied()
+            .collect();
+        occupancy.release_for_pertile_template(
+            &release_rect,
+            Some(&releasable_ghost_tiles),
+            Some(&preserve_trunk_tiles),
+        );
         for ent in sol.entities {
             let tile = (ent.x, ent.y);
             if occupancy.is_hard_obstacle(tile) {

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -288,6 +288,7 @@ impl GrowingRegion {
         routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
         spec_belt_tiers: &FxHashMap<String, BeltTier>,
         spec_items: &FxHashMap<String, String>,
+        spec_exit_dirs: &FxHashMap<String, EntityDirection>,
     ) -> Junction {
         let mut specs: Vec<SpecCrossing> = Vec::with_capacity(self.participating.len());
         for key in &self.participating {
@@ -297,8 +298,9 @@ impl GrowingRegion {
             let Some(&(start, end)) = self.frontiers.get(key) else {
                 continue;
             };
-            let entry_dir = direction_at(path, start);
-            let exit_dir = direction_at(path, end);
+            let dir_hint = spec_exit_dirs.get(key).copied();
+            let entry_dir = direction_at(path, start, dir_hint);
+            let exit_dir = direction_at(path, end, dir_hint);
             let entry = PortPoint {
                 x: path[start].0,
                 y: path[start].1,
@@ -334,7 +336,13 @@ impl GrowingRegion {
 
 /// Direction of flow at path index `idx`. Looks at the next step when
 /// possible, falling back to the previous step at the tail of the path.
-fn direction_at(path: &[(i32, i32)], idx: usize) -> EntityDirection {
+/// `fallback` is used when the path is a single tile (no neighbours to
+/// derive direction from) — callers should pass the spec's `exit_dir`.
+fn direction_at(
+    path: &[(i32, i32)],
+    idx: usize,
+    fallback: Option<EntityDirection>,
+) -> EntityDirection {
     if idx + 1 < path.len() {
         let (x0, y0) = path[idx];
         let (x1, y1) = path[idx + 1];
@@ -344,7 +352,7 @@ fn direction_at(path: &[(i32, i32)], idx: usize) -> EntityDirection {
         let (x1, y1) = path[idx];
         step_direction(x1 - x0, y1 - y0)
     } else {
-        EntityDirection::East
+        fallback.unwrap_or(EntityDirection::East)
     }
 }
 
@@ -433,6 +441,7 @@ pub fn solve_crossing(
     unreleasable_obstacles: &FxHashSet<(i32, i32)>,
     spec_belt_tiers: &FxHashMap<String, BeltTier>,
     spec_items: &FxHashMap<String, String>,
+    spec_exit_dirs: &FxHashMap<String, EntityDirection>,
     placed_entities: &[crate::models::PlacedEntity],
     strategies: &[&dyn JunctionStrategy],
 ) -> Option<JunctionSolution> {
@@ -445,7 +454,7 @@ pub fn solve_crossing(
     );
 
     for iter in 0..MAX_GROWTH_ITERS {
-        let junction = region.to_junction(routed_paths, spec_belt_tiers, spec_items);
+        let junction = region.to_junction(routed_paths, spec_belt_tiers, spec_items, spec_exit_dirs);
         let ctx = JunctionStrategyContext {
             junction: &junction,
             region: &region,

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -36,6 +36,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::bus::junction::{BeltTier, Junction, Rect, SpecCrossing};
+use crate::bus::region_walker::{walk_affected, AffectedPath, ShadowView, WalkResult};
 use crate::models::{EntityDirection, PlacedEntity, PortPoint};
 use crate::trace::{self, TraceEvent};
 
@@ -277,6 +278,48 @@ impl GrowingRegion {
         }
     }
 
+    /// Promote any encountered spec whose *entire* routed path is already
+    /// inside the current tile set. These specs are "fully engulfed" —
+    /// every tile they occupy is within the zone bbox — and must be routed
+    /// by the SAT solver or they become orphaned crossing specs.
+    ///
+    /// Typical case: a 1-tile trunk column that sits directly on the path
+    /// of a longer tap. The tap's crossing zone grows to include that tile,
+    /// which causes the trunk to appear in `encountered`. Without promotion
+    /// the SAT doesn't know about the trunk and places an entity that
+    /// conflicts with it.
+    #[allow(dead_code)]
+    pub fn promote_fully_enclosed(
+        &mut self,
+        routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
+        hard_obstacles: &FxHashSet<(i32, i32)>,
+        strict_obstacles: &FxHashSet<(i32, i32)>,
+    ) {
+        let to_promote: Vec<String> = self
+            .encountered
+            .iter()
+            .filter(|key| {
+                routed_paths
+                    .get(key.as_str())
+                    .is_some_and(|path| path.iter().all(|t| self.tiles.contains(t)))
+            })
+            .cloned()
+            .collect();
+        if to_promote.is_empty() {
+            return;
+        }
+        for key in &to_promote {
+            if let Some(path) = routed_paths.get(key.as_str()) {
+                let start = 0;
+                let end = path.len().saturating_sub(1);
+                self.frontiers.insert(key.clone(), (start, end));
+            }
+            self.participating.push(key.clone());
+        }
+        self.encountered.retain(|k| !to_promote.contains(k));
+        self.refresh_forbidden(routed_paths, hard_obstacles, strict_obstacles);
+    }
+
     /// Materialize a `Junction` snapshot suitable for strategy input.
     /// Entry/exit points for each participating spec are the first and
     /// last tiles of its current frontier range, with directions taken
@@ -444,6 +487,11 @@ pub fn solve_crossing(
     spec_exit_dirs: &FxHashMap<String, EntityDirection>,
     placed_entities: &[crate::models::PlacedEntity],
     strategies: &[&dyn JunctionStrategy],
+    // All crossing tiles in the layout. Used to detect when a spec's
+    // frontier exit lands on another unresolved crossing — in that case
+    // the zone defers (grows one more step) so the solution exits beyond
+    // all consecutive crossings rather than stopping mid-run.
+    all_crossings: &FxHashSet<(i32, i32)>,
 ) -> Option<JunctionSolution> {
     let mut region = GrowingRegion::from_crossing(
         initial_tile,
@@ -467,6 +515,61 @@ pub fn solve_crossing(
         };
         for strategy in strategies {
             if let Some(sol) = strategy.try_solve(&ctx) {
+                // Deferred-exit check: if any participating spec currently
+                // exits at another unresolved crossing tile (not the initial
+                // tile), the solution would leave a consecutive crossing
+                // unresolved. Grow one more step so the spec's frontier
+                // extends past all consecutive crossings before we commit.
+                let exits_at_crossing = ctx.junction.specs.iter().any(|s| {
+                    let exit = (s.exit.x, s.exit.y);
+                    exit != initial_tile && all_crossings.contains(&exit)
+                });
+                if exits_at_crossing {
+                    break; // skip this iter's solution; fall through to grow
+                }
+
+                // Walker veto: reject solutions that would break a routed
+                // path whose tiles touch the region's bbox (or its 1-tile
+                // perimeter). Catches the tier2_electronic_circuit class
+                // where SAT is locally valid but breaks a perpendicular
+                // trunk the region was unaware of.
+                let bbox = region.bbox;
+                let released = bbox_tiles_set(bbox);
+                let affected: Vec<AffectedPath<'_>> = routed_paths
+                    .iter()
+                    .filter_map(|(seg, tiles)| {
+                        if tiles.iter().any(|&t| near_bbox(bbox, t)) {
+                            let item = spec_items
+                                .get(seg)
+                                .map(|s| s.as_str())
+                                .unwrap_or("");
+                            Some(AffectedPath {
+                                segment_id: seg.as_str(),
+                                tiles: tiles.as_slice(),
+                                item,
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                let shadow = ShadowView::build(placed_entities, &released, &sol.entities);
+                if let WalkResult::Broken { breaks } = walk_affected(&affected, &shadow) {
+                    if let Some(first) = breaks.first() {
+                        trace::emit(TraceEvent::RegionWalkerVeto {
+                            tile_x: initial_tile.0,
+                            tile_y: initial_tile.1,
+                            strategy: strategy.name().to_string(),
+                            growth_iter: iter,
+                            broken_segment: first.segment_id.clone(),
+                            break_tile_x: first.tile.0,
+                            break_tile_y: first.tile.1,
+                            break_count: breaks.len(),
+                        });
+                    }
+                    continue; // try the next strategy; if all fail, grow
+                }
+
                 trace::emit(TraceEvent::JunctionSolved {
                     tile_x: initial_tile.0,
                     tile_y: initial_tile.1,
@@ -508,4 +611,30 @@ pub fn solve_crossing(
         reason: "iter_cap".to_string(),
     });
     None
+}
+
+/// Every tile inside `bbox` (inclusive on the min side, exclusive on the
+/// max side, per `Rect`'s convention). Used as the "released set" when
+/// building a walker shadow view — a strategy's solution is authoritative
+/// over every tile in its footprint.
+fn bbox_tiles_set(bbox: Rect) -> FxHashSet<(i32, i32)> {
+    let mut out = FxHashSet::default();
+    for dy in 0..bbox.h as i32 {
+        for dx in 0..bbox.w as i32 {
+            out.insert((bbox.x + dx, bbox.y + dy));
+        }
+    }
+    out
+}
+
+/// True iff `(x, y)` falls inside `bbox` expanded by one tile on each
+/// side. The walker uses this to decide which routed paths to check —
+/// anything one tile beyond the bbox can still interact with the
+/// region's boundary entities (e.g. a sideload onto a UG input).
+fn near_bbox(bbox: Rect, (x, y): (i32, i32)) -> bool {
+    let min_x = bbox.x - 1;
+    let min_y = bbox.y - 1;
+    let max_x = bbox.x + bbox.w as i32; // inclusive upper bound with +1 perimeter
+    let max_y = bbox.y + bbox.h as i32;
+    x >= min_x && x <= max_x && y >= min_y && y <= max_y
 }

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -122,10 +122,144 @@ impl GrowingRegion {
         region
     }
 
+    /// Expand the region's bbox by the given per-side deltas, absorb
+    /// every tile inside the new rectangle into the region, and
+    /// recompute the frontiers of already-participating specs. A
+    /// non-participating spec is *only* promoted when its path
+    /// genuinely crosses another participating spec inside the new
+    /// bbox (i.e. they share an interior tile). Specs that just happen
+    /// to pass through the bbox without touching any participating
+    /// path are left as obstacles — promoting them would over-constrain
+    /// the SAT encoder with specs that aren't part of the actual
+    /// crossing being resolved.
+    ///
+    /// This is the growth primitive used by the CEGAR loop: unlike
+    /// `grow()` (which walks each spec's frontier by one step along
+    /// its own axis), `expand_bbox` grows perpendicular to spec axes
+    /// and can absorb perpendicular trunks the seed crossing had never
+    /// heard of — the copper-cable column-4 trunk in the
+    /// tier2_electronic_circuit case being the canonical example.
+    ///
+    /// Returns `true` if the bbox changed.
+    pub fn expand_bbox(
+        &mut self,
+        left: i32,
+        top: i32,
+        right: i32,
+        bottom: i32,
+        routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
+        hard_obstacles: &FxHashSet<(i32, i32)>,
+        strict_obstacles: &FxHashSet<(i32, i32)>,
+    ) -> bool {
+        if left <= 0 && top <= 0 && right <= 0 && bottom <= 0 {
+            return false;
+        }
+        let new_x = self.bbox.x - left.max(0);
+        let new_y = self.bbox.y - top.max(0);
+        let new_w = self.bbox.w + (left.max(0) + right.max(0)) as u32;
+        let new_h = self.bbox.h + (top.max(0) + bottom.max(0)) as u32;
+        self.bbox = Rect {
+            x: new_x,
+            y: new_y,
+            w: new_w,
+            h: new_h,
+        };
+
+        // Absorb every tile in the new bbox into the region's tile set.
+        for dy in 0..new_h as i32 {
+            for dx in 0..new_w as i32 {
+                self.tiles.insert((new_x + dx, new_y + dy));
+            }
+        }
+
+        let in_bbox = |tx: i32, ty: i32| -> bool {
+            tx >= new_x
+                && tx < new_x + new_w as i32
+                && ty >= new_y
+                && ty < new_y + new_h as i32
+        };
+        let in_bbox_range = |path: &[(i32, i32)]| -> Option<(usize, usize)> {
+            let mut first: Option<usize> = None;
+            let mut last: Option<usize> = None;
+            for (i, &(tx, ty)) in path.iter().enumerate() {
+                if in_bbox(tx, ty) {
+                    if first.is_none() {
+                        first = Some(i);
+                    }
+                    last = Some(i);
+                }
+            }
+            match (first, last) {
+                (Some(s), Some(e)) if s < e => Some((s, e)),
+                _ => None,
+            }
+        };
+
+        // 1. Update frontiers for existing participating specs. Keep
+        //    any spec whose in-bbox range is at least 2 tiles and has
+        //    non-collapsed start < end.
+        let mut new_frontiers: FxHashMap<String, (usize, usize)> = FxHashMap::default();
+        let mut kept: Vec<String> = Vec::new();
+        for key in &self.participating {
+            if let Some(path) = routed_paths.get(key) {
+                if let Some(range) = in_bbox_range(path) {
+                    new_frontiers.insert(key.clone(), range);
+                    kept.push(key.clone());
+                    continue;
+                }
+            }
+            // Spec lost its in-bbox presence (shouldn't happen during
+            // monotonic growth, but be defensive): drop it.
+        }
+
+        // 2. Promote a non-participating spec only if its path shares
+        //    at least one in-bbox tile with an existing participating
+        //    spec — that tile is the genuine crossing we want SAT to
+        //    solve jointly. A spec whose path merely passes through
+        //    the bbox without touching any participating path is left
+        //    alone.
+        let kept_tiles: FxHashSet<(i32, i32)> = kept
+            .iter()
+            .filter_map(|k| routed_paths.get(k))
+            .flat_map(|p| {
+                p.iter().copied().filter(|&(tx, ty)| in_bbox(tx, ty))
+            })
+            .collect();
+        let kept_set: FxHashSet<&str> = kept.iter().map(|s| s.as_str()).collect();
+        let mut promoted: Vec<String> = Vec::new();
+        for (key, path) in routed_paths {
+            if kept_set.contains(key.as_str()) {
+                continue;
+            }
+            let Some(range) = in_bbox_range(path) else {
+                continue;
+            };
+            let (start, end) = range;
+            let touches_participating = (start..=end)
+                .any(|i| kept_tiles.contains(&path[i]));
+            if !touches_participating {
+                continue;
+            }
+            new_frontiers.insert(key.clone(), range);
+            promoted.push(key.clone());
+        }
+
+        self.participating = kept;
+        for key in promoted {
+            self.participating.push(key);
+        }
+        self.frontiers = new_frontiers;
+        self.encountered.retain(|k| !self.participating.contains(k));
+
+        self.refresh_forbidden(routed_paths, hard_obstacles, strict_obstacles);
+        true
+    }
+
     /// Advance each participating spec's frontier by one step in each
     /// direction along its path. Updates the bbox, the tile set, and
     /// the forbidden cache. Returns `true` if any new tile entered the
     /// region.
+    #[allow(dead_code)]
     pub fn grow(
         &mut self,
         routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
@@ -591,13 +725,26 @@ pub fn solve_crossing(
             });
             return None;
         }
-        if !region.grow(routed_paths, hard_obstacles, strict_obstacles) {
+        // Uniform bbox expansion: +1 on every side each iter. Absorbs
+        // perpendicular trunks the seed crossing never heard of; lets
+        // SAT make joint decisions across the whole absorbed region.
+        // A smarter tap-vs-trunk-aware sequence can replace this once
+        // uniform demonstrates the pipeline is sound.
+        if !region.expand_bbox(
+            1,
+            1,
+            1,
+            1,
+            routed_paths,
+            hard_obstacles,
+            strict_obstacles,
+        ) {
             trace::emit(TraceEvent::JunctionGrowthCapped {
                 tile_x: initial_tile.0,
                 tile_y: initial_tile.1,
                 iters: iter,
                 region_tiles: region.tile_count(),
-                reason: "frontier_exhausted".to_string(),
+                reason: "bbox_expand_failed".to_string(),
             });
             return None;
         }

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -667,8 +667,17 @@ pub fn solve_crossing(
                 // perimeter). Catches the tier2_electronic_circuit class
                 // where SAT is locally valid but breaks a perpendicular
                 // trunk the region was unaware of.
+                //
+                // Release set = exactly the tiles SAT proposed a new
+                // entity for. Everything else keeps its existing entity
+                // in the shadow. Proposed overrides existing at the
+                // shared tile via `ShadowView::build`. This preserves
+                // non-participating trunks that sit inside the bbox but
+                // SAT never promised to own — the walker would
+                // otherwise flag them as MissingEntity.
                 let bbox = region.bbox;
-                let released = bbox_tiles_set(bbox);
+                let released: FxHashSet<(i32, i32)> =
+                    sol.entities.iter().map(|e| (e.x, e.y)).collect();
                 let affected: Vec<AffectedPath<'_>> = routed_paths
                     .iter()
                     .filter_map(|(seg, tiles)| {
@@ -761,9 +770,10 @@ pub fn solve_crossing(
 }
 
 /// Every tile inside `bbox` (inclusive on the min side, exclusive on the
-/// max side, per `Rect`'s convention). Used as the "released set" when
-/// building a walker shadow view — a strategy's solution is authoritative
-/// over every tile in its footprint.
+/// max side, per `Rect`'s convention). Kept as a helper in case future
+/// strategies want to release the whole footprint — the current walker
+/// wiring releases only SAT-proposed tiles instead.
+#[allow(dead_code)]
 fn bbox_tiles_set(bbox: Rect) -> FxHashSet<(i32, i32)> {
     let mut out = FxHashSet::default();
     for dy in 0..bbox.h as i32 {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -31,6 +31,7 @@ pub mod ghost_router;
 pub(crate) mod junction;
 pub(crate) mod junction_sat_strategy;
 pub(crate) mod junction_solver;
+pub(crate) mod region_walker;
 pub(crate) mod lane_order;
 pub mod lane_planner;
 pub mod layout;

--- a/crates/core/src/bus/region_walker.rs
+++ b/crates/core/src/bus/region_walker.rs
@@ -159,6 +159,16 @@ fn walk_single(path: &AffectedPath<'_>, shadow: &ShadowView) -> Result<(), WalkB
     let mut i = 0usize;
     while i < tiles.len() {
         let t = tiles[i];
+        // Factorio UG corridor rule: if this tile sits strictly between
+        // a UG input and a paired UG output on THIS path, anything can
+        // live on the surface here (or nothing) — the flow passes
+        // underneath. Handled up-front so a perpendicular surface belt
+        // sitting on top of our corridor doesn't trigger a spurious
+        // item-mismatch break.
+        if is_hidden_middle_of_own_ug(tiles, i, path.item, shadow) {
+            i += 1;
+            continue;
+        }
         match shadow.get(t) {
             Some(e) => {
                 // Item must match. Wrong carries means SAT replaced our
@@ -205,14 +215,7 @@ fn walk_single(path: &AffectedPath<'_>, shadow: &ShadowView) -> Result<(), WalkB
                 i += 1;
             }
             None => {
-                // No entity at this tile. Only legal if it's the hidden
-                // middle of a UG pair belonging to this same path (in →
-                // middle → out all in `tiles` with `i` strictly between
-                // the in and out indices).
-                if is_hidden_middle_of_own_ug(tiles, i, path.item, shadow) {
-                    i += 1;
-                    continue;
-                }
+                // Empty tile and not a hidden middle — broken.
                 return Err(WalkBreak {
                     segment_id: path.segment_id.to_string(),
                     tile: t,

--- a/crates/core/src/bus/region_walker.rs
+++ b/crates/core/src/bus/region_walker.rs
@@ -1,0 +1,478 @@
+//! Region walker: structural reachability check for the junction solver's
+//! CEGAR (counter-example guided) loop.
+//!
+//! When a `JunctionStrategy` returns a candidate solution for a growing
+//! region, we can't commit it blindly — the strategy only knows about the
+//! specs it was handed, not about other routed paths that touch the
+//! region's footprint. The walker is the veto: it merges the proposed
+//! entities into a shadow view of the world and walks every affected
+//! path end-to-end. If any walk fails, the solution is rejected and the
+//! outer loop grows the region and retries.
+//!
+//! Scope, deliberately small for the MVP:
+//! - Checks presence + item match at each tile on each affected path.
+//! - Accepts UG passthroughs (same-path UG in → paired UG out) and
+//!   hidden-middle tiles between them.
+//! - Does *not* yet verify flow direction at each step; a belt carrying
+//!   the right item is treated as "probably fine." The assumption is
+//!   that the downstream validator still runs on the committed layout
+//!   and catches direction bugs we miss here. This keeps the walker
+//!   simple enough to trust and cheap enough to run on every iteration.
+//!
+//! The walker is intentionally decoupled from `GrowingRegion` and
+//! `JunctionStrategyContext`. The caller constructs an `AffectedPath`
+//! list and a `ShadowView`; we return a `WalkResult`. Everything else
+//! lives in the caller.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::models::{EntityDirection, PlacedEntity};
+
+/// A routed path the caller wants us to verify against the shadow view.
+/// Held by reference so the caller doesn't need to clone path data.
+#[derive(Debug, Clone, Copy)]
+pub struct AffectedPath<'a> {
+    /// Segment id used in traces and error reports (e.g. `trunk:copper-cable#0`).
+    pub segment_id: &'a str,
+    /// Ordered tile sequence from source to sink, inclusive.
+    pub tiles: &'a [(i32, i32)],
+    /// Item this path carries. Used for item-match checks.
+    pub item: &'a str,
+}
+
+/// Outcome of walking all affected paths.
+#[derive(Debug, Clone)]
+pub enum WalkResult {
+    /// Every affected path walks cleanly from source to sink. Commit the
+    /// proposed solution.
+    Passed,
+    /// At least one path failed. Caller should reject the solution and
+    /// grow the region.
+    Broken { breaks: Vec<WalkBreak> },
+}
+
+impl WalkResult {
+    #[allow(dead_code)]
+    pub fn is_passed(&self) -> bool {
+        matches!(self, WalkResult::Passed)
+    }
+}
+
+/// A single point of failure on a path. One walk can produce at most one
+/// break — we stop at the first bad tile.
+///
+/// The `reason` field is only observed via `Debug` today (trace output,
+/// test panics); `#[allow(dead_code)]` is there so rustc doesn't flag
+/// the variant fields while we iterate on the walker's surface.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct WalkBreak {
+    pub segment_id: String,
+    pub tile: (i32, i32),
+    pub reason: BreakReason,
+}
+
+/// Why a walk step failed. Fields carry enough detail for a
+/// human-readable trace line; not yet read programmatically.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum BreakReason {
+    /// Nothing at this tile in the shadow, and the tile is not a
+    /// legitimate UG hidden-middle on this path.
+    MissingEntity,
+    /// Shadow has an entity but it's carrying the wrong item.
+    ItemMismatch {
+        expected: String,
+        actual: Option<String>,
+    },
+    /// Found a UG input on this path but couldn't find a paired UG
+    /// output further along the path carrying the same item and
+    /// facing the same direction.
+    UnpairedUgIn { direction: EntityDirection },
+}
+
+/// A view of the world after a region's proposed entities are committed:
+/// existing entities outside the region, minus any tiles the region
+/// releases, plus the proposed entities inside the region.
+///
+/// This is a plain tile map; it's cheap to build and throw away because
+/// affected regions are small.
+///
+/// Perf note: `build` clones every existing entity into the map. For a
+/// ~1000-entity layout with a ~50-tile region that's fine (runs per
+/// veto attempt, measured in microseconds), but if profiling ever shows
+/// it as hot we can switch to a borrowed overlay (`FxHashMap<(i32,i32),
+/// &PlacedEntity>`) with a lifetime tied to `existing`.
+pub struct ShadowView {
+    by_tile: FxHashMap<(i32, i32), PlacedEntity>,
+}
+
+impl ShadowView {
+    /// Build a shadow view from the current world state plus a region's
+    /// proposed solution.
+    pub fn build(
+        existing: &[PlacedEntity],
+        released: &FxHashSet<(i32, i32)>,
+        proposed: &[PlacedEntity],
+    ) -> Self {
+        let mut by_tile: FxHashMap<(i32, i32), PlacedEntity> = FxHashMap::default();
+        for e in existing {
+            if released.contains(&(e.x, e.y)) {
+                continue;
+            }
+            by_tile.insert((e.x, e.y), e.clone());
+        }
+        // Proposed entities always win over existing — the region is
+        // authoritative inside its footprint.
+        for e in proposed {
+            by_tile.insert((e.x, e.y), e.clone());
+        }
+        Self { by_tile }
+    }
+
+    pub fn get(&self, tile: (i32, i32)) -> Option<&PlacedEntity> {
+        self.by_tile.get(&tile)
+    }
+}
+
+/// Walk every affected path in the shadow view and return a combined
+/// result.
+pub fn walk_affected(paths: &[AffectedPath<'_>], shadow: &ShadowView) -> WalkResult {
+    let mut breaks = Vec::new();
+    for p in paths {
+        if let Err(br) = walk_single(p, shadow) {
+            breaks.push(br);
+        }
+    }
+    if breaks.is_empty() {
+        WalkResult::Passed
+    } else {
+        WalkResult::Broken { breaks }
+    }
+}
+
+fn walk_single(path: &AffectedPath<'_>, shadow: &ShadowView) -> Result<(), WalkBreak> {
+    let tiles = path.tiles;
+    if tiles.is_empty() {
+        return Ok(());
+    }
+    let mut i = 0usize;
+    while i < tiles.len() {
+        let t = tiles[i];
+        match shadow.get(t) {
+            Some(e) => {
+                // Item must match. Wrong carries means SAT replaced our
+                // belt with something else (the tier2_ec sideload bug).
+                if e.carries.as_deref() != Some(path.item) {
+                    return Err(WalkBreak {
+                        segment_id: path.segment_id.to_string(),
+                        tile: t,
+                        reason: BreakReason::ItemMismatch {
+                            expected: path.item.into(),
+                            actual: e.carries.clone(),
+                        },
+                    });
+                }
+                // A UG input on this path jumps to its paired output
+                // further along the sequence; tiles between them are
+                // hidden middles we don't need to verify.
+                if is_ug_in(e) {
+                    let dir = e.direction;
+                    let paired = (i + 1..tiles.len()).find(|&j| {
+                        shadow
+                            .get(tiles[j])
+                            .map(|e2| {
+                                is_ug_out(e2)
+                                    && e2.direction == dir
+                                    && e2.carries.as_deref() == Some(path.item)
+                            })
+                            .unwrap_or(false)
+                    });
+                    match paired {
+                        Some(j) => {
+                            i = j + 1;
+                            continue;
+                        }
+                        None => {
+                            return Err(WalkBreak {
+                                segment_id: path.segment_id.to_string(),
+                                tile: t,
+                                reason: BreakReason::UnpairedUgIn { direction: dir },
+                            });
+                        }
+                    }
+                }
+                i += 1;
+            }
+            None => {
+                // No entity at this tile. Only legal if it's the hidden
+                // middle of a UG pair belonging to this same path (in →
+                // middle → out all in `tiles` with `i` strictly between
+                // the in and out indices).
+                if is_hidden_middle_of_own_ug(tiles, i, path.item, shadow) {
+                    i += 1;
+                    continue;
+                }
+                return Err(WalkBreak {
+                    segment_id: path.segment_id.to_string(),
+                    tile: t,
+                    reason: BreakReason::MissingEntity,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_ug(e: &PlacedEntity) -> bool {
+    e.name.contains("underground-belt")
+}
+
+fn is_ug_in(e: &PlacedEntity) -> bool {
+    is_ug(e) && e.io_type.as_deref() == Some("input")
+}
+
+fn is_ug_out(e: &PlacedEntity) -> bool {
+    is_ug(e) && e.io_type.as_deref() == Some("output")
+}
+
+/// True iff `tiles[idx]` sits strictly between a UG-input and matching
+/// UG-output on this same path. A matching pair carries the same item.
+fn is_hidden_middle_of_own_ug(
+    tiles: &[(i32, i32)],
+    idx: usize,
+    item: &str,
+    shadow: &ShadowView,
+) -> bool {
+    // Find the nearest UG input on this path at some j < idx.
+    let in_idx = (0..idx).rev().find(|&j| {
+        shadow
+            .get(tiles[j])
+            .map(|e| is_ug_in(e) && e.carries.as_deref() == Some(item))
+            .unwrap_or(false)
+    });
+    let Some(in_idx) = in_idx else { return false; };
+    // Find a matching UG output strictly after idx.
+    let out_idx = (idx + 1..tiles.len()).find(|&k| {
+        shadow
+            .get(tiles[k])
+            .map(|e| is_ug_out(e) && e.carries.as_deref() == Some(item))
+            .unwrap_or(false)
+    });
+    match out_idx {
+        Some(k) => in_idx < idx && idx < k,
+        None => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::EntityDirection;
+
+    fn belt(x: i32, y: i32, dir: EntityDirection, item: &str) -> PlacedEntity {
+        PlacedEntity {
+            name: "fast-transport-belt".into(),
+            x,
+            y,
+            direction: dir,
+            carries: Some(item.into()),
+            ..Default::default()
+        }
+    }
+
+    fn ug_in(x: i32, y: i32, dir: EntityDirection, item: &str) -> PlacedEntity {
+        PlacedEntity {
+            name: "fast-underground-belt".into(),
+            x,
+            y,
+            direction: dir,
+            carries: Some(item.into()),
+            io_type: Some("input".into()),
+            ..Default::default()
+        }
+    }
+
+    fn ug_out(x: i32, y: i32, dir: EntityDirection, item: &str) -> PlacedEntity {
+        PlacedEntity {
+            name: "fast-underground-belt".into(),
+            x,
+            y,
+            direction: dir,
+            carries: Some(item.into()),
+            io_type: Some("output".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn passes_unchanged_surface_path() {
+        // Straight copper-cable south belt run: (3,8)..(3,12).
+        let existing = vec![
+            belt(3, 8, EntityDirection::South, "copper-cable"),
+            belt(3, 9, EntityDirection::South, "copper-cable"),
+            belt(3, 10, EntityDirection::South, "copper-cable"),
+            belt(3, 11, EntityDirection::South, "copper-cable"),
+            belt(3, 12, EntityDirection::South, "copper-cable"),
+        ];
+        let shadow = ShadowView::build(&existing, &FxHashSet::default(), &[]);
+        let tiles = vec![(3, 8), (3, 9), (3, 10), (3, 11), (3, 12)];
+        let path = AffectedPath {
+            segment_id: "trunk:copper-cable#0",
+            tiles: &tiles,
+            item: "copper-cable",
+        };
+        let result = walk_affected(&[path], &shadow);
+        assert!(result.is_passed(), "expected Passed, got {result:?}");
+    }
+
+    #[test]
+    fn fails_on_item_mismatch_tier2_ec_bug() {
+        // Simulates the buggy tier2_electronic_circuit layout: column-3
+        // copper-cable is broken at (3,10) by an iron-plate UG input
+        // that SAT placed there. The walker must reject this.
+        let existing = vec![
+            belt(3, 8, EntityDirection::South, "copper-cable"),
+            belt(3, 9, EntityDirection::South, "copper-cable"),
+            // (3,10) was copper-cable, now the region released it.
+            belt(3, 11, EntityDirection::South, "copper-cable"),
+        ];
+        let released: FxHashSet<(i32, i32)> = [(3, 10)].into_iter().collect();
+        let proposed = vec![
+            // SAT put an iron-plate UG input East at (3,10) — the bug.
+            ug_in(3, 10, EntityDirection::East, "iron-plate"),
+            ug_out(5, 10, EntityDirection::East, "iron-plate"),
+        ];
+        let shadow = ShadowView::build(&existing, &released, &proposed);
+
+        let tiles = vec![(3, 8), (3, 9), (3, 10), (3, 11)];
+        let copper = AffectedPath {
+            segment_id: "trunk:copper-cable#0",
+            tiles: &tiles,
+            item: "copper-cable",
+        };
+        let result = walk_affected(&[copper], &shadow);
+        match result {
+            WalkResult::Broken { breaks } => {
+                assert_eq!(breaks.len(), 1);
+                assert_eq!(breaks[0].tile, (3, 10));
+                matches!(breaks[0].reason, BreakReason::ItemMismatch { .. });
+            }
+            _ => panic!("expected Broken, got {result:?}"),
+        }
+    }
+
+    #[test]
+    fn passes_when_ug_pair_bridges_the_conflict() {
+        // Simulates the 3×4 SAT-solved layout: column-3 copper-cable is
+        // undergrounded at (3,9) → (3,11), letting iron-plate take
+        // (3,10) as its own UG input without breaking copper-cable.
+        // The walker must accept this.
+        let existing = vec![
+            belt(3, 8, EntityDirection::South, "copper-cable"),
+            belt(3, 12, EntityDirection::South, "copper-cable"),
+        ];
+        let released: FxHashSet<(i32, i32)> = [(3, 9), (3, 10), (3, 11)].into_iter().collect();
+        let proposed = vec![
+            ug_in(3, 9, EntityDirection::South, "copper-cable"),
+            ug_in(3, 10, EntityDirection::East, "iron-plate"),
+            ug_out(3, 11, EntityDirection::South, "copper-cable"),
+        ];
+        let shadow = ShadowView::build(&existing, &released, &proposed);
+
+        let tiles = vec![(3, 8), (3, 9), (3, 10), (3, 11), (3, 12)];
+        let copper = AffectedPath {
+            segment_id: "trunk:copper-cable#0",
+            tiles: &tiles,
+            item: "copper-cable",
+        };
+        let result = walk_affected(&[copper], &shadow);
+        assert!(
+            result.is_passed(),
+            "expected Passed (legitimate UG bridge), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn passes_when_hidden_middle_between_ug_pair_on_own_path() {
+        // Path is entirely undergrounded from (5,5) to (5,8) with
+        // hidden middles at (5,6) and (5,7). Shadow has nothing at the
+        // middles — the walker's is_hidden_middle_of_own_ug check must
+        // recognise them as legal.
+        let proposed = vec![
+            ug_in(5, 5, EntityDirection::South, "iron-plate"),
+            ug_out(5, 8, EntityDirection::South, "iron-plate"),
+        ];
+        let shadow = ShadowView::build(&[], &FxHashSet::default(), &proposed);
+        let tiles = vec![(5, 5), (5, 6), (5, 7), (5, 8)];
+        let path = AffectedPath {
+            segment_id: "tapoff:iron-plate#2",
+            tiles: &tiles,
+            item: "iron-plate",
+        };
+        let result = walk_affected(&[path], &shadow);
+        assert!(result.is_passed(), "expected Passed, got {result:?}");
+    }
+
+    #[test]
+    fn fails_on_missing_entity_outside_ug_pair() {
+        // Path expects belts at (2,2)..(2,4) but (2,3) is empty in the
+        // shadow and there's no UG pair to justify it.
+        let existing = vec![
+            belt(2, 2, EntityDirection::South, "iron-plate"),
+            belt(2, 4, EntityDirection::South, "iron-plate"),
+        ];
+        let shadow = ShadowView::build(&existing, &FxHashSet::default(), &[]);
+        let tiles = vec![(2, 2), (2, 3), (2, 4)];
+        let path = AffectedPath {
+            segment_id: "tapoff:iron-plate#0",
+            tiles: &tiles,
+            item: "iron-plate",
+        };
+        match walk_affected(&[path], &shadow) {
+            WalkResult::Broken { breaks } => {
+                assert_eq!(breaks.len(), 1);
+                assert_eq!(breaks[0].tile, (2, 3));
+                assert!(matches!(breaks[0].reason, BreakReason::MissingEntity));
+            }
+            r => panic!("expected Broken(MissingEntity), got {r:?}"),
+        }
+    }
+
+    #[test]
+    fn fails_on_unpaired_ug_in() {
+        // Path has a UG input at (1,1) but no matching UG output later.
+        let proposed = vec![ug_in(1, 1, EntityDirection::East, "iron-plate")];
+        let shadow = ShadowView::build(&[], &FxHashSet::default(), &proposed);
+        let tiles = vec![(1, 1), (2, 1), (3, 1)];
+        let path = AffectedPath {
+            segment_id: "tapoff:iron-plate#1",
+            tiles: &tiles,
+            item: "iron-plate",
+        };
+        match walk_affected(&[path], &shadow) {
+            WalkResult::Broken { breaks } => {
+                assert_eq!(breaks[0].tile, (1, 1));
+                assert!(matches!(breaks[0].reason, BreakReason::UnpairedUgIn { .. }));
+            }
+            r => panic!("expected Broken(UnpairedUgIn), got {r:?}"),
+        }
+    }
+
+    #[test]
+    fn proposed_entity_wins_over_existing_at_same_tile() {
+        // If the same tile appears in both existing and proposed, the
+        // proposal must take priority — it's the region's authoritative
+        // solution.
+        let existing = vec![belt(4, 4, EntityDirection::South, "copper-cable")];
+        let proposed = vec![belt(4, 4, EntityDirection::East, "iron-plate")];
+        let shadow = ShadowView::build(&existing, &FxHashSet::default(), &proposed);
+        let e = shadow.get((4, 4)).unwrap();
+        assert_eq!(e.carries.as_deref(), Some("iron-plate"));
+        assert_eq!(e.direction, EntityDirection::East);
+    }
+}

--- a/crates/core/src/sat.rs
+++ b/crates/core/src/sat.rs
@@ -1651,4 +1651,126 @@ mod tests {
             );
         }
     }
+
+    /// 3×4 grown-region experiment for the tier2_electronic_circuit
+    /// sideload bug. Bbox x:3-5, y:9-12. Three item pairs cross:
+    ///   - iron-plate: enters left (3,10) East, exits right (5,10) East
+    ///   - copper-cable col-3: enters top (3,9) South, exits bottom (3,12) South
+    ///   - copper-cable col-4: enters top (4,9) South, exits right (5,11) East
+    ///
+    /// The question is whether the existing SAT encoder can find a
+    /// routing that avoids sideloading (3,9) south-belt into a putative
+    /// iron-plate UG input at (3,10). A valid solution exists by
+    /// undergrounding col-3 copper-cable around the iron-plate crossing.
+    #[test]
+    fn test_3x4_tier2_ec_grown_region() {
+        let zone = CrossingZone {
+            x: 3,
+            y: 9,
+            width: 3,
+            height: 4,
+            boundaries: vec![
+                ZoneBoundary {
+                    x: 3, y: 10,
+                    direction: EntityDirection::East,
+                    item: "iron-plate".into(),
+                    is_input: true,
+                },
+                ZoneBoundary {
+                    x: 5, y: 10,
+                    direction: EntityDirection::East,
+                    item: "iron-plate".into(),
+                    is_input: false,
+                },
+                ZoneBoundary {
+                    x: 3, y: 9,
+                    direction: EntityDirection::South,
+                    item: "copper-cable".into(),
+                    is_input: true,
+                },
+                ZoneBoundary {
+                    x: 3, y: 12,
+                    direction: EntityDirection::South,
+                    item: "copper-cable".into(),
+                    is_input: false,
+                },
+                ZoneBoundary {
+                    x: 4, y: 9,
+                    direction: EntityDirection::South,
+                    item: "copper-cable".into(),
+                    is_input: true,
+                },
+                ZoneBoundary {
+                    x: 5, y: 11,
+                    direction: EntityDirection::East,
+                    item: "copper-cable".into(),
+                    is_input: false,
+                },
+            ],
+            forced_empty: vec![],
+        };
+
+        let result = solve_crossing_zone(&zone, 7, "fast-transport-belt");
+        match &result {
+            Some(sol) => eprintln!(
+                "\n3×4 SAT SOLVED: {} entities ({} vars, {} clauses, {}µs)",
+                sol.entities.len(),
+                sol.stats.variables,
+                sol.stats.clauses,
+                sol.stats.solve_time_us,
+            ),
+            None => eprintln!("\n3×4 SAT returned None (UNSAT or encoder limitation)"),
+        }
+        let solution = result.expect("3×4 grown region should be solvable");
+
+        let by_pos: std::collections::HashMap<(i32, i32), &crate::models::PlacedEntity> =
+            solution.entities.iter().map(|e| ((e.x, e.y), e)).collect();
+
+        eprintln!("       x=3        x=4        x=5");
+        for wy in 9..=12 {
+            eprint!("y={wy:<2} ");
+            for wx in 3..=5 {
+                if let Some(e) = by_pos.get(&(wx, wy)) {
+                    let carry = e.carries.as_deref().unwrap_or("??");
+                    let tag = &carry[..2];
+                    let sym = match (&e.direction, &e.io_type) {
+                        (d, Some(t)) if t == "input" => {
+                            let arrow = match d {
+                                EntityDirection::North => "↑",
+                                EntityDirection::East => "→",
+                                EntityDirection::South => "↓",
+                                EntityDirection::West => "←",
+                            };
+                            format!("UGin{arrow}{tag}")
+                        }
+                        (d, Some(_)) => {
+                            let arrow = match d {
+                                EntityDirection::North => "↑",
+                                EntityDirection::East => "→",
+                                EntityDirection::South => "↓",
+                                EntityDirection::West => "←",
+                            };
+                            format!("UGot{arrow}{tag}")
+                        }
+                        (EntityDirection::North, _) => format!("↑({tag})"),
+                        (EntityDirection::South, _) => format!("↓({tag})"),
+                        (EntityDirection::East,  _) => format!("→({tag})"),
+                        (EntityDirection::West,  _) => format!("←({tag})"),
+                    };
+                    eprint!("{sym:<10} ");
+                } else {
+                    eprint!(".          ");
+                }
+            }
+            eprintln!();
+        }
+        eprintln!();
+
+        for e in &solution.entities {
+            eprintln!(
+                "  ({},{}) {} {:?} carries={:?} io={:?}",
+                e.x, e.y, e.name, e.direction, e.carries, e.io_type
+            );
+        }
+    }
 }

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -336,6 +336,24 @@ pub enum TraceEvent {
         region_tiles: usize,
         reason: String,
     },
+    // Emitted when the region walker rejects a strategy's proposed
+    // solution because it would break a routed path that touches the
+    // region's footprint. Caller treats this the same as the strategy
+    // returning `None`: fall through to the next strategy, and if all
+    // strategies fail (or are vetoed), grow and retry.
+    RegionWalkerVeto {
+        tile_x: i32,
+        tile_y: i32,
+        strategy: String,
+        growth_iter: usize,
+        /// Segment id of the first broken path (there may be more).
+        broken_segment: String,
+        /// Tile where the walker's check fired for that path.
+        break_tile_x: i32,
+        break_tile_y: i32,
+        /// Total number of breaks (one per affected path that failed).
+        break_count: usize,
+    },
 
     // Phase-1 instrumentation: emitted after all ghost specs are routed but
     // before crossing resolution. Reports per-tile axis occupancy so we can


### PR DESCRIPTION
## Summary
This change propagates explicit exit direction hints through the junction solving pipeline to improve handling of single-tile paths where direction cannot be derived from neighboring tiles.

## Key Changes
- Added `spec_exit_dirs` parameter to `GrowingRegion::to_junction()` to pass exit direction specifications
- Updated `direction_at()` function to accept an optional `fallback` parameter for cases where path has no neighbors to derive direction from
- Modified `solve_crossing()` to accept and forward `spec_exit_dirs` to junction creation
- Updated `route_bus_ghost()` to build a `spec_exit_dirs` map from specs and pass it through to `solve_crossing()`
- Enhanced `classify_crossing()` to use explicit `exit_dir` from spec when path is a single tile

## Implementation Details
- The fallback direction is used when a path contains only a single tile, making it impossible to determine flow direction from neighboring tiles
- Specs with explicit `exit_dir` values are collected into a map and threaded through the junction solving pipeline
- When `direction_at()` cannot derive direction from path neighbors, it falls back to the provided hint or defaults to `EntityDirection::East`
- This ensures consistent directional information for single-tile paths throughout the crossing classification and junction solving process

https://claude.ai/code/session_012WFCzeBDArQbd2u7ZMvWeR