### PR TITLE
feat(web): move WASM to worker + progressive phase reveal

### DIFF
--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -1,14 +1,7 @@
-import wasmInit, {
-  init,
-  solve as wasmSolve,
-  all_producible_items,
-  all_producer_machines,
-  default_machine_for_item as wasmDefaultMachineForItem,
-  export_blueprint as wasmExportBlueprint,
-  layout as wasmLayout,
-  layout_traced as wasmLayoutTraced,
-  parse_blueprint as wasmParseBlueprint,
-  validate_layout as wasmValidateLayout,
+import type {
+  SolverResult,
+  LayoutResult,
+  ValidationIssue,
 } from "./wasm-pkg/fucktorio_wasm.js";
 
 export type {
@@ -26,14 +19,78 @@ export type {
   ValidationIssue,
   TraceEvent,
 } from "./wasm-pkg/fucktorio_wasm.js";
-import type { SolverResult, LayoutResult, ValidationIssue } from "./wasm-pkg/fucktorio_wasm.js";
 
-let itemsCache: string[] | null = null;
-let machinesCache: string[] | null = null;
+type WorkerResponse = { id: number; ok: true; result: unknown } | { id: number; ok: false; error: string };
+
+let worker: Worker | null = null;
+let nextId = 0;
+const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+let itemsCache: string[] = [];
+let machinesCache: string[] = [];
+let defaultMachineCache = new Map<string, string>();
+
+let activeCountListeners = new Set<(active: number) => void>();
+let activeCount = 0;
+
+function onActive(delta: number): void {
+  activeCount += delta;
+  for (const cb of activeCountListeners) cb(activeCount);
+}
+
+/** Subscribe to engine activity (>0 while any RPC is in flight). Returns an unsubscribe fn. */
+export function onEngineActivity(cb: (active: number) => void): () => void {
+  activeCountListeners.add(cb);
+  cb(activeCount);
+  return () => activeCountListeners.delete(cb);
+}
+
+function call<T>(payload: Record<string, unknown>): Promise<T> {
+  if (!worker) throw new Error("Engine not initialized — call initEngine() first");
+  const id = ++nextId;
+  onActive(+1);
+  return new Promise<T>((resolve, reject) => {
+    pending.set(id, {
+      resolve: (v) => {
+        onActive(-1);
+        resolve(v as T);
+      },
+      reject: (e) => {
+        onActive(-1);
+        reject(e);
+      },
+    });
+    worker!.postMessage({ id, ...payload });
+  });
+}
 
 export async function initEngine(): Promise<void> {
-  await wasmInit();
-  init();
+  if (worker) return;
+  worker = new Worker(new URL("./workers/engine.worker.ts", import.meta.url), {
+    type: "module",
+    name: "fucktorio-engine",
+  });
+  worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+    const { id } = e.data;
+    const p = pending.get(id);
+    if (!p) return;
+    pending.delete(id);
+    if (e.data.ok) p.resolve(e.data.result);
+    else p.reject(new Error(e.data.error));
+  };
+  worker.onerror = (e) => {
+    console.error("[engine.worker] error", e);
+  };
+
+  await call<null>({ method: "init" });
+  itemsCache = await call<string[]>({ method: "allProducibleItems" });
+  machinesCache = await call<string[]>({ method: "allProducerMachines" });
+  const defaults = await call<[string, string][]>({
+    method: "defaultMachinesForItems",
+    items: itemsCache,
+    fallback: "assembling-machine-3",
+  });
+  defaultMachineCache = new Map(defaults);
 }
 
 function solve(
@@ -41,46 +98,49 @@ function solve(
   targetRate: number,
   availableInputs: string[],
   machineEntity: string,
-): SolverResult {
-  return wasmSolve(targetItem, targetRate, availableInputs, machineEntity);
+): Promise<SolverResult> {
+  return call<SolverResult>({
+    method: "solve",
+    targetItem,
+    targetRate,
+    availableInputs,
+    machineEntity,
+  });
 }
 
 function allProducibleItems(): string[] {
-  if (itemsCache === null) {
-    itemsCache = all_producible_items();
-  }
   return itemsCache;
 }
 
 function allProducerMachines(): string[] {
-  if (machinesCache === null) {
-    machinesCache = all_producer_machines();
-  }
   return machinesCache;
 }
 
-function buildLayout(result: SolverResult, maxBeltTier?: string): LayoutResult {
-  return wasmLayout(result, maxBeltTier ?? null);
+function buildLayout(result: SolverResult, maxBeltTier?: string): Promise<LayoutResult> {
+  return call<LayoutResult>({ method: "layout", result, maxBeltTier: maxBeltTier ?? null });
 }
 
-function buildLayoutTraced(result: SolverResult, maxBeltTier?: string): LayoutResult {
-  return wasmLayoutTraced(result, maxBeltTier ?? null);
+function buildLayoutTraced(result: SolverResult, maxBeltTier?: string): Promise<LayoutResult> {
+  return call<LayoutResult>({ method: "layoutTraced", result, maxBeltTier: maxBeltTier ?? null });
 }
 
-function exportBlueprint(layout: LayoutResult, label: string): string {
-  return wasmExportBlueprint(layout, label);
+function exportBlueprint(layout: LayoutResult, label: string): Promise<string> {
+  return call<string>({ method: "exportBlueprint", layout, label });
 }
 
 function defaultMachineForItem(item: string, fallback: string): string {
-  return wasmDefaultMachineForItem(item, fallback);
+  return defaultMachineCache.get(item) ?? fallback;
 }
 
-function validateLayout(layout: LayoutResult, solverResult: SolverResult | null): ValidationIssue[] {
-  return wasmValidateLayout(layout, solverResult, "Bus");
+function validateLayout(
+  layout: LayoutResult,
+  solverResult: SolverResult | null,
+): Promise<ValidationIssue[]> {
+  return call<ValidationIssue[]>({ method: "validateLayout", layout, solverResult });
 }
 
-export function parseBlueprint(bpString: string): LayoutResult {
-  return wasmParseBlueprint(bpString);
+export function parseBlueprint(bpString: string): Promise<LayoutResult> {
+  return call<LayoutResult>({ method: "parseBlueprint", bp: bpString });
 }
 
 export type Engine = {

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -23,6 +23,8 @@ import { createIssuesDialog } from "./ui/issuesDialog";
 import { createInspector } from "./ui/inspector";
 import { createSnapshotMode } from "./ui/snapshotMode";
 import { createStepThrough } from "./ui/stepThrough";
+import { attachBusyOverlay } from "./ui/busyOverlay";
+import { renderLayoutPhaseAnimated, type PhaseAnimationHandle } from "./renderer/phaseAnimation";
 
 const MACHINE_SLUGS = [
   "assembling-machine-1", "assembling-machine-2", "assembling-machine-3",
@@ -85,6 +87,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   const { app, viewport } = await createApp(container);
   drawGrid(viewport);
   drawGraph(viewport, null);
+
+  attachBusyOverlay(container);
 
   debugState.create();
 
@@ -191,6 +195,11 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       : null;
 
     if (snapshot) {
+      // Step-through is about to replace entities wholesale; stop any
+      // in-progress phase animation so its ticker doesn't write alphas on
+      // about-to-be-destroyed graphics.
+      phaseAnimHandle?.cancel();
+      phaseAnimHandle = null;
       snapshotActive = true;
       const ctrl = renderLayout(
         { ...lastLayout!, entities: snapshot.entities, width: snapshot.width, height: snapshot.height },
@@ -245,6 +254,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   let valOverlayLayer: Container | null = null;
   let valCircleMap: Map<string, Graphics[]> = new Map();
   let cachedValidationIssues: ValidationIssue[] | null = null;
+  let validationInFlightFor: LayoutResult | null = null;
 
   let regionOverlayLayer: Container | null = null;
   let regionHitTest: ((wx: number, wy: number) => RegionOverlayItem | null) | null = null;
@@ -263,12 +273,26 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     issuesDialog.clearPulse();
     issuesDialog.setCircleMap(valCircleMap);
 
-    if (lastLayout && !cachedValidationIssues) {
-      try {
-        cachedValidationIssues = engine.validateLayout(lastLayout, null);
-      } catch {
-        cachedValidationIssues = [];
-      }
+    // If we don't have cached issues yet for the current layout, kick off a
+    // validate in the worker and re-render when it lands. Guard against stale
+    // results by checking lastLayout identity when the promise resolves.
+    if (lastLayout && !cachedValidationIssues && validationInFlightFor !== lastLayout) {
+      const target = lastLayout;
+      validationInFlightFor = target;
+      engine
+        .validateLayout(target, null)
+        .then((issues) => {
+          if (lastLayout !== target) return; // superseded
+          cachedValidationIssues = issues;
+          validationInFlightFor = null;
+          updateValidationOverlay();
+        })
+        .catch(() => {
+          if (lastLayout !== target) return;
+          cachedValidationIssues = [];
+          validationInFlightFor = null;
+          updateValidationOverlay();
+        });
     }
 
     sidebarCtrl?.updateValidation(cachedValidationIssues ?? [], panToTile);
@@ -336,6 +360,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   let lastLayout: LayoutResult | null = null;
   let selectionCtrl: SelectionController | null = null;
+  let phaseAnimHandle: PhaseAnimationHandle | null = null;
 
   const snapshotMode = createSnapshotMode({
     sidebarEl: document.getElementById("sidebar"),
@@ -404,6 +429,9 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   window.addEventListener("blur", () => viewport.plugins.resume("drag"));
 
   function renderGraph(result: SolverResult | null): void {
+    // Stop any in-flight phase animation before we destroy its graphics.
+    phaseAnimHandle?.cancel();
+    phaseAnimHandle = null;
     entityLayer.removeChildren();
     drawGraph(viewport, result);
     legendEl.style.display = "none";
@@ -445,11 +473,26 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     snapshotActive = false;
     prevSnapshotEntities = null;
     if (selectionCtrl) { selectionCtrl.destroy(); selectionCtrl = null; }
+    phaseAnimHandle?.cancel();
+    phaseAnimHandle = null;
     annotationBar.style.display = "none";
     annotationNote.value = "";
     cachedValidationIssues = null;
     drawGraph(viewport, null);
-    const ctrl = renderLayout(layout, entityLayer, onHover, onSelect);
+
+    const traceEvents = Array.isArray(layout.trace) ? layout.trace : [];
+    const hasSnapshots = traceEvents.some(
+      (e) => (e as { phase?: string }).phase === "PhaseSnapshot",
+    );
+
+    let ctrl;
+    if (hasSnapshots) {
+      const out = renderLayoutPhaseAnimated(layout, entityLayer, onHover, onSelect, app);
+      ctrl = out.controller;
+      phaseAnimHandle = out.handle;
+    } else {
+      ctrl = renderLayout(layout, entityLayer, onHover, onSelect);
+    }
     inspector.setHighlightController(ctrl);
     selectionCtrl = createSelectionController(app.canvas, viewport, entityLayer, layout, onSelectionChange);
     buildLegend(layout);

--- a/web/src/renderer/entities.ts
+++ b/web/src/renderer/entities.ts
@@ -792,6 +792,7 @@ export function renderLayout(
   container: Container,
   onHover?: (entity: PlacedEntity | null) => void,
   onSelect?: (entity: PlacedEntity | null) => void,
+  onEntityRendered?: (entity: PlacedEntity, graphics: Graphics[]) => void,
 ): HighlightController {
   container.removeChildren();
 
@@ -936,6 +937,8 @@ export function renderLayout(
     allGraphics.push(g);
 
     container.addChild(g);
+
+    onEntityRendered?.(entity, [g]);
   }
 
   // Build belt connectivity graph (once per layout)

--- a/web/src/renderer/phaseAnimation.ts
+++ b/web/src/renderer/phaseAnimation.ts
@@ -1,0 +1,256 @@
+/**
+ * Progressive phase-reveal animation.
+ *
+ * Renders a layout but starts every entity at alpha=0, then fades them in
+ * phase-by-phase (rows_placed → lanes_planned → bus_routed → poles_placed →
+ * "final" pseudo-phase for output-merger stragglers). Within each phase,
+ * entities reveal staggered in NW→SE order (row-by-row top-to-bottom,
+ * left-to-right within each row).
+ *
+ * Driven by `app.ticker`. Cancellable mid-flight via the returned handle.
+ * Callers that don't want animation (corpus, parsed blueprints) just use
+ * `renderLayout` directly.
+ */
+
+import type { Application, Container, Graphics } from "pixi.js";
+import type { LayoutResult, PlacedEntity } from "../wasm-pkg/fucktorio_wasm";
+import { renderLayout, type HighlightController } from "./entities";
+
+const TOTAL_BUDGET_MS = 2200;
+const PHASE_PAUSE_MS = 180;
+const FADE_MS = 200;
+const DEFAULT_STAGGER_MS = 8;
+const PHASE_ORDER = ["rows_placed", "lanes_planned", "bus_routed", "poles_placed"] as const;
+
+type PhaseName = (typeof PHASE_ORDER)[number] | "final";
+
+export interface PhaseAnimationHandle {
+  cancel(): void;
+  finish(): void;
+  isDone(): boolean;
+}
+
+interface ScheduledReveal {
+  graphics: Graphics[];
+  revealStartMs: number;
+}
+
+function entityKey(e: PlacedEntity): string {
+  return `${e.x ?? 0},${e.y ?? 0},${e.name},${e.recipe ?? ""}`;
+}
+
+interface PhaseSnapshotData {
+  phase: string;
+  entities: PlacedEntity[];
+  width: number;
+  height: number;
+}
+
+function extractPhaseSnapshots(
+  layout: LayoutResult,
+): Map<string, PhaseSnapshotData> {
+  const byPhase = new Map<string, PhaseSnapshotData>();
+  const trace = layout.trace;
+  if (!Array.isArray(trace)) return byPhase;
+  for (const evt of trace) {
+    const anyEvt = evt as { phase?: string; data?: PhaseSnapshotData };
+    if (anyEvt.phase === "PhaseSnapshot" && anyEvt.data) {
+      byPhase.set(anyEvt.data.phase, anyEvt.data);
+    }
+  }
+  return byPhase;
+}
+
+/**
+ * Bucket entities into ordered phases using snapshot diffs.
+ * Each phase's bucket contains entities that were NEW in that snapshot
+ * (relative to the previous one). A synthetic "final" bucket catches
+ * anything in layout.entities not seen in any snapshot.
+ */
+function bucketByPhase(
+  layout: LayoutResult,
+): Array<{ phase: PhaseName; entities: PlacedEntity[] }> {
+  const snapshots = extractPhaseSnapshots(layout);
+  const buckets: Array<{ phase: PhaseName; entities: PlacedEntity[] }> = [];
+  const seen = new Set<string>();
+
+  for (const phase of PHASE_ORDER) {
+    const snap = snapshots.get(phase);
+    if (!snap) {
+      buckets.push({ phase, entities: [] });
+      continue;
+    }
+    const added: PlacedEntity[] = [];
+    for (const e of snap.entities) {
+      const k = entityKey(e);
+      if (!seen.has(k)) {
+        seen.add(k);
+        added.push(e);
+      }
+    }
+    buckets.push({ phase, entities: added });
+  }
+
+  // Synthetic "final" phase for entities that never appeared in a snapshot
+  // (e.g. output-merger stragglers emitted after poles_placed).
+  const stragglers: PlacedEntity[] = [];
+  for (const e of layout.entities) {
+    const k = entityKey(e);
+    if (!seen.has(k)) {
+      seen.add(k);
+      stragglers.push(e);
+    }
+  }
+  buckets.push({ phase: "final", entities: stragglers });
+
+  // NW→SE sort within each phase: y ascending (north→south), then x
+  // ascending (west→east). Gives a row-by-row top-to-bottom sweep.
+  for (const b of buckets) {
+    b.entities.sort((a, c) => {
+      const ay = a.y ?? 0;
+      const cy = c.y ?? 0;
+      if (ay !== cy) return ay - cy;
+      return (a.x ?? 0) - (c.x ?? 0);
+    });
+  }
+
+  return buckets;
+}
+
+export function renderLayoutPhaseAnimated(
+  layout: LayoutResult,
+  container: Container,
+  onHover: ((entity: PlacedEntity | null) => void) | undefined,
+  onSelect: ((entity: PlacedEntity | null) => void) | undefined,
+  app: Application,
+): { controller: HighlightController; handle: PhaseAnimationHandle } {
+  const entityGraphics = new Map<string, Graphics[]>();
+
+  const controller = renderLayout(layout, container, onHover, onSelect, (entity, gfx) => {
+    entityGraphics.set(entityKey(entity), gfx);
+  });
+
+  // Any container child not owned by an entity is an ambient decoration
+  // (currently: underground-belt tunnel stripes, drawn before the main
+  // entity loop in renderLayout). Fade those in at the start of the
+  // bus_routed phase so they don't float visible over hidden belts.
+  const entityOwned = new Set<Graphics>();
+  for (const arr of entityGraphics.values()) {
+    for (const g of arr) entityOwned.add(g);
+  }
+  const ambientGraphics: Graphics[] = [];
+  for (const child of container.children) {
+    const g = child as Graphics;
+    if (!entityOwned.has(g)) ambientGraphics.push(g);
+  }
+
+  // Start everything invisible.
+  for (const g of ambientGraphics) g.alpha = 0;
+  for (const arr of entityGraphics.values()) {
+    for (const g of arr) g.alpha = 0;
+  }
+
+  const buckets = bucketByPhase(layout);
+  const nonEmptyCount = buckets.reduce((n, b) => n + (b.entities.length > 0 ? 1 : 0), 0);
+
+  // Trivial case: nothing to animate. Snap everything and bail early.
+  if (nonEmptyCount === 0) {
+    for (const g of ambientGraphics) g.alpha = 1;
+    for (const arr of entityGraphics.values()) for (const g of arr) g.alpha = 1;
+    return {
+      controller,
+      handle: { cancel: () => {}, finish: () => {}, isDone: () => true },
+    };
+  }
+
+  // Budget per phase. Single shared budget so short phases don't waste time;
+  // stagger shrinks adaptively for large buckets so we never exceed the cap.
+  const budgetForStaggers = Math.max(0, TOTAL_BUDGET_MS - PHASE_PAUSE_MS * nonEmptyCount);
+  const perPhaseBudget = budgetForStaggers / nonEmptyCount;
+
+  const scheduled: ScheduledReveal[] = [];
+  const phaseStartByName = new Map<PhaseName, number>();
+  let cursorMs = 0;
+
+  for (const bucket of buckets) {
+    if (bucket.entities.length === 0) continue;
+    phaseStartByName.set(bucket.phase, cursorMs);
+    const stagger = Math.min(DEFAULT_STAGGER_MS, perPhaseBudget / bucket.entities.length);
+    bucket.entities.forEach((e, i) => {
+      const gfx = entityGraphics.get(entityKey(e));
+      if (!gfx || gfx.length === 0) return; // entity with no matching graphic — skip silently
+      scheduled.push({ graphics: gfx, revealStartMs: cursorMs + i * stagger });
+    });
+    const lastEntityStart = (bucket.entities.length - 1) * stagger;
+    cursorMs += lastEntityStart + FADE_MS + PHASE_PAUSE_MS;
+  }
+
+  // Ambient graphics fade in with the bus_routed phase (where belts first
+  // appear). Fall back to phase 0 if bus_routed is empty.
+  if (ambientGraphics.length > 0) {
+    const ambientStart =
+      phaseStartByName.get("bus_routed") ??
+      phaseStartByName.get("rows_placed") ??
+      0;
+    for (const g of ambientGraphics) {
+      scheduled.push({ graphics: [g], revealStartMs: ambientStart });
+    }
+  }
+
+  scheduled.sort((a, b) => a.revealStartMs - b.revealStartMs);
+
+  // --- Ticker loop ---
+  const startWallMs = performance.now();
+  let pointer = 0;
+  let cancelled = false;
+  let done = scheduled.length === 0;
+
+  const tick = (): void => {
+    if (cancelled || done) return;
+    const elapsed = performance.now() - startWallMs;
+
+    // Update alpha on every item currently in its fade window.
+    for (let i = pointer; i < scheduled.length; i++) {
+      const item = scheduled[i];
+      if (item.revealStartMs > elapsed) break;
+      const t = Math.min(1, (elapsed - item.revealStartMs) / FADE_MS);
+      for (const g of item.graphics) g.alpha = t;
+    }
+
+    // Advance the pointer past items that have fully faded in.
+    while (pointer < scheduled.length) {
+      const item = scheduled[pointer];
+      if (elapsed - item.revealStartMs < FADE_MS) break;
+      for (const g of item.graphics) g.alpha = 1;
+      pointer++;
+    }
+
+    if (pointer >= scheduled.length) {
+      done = true;
+      app.ticker.remove(tick);
+    }
+  };
+
+  app.ticker.add(tick);
+
+  const handle: PhaseAnimationHandle = {
+    cancel() {
+      if (cancelled || done) return;
+      cancelled = true;
+      app.ticker.remove(tick);
+    },
+    finish() {
+      if (cancelled || done) return;
+      for (const item of scheduled) {
+        for (const g of item.graphics) g.alpha = 1;
+      }
+      done = true;
+      app.ticker.remove(tick);
+    },
+    isDone() {
+      return done || cancelled;
+    },
+  };
+
+  return { controller, handle };
+}

--- a/web/src/ui/busyOverlay.ts
+++ b/web/src/ui/busyOverlay.ts
@@ -1,0 +1,89 @@
+/**
+ * Busy overlay — a small spinner that appears over the canvas while the
+ * WASM worker is churning on a solve/layout/validate. Avoids the old UX of
+ * the main thread freezing during a long layout.
+ *
+ * Shows after a short grace period so trivially fast calls don't flicker.
+ * Driven by `onEngineActivity` from engine.ts.
+ */
+
+import { onEngineActivity } from "../engine";
+
+const STYLE = `
+.fucktorio-busy {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(20, 20, 20, 0.82);
+  color: #d4d4d4;
+  padding: 6px 12px;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  font: 11px 'JetBrains Mono', 'Consolas', monospace;
+  letter-spacing: 0.5px;
+  pointer-events: none;
+  z-index: 20;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.fucktorio-busy.visible { opacity: 1; }
+.fucktorio-busy-spin {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #2a2a2a;
+  border-top-color: #569cd6;
+  border-radius: 50%;
+  animation: fucktorio-busy-spin 0.7s linear infinite;
+  display: inline-block;
+}
+@keyframes fucktorio-busy-spin { to { transform: rotate(360deg); } }
+`;
+
+function injectStyle(): void {
+  if (document.getElementById("fucktorio-busy-style")) return;
+  const el = document.createElement("style");
+  el.id = "fucktorio-busy-style";
+  el.textContent = STYLE;
+  document.head.appendChild(el);
+}
+
+const SHOW_GRACE_MS = 120;
+
+export function attachBusyOverlay(container: HTMLElement): void {
+  injectStyle();
+
+  const overlay = document.createElement("div");
+  overlay.className = "fucktorio-busy";
+
+  const spinner = document.createElement("span");
+  spinner.className = "fucktorio-busy-spin";
+  overlay.appendChild(spinner);
+
+  const label = document.createElement("span");
+  label.textContent = "computing…";
+  overlay.appendChild(label);
+
+  container.appendChild(overlay);
+
+  let showTimer: ReturnType<typeof setTimeout> | null = null;
+
+  onEngineActivity((active) => {
+    if (active > 0) {
+      if (showTimer === null && !overlay.classList.contains("visible")) {
+        showTimer = setTimeout(() => {
+          overlay.classList.add("visible");
+          showTimer = null;
+        }, SHOW_GRACE_MS);
+      }
+    } else {
+      if (showTimer !== null) {
+        clearTimeout(showTimer);
+        showTimer = null;
+      }
+      overlay.classList.remove("visible");
+    }
+  });
+}

--- a/web/src/ui/corpus.ts
+++ b/web/src/ui/corpus.ts
@@ -302,23 +302,28 @@ export function initCorpusPanel(
 
   panel.appendChild(pasteSection);
 
+  let pasteGen = 0;
   pasteArea.addEventListener("input", () => {
     const val = pasteArea.value.trim();
+    const gen = ++pasteGen;
     if (!val) {
       pasteArea.classList.remove("error");
       pasteError.style.display = "none";
       return;
     }
-    try {
-      const layout = parseBlueprint(val);
-      pasteArea.classList.remove("error");
-      pasteError.style.display = "none";
-      onRender(layout);
-    } catch (err) {
-      pasteArea.classList.add("error");
-      pasteError.textContent = String(err);
-      pasteError.style.display = "block";
-    }
+    parseBlueprint(val)
+      .then((layout) => {
+        if (gen !== pasteGen) return;
+        pasteArea.classList.remove("error");
+        pasteError.style.display = "none";
+        onRender(layout);
+      })
+      .catch((err) => {
+        if (gen !== pasteGen) return;
+        pasteArea.classList.add("error");
+        pasteError.textContent = String(err);
+        pasteError.style.display = "block";
+      });
   });
 
   // ---- Filters section ----

--- a/web/src/ui/landing.ts
+++ b/web/src/ui/landing.ts
@@ -603,39 +603,37 @@ function openPreview(
   card.classList.add("loading");
   entityCountEl.innerHTML = '<span class="fucktorio-spinner"></span>';
 
-  // Yield to let the spinner paint, then do synchronous WASM work
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      let solverResult: SolverResult;
-      let layout: LayoutResult;
-      try {
-        const machine = engine.defaultMachineForItem(entry.item, entry.machine);
-        solverResult = engine.solve(entry.item, entry.rate, entry.inputs, machine);
-        layout = engine.buildLayout(solverResult, entry.beltTier);
-      } catch (err) {
-        card.classList.remove("loading");
-        entityCountEl.textContent = "error";
-        console.error("Landing solve/layout failed:", err);
-        return;
-      }
-
-      entityCountEl.textContent = String(layout.entities.length);
+  // Kick off the solve/layout in the worker. UI stays responsive while it runs.
+  (async () => {
+    let solverResult: SolverResult;
+    let layout: LayoutResult;
+    try {
+      const machine = engine.defaultMachineForItem(entry.item, entry.machine);
+      solverResult = await engine.solve(entry.item, entry.rate, entry.inputs, machine);
+      layout = await engine.buildLayout(solverResult, entry.beltTier);
+    } catch (err) {
       card.classList.remove("loading");
+      entityCountEl.textContent = "error";
+      console.error("Landing solve/layout failed:", err);
+      return;
+    }
 
-      setRecipeFlows(
-        solverResult.machines.map((m) => ({
-          recipe: m.recipe,
-          count: m.count,
-          inputs: m.inputs.map((f) => ({ item: f.item, rate: f.rate })),
-          outputs: m.outputs.map((f) => ({ item: f.item, rate: f.rate })),
-        })),
-      );
+    entityCountEl.textContent = String(layout.entities.length);
+    card.classList.remove("loading");
 
-      showModal(entry, layout, solverResult).catch((err) => {
-        console.error("Modal init failed:", err);
-      });
+    setRecipeFlows(
+      solverResult.machines.map((m) => ({
+        recipe: m.recipe,
+        count: m.count,
+        inputs: m.inputs.map((f) => ({ item: f.item, rate: f.rate })),
+        outputs: m.outputs.map((f) => ({ item: f.item, rate: f.rate })),
+      })),
+    );
+
+    showModal(entry, layout, solverResult).catch((err) => {
+      console.error("Modal init failed:", err);
     });
-  });
+  })();
 }
 
 async function showModal(

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -344,13 +344,16 @@ export function renderSidebar(
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let previousItem = urlState.item;
   let currentLayout: LayoutResult | null = null;
+  let solveGeneration = 0;
 
   function scheduleAutoSolve(): void {
     if (debounceTimer !== null) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(runSolve, 150);
+    debounceTimer = setTimeout(() => {
+      runSolve().catch((err) => console.error("runSolve failed:", err));
+    }, 150);
   }
 
-  function runSolve(): void {
+  async function runSolve(): Promise<void> {
     const targetItem = itemInput.value.trim();
     const targetRate = parseFloat(rateInput.value);
     const machineEntity = machineSelect.value;
@@ -384,17 +387,16 @@ export function renderSidebar(
       belt: beltSelect.value || null,
     });
 
+    const gen = ++solveGeneration;
     resultContainer.innerHTML = "";
     currentLayout = null;
     blueprintSection.style.display = "none";
+
     let result: SolverResult;
     try {
-      result = engine.solve(targetItem, targetRate, availableInputs, machineSelect.value);
-      renderResult(resultContainer, result);
-      callbacks.renderGraph(result);
-      const totalMachines = result.machines.reduce((sum, m) => sum + Math.ceil(m.count), 0);
-      if (solverCount) solverCount.textContent = `${totalMachines} machines`;
+      result = await engine.solve(targetItem, targetRate, availableInputs, machineSelect.value);
     } catch (err) {
+      if (gen !== solveGeneration) return;
       callbacks.renderGraph(null);
       if (solverCount) solverCount.textContent = "error";
       const errDiv = document.createElement("div");
@@ -403,39 +405,49 @@ export function renderSidebar(
       resultContainer.appendChild(errDiv);
       return;
     }
+    if (gen !== solveGeneration) return;
 
-    // Build the layout directly — no explicit button needed since
-    // scheduleAutoSolve already debounces input changes.
+    renderResult(resultContainer, result);
+    callbacks.renderGraph(result);
+    const totalMachines = result.machines.reduce((sum, m) => sum + Math.ceil(m.count), 0);
+    if (solverCount) solverCount.textContent = `${totalMachines} machines`;
+
+    let layout: LayoutResult;
     try {
       const maxTier = beltSelect.value || undefined;
-      currentLayout = engine.buildLayoutTraced(result, maxTier);
-      setRecipeFlows(result.machines);
-      callbacks.renderLayout(currentLayout);
-      if (currentLayout.warnings?.length) {
-        for (const w of currentLayout.warnings) {
-          const wDiv = document.createElement("div");
-          wDiv.className = "sb-warning";
-          wDiv.textContent = `\u26A0 ${w}`;
-          resultContainer.appendChild(wDiv);
-        }
-        blueprintSection.style.display = "none";
-      } else {
-        blueprintSection.style.display = "flex";
-      }
-      if (currentLayout.trace?.length && options?.getDebugMode?.()) {
-        resultContainer.appendChild(renderDebugPanel(currentLayout.trace));
-      }
+      layout = await engine.buildLayoutTraced(result, maxTier);
     } catch (err) {
+      if (gen !== solveGeneration) return;
       const errDiv = document.createElement("div");
       errDiv.className = "sb-result-error";
       errDiv.textContent = `Layout error: ${err}`;
       resultContainer.appendChild(errDiv);
+      return;
+    }
+    if (gen !== solveGeneration) return;
+
+    currentLayout = layout;
+    setRecipeFlows(result.machines);
+    callbacks.renderLayout(layout);
+    if (layout.warnings?.length) {
+      for (const w of layout.warnings) {
+        const wDiv = document.createElement("div");
+        wDiv.className = "sb-warning";
+        wDiv.textContent = `\u26A0 ${w}`;
+        resultContainer.appendChild(wDiv);
+      }
+      blueprintSection.style.display = "none";
+    } else {
+      blueprintSection.style.display = "flex";
+    }
+    if (layout.trace?.length && options?.getDebugMode?.()) {
+      resultContainer.appendChild(renderDebugPanel(layout.trace));
     }
   }
 
   copyBtn.addEventListener("click", async () => {
     if (!currentLayout) return;
-    const bp = engine.exportBlueprint(currentLayout, itemInput.value.trim());
+    const bp = await engine.exportBlueprint(currentLayout, itemInput.value.trim());
     await navigator.clipboard.writeText(bp);
     copyStatus.textContent = "Copied!";
     setTimeout(() => { copyStatus.textContent = ""; }, 2000);
@@ -447,7 +459,7 @@ export function renderSidebar(
   beltSelect.addEventListener("change", scheduleAutoSolve);
   checkboxes.forEach((cb) => cb.addEventListener("change", scheduleAutoSolve));
 
-  runSolve();
+  runSolve().catch((err) => console.error("runSolve failed:", err));
 
   return {
     getParams() {

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -1,0 +1,108 @@
+import wasmInit, {
+  init,
+  solve,
+  all_producible_items,
+  all_producer_machines,
+  default_machine_for_item,
+  export_blueprint,
+  layout,
+  layout_traced,
+  parse_blueprint,
+  validate_layout,
+} from "../wasm-pkg/fucktorio_wasm.js";
+import type {
+  SolverResult,
+  LayoutResult,
+} from "../wasm-pkg/fucktorio_wasm.js";
+
+type Request =
+  | { id: number; method: "init" }
+  | { id: number; method: "allProducibleItems" }
+  | { id: number; method: "allProducerMachines" }
+  | { id: number; method: "defaultMachinesForItems"; items: string[]; fallback: string }
+  | {
+      id: number;
+      method: "solve";
+      targetItem: string;
+      targetRate: number;
+      availableInputs: string[];
+      machineEntity: string;
+    }
+  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null }
+  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null }
+  | { id: number; method: "exportBlueprint"; layout: LayoutResult; label: string }
+  | {
+      id: number;
+      method: "validateLayout";
+      layout: LayoutResult;
+      solverResult: SolverResult | null;
+    }
+  | { id: number; method: "parseBlueprint"; bp: string };
+
+let ready: Promise<void> | null = null;
+
+function ensureReady(): Promise<void> {
+  if (!ready) {
+    ready = (async () => {
+      await wasmInit();
+      init();
+    })();
+  }
+  return ready;
+}
+
+function post(id: number, ok: boolean, value: unknown): void {
+  if (ok) {
+    (self as unknown as Worker).postMessage({ id, ok: true, result: value });
+  } else {
+    (self as unknown as Worker).postMessage({ id, ok: false, error: value });
+  }
+}
+
+self.onmessage = async (e: MessageEvent<Request>) => {
+  const req = e.data;
+  try {
+    await ensureReady();
+    let result: unknown;
+    switch (req.method) {
+      case "init":
+        result = null;
+        break;
+      case "allProducibleItems":
+        result = all_producible_items();
+        break;
+      case "allProducerMachines":
+        result = all_producer_machines();
+        break;
+      case "defaultMachinesForItems": {
+        const out: [string, string][] = [];
+        for (const item of req.items) {
+          out.push([item, default_machine_for_item(item, req.fallback)]);
+        }
+        result = out;
+        break;
+      }
+      case "solve":
+        result = solve(req.targetItem, req.targetRate, req.availableInputs, req.machineEntity);
+        break;
+      case "layout":
+        result = layout(req.result, req.maxBeltTier ?? undefined);
+        break;
+      case "layoutTraced":
+        result = layout_traced(req.result, req.maxBeltTier ?? undefined);
+        break;
+      case "exportBlueprint":
+        result = export_blueprint(req.layout, req.label);
+        break;
+      case "validateLayout":
+        result = validate_layout(req.layout, req.solverResult ?? undefined, "Bus");
+        break;
+      case "parseBlueprint":
+        result = parse_blueprint(req.bp);
+        break;
+    }
+    post(req.id, true, result);
+  } catch (err) {
+    post(req.id, false, err instanceof Error ? err.message : String(err));
+  }
+};


### PR DESCRIPTION
## Summary

Two improvements to the web UI around layout responsiveness:

- **WASM in a Web Worker** — the main thread no longer freezes during layouts. `solve`, `buildLayout`, `buildLayoutTraced`, `validateLayout`, `exportBlueprint`, and `parseBlueprint` all run in `web/src/workers/engine.worker.ts` and return promises. A small "computing…" overlay in the top-right shows when a call is in flight (120ms grace so fast calls don't flicker).
- **Progressive phase reveal** — fresh sidebar-triggered layouts fade in phase-by-phase using the existing `PhaseSnapshot` trace events (rows_placed → bus_routed → poles_placed), with a staggered NW→SE sweep within each phase. Total animation capped at ~2.2s. Corpus paste and landing-preview paths render instantly as before.

### Key files
- `web/src/workers/engine.worker.ts` (new) — WASM RPC worker
- `web/src/engine.ts` — async RPC wrapper, preloads items/machines/defaults during init
- `web/src/ui/busyOverlay.ts` (new) — the top-right spinner
- `web/src/renderer/phaseAnimation.ts` (new) — phase diffing + ticker-driven fade
- `web/src/renderer/entities.ts` — optional `onEntityRendered` callback on `renderLayout`
- `web/src/main.ts` — wires animator into `renderLayoutOnCanvas`; cancels on new-layout/step-through/graph-view

### Tunables (top of `phaseAnimation.ts`)
- `TOTAL_BUDGET_MS = 2200` — cap total animation time
- `PHASE_PAUSE_MS = 180` — pause between phases
- `FADE_MS = 200` — per-entity fade duration
- `DEFAULT_STAGGER_MS = 8` — stagger cap (adapts down for large layouts)

### Measured
Main thread stays at 60fps (16.5ms avg frame) while the worker chews on a 661-machine advanced-circuit layout that previously would have frozen the UI.

## Test plan
- [ ] `cd web && npx tsc --noEmit` clean
- [ ] Dev server, open `?item=electronic-circuit&rate=20` — entities fade in top-to-bottom per phase
- [ ] Retrigger with `?item=advanced-circuit&rate=30` — stagger adapts, UI stays responsive
- [ ] Change inputs mid-animation — no frozen half-faded entities
- [ ] Corpus paste → instant render, no animation
- [ ] Enable debug + step-through → animation runs, scrubbing after it completes works; scrubbing during it snaps to full alpha
- [ ] Browser console error-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)