### PR TITLE
Add RFP and PR templates for design documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+Keep this short. The goal is to capture intent and surface deviations,
+not to ceremony-ise small changes. Trivial PRs (typo, one-liner, obvious
+bug from a stack trace) can delete sections that don't apply — say so
+explicitly rather than leaving them blank.
+-->
+
+## Intent
+
+What problem this solves and why now. 1–3 sentences. If this implements an
+RFP or closes an issue, link it.
+
+## Scope
+
+- **In:** what's included
+- **Out:** what was deliberately not done (and why, if non-obvious)
+
+## Verification
+
+What was actually run — not "tests pass," but *which* tests, *which* URL in
+the web app, *which* snapshot. For layout-engine changes follow the
+verification protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protocol-for-layout-engine-changes).
+
+- [ ] `cargo test --manifest-path crates/core/Cargo.toml`
+- [ ] `cargo clippy -- -D warnings`
+- [ ] WASM rebuild + browser eyeball (URL: …)
+- [ ] Snapshot inspected for the specific bug being fixed (if applicable)
+
+## Deviations from intent
+
+Anything that differs from what was discussed or RFP'd, judgement calls
+made mid-flight, things intentionally deferred. **"None" is a valid answer
+— write it explicitly so it's clear nothing was glossed over.**
+
+## Models / contracts touched
+
+Which abstraction this affects (e.g. `ghost-pipeline-contracts.md`,
+`factorio-mechanics.md`, the tier ladder in `CLAUDE.md`). If a contract
+changed, the doc update is part of this PR. "None" is fine for chores.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
 - **Pre-commit hooks**: in `.githooks/pre-commit`, activate with `git config core.hooksPath .githooks`. Runs `cargo clippy` on staged Rust and `tsc` on staged TS. Bypass with `--no-verify` only for genuine emergencies.
 - **Scripts**: put exploratory snippets in `scripts/` rather than inline one-liners. Rust debug scripts go in `crates/core/examples/` or as `#[test] #[ignore]` benchmarks.
 - **Snapshots**: `FUCKTORIO_DUMP_SNAPSHOTS=1 cargo test ...` writes `.fls` files under `crates/core/target/tmp/`. Decode with `tail -c +5 <file> | base64 -d | gunzip`. See [`docs/layout-snapshot-debugger.md`](docs/layout-snapshot-debugger.md).
+- **Process docs**: non-trivial design work uses [`docs/rfp-template.md`](docs/rfp-template.md) — the **kill criteria** section is required, since the dominant rework shape on this project is exploration that overruns its evidence. PRs follow [`.github/pull_request_template.md`](.github/pull_request_template.md), which captures intent, scope, verification actually run, and any deviations from agreed approach. Trivial changes can omit sections explicitly rather than leaving them blank.
 
 ## Architecture
 

--- a/docs/rfp-template.md
+++ b/docs/rfp-template.md
@@ -1,0 +1,97 @@
+# RFP template
+
+Copy this file to `docs/rfp-<short-name>.md` for any non-trivial design
+work. The goal of an RFP is **shared understanding before code** and
+**a way to know when to stop** if the approach turns out to be wrong.
+
+The dominant rework shape on this project is *exploration rework* — we
+build something, discover it doesn't pan out, and pivot. The
+**kill criteria** section below is the most important part of this
+template. Without explicit kill criteria, exploration drags on past the
+point where the evidence already says "this approach is wrong."
+
+Existing examples live in [`docs/archive/`](archive/) — read one or two
+before writing your own. Note that the archived ones predate this
+template, so they don't have kill criteria; the new ones must.
+
+---
+
+# RFP: <Title>
+
+## Summary
+
+One paragraph. What is being proposed and why. Someone who has never
+seen this should be able to read the summary and know what they'd be
+agreeing to.
+
+## Motivation
+
+The concrete problem this solves. Prefer a real failing case (a test
+that fails, a layout that produces N validator errors, a screenshot of
+the bug) over abstract reasoning. If the problem isn't reproducible
+*today*, that's a yellow flag — say so.
+
+## Design
+
+The proposed approach. Doesn't need to be exhaustive — enough that a
+reader can predict what the diff will look like and spot disagreements
+early. Include:
+
+- The shape of the new code (types, functions, modules touched)
+- How it integrates with existing pipeline phases
+- Anything load-bearing about correctness or performance
+- Trade-offs against alternatives you considered (and rejected)
+
+## Kill criteria
+
+**Required.** Explicit, observable conditions under which this RFP
+should be abandoned or rethought. Phrase them so the answer is
+unambiguous after you run the experiment.
+
+Good examples:
+
+- *"After implementing strategy 1 + 2, if the
+  `tier4_advanced_circuit_from_ore_am1` snapshot still has phantom
+  belts in any junction zone, this approach is wrong — the SAT zones
+  are not the root cause."*
+- *"If the new junction solver requires more than ~500 LOC of strategy
+  code per template, the strategy abstraction is too granular and we
+  should reconsider."*
+- *"If end-to-end runtime regresses by >2x on the existing test corpus,
+  we drop this even if correctness improves."*
+
+Bad examples (vague, unfalsifiable, post-hoc):
+
+- *"If it doesn't work, we'll stop."*
+- *"If users don't like it."*
+- *"If performance is bad."*
+
+If you can't write a kill criterion you'd actually act on, the RFP
+isn't ready — the success/failure shape is too fuzzy and you'll know
+even less after building it.
+
+## Verification plan
+
+How you'll know this is done and correct, before writing the PR.
+Reference the relevant verification protocol in
+[`CLAUDE.md`](../CLAUDE.md#verification-protocol-for-layout-engine-changes)
+where applicable. Include the specific tests, URLs, snapshots, or
+trace-event signals you'll check.
+
+## Phasing (optional)
+
+If the work splits into landable chunks, list them here so partial
+landings are obviously partial.
+
+## Decision log
+
+Append entries here as the RFP progresses. Date them.
+
+- *2026-MM-DD — accepted, work tracked in #NNN.*
+- *2026-MM-DD — phase 1 landed in <commit>; phase 2 deferred pending …*
+- *2026-MM-DD — abandoned; kill criterion <X> tripped on <test>. See
+  follow-up notes in `docs/<...>.md`. Move this file to `docs/archive/`
+  with a status of "Rejected" in the archive README.*
+
+The decision log is the part that prevents "why did we drop this?"
+amnesia six months later. Don't skip it.


### PR DESCRIPTION
## Summary

This PR establishes formal templates and processes for design documentation and pull request reviews. It adds two new templates to guide contributors through structured design proposals (RFPs) and pull request descriptions, along with updates to the main development guide.

## Key changes

- **`docs/rfp-template.md`** — New RFP (Request for Proposal) template that enforces explicit kill criteria and verification plans before implementation. This addresses the project's pattern of "exploration rework" by requiring shared understanding and clear success/failure conditions upfront.

- **`.github/pull_request_template.md`** — New PR template that captures intent, scope, verification steps, and deviations from plan. Emphasizes concrete verification (specific tests, URLs, snapshots) over generic claims.

- **`CLAUDE.md`** — Updated to reference the new templates and verification protocols.

## Notable implementation details

The RFP template emphasizes **kill criteria** as the most critical section — explicit, observable conditions for abandoning an approach. This is designed to prevent exploration work from dragging on past the point where evidence already indicates failure.

The PR template is intentionally lightweight, allowing trivial changes to delete inapplicable sections while requiring non-obvious decisions to be documented. Both templates link to existing verification protocols and decision logs to maintain institutional memory.

https://claude.ai/code/session_01Xu9Ver2i8DLBVXYYgc8Ph7