### PR TITLE
refactor(web): declutter junction view, pinnable tile inspector

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,4 @@
-import { Container } from "pixi.js";
-import type { Graphics } from "pixi.js";
+import { Container, Graphics } from "pixi.js";
 import { createApp, WORLD_SIZE } from "./renderer/app";
 import { drawGrid } from "./renderer/grid";
 import { drawGraph } from "./renderer/graph";
@@ -27,6 +26,7 @@ import * as debugState from "./state/debugState";
 import { createOverlayPanel } from "./ui/overlayPanel";
 import { createIssuesDialog } from "./ui/issuesDialog";
 import { createInspector } from "./ui/inspector";
+import { buildTileContext } from "./ui/tileContext";
 import { createSnapshotMode } from "./ui/snapshotMode";
 import { createStepThrough } from "./ui/stepThrough";
 import { attachBusyOverlay } from "./ui/busyOverlay";
@@ -162,6 +162,19 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   // SAT-zone detail overlay sits above the entity layer so the bbox,
   // boundary bars, and item icons always read on top of the belts.
   viewport.addChild(satZoneOverlay.layer);
+  // Pin-highlight ring — drawn on top of everything so the user can
+  // always see which tile the detail panel is describing.
+  const pinHighlight = new Graphics();
+  pinHighlight.label = "pin-highlight";
+  viewport.addChild(pinHighlight);
+  inspector.onPinChange((tile) => {
+    pinHighlight.clear();
+    if (!tile) return;
+    const px = tile.x * TILE_PX;
+    const py = tile.y * TILE_PX;
+    pinHighlight.setStrokeStyle({ width: 2, color: 0x80c8ff, alpha: 0.95 });
+    pinHighlight.rect(px - 2, py - 2, TILE_PX + 4, TILE_PX + 4).stroke();
+  });
   viewport.moveCenter(WORLD_SIZE / 2, WORLD_SIZE / 2);
 
   // Click-to-inspect removed; pass no-op to renderLayout.
@@ -470,6 +483,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     onClear: () => {
       snapshotMode.clear();
       entityLayer.removeChildren();
+      inspector.clearPin();
+      inspector.setTileContext(null);
       lastLayout = null;
       cachedValidationIssues = null;
       drawGraph(viewport, null);
@@ -515,10 +530,21 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   // already selected, a click outside its bbox deselects it — matches
   // the "selected thing dims everything else" UX convention.
   app.canvas.addEventListener("pointerdown", (e) => {
-    if (!regionsCb.checked) return;
     if (e.button !== 0 || e.shiftKey || e.altKey || e.ctrlKey || e.metaKey) return;
     const rect = app.canvas.getBoundingClientRect();
     const world = viewport.toWorld(e.clientX - rect.left, e.clientY - rect.top);
+    const tx = Math.floor(world.x / TILE_PX);
+    const ty = Math.floor(world.y / TILE_PX);
+
+    if (!regionsCb.checked) {
+      // Debug regions off — a bare canvas click pins the tile under
+      // the cursor so the inspector freezes on its detail.
+      const entity = hoveredEntity && hoveredEntity.x === tx && hoveredEntity.y === ty
+        ? hoveredEntity : null;
+      inspector.pinTile(entity, tx, ty);
+      return;
+    }
+
     const jc = junctionHitTest?.(world.x, world.y) ?? null;
     if (jc) {
       junctionDebugger.open(jc, lastLayout?.trace);
@@ -547,6 +573,21 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       const cx = (it.region.x + it.region.width / 2) * TILE_PX;
       const cy = (it.region.y + it.region.height / 2) * TILE_PX;
       viewport.moveCenter(cx, cy);
+      // Fall through — also pin the clicked tile so the inspector can
+      // describe it in detail. Panning alone doesn't give the user any
+      // detail; the combination is what they came for.
+    }
+
+    // Fell through every overlay — pin the tile so the inspector
+    // keeps showing its full detail. Click on an already-pinned tile
+    // to unpin.
+    const current = inspector.getPinnedTile();
+    if (current && current.x === tx && current.y === ty) {
+      inspector.clearPin();
+    } else {
+      const entity = hoveredEntity && hoveredEntity.x === tx && hoveredEntity.y === ty
+        ? hoveredEntity : null;
+      inspector.pinTile(entity, tx, ty);
     }
   });
 
@@ -653,6 +694,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       }
     }
     inspector.setHighlightController(ctrl);
+    inspector.setTileContext(buildTileContext(layout.trace));
+    inspector.clearPin();
     selectionCtrl = createSelectionController(app.canvas, viewport, entityLayer, layout, onSelectionChange);
     buildLegend(layout);
     updateTraceOverlay();

--- a/web/src/renderer/entities.ts
+++ b/web/src/renderer/entities.ts
@@ -275,32 +275,40 @@ const TILE_RADIUS = 3;
 const BELT_BODY = 0x3a3a3a;
 const BELT_BORDER = 0x555555;
 
+/** Visible belt occupies 90% of the tile, centred — leaves a thin gutter
+ * on either side so the bus reads as discrete lanes rather than a
+ * seamless solid. `BELT_INSET` is the per-side gap in px. */
+const BELT_SCALE = 0.9;
+const BELT_INSET = (TILE_PX * (1 - BELT_SCALE)) / 2;
+const BELT_SIZE = TILE_PX * BELT_SCALE;
+
 function drawBelt(entity: PlacedEntity, turn: BeltTurn | null): Graphics {
   const g = new Graphics();
   const s = TILE_PX;
+  const bs = BELT_SIZE;
   const [, chev] = BELT_COLORS[entity.name] ?? [0xa89030, 0xe0d070];
   const laneColor = itemColor(entity.carries);
 
   if (turn) {
     drawBeltCorner(g, s, chev, entity.direction, turn, laneColor);
   } else {
-    // Dark belt body with subtle border
-    g.rect(0, 0, s, s).fill(BELT_BODY);
+    // Dark belt body with subtle border, inset so a gutter frames every tile.
+    g.rect(BELT_INSET, BELT_INSET, bs, bs).fill(BELT_BODY);
     g.setStrokeStyle({ width: 1, color: BELT_BORDER, alignment: 0 });
-    g.rect(0, 0, s, s).stroke();
+    g.rect(BELT_INSET, BELT_INSET, bs, bs).stroke();
 
     const rg = new Graphics();
     rg.x = s / 2;
     rg.y = s / 2;
     rg.rotation = dirAngle(entity.direction);
 
-    // Lane stripes: left lane = left half, right lane = right half
-    rg.rect(-s / 2, -s / 2, s / 2 - 1, s).fill({ color: laneColor, alpha: 0.45 });
-    rg.rect(1, -s / 2, s / 2 - 1, s).fill({ color: laneColor, alpha: 0.45 });
-    // Dark center divider
-    rg.rect(-1, -s / 2, 2, s).fill(0x0a0a0a);
+    // Lane stripes: left lane = left half, right lane = right half.
+    rg.rect(-bs / 2, -bs / 2, bs / 2 - 1, bs).fill({ color: laneColor, alpha: 0.45 });
+    rg.rect(1, -bs / 2, bs / 2 - 1, bs).fill({ color: laneColor, alpha: 0.45 });
+    // Dark centre divider
+    rg.rect(-1, -bs / 2, 2, bs).fill(0x0a0a0a);
 
-    addBeltChevrons(rg, s, chev);
+    addBeltChevrons(rg, bs, chev);
     g.addChild(rg);
   }
 
@@ -320,6 +328,7 @@ function drawBeltCorner(
   cg.x = s / 2;
   cg.y = s / 2;
   cg.rotation = dirAngle(direction);
+  cg.scale.set(BELT_SCALE); // match straight-belt 90%-centred footprint
 
   const r = s / 2;
   const sign = turn.turn === "cw" ? 1 : -1;
@@ -402,49 +411,55 @@ function addBeltChevrons(g: Graphics, s: number, chevColor: number): void {
 function drawUndergroundBelt(entity: PlacedEntity): Graphics {
   const g = new Graphics();
   const s = TILE_PX;
-  const [base, chev] = BELT_COLORS[entity.name] ?? [0xa89030, 0xe0d070];
+  const [, chev] = BELT_COLORS[entity.name] ?? [0xa89030, 0xe0d070];
   const isInput = entity.io_type === "input";
   const half = s / 2;
 
   // In local coords (rotation=0 = North): flow direction = -y.
   // Input UG:  items flow in (-y), tunnel goes in flow direction. Open mouth at +y.
   // Output UG: items emerge in flow direction (-y), tunnel comes from +y. Open mouth at -y.
-  const tunnelY = isInput ? -half : 0;   // underground half (very dark)
-  const surfaceY = isInput ? 0 : -half;  // open/surface half (belt-coloured)
-
-  g.rect(0, 0, s, s).fill(BELT_BODY);
-  g.setStrokeStyle({ width: 1, color: BELT_BORDER, alignment: 0 });
-  g.rect(0, 0, s, s).stroke();
+  // `surfaceSign` = +1 if the open mouth faces +y (input), -1 if it faces -y (output).
+  const surfaceSign = isInput ? 1 : -1;
 
   const m = new Graphics();
   m.x = half;
   m.y = half;
   m.rotation = dirAngle(entity.direction);
 
-  // Underground half — near-black to read as "buried"
-  m.rect(-half, tunnelY, s, half).fill(0x181818);
+  // Surface half: a trapezoid, wide at the open mouth (matches belt width)
+  // and narrow where it meets the buried half. Communicates "items funnel
+  // into/out of the ground" without a heavy frame around the tunnel.
+  const laneC = itemColor(entity.carries);
+  const mouthHalf = BELT_SIZE / 2;            // matches surface-belt 90% width
+  const throatHalf = s * 0.25;                // ~half the tile width at the divider
+  const mouthY = surfaceSign * half;
+  const throatY = 0;
+  m.moveTo(-mouthHalf, mouthY)
+    .lineTo( mouthHalf, mouthY)
+    .lineTo( throatHalf, throatY)
+    .lineTo(-throatHalf, throatY)
+    .closePath()
+    .fill({ color: laneC, alpha: 0.7 });
+  m.setStrokeStyle({ width: 1, color: BELT_BORDER, alpha: 0.8 });
+  m.moveTo(-mouthHalf, mouthY)
+    .lineTo(-throatHalf, throatY)
+    .lineTo( throatHalf, throatY)
+    .lineTo( mouthHalf, mouthY)
+    .stroke();
 
-  // Surface half — item colour so it reads as a belt connection
-  m.rect(-half, surfaceY, s, half).fill({ color: itemColor(entity.carries), alpha: 0.7 });
-
-  // Dividing line between the two halves
-  m.setStrokeStyle({ width: 1, color: 0x505050 });
-  m.moveTo(-half, 0).lineTo(half, 0).stroke();
-
-  // Filled triangle arrow pointing in flow direction (-y), centered on tile.
-  // Large enough to be unambiguous at 32 px.
-  const arrW = s * 0.52;
-  const arrH = s * 0.36;
-  m.moveTo(0, -arrH / 2)
-    .lineTo( arrW / 2,  arrH / 2)
-    .lineTo(-arrW / 2,  arrH / 2)
+  // Flow-direction triangle, centred on the tile. Sits on the surface side
+  // so it points *out* of the ground for outputs and *into* the ground for
+  // inputs — reads as motion, not a labelled arrow.
+  const arrW = s * 0.38;
+  const arrH = s * 0.3;
+  const arrCy = surfaceSign * s * 0.22;
+  const arrTipY = arrCy - arrH / 2; // tip always toward -y (flow)
+  const arrBaseY = arrCy + arrH / 2;
+  m.moveTo(0, arrTipY)
+    .lineTo(arrW / 2, arrBaseY)
+    .lineTo(-arrW / 2, arrBaseY)
     .closePath()
     .fill(chev);
-
-  // Bright edge stripe at the open mouth to mark where surface belt connects
-  const stripeH = Math.max(2, s * 0.08);
-  const stripeY = isInput ? half - stripeH : -half;
-  m.rect(-half, stripeY, s, stripeH).fill(base);
 
   g.addChild(m);
   return g;
@@ -862,10 +877,12 @@ export function renderLayout(
           for (let i = 1; i < dist; i++) {
             const tx = (x + dx * i) * TILE_PX;
             const ty = (y + dy * i) * TILE_PX;
+            // Width matches the UG-mouth "throat" (~50% tile) so the
+            // tunnel reads as a continuous pipe through the pair.
             if (isHoriz) {
-              tg.rect(tx, ty + TILE_PX * 0.2, TILE_PX, TILE_PX * 0.6).fill({ color: base, alpha: 0.3 });
+              tg.rect(tx, ty + TILE_PX * 0.25, TILE_PX, TILE_PX * 0.5).fill({ color: base, alpha: 0.25 });
             } else {
-              tg.rect(tx + TILE_PX * 0.2, ty, TILE_PX * 0.6, TILE_PX).fill({ color: base, alpha: 0.3 });
+              tg.rect(tx + TILE_PX * 0.25, ty, TILE_PX * 0.5, TILE_PX).fill({ color: base, alpha: 0.25 });
             }
           }
           container.addChild(tg);

--- a/web/src/renderer/regionOverlay.ts
+++ b/web/src/renderer/regionOverlay.ts
@@ -1,7 +1,7 @@
-import { Container, Graphics, Text, TextStyle } from "pixi.js";
+import { Container, Graphics } from "pixi.js";
 import { TILE_PX, itemColor } from "./entities";
 import type { LayoutResult, LayoutRegion, EntityDirection, RegionKind, RegionPort, TraceEvent } from "../engine";
-import { classifyRegion, kindColor, classColor, classLabel, type RegionClassification } from "./regionClassify";
+import { classifyRegion, kindColor, classColor, type RegionClassification } from "./regionClassify";
 
 type GhostSpecRoutedEvent = Extract<TraceEvent, { phase: "GhostSpecRouted" }>;
 
@@ -102,20 +102,6 @@ interface LayoutRegionWithPorts {
 
 const INPUT_COLOR = 0x50c050;  // green
 const OUTPUT_COLOR = 0xd04040; // red
-
-const LABEL_STYLE = new TextStyle({
-  fontFamily: "monospace",
-  fontSize: 10,
-  fill: 0xffffff,
-  dropShadow: { color: 0x000000, distance: 1, blur: 2, alpha: 0.8 },
-});
-
-const PORT_LABEL_STYLE = new TextStyle({
-  fontFamily: "monospace",
-  fontSize: 9,
-  fill: 0xffffff,
-  dropShadow: { color: 0x000000, distance: 1, blur: 2, alpha: 0.9 },
-});
 
 // ---------------------------------------------------------------------------
 // Arrow drawing helper
@@ -230,16 +216,6 @@ function pairRegionPorts(
   return pairs;
 }
 
-/** Pick a label "side" for a port based on its flow direction. */
-function portEdgeHint(port: RegionPort): "N" | "S" | "E" | "W" {
-  switch (port.point.direction) {
-    case "North": return "N";
-    case "South": return "S";
-    case "East":  return "E";
-    case "West":  return "W";
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -295,13 +271,9 @@ export function renderRegionOverlayDetailed(layout: LayoutResult, events?: reado
     rect.setStrokeStyle({ width: 2, color: strokeColor, alpha: 0.85 });
     rect.rect(rx, ry, rw, rh).stroke();
     layer.addChild(rect);
-
-    // Dimension + class label at top-left corner
-    const labelText = `${region.width}×${region.height}  ${classLabel(classification.cls)}`;
-    const label = new Text({ text: labelText, style: LABEL_STYLE });
-    label.x = rx + 3;
-    label.y = ry + 2;
-    layer.addChild(label);
+    // The "4×1 no-ports" corner label used to sit here. Region dimensions
+    // are self-evident from the bbox; the class is available on the
+    // `classification.cls` field if a future panel wants to show it.
 
     // Boundary ports — draw input→output dashed connectors first so the
     // port markers and arrows sit on top.
@@ -335,31 +307,10 @@ export function renderRegionOverlayDetailed(layout: LayoutResult, events?: reado
       drawArrow(ag, px, py, port.point.direction, arrowColor);
       layer.addChild(ag);
 
-      const ioTag = port.io === "Input" ? "IN" : "OUT";
-      const itemAbbr = port.item ? port.item.slice(0, 3) : "?";
-      const portLabel = new Text({
-        text: `${itemAbbr} ${ioTag}`,
-        style: PORT_LABEL_STYLE,
-      });
-      switch (portEdgeHint(port)) {
-        case "N":
-          portLabel.x = px - portLabel.width / 2;
-          portLabel.y = py - TILE_PX * 0.9;
-          break;
-        case "S":
-          portLabel.x = px - portLabel.width / 2;
-          portLabel.y = py + TILE_PX * 0.5;
-          break;
-        case "W":
-          portLabel.x = px - TILE_PX * 1.2;
-          portLabel.y = py - 5;
-          break;
-        case "E":
-          portLabel.x = px + TILE_PX * 0.5;
-          portLabel.y = py - 5;
-          break;
-      }
-      layer.addChild(portLabel);
+      // The "ele IN" / "ele OUT" per-port text labels used to sit around
+      // each marker. They overlapped whenever a region had >1 port on the
+      // same edge. Port identity (item + IO) is now available via hover
+      // in the inspector.
     }
   }
 

--- a/web/src/renderer/traceOverlay.ts
+++ b/web/src/renderer/traceOverlay.ts
@@ -10,8 +10,6 @@ type LanesPlanned = Extract<TraceEvent, { phase: "LanesPlanned" }>;
 export type PhaseSnapshot = Extract<TraceEvent, { phase: "PhaseSnapshot" }>;
 export type PhaseComplete = Extract<TraceEvent, { phase: "PhaseComplete" }>;
 type RouteFailureEvent = Extract<TraceEvent, { phase: "RouteFailure" }>;
-type LaneConsolidatedEvent = Extract<TraceEvent, { phase: "LaneConsolidated" }>;
-type RowSplitEvent = Extract<TraceEvent, { phase: "RowSplit" }>;
 type LaneOrderOptimizedEvent = Extract<TraceEvent, { phase: "LaneOrderOptimized" }>;
 type GhostSpecRoutedEvent = Extract<TraceEvent, { phase: "GhostSpecRouted" }>;
 type GhostSpecFailedEvent = Extract<TraceEvent, { phase: "GhostSpecFailed" }>;
@@ -149,55 +147,17 @@ export function renderTraceOverlay(
     layer.addChild(g);
   }
 
-  // --- Lane consolidation badges (from LaneConsolidated) ---
-  const badgeStyle = new TextStyle({ fontSize: 10, fill: "#ffaa44", fontFamily: "monospace", fontWeight: "bold" });
-  for (const evt of events) {
-    if (evt.phase !== "LaneConsolidated") continue;
-    const d = (evt as LaneConsolidatedEvent).data;
-    let laneX = -1;
-    if (lanesEvent) {
-      const match = lanesEvent.data.lanes.find(l => l.item === d.item);
-      if (match) laneX = match.x;
-    }
-    if (laneX < 0) continue;
-    const badge = new Text({ text: `\u00F7${d.n_trunk_lanes}`, style: badgeStyle });
-    badge.x = laneX * TILE_PX + TILE_PX / 2 - badge.width / 2;
-    badge.y = 2;
-    badge.eventMode = "static";
-    badge.on("pointerenter", () => onHover(`${d.item}: ${d.consumer_count} consumers share ${d.n_trunk_lanes} lane(s) @ ${d.rate_per_lane.toFixed(1)}/s each`));
-    badge.on("pointerleave", () => onHover(null));
-    layer.addChild(badge);
-  }
-
-  // --- Row split indicators (from RowSplit) ---
-  const splitStyle = new TextStyle({ fontSize: 10, fill: "#ffcc44", fontFamily: "monospace", fontWeight: "bold" });
-  for (const evt of events) {
-    if (evt.phase !== "RowSplit") continue;
-    const d = (evt as RowSplitEvent).data;
-    let splitY = -1;
-    if (rowsEvent) {
-      const matching = rowsEvent.data.rows.filter(r => r.recipe === d.recipe);
-      if (matching.length > 0) {
-        splitY = matching.reduce((a, b) => a.y_end > b.y_end ? a : b).y_end;
-      }
-    }
-    if (splitY < 0) continue;
-    const label = new Text({ text: `\u2295${d.split_into}`, style: splitStyle });
-    label.x = 4;
-    label.y = splitY * TILE_PX - label.height - 1;
-    label.eventMode = "static";
-    label.on("pointerenter", () => onHover(`${d.recipe}: split ${d.original_count}\u2192${d.split_into} rows \u2014 ${d.reason}`));
-    label.on("pointerleave", () => onHover(null));
-    layer.addChild(label);
-  }
+  // Lane-consolidation (÷n) and row-split (⊕n) badges used to live at
+  // the top of each lane/row column. They were clutter in the junction
+  // view; the same information is available on hover via the lane/row
+  // rectangles' pointerenter handlers above.
 
   const summaryStyle = new TextStyle({ fontSize: 10, fill: "#aaa", fontFamily: "monospace" });
 
   // --- Ghost routing paths (from GhostSpecRouted) ---
-  const ghostPalette = [
-    0x569cd6, 0xd0a040, 0x6ac080, 0xc06090, 0x70b0e0,
-    0xb080d0, 0xe07050, 0x60c0c0, 0xd0d060, 0x80b060,
-  ];
+  // Small cycled palette — the colour just needs to differ from its
+  // immediate neighbours; exact identity is confirmed via inspector.
+  const ghostPalette = GHOST_PALETTE;
   let ghostPathIdx = 0;
   for (const evt of events) {
     if (evt.phase !== "GhostSpecRouted") continue;
@@ -214,16 +174,9 @@ export function renderTraceOverlay(
       }
       g.stroke();
     }
-    // Crossing tiles as yellow diamonds
-    if (d.crossing_tiles) {
-      for (const [cx, cy] of d.crossing_tiles) {
-        const px = cx * TILE_PX + TILE_PX / 2;
-        const py = cy * TILE_PX + TILE_PX / 2;
-        const ds = TILE_PX * 0.25;
-        g.moveTo(px, py - ds).lineTo(px + ds, py).lineTo(px, py + ds).lineTo(px - ds, py).closePath()
-          .fill({ color: 0xffdd00, alpha: 0.85 });
-      }
-    }
+    // Crossing tiles are surfaced via the orange multi-item heatmap in
+    // `renderGhostRoutingOverlay` (the authoritative signal); per-spec
+    // yellow diamonds here were a duplicate layer and have been removed.
     g.eventMode = "static";
     g.on("pointerenter", () => onHover(`Ghost path: ${d.spec_key} len=${d.path_len} crossings=${d.crossings} turns=${d.turns}`));
     g.on("pointerleave", () => onHover(null));
@@ -296,10 +249,14 @@ export function renderTraceOverlay(
 type GhostClusterSolvedEvent = Extract<TraceEvent, { phase: "GhostClusterSolved" }>;
 type GhostClusterFailedEvent = Extract<TraceEvent, { phase: "GhostClusterFailed" }>;
 
+// Small cycled palette — four easy-to-discriminate hues. The job of the
+// colour is just "different from its neighbours"; exact identity is
+// confirmed via hover/pin in the inspector.
 const GHOST_PALETTE = [
-  0x569cd6, 0xd0a040, 0x6ac080, 0xc06090, 0x70b0e0,
-  0xb080d0, 0xe07050, 0x60c0c0, 0xd0d060, 0x80b060,
-  0xe0a060, 0x60a0d0, 0xd060a0, 0xa0d060, 0x9060d0,
+  0x569cd6, // cool blue
+  0x6ac080, // muted green
+  0xd0a040, // warm ochre
+  0xb080d0, // dusty purple
 ];
 
 /** Deterministic color assignment by item name. */
@@ -373,54 +330,19 @@ export function renderGhostRoutingOverlay(
   }
   layer.addChild(heatG);
 
-  // --- Axis occupancy (Phase-1 instrumentation) ---
-  // Red square = same-axis conflict (>=2 N/S OR >=2 E/W specs at this tile).
-  // Blue dot   = perpendicular crossing (>=1 N/S AND >=1 E/W spec at this tile).
-  // A tile can be both — render both layers; the hover hit-rect covers either.
+  // Axis occupancy (V/H counts per tile) used to paint red squares and
+  // blue dots across the whole zone. That was the biggest single source
+  // of visual noise in the junction-debug view. The raw counts are now
+  // surfaced per-tile via the inspector (see `ui/tileContext.ts`), so
+  // the canvas keeps only the orange multi-item heatmap. The summary
+  // line below still reports aggregate counts.
   const axisEvent = events.find(
     (e): e is Extract<TraceEvent, { phase: "GhostAxisOccupancy" }> =>
       e.phase === "GhostAxisOccupancy",
   );
-  let axisSummary = "";
-  if (axisEvent) {
-    const axisG = new Graphics();
-    const dotG = new Graphics();
-    for (const tile of axisEvent.data.tiles) {
-      const sameAxis = tile.vert_count >= 2 || tile.horiz_count >= 2;
-      const perp = tile.vert_count >= 1 && tile.horiz_count >= 1;
-      if (sameAxis) {
-        const maxSame = Math.max(tile.vert_count, tile.horiz_count);
-        const alpha = Math.min(0.25 + maxSame * 0.15, 0.85);
-        axisG.rect(tile.x * TILE_PX, tile.y * TILE_PX, TILE_PX, TILE_PX)
-          .fill({ color: 0xff2222, alpha });
-      }
-      if (perp) {
-        dotG.circle(tile.x * TILE_PX + TILE_PX / 2, tile.y * TILE_PX + TILE_PX / 2, TILE_PX * 0.22)
-          .fill({ color: 0x3399ff, alpha: 0.9 })
-          .stroke({ width: 1, color: 0x0a2a55, alpha: 0.9 });
-      }
-    }
-    // Hit-rect layer (separate so dots and squares don't fight for hover hits).
-    const hitLayer = new Container();
-    for (const tile of axisEvent.data.tiles) {
-      const hit = new Graphics();
-      hit.rect(tile.x * TILE_PX, tile.y * TILE_PX, TILE_PX, TILE_PX)
-        .fill({ color: 0xffffff, alpha: 0.001 });
-      hit.eventMode = "static";
-      const tags =
-        (tile.vert_count >= 2 || tile.horiz_count >= 2 ? " [same-axis]" : "") +
-        (tile.vert_count >= 1 && tile.horiz_count >= 1 ? " [perpendicular]" : "");
-      const label = `Axis (${tile.x},${tile.y}): V=${tile.vert_count} H=${tile.horiz_count}${tags}`;
-      hit.on("pointerenter", () => onHover(label));
-      hit.on("pointerleave", () => onHover(null));
-      hitLayer.addChild(hit);
-    }
-    layer.addChild(axisG);
-    layer.addChild(dotG);
-    layer.addChild(hitLayer);
-
-    axisSummary = ` | axis: ${axisEvent.data.same_axis_conflict_count} same, ${axisEvent.data.perpendicular_crossing_count} perp`;
-  }
+  const axisSummary = axisEvent
+    ? ` | axis: ${axisEvent.data.same_axis_conflict_count} same, ${axisEvent.data.perpendicular_crossing_count} perp`
+    : "";
 
   // --- Cluster zones ---
   for (const evt of events) {
@@ -443,13 +365,6 @@ export function renderGhostRoutingOverlay(
     zg.on("pointerenter", () => onHover(label));
     zg.on("pointerleave", () => onHover(null));
     layer.addChild(zg);
-
-    // Zone dimension label
-    const zoneStyle = new TextStyle({ fontSize: 9, fill: isFailed ? "#ff8888" : "#88ccff", fontFamily: "monospace" });
-    const zoneText = new Text({ text: `#${d.cluster_id} ${d.zone_w}×${d.zone_h}`, style: zoneStyle });
-    zoneText.x = d.zone_x * TILE_PX + 2;
-    zoneText.y = d.zone_y * TILE_PX + 2;
-    layer.addChild(zoneText);
   }
 
   // --- Routed paths ---

--- a/web/src/ui/inspector.ts
+++ b/web/src/ui/inspector.ts
@@ -1,5 +1,6 @@
 import type { PlacedEntity } from "../engine";
 import { niceName, getRecipeFlows, isBeltEntity, type HighlightController } from "../renderer/entities";
+import type { TileContext, TileInfo } from "./tileContext";
 
 export interface InspectorControls {
   onHover(entity: PlacedEntity | null, tileX?: number, tileY?: number): void;
@@ -10,12 +11,41 @@ export interface InspectorControls {
    * overlay override, etc.). Pass nulls when the cursor leaves the
    * canvas. */
   setCursorTile(x: number | null, y?: number): void;
+  /** Replace the per-tile aggregator. Call whenever a new layout lands
+   * so the inspector has fresh ghost/axis/junction data to display. */
+  setTileContext(ctx: TileContext | null): void;
+  /** Pin the inspector to a specific tile. The pinned panel sits in a
+   * fixed corner of the viewport and keeps showing full detail until
+   * cleared (pass null) or re-pinned to a different tile. */
+  pinTile(entity: PlacedEntity | null, x: number, y: number): void;
+  /** Remove any pinned tile. */
+  clearPin(): void;
+  /** Current pinned tile (if any) — callers can check so they can draw
+   * a highlight ring on canvas. */
+  getPinnedTile(): { x: number; y: number } | null;
+  /** Register a listener for pin changes so overlay layers can redraw
+   * the pinned-tile highlight. */
+  onPinChange(cb: (tile: { x: number; y: number } | null) => void): () => void;
 }
+
+const DIR_ARROW: Record<string, string> = {
+  North: "\u2191", East: "\u2192", South: "\u2193", West: "\u2190",
+};
+const COMPACT_DIR: Record<string, string> = {
+  N: "\u2191", E: "\u2192", S: "\u2193", W: "\u2190",
+};
 
 export function createInspector(container: HTMLElement): InspectorControls {
   const tooltip = document.createElement("div");
-  tooltip.style.cssText = "position:fixed;background:#1e1e1e;color:#e0e0e0;border:1px solid #555;padding:4px 8px;font:12px monospace;pointer-events:none;border-radius:3px;display:none;z-index:1000;max-width:200px;line-height:1.5";
+  tooltip.style.cssText = "position:fixed;background:#1e1e1e;color:#e0e0e0;border:1px solid #555;padding:4px 8px;font:12px monospace;pointer-events:none;border-radius:3px;display:none;z-index:1000;max-width:240px;line-height:1.5";
   document.body.appendChild(tooltip);
+
+  // Pinned detail panel — fixed in the top-right of the canvas container
+  // so it never obscures the hovered tile. Interactive (pointer events
+  // enabled) so the user can click the close button.
+  const pinned = document.createElement("div");
+  pinned.style.cssText = "position:absolute;top:8px;right:8px;background:#141414;color:#e0e0e0;border:1px solid #888;padding:8px 10px;font:12px monospace;border-radius:4px;display:none;z-index:20;min-width:220px;max-width:340px;line-height:1.55;box-shadow:0 4px 14px rgba(0,0,0,0.5)";
+  container.appendChild(pinned);
 
   document.addEventListener("mousemove", (e) => {
     tooltip.style.left = e.clientX + 14 + "px";
@@ -26,20 +56,27 @@ export function createInspector(container: HTMLElement): InspectorControls {
   let tooltipOverride: string | null = null;
   let hoveredEntity: PlacedEntity | null = null;
   let cursorTile: { x: number; y: number } | null = null;
+  let tileContext: TileContext | null = null;
+  let pinnedState: { entity: PlacedEntity | null; x: number; y: number } | null = null;
+  const pinListeners = new Set<(tile: { x: number; y: number } | null) => void>();
+
+  function notifyPin(): void {
+    const tile = pinnedState ? { x: pinnedState.x, y: pinnedState.y } : null;
+    for (const cb of pinListeners) cb(tile);
+  }
 
   function iconTag(slug: string, size = 16): string {
     return `<img src="${import.meta.env.BASE_URL}icons/${slug}.png" width="${size}" height="${size}" style="vertical-align:middle;margin-right:3px;image-rendering:pixelated" onerror="this.style.display='none'">`;
   }
 
-  function coordLine(): string {
-    if (!cursorTile) return "";
-    return `<span style="color:#888">(${cursorTile.x}, ${cursorTile.y})</span>`;
+  function coordLine(x: number | null, y: number | null): string {
+    if (x == null || y == null) return "";
+    return `<span style="color:#888">(${x}, ${y})</span>`;
   }
 
   function entityHtml(entity: PlacedEntity): string {
-    const dirArrow: Record<string, string> = { North: "\u2191", East: "\u2192", South: "\u2193", West: "\u2190" };
     let html = `${iconTag(entity.name)}<b>${niceName(entity.name)}</b>`;
-    if (entity.direction && entity.name !== "pipe") html += `<br>${dirArrow[entity.direction] ?? ""} ${entity.direction}`;
+    if (entity.direction && entity.name !== "pipe") html += `<br>${DIR_ARROW[entity.direction] ?? ""} ${entity.direction}`;
     if (entity.carries) html += `<br>${iconTag(entity.carries)} ${niceName(entity.carries)}`;
     if (entity.rate != null) html += `<br><span style="color:#b5cea8">${entity.rate.toFixed(1)}/s</span>`;
     if (entity.io_type) html += `<br>io: ${entity.io_type}`;
@@ -52,53 +89,160 @@ export function createInspector(container: HTMLElement): InspectorControls {
       }
     }
     if (entity.segment_id) html += `<br><span style="color:#9cdcfe">${entity.segment_id}</span>`;
-    html += `<br><span style="color:#888">(${entity.x ?? 0}, ${entity.y ?? 0})</span>`;
     return html;
   }
 
-  function render(): void {
+  /** One-line compact ghost summary for the hover tooltip. */
+  function ghostCompact(info: TileInfo): string {
+    if (info.ghosts.length === 0) return "";
+    if (info.ghosts.length === 1) {
+      const g = info.ghosts[0];
+      const arrow = g.direction ? COMPACT_DIR[g.direction] : "";
+      return `<span style="color:#8af">ghost</span> ${iconTag(g.item, 12)}${g.item} ${arrow}`;
+    }
+    return `<span style="color:#ffa060">\u26A0 ${info.ghosts.length} ghosts crossing</span>`;
+  }
+
+  function axisCompact(info: TileInfo): string {
+    if (!info.axis) return "";
+    const { vert, horiz } = info.axis;
+    if (vert === 0 && horiz === 0) return "";
+    const conflict = vert >= 2 || horiz >= 2;
+    const perp = vert >= 1 && horiz >= 1;
+    const color = conflict ? "#ff6060" : perp ? "#60b0ff" : "#888";
+    return `<span style="color:${color}">axis V${vert} H${horiz}</span>`;
+  }
+
+  function junctionCompact(info: TileInfo): string {
+    if (!info.junction) return "";
+    const j = info.junction;
+    const color = j.outcome === "Solved" ? "#80d080" : j.outcome === "Capped" ? "#e0b060" : "#c06060";
+    return `<span style="color:${color}">junction seed (${j.seedX},${j.seedY}) \u00b7 ${j.outcome}</span>`;
+  }
+
+  /** Expanded ghost list for the pinned panel. */
+  function ghostExpanded(info: TileInfo): string {
+    if (info.ghosts.length === 0) return "";
+    const rows: string[] = [];
+    for (const g of info.ghosts) {
+      const arrow = g.direction ? COMPACT_DIR[g.direction] : "\u00b7";
+      const endpointTag = g.isStart ? " <span style=\"color:#80d080\">start</span>" :
+                         g.isEnd ? " <span style=\"color:#d08080\">end</span>" : "";
+      rows.push(`${arrow} ${iconTag(g.item, 14)}${g.item}${endpointTag}`);
+    }
+    const header = info.ghosts.length >= 2
+      ? `<div style="color:#ffa060;margin-top:4px">\u26A0 ${info.ghosts.length} ghost specs at this tile</div>`
+      : `<div style="color:#8af;margin-top:4px">ghost</div>`;
+    return header + rows.map(r => `<div style="margin-left:4px">${r}</div>`).join("");
+  }
+
+  function renderHover(): void {
     // Override beats everything except — we still append the cursor
     // coord so lane/row/ghost overlays stop hiding the coordinate.
     if (tooltipOverride !== null) {
-      const coord = coordLine();
+      const coord = cursorTile ? coordLine(cursorTile.x, cursorTile.y) : "";
       tooltip.innerHTML = coord ? `${tooltipOverride}<br>${coord}` : tooltipOverride;
       tooltip.style.display = "block";
       return;
     }
 
-    if (hoveredEntity) {
-      tooltip.innerHTML = entityHtml(hoveredEntity);
-      tooltip.style.display = "block";
-      if (highlightCtrl) {
-        if (isBeltEntity(hoveredEntity.name)) {
-          highlightCtrl.highlightBeltNetwork(hoveredEntity);
-        } else {
-          highlightCtrl.highlightItem(highlightCtrl.chainKey(hoveredEntity));
+    const parts: string[] = [];
+    if (hoveredEntity) parts.push(entityHtml(hoveredEntity));
+    if (cursorTile) {
+      const info = tileContext?.lookup(cursorTile.x, cursorTile.y);
+      if (info) {
+        const g = ghostCompact(info);
+        const a = axisCompact(info);
+        const j = junctionCompact(info);
+        for (const s of [g, a, j]) if (s) parts.push(s);
+      }
+      parts.push(coordLine(cursorTile.x, cursorTile.y));
+    }
+
+    if (parts.length === 0) {
+      tooltip.style.display = "none";
+      if (highlightCtrl) highlightCtrl.clearHighlight();
+      return;
+    }
+
+    tooltip.innerHTML = parts.join("<br>");
+    tooltip.style.display = "block";
+
+    if (hoveredEntity && highlightCtrl) {
+      if (isBeltEntity(hoveredEntity.name)) {
+        highlightCtrl.highlightBeltNetwork(hoveredEntity);
+      } else {
+        highlightCtrl.highlightItem(highlightCtrl.chainKey(hoveredEntity));
+      }
+    } else if (highlightCtrl) {
+      highlightCtrl.clearHighlight();
+    }
+  }
+
+  function renderPinned(): void {
+    if (!pinnedState) {
+      pinned.style.display = "none";
+      return;
+    }
+    const { entity, x, y } = pinnedState;
+    const info = tileContext?.lookup(x, y);
+
+    const parts: string[] = [];
+    parts.push(`<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px"><span style="color:#8af;font-weight:bold">pinned</span> <span style="color:#888">(${x}, ${y})</span></div>`);
+
+    if (entity) parts.push(entityHtml(entity));
+    else parts.push(`<span style="color:#888">no entity at tile</span>`);
+
+    if (info) {
+      if (info.junction) {
+        const color = info.junction.outcome === "Solved" ? "#80d080" : info.junction.outcome === "Capped" ? "#e0b060" : "#c06060";
+        parts.push(`<div style="margin-top:6px;padding-top:4px;border-top:1px solid #333">` +
+          `<span style="color:${color}">junction seed (${info.junction.seedX},${info.junction.seedY})</span> <span style="color:#888">\u00b7 ${info.junction.outcome}</span>` +
+          `</div>`);
+      }
+      if (info.axis) {
+        const { vert, horiz } = info.axis;
+        if (vert > 0 || horiz > 0) {
+          const conflict = vert >= 2 || horiz >= 2;
+          const perp = vert >= 1 && horiz >= 1;
+          const label = conflict ? " same-axis conflict" : perp ? " perpendicular crossing" : "";
+          const color = conflict ? "#ff6060" : perp ? "#60b0ff" : "#bbb";
+          parts.push(`<div style="color:${color};margin-top:4px">axis: V=${vert} H=${horiz}${label}</div>`);
         }
       }
-      return;
+      const expanded = ghostExpanded(info);
+      if (expanded) parts.push(expanded);
     }
 
-    if (highlightCtrl) highlightCtrl.clearHighlight();
+    parts.push(`<div style="color:#555;margin-top:6px;font-size:10px">click elsewhere or press Esc to unpin</div>`);
 
-    if (cursorTile) {
-      tooltip.innerHTML = coordLine();
-      tooltip.style.display = "block";
-      return;
-    }
+    pinned.innerHTML = parts.join("");
+    pinned.style.display = "block";
+  }
 
-    tooltip.style.display = "none";
+  function render(): void {
+    renderHover();
+    renderPinned();
   }
 
   function onHover(entity: PlacedEntity | null, tileX?: number, tileY?: number): void {
     hoveredEntity = entity;
-    if (!entity && tileX !== undefined && tileY !== undefined) {
+    if (tileX !== undefined && tileY !== undefined) {
       cursorTile = { x: tileX, y: tileY };
+    } else if (entity) {
+      cursorTile = { x: entity.x ?? 0, y: entity.y ?? 0 };
     }
     render();
   }
 
-  void container;
+  // Allow Escape to unpin without the user having to aim.
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && pinnedState) {
+      pinnedState = null;
+      notifyPin();
+      render();
+    }
+  });
 
   return {
     onHover,
@@ -116,6 +260,27 @@ export function createInspector(container: HTMLElement): InspectorControls {
         cursorTile = { x, y };
       }
       render();
+    },
+    setTileContext(ctx: TileContext | null): void {
+      tileContext = ctx;
+      render();
+    },
+    pinTile(entity: PlacedEntity | null, x: number, y: number): void {
+      pinnedState = { entity, x, y };
+      notifyPin();
+      render();
+    },
+    clearPin(): void {
+      pinnedState = null;
+      notifyPin();
+      render();
+    },
+    getPinnedTile(): { x: number; y: number } | null {
+      return pinnedState ? { x: pinnedState.x, y: pinnedState.y } : null;
+    },
+    onPinChange(cb: (tile: { x: number; y: number } | null) => void): () => void {
+      pinListeners.add(cb);
+      return () => pinListeners.delete(cb);
     },
   };
 }

--- a/web/src/ui/tileContext.ts
+++ b/web/src/ui/tileContext.ts
@@ -1,0 +1,139 @@
+// Per-tile aggregator: given a layout, indexes everything we know about
+// a single tile (x,y) so the inspector can show it in one place instead
+// of scattering on-canvas labels everywhere.
+//
+// Currently surfaces:
+//   - ghost specs routed through the tile (item + direction at the tile)
+//   - axis occupancy (V/H counts from the negotiated router)
+//   - junction-cluster membership (which solver seed this tile belongs to,
+//     if any, plus the outcome)
+
+import type { TraceEvent } from "../engine";
+
+export interface GhostSpecAtTile {
+  item: string;
+  specKey: string;
+  direction: "N" | "S" | "E" | "W" | null;
+  /** true if this tile is the start of the spec path. */
+  isStart: boolean;
+  /** true if this tile is the end of the spec path. */
+  isEnd: boolean;
+}
+
+export interface AxisAtTile {
+  vert: number;
+  horiz: number;
+}
+
+export interface JunctionMembership {
+  seedX: number;
+  seedY: number;
+  outcome: "Solved" | "Capped" | "Open";
+}
+
+export interface TileInfo {
+  ghosts: GhostSpecAtTile[];
+  axis: AxisAtTile | null;
+  junction: JunctionMembership | null;
+}
+
+export interface TileContext {
+  lookup(x: number, y: number): TileInfo;
+}
+
+function itemFromSpecKey(key: string): string {
+  const i = key.indexOf(":");
+  return i >= 0 ? key.slice(0, i) : key;
+}
+
+function tileDirection(ax: number, ay: number, bx: number, by: number): "N" | "S" | "E" | "W" | null {
+  if (bx > ax) return "E";
+  if (bx < ax) return "W";
+  if (by > ay) return "S";
+  if (by < ay) return "N";
+  return null;
+}
+
+const EMPTY: TileInfo = { ghosts: [], axis: null, junction: null };
+
+export function buildTileContext(trace: readonly TraceEvent[] | undefined): TileContext {
+  if (!trace || trace.length === 0) {
+    return { lookup: () => EMPTY };
+  }
+
+  const ghostMap = new Map<string, GhostSpecAtTile[]>();
+  const axisMap = new Map<string, AxisAtTile>();
+  const junctionMap = new Map<string, JunctionMembership>();
+
+  for (const evt of trace) {
+    if (evt.phase === "GhostSpecRouted") {
+      const { spec_key, tiles } = evt.data;
+      const item = itemFromSpecKey(spec_key);
+      if (!tiles || tiles.length === 0) continue;
+      for (let i = 0; i < tiles.length; i++) {
+        const [tx, ty] = tiles[i];
+        let dir: "N" | "S" | "E" | "W" | null = null;
+        if (i < tiles.length - 1) {
+          dir = tileDirection(tx, ty, tiles[i + 1][0], tiles[i + 1][1]);
+        } else if (i > 0) {
+          dir = tileDirection(tiles[i - 1][0], tiles[i - 1][1], tx, ty);
+        }
+        const key = `${tx},${ty}`;
+        const list = ghostMap.get(key);
+        const entry: GhostSpecAtTile = {
+          item,
+          specKey: spec_key,
+          direction: dir,
+          isStart: i === 0,
+          isEnd: i === tiles.length - 1,
+        };
+        if (list) list.push(entry);
+        else ghostMap.set(key, [entry]);
+      }
+    } else if (evt.phase === "GhostAxisOccupancy") {
+      for (const t of evt.data.tiles) {
+        axisMap.set(`${t.x},${t.y}`, { vert: t.vert_count, horiz: t.horiz_count });
+      }
+    } else if (
+      evt.phase === "JunctionSolved" ||
+      evt.phase === "JunctionGrowthCapped"
+    ) {
+      // Seed-level outcome — we tag only the seed tile here; bbox-level
+      // containment is surfaced via `junctionCluster.ts` downstream. For
+      // now the seed match is enough to indicate "this is a junction".
+      const d = evt.data;
+      const outcome: JunctionMembership["outcome"] =
+        evt.phase === "JunctionSolved" ? "Solved" :
+        "Capped";
+      junctionMap.set(`${d.tile_x},${d.tile_y}`, {
+        seedX: d.tile_x, seedY: d.tile_y, outcome,
+      });
+    } else if (evt.phase === "JunctionGrowthIteration") {
+      // Tag every tile in the grown region with the seed. Later iters
+      // overwrite earlier ones so the last-seen membership wins (fine
+      // for display — we just want "which junction is this tile in").
+      const d = evt.data;
+      const seedKey = `${d.seed_x},${d.seed_y}`;
+      for (const [tx, ty] of d.tiles) {
+        const key = `${tx},${ty}`;
+        if (!junctionMap.has(key) || junctionMap.get(key)!.seedX === d.seed_x) {
+          junctionMap.set(key, {
+            seedX: d.seed_x, seedY: d.seed_y,
+            outcome: junctionMap.get(seedKey)?.outcome ?? "Open",
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    lookup(x: number, y: number): TileInfo {
+      const key = `${x},${y}`;
+      return {
+        ghosts: ghostMap.get(key) ?? [],
+        axis: axisMap.get(key) ?? null,
+        junction: junctionMap.get(key) ?? null,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Junction-solver debugging had become illegible — on-tile labels (\`ele IN\`, \`no ports\`, \`Capped · 4 iters\`), axis occupancy dots/squares, yellow crossing diamonds, and colored path lines all stacked at the same z-level. This PR moves per-tile detail into a click-to-pin inspector and strips the canvas down to one visual signal per concept.

**Canvas declutter** (one signal per concept)
- Removed redundant yellow crossing diamonds — the orange multi-item heatmap is the authoritative crossing signal.
- Removed red-square / blue-dot axis occupancy glyphs — counts live in the inspector now.
- Dropped \`÷n\` lane-consolidation and \`⊕n\` row-split badges, cluster-ID size labels.
- Dropped region corner labels (\`4×1 no-ports\`) and per-port \`ele IN / ele OUT\` text.
- Ghost path palette: 10 → 4 cycled colours.

**Inspector upgrade** (progressive disclosure)
- New \`ui/tileContext.ts\` aggregates per-tile info from the trace: ghost specs touching the tile (with direction), axis V/H counts, junction-seed membership + outcome.
- Hover: compact summary (entity + 1-line ghost/axis/junction indicators + coords).
- **Click any tile to pin** a detail panel (top-right, fixed) with full expanded info. Click the same tile again, or press Esc, to unpin.
- Pinned tile gets a light-blue outline on canvas so you always see what the panel describes.

**Belt visuals**
- Straight + corner belts now occupy 90% of the tile width, centred.
- UG belts reworked: transparent tunnel section (no black fill), surface replaced with a trapezoid tapering from belt-width at the mouth to ~50% tile-width at the divider. Intermediate tunnel stripe narrowed to match the throat so paired UGs read as one continuous pipe.

**Line count**: +466 / −236. Most of the additions are the inspector + tile-context modules; most of the deletions are on-canvas rendering that's no longer needed.

## Test plan

- [ ] Open a junction-heavy layout (e.g. \`?item=advanced-circuit\`) with Debug + Regions toggles on.
- [ ] Confirm canvas is substantially quieter: no per-port text, no axis dots, no badges, no crossing diamonds.
- [ ] Hover tiles inside a junction zone: inspector shows compact ghost/axis/junction summary.
- [ ] Click a tile: fixed pinned panel appears top-right with full detail; tile gets a blue outline.
- [ ] Click the same tile again or press Esc: unpins.
- [ ] Click a different tile: pin moves.
- [ ] Belts: straights and corners visibly narrower than tile (gutter on each side).
- [ ] UG belts: tunnel section shows through (no black fill); surface reads as a trapezoid.
- [ ] SAT zone selection still works (click on a junction zone opens debugger, boundary bars + chevrons + item icons still render on the selected zone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)