### PR TITLE
fix(web): make streaming render visible + grid follows layout

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,6 +1,6 @@
 import { Container, Graphics } from "pixi.js";
 import { createApp, WORLD_SIZE } from "./renderer/app";
-import { drawGrid } from "./renderer/grid";
+import { drawGrid, updateGrid } from "./renderer/grid";
 import { drawGraph } from "./renderer/graph";
 import { initEntityIcons, renderLayout, setItemColoring, itemColor, TILE_PX } from "./renderer/entities";
 import { createSelectionController, type SelectionController } from "./renderer/selection";
@@ -93,7 +93,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   container.style.display = "";
 
   const { app, viewport } = await createApp(container);
-  drawGrid(viewport);
+  const gridGfx = drawGrid(viewport);
   drawGraph(viewport, null);
 
   attachBusyOverlay(container);
@@ -635,12 +635,25 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   }
 
   function startStreaming(): (evt: TraceEvent) => void {
-    // Cancel any prior streaming render before starting a fresh one. The
-    // entity layer has already been cleared by renderGraph just before this
-    // call; the new handle attaches fresh sub-layers.
     streamingHandle?.cancel();
+    // Remove the dependency graph — it sits on top of entityLayer in viewport's
+    // child order, so it would hide streaming entities. Switch to entity view now.
+    drawGraph(viewport, null);
     streamingHandle = createStreamingRenderer(entityLayer, app, onHover, onSelect);
-    return (evt) => streamingHandle?.onEvent(evt);
+    let viewportFitted = false;
+    return (evt) => {
+      // On the first PhaseSnapshot, pan+zoom to frame the layout so streaming
+      // entities are visible. Subsequent snaps don't re-pan (user may have moved).
+      if (!viewportFitted && (evt as { phase?: string }).phase === "PhaseSnapshot") {
+        const d = (evt as { phase: string; data: { width: number; height: number } }).data;
+        if (d.width > 0 && d.height > 0) {
+          viewport.fit(true, d.width * TILE_PX * 1.15, d.height * TILE_PX * 1.25);
+          viewport.moveCenter(d.width * TILE_PX / 2, d.height * TILE_PX / 2);
+          viewportFitted = true;
+        }
+      }
+      streamingHandle?.onEvent(evt);
+    };
   }
 
   function buildLegend(layout: LayoutResult): void {
@@ -690,15 +703,14 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       : null;
 
     if (streamingHandle && streamedCtrl) {
-      // Streaming already drew entities into entityLayer's sub-layers.
-      // Snap any in-flight fades + overlays to their final state; keep the
-      // streaming graphics as the authoritative render.
+      // Streaming drew entities progressively during layout. Snap any in-flight
+      // fades to final state and keep the streaming graphics as authoritative.
       streamingHandle.finish();
       streamingHandle = null;
       ctrl = streamedCtrl;
     } else {
-      // Non-streaming path: corpus, parsed blueprints, or fallback if the
-      // streaming handle somehow never saw a PhaseSnapshot.
+      // Non-streaming path: corpus, parsed blueprints, or fast layouts where
+      // all snapshots arrived before any streaming frame could commit.
       streamingHandle?.cancel();
       streamingHandle = null;
       const traceEvents = Array.isArray(layout.trace) ? layout.trace : [];
@@ -725,6 +737,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     updateLegend();
     const w = layout.width ?? 0;
     const h = layout.height ?? 0;
+    updateGrid(gridGfx, w + 2, h + 2);
     if (w > 0 && h > 0) {
       const pxW = w * 32;
       const pxH = h * 32;

--- a/web/src/renderer/grid.ts
+++ b/web/src/renderer/grid.ts
@@ -2,26 +2,28 @@ import { Graphics } from "pixi.js";
 import type { Viewport } from "pixi-viewport";
 
 const TILE_SIZE = 32;
-const GRID_TILES = 100;
 const MINOR_COLOR = 0x2a2a2a;
 const MAJOR_COLOR = 0x3a3a3a;
 
 export function drawGrid(viewport: Viewport): Graphics {
   const g = new Graphics();
-  const size = GRID_TILES * TILE_SIZE;
-
-  for (let i = 0; i <= GRID_TILES; i++) {
-    const pos = i * TILE_SIZE;
-    const isMajor = i % 10 === 0;
-    const color = isMajor ? MAJOR_COLOR : MINOR_COLOR;
-    const width = isMajor ? 1.5 : 1;
-
-    // Vertical line
-    g.moveTo(pos, 0).lineTo(pos, size).stroke({ width, color });
-    // Horizontal line
-    g.moveTo(0, pos).lineTo(size, pos).stroke({ width, color });
-  }
-
-  viewport.addChild(g);
+  viewport.addChildAt(g, 0);
   return g;
+}
+
+export function updateGrid(g: Graphics, widthTiles: number, heightTiles: number): void {
+  g.clear();
+  if (widthTiles <= 0 || heightTiles <= 0) return;
+  const pw = widthTiles * TILE_SIZE;
+  const ph = heightTiles * TILE_SIZE;
+  for (let i = 0; i <= widthTiles; i++) {
+    const x = i * TILE_SIZE;
+    const major = i % 10 === 0;
+    g.moveTo(x, 0).lineTo(x, ph).stroke({ width: major ? 1.5 : 1, color: major ? MAJOR_COLOR : MINOR_COLOR });
+  }
+  for (let j = 0; j <= heightTiles; j++) {
+    const y = j * TILE_SIZE;
+    const major = j % 10 === 0;
+    g.moveTo(0, y).lineTo(pw, y).stroke({ width: major ? 1.5 : 1, color: major ? MAJOR_COLOR : MINOR_COLOR });
+  }
 }


### PR DESCRIPTION
## Summary

- **Streaming was invisible**: the dependency graph layer is appended to the viewport *after* `entityLayer`, so it sits on top in draw order. Streaming entities were being rendered correctly but hidden underneath the graph. `startStreaming()` now calls `drawGraph(viewport, null)` to clear the graph before layout begins, and fits+centres the viewport on the first `PhaseSnapshot` dimensions so entities near (0,0) aren't off-screen.
- **Streaming path restored as primary**: `renderLayoutOnCanvas` keeps `streamingHandle.finish()` as the authoritative path when snapshots were committed. Phase animation falls back for fast layouts where all snapshots arrived before any frame could commit.
- **Grid follows layout bounding box**: the grid was a fixed 100×100 tile square drawn once at init. `drawGrid()` now returns the `Graphics`; `updateGrid(g, w, h)` clears and redraws to the given dimensions. `renderLayoutOnCanvas` calls `updateGrid` with `layout.width+2 × layout.height+2` so the grid always underlays the full factory.

## Test plan

- [ ] Load a slow/complex recipe (advanced-circuit): machine rows should appear in the canvas while SAT is solving — grid should appear under them, viewport should jump to frame the layout
- [ ] Load a fast recipe (iron-gear-wheel): phase animation fallback plays after layout completes
- [ ] Grid lines cover the full factory width, no cutoff at 100 tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)