### PR TITLE
fix(web): selection only starts on entity tiles; panning preserves selection

### DIFF
--- a/web/src/renderer/selection.ts
+++ b/web/src/renderer/selection.ts
@@ -92,6 +92,10 @@ export function createSelectionController(
 
   const onDown = (e: PointerEvent) => {
     if (e.button !== 0 || !e.shiftKey) return;
+    const w = toWorld(e.clientX, e.clientY);
+    const tx = Math.floor(w.x / TILE_PX);
+    const ty = Math.floor(w.y / TILE_PX);
+    if (!tileMap.has(`${tx},${ty}`)) return;
     dragStart = { sx: e.clientX, sy: e.clientY };
     isDragging = false;
   };
@@ -116,12 +120,14 @@ export function createSelectionController(
       selected = collectEntities(e.clientX, e.clientY);
       redrawBorders(selected);
       onSelectionChange(selected);
-    } else {
-      // Plain click — clear selection (entity click events still fire normally)
+    } else if (dragStart !== null) {
+      // Shift was held but drag threshold not reached — Shift+click on empty
+      // space. Clear selection; entity clicks are handled by their own handlers.
       selected = [];
       borderG.clear();
       onSelectionChange([]);
     }
+    // Plain click/drag with no Shift: pure navigation — leave selection alone.
     dragStart = null;
     isDragging = false;
   };


### PR DESCRIPTION
## Summary

- Shift+drag no longer starts a selection gesture when the pointer-down lands on an empty tile — it falls through to the viewport as normal navigation.
- Plain click-drag (no Shift) no longer clears the current selection; `onUp` only touches selection state when a gesture was actually initiated (`dragStart !== null`).

Together these make click-drag panning non-destructive to selection, and prevent accidentally entering selection mode by dragging from empty space.

## Test plan

- [ ] Shift+drag starting on an entity tile still selects entities in the rect
- [ ] Shift+drag starting on empty space pans the viewport normally
- [ ] Plain click-drag pans without clearing selection
- [ ] Shift+click on empty space still clears selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)