### PR TITLE
feat(agent): persistent volumes, --reset, baked dev tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN cargo install --git https://github.com/rtk-ai/rtk --locked
 # register and enable.
 RUN pi install npm:lsp-pi \
  && pi install npm:@sherif-fanous/pi-rtk \
- && pi install npm:pi-subagents
+ && pi install npm:pi-subagents \
+ && pi install npm:@the-forge-flow/gh-pi
 
 COPY --chown=node:node docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chown=node:node scripts/agent-runner.sh /usr/local/bin/agent-runner.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,42 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       git gh jq less procps sudo curl ca-certificates gettext-base \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @mariozechner/pi-coding-agent
+# Language servers the pi lsp-pi extension uses. typescript-language-server
+# is installed globally via npm; rust-analyzer comes via rustup component
+# (further down) after rust itself is installed.
+RUN npm install -g @mariozechner/pi-coding-agent \
+                   typescript \
+                   typescript-language-server
 
 RUN echo "node ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/node
 
 USER node
 
+# User-local npm prefix — `pi install npm:*` delegates to `npm install -g`
+# which otherwise needs /usr/local write perms (root-only). This routes
+# global installs into the node user's home instead.
+RUN mkdir -p "$HOME/.npm-global" \
+ && npm config set prefix "$HOME/.npm-global"
+ENV PATH="/home/node/.npm-global/bin:/home/node/.cargo/bin:$PATH"
+
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable \
-      --component clippy --component rustfmt
-ENV PATH="/home/node/.cargo/bin:$PATH"
+      --component clippy --component rustfmt --component rust-analyzer
 RUN rustup target add wasm32-unknown-unknown
 
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# rtk (Rust Token Killer) — CLI proxy that trims common command output
+# before it hits the model context. Compiled from source via cargo --git
+# because the crates.io 'rtk' name is taken by an unrelated project.
+RUN cargo install --git https://github.com/rtk-ai/rtk --locked
+
+# pi extensions. These write to ~/.pi/settings.json and install npm packages
+# into the user-local prefix we set above. `pi config` is an interactive TUI
+# for toggling extensions — we don't invoke it; `pi install` is enough to
+# register and enable.
+RUN pi install npm:lsp-pi \
+ && pi install npm:@sherif-fanous/pi-rtk \
+ && pi install npm:pi-subagents
 
 COPY --chown=node:node docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chown=node:node scripts/agent-runner.sh /usr/local/bin/agent-runner.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,7 +38,10 @@ have_llama=0
 
 if [ -d /mnt/pi-ro ]; then
     mkdir -p "$HOME/.pi"
-    cp -a /mnt/pi-ro/. "$HOME/.pi/"
+    # -n (no-clobber): image-baked files in ~/.pi (e.g. installed extensions
+    # listed in settings.json) win. Host mount only fills in what the image
+    # doesn't already have — typically auth.json / credentials.
+    cp -an /mnt/pi-ro/. "$HOME/.pi/"
     chmod -R u+w "$HOME/.pi"
     # auth.json is user-only by design (0600); keep that after the copy.
     [ -f "$HOME/.pi/agent/auth.json" ] && chmod 600 "$HOME/.pi/agent/auth.json"
@@ -47,7 +50,7 @@ fi
 
 if [ -n "${LLAMA_MODEL:-}" ]; then
     : "${LLAMA_PORT:=8080}"
-    : "${LLAMA_CONTEXT:=32768}"
+    : "${LLAMA_CONTEXT:=65536}"
     : "${LLAMA_MAX_TOKENS:=8192}"
     export LLAMA_PORT LLAMA_MODEL LLAMA_CONTEXT LLAMA_MAX_TOKENS
     mkdir -p "$HOME/.pi/agent"

--- a/docs/agent-container.md
+++ b/docs/agent-container.md
@@ -61,12 +61,16 @@ export GH_TOKEN=ghp_... LLAMA_MODEL=qwen2.5-coder-32b-instruct
 ./scripts/run-watcher.sh --logs misia         # docker logs -f
 ./scripts/run-watcher.sh --stop misia         # SIGTERM, waits 30s
 ./scripts/run-watcher.sh --status             # list running watchers
+./scripts/run-watcher.sh --reset misia        # stop + wipe workspace + cargo caches
 ```
 
 The watcher:
 
-1. Clones the repo once into `/tmp/workspace` (the clone survives across
-   issues, so cargo's `target/` stays warm).
+1. Clones the repo into `/tmp/workspace` *if the persistent volume is empty*;
+   otherwise it reuses what's there and `git fetch`es. The workspace volume
+   (`fucktorio-workspace-<agent>`) and cargo cache volume
+   (`fucktorio-cargo-<agent>`) survive container recreation and image
+   rebuilds, so cold-compile costs are paid once per `--reset`.
 2. Loops: pick one open issue labelled `${AGENT_NAME}-ready` (e.g.
    `misia-ready`), reset the workspace to `origin/main`, branch to
    `agent/<name>/issue-<n>`, run pi, check for the resulting PR, relabel the
@@ -74,6 +78,21 @@ The watcher:
    commented on the issue). Sleep `POLL_INTERVAL` seconds if no candidate.
 3. SIGTERM (`docker stop`, `./run-watcher.sh --stop`) finishes the current
    iteration and exits cleanly within ~30s.
+
+### Workspace persistence
+
+Two named Docker volumes per watcher:
+
+| Volume | Mount point | Contents |
+|--------|-------------|----------|
+| `fucktorio-workspace-<agent>` | `/tmp/workspace` | Git clone, `target/` build cache |
+| `fucktorio-cargo-<agent>` | `~/.cargo/registry` | Downloaded crates |
+
+Host reboot: volumes survive, Docker auto-restarts the container (`--restart unless-stopped`), container picks up mid-idle (or mid-issue if it was working — without resume semantics; see [Limits](#limits)).
+
+Image rebuild: volumes survive. A fresh container on the new image reuses the old workspace — `git fetch` catches up to whatever landed on main.
+
+Clean start: `--reset <agent>` prompts, stops the container, removes both volumes. Next launch cold-clones and cold-compiles.
 
 **One watcher per agent name.** The launcher refuses to start a second
 watcher with the same name; use `--logs` or `--stop` instead. If you want
@@ -121,11 +140,35 @@ The launcher auto-detects the WSL-to-Windows gateway via
 | `ISSUE` | one-shot only | — | Positive integer; ignored by the watcher. |
 | `LLAMA_MODEL` | llama backend | — | Model id from `/v1/models` on the server. |
 | `LLAMA_PORT` | no | `8080` | Windows-side llama-server port. |
-| `LLAMA_CONTEXT` | no | `32768` | Context window (tokens). |
+| `LLAMA_CONTEXT` | no | `65536` | Context window (tokens). Your llama-server must have been started with at least this much context (`-c` flag). |
 | `LLAMA_MAX_TOKENS` | no | `8192` | Per-response cap. |
 | `AGENT_READY_LABEL` | no | `${AGENT_NAME}-ready` | Label the watcher polls on. |
 | `POLL_INTERVAL` | no | `60` | Seconds between queue polls. |
 | `LLAMA_HOST_IP` | no | auto | Override the WSL-gateway auto-detection. |
+
+## Baked-in dev tooling
+
+The image ships with the tools pi reaches for when doing real development work:
+
+| Tool | Purpose |
+|------|---------|
+| `typescript-language-server` + `typescript` | TS/JS LSP (via `lsp-pi`) |
+| `rust-analyzer` (rustup component) | Rust LSP (via `lsp-pi`) |
+| `wasm-pack` | WASM build for `crates/wasm-bindings/` |
+| `rtk` | [Rust Token Killer](https://github.com/rtk-ai/rtk) — trims verbose CLI output before it reaches the model context. pi uses it via the `pi-rtk` extension. |
+| `gh`, `git`, `jq`, `less` | Everyday repo/issue tooling |
+
+Pre-installed pi extensions (registered in the image-baked `~/.pi/settings.json`):
+
+- `lsp-pi` — LSP integration (goto-def, references, diagnostics via the two language servers above).
+- `@sherif-fanous/pi-rtk` — wraps pi's `bash` tool so heavy commands route through `rtk` and come back trimmed.
+- `pi-subagents` — adds delegation-to-subagent capability that upstream pi deliberately omits.
+
+The entrypoint's host-mount copy uses `cp -an` so a bind-mounted `~/.pi` from the host can't clobber these image-baked settings. Host wins only for paths the image doesn't already have (typically `auth.json`).
+
+### Project context
+
+pi auto-discovers `CLAUDE.md` and `AGENTS.md` from the workspace root on every run (unless `--no-context-files` is passed — we don't). So project-level conventions (build commands, verification protocol, the source-file map) come from `CLAUDE.md` automatically, not from personality files. Keep `scripts/agents/<name>.md` for *personality* — tone, preferences, standing style orders — and trust `CLAUDE.md` for *project*.
 
 ## Recommended `GH_TOKEN` scopes
 

--- a/docs/agent-container.md
+++ b/docs/agent-container.md
@@ -163,6 +163,7 @@ Pre-installed pi extensions (registered in the image-baked `~/.pi/settings.json`
 - `lsp-pi` — LSP integration (goto-def, references, diagnostics via the two language servers above).
 - `@sherif-fanous/pi-rtk` — wraps pi's `bash` tool so heavy commands route through `rtk` and come back trimmed.
 - `pi-subagents` — adds delegation-to-subagent capability that upstream pi deliberately omits.
+- `@the-forge-flow/gh-pi` — GitHub-focused tooling for pi (adds to whatever `gh` already provides).
 
 The entrypoint's host-mount copy uses `cp -an` so a bind-mounted `~/.pi` from the host can't clobber these image-baked settings. Host wins only for paths the image doesn't already have (typically `auth.json`).
 

--- a/scripts/agent-watcher.sh
+++ b/scripts/agent-watcher.sh
@@ -29,12 +29,36 @@ on_signal() {
 trap on_signal TERM INT
 
 # ---------------------------------------------------------------------------
-# Initial clone (once per container lifetime)
+# Workspace setup — clone if cold, otherwise reuse the persisted volume.
+# Volume is /tmp/workspace (a named Docker volume in production); contents
+# survive container recreation, which is the whole point of warm caches.
 # ---------------------------------------------------------------------------
-rm -rf "$WORKSPACE"
-echo "cloning ${REPO} into ${WORKSPACE}..."
-gh repo clone "$REPO" "$WORKSPACE" -- --quiet
-cd "$WORKSPACE"
+if [ -d "$WORKSPACE/.git" ]; then
+    echo "reusing existing workspace at ${WORKSPACE}"
+    cd "$WORKSPACE"
+    # make sure we're tracking the right repo (defensive — catches cases
+    # where the volume was populated by another repo earlier).
+    actual_remote="$(git remote get-url origin 2>/dev/null || echo '')"
+    expected_remote="https://github.com/${REPO}.git"
+    if [ -n "$actual_remote" ] && [ "$actual_remote" != "$expected_remote" ]; then
+        echo "workspace has remote ${actual_remote}, expected ${expected_remote}"
+        echo "wiping and re-cloning."
+        cd /
+        rm -rf "$WORKSPACE"/*  "$WORKSPACE"/.[!.]* 2>/dev/null || true
+        gh repo clone "$REPO" "$WORKSPACE" -- --quiet
+        cd "$WORKSPACE"
+    else
+        git fetch origin --quiet
+    fi
+else
+    # First boot, or someone wiped the volume.
+    # We can't `rm -rf $WORKSPACE` because it's the volume mountpoint;
+    # clear contents instead.
+    rm -rf "$WORKSPACE"/*  "$WORKSPACE"/.[!.]* 2>/dev/null || true
+    echo "cloning ${REPO} into ${WORKSPACE}..."
+    gh repo clone "$REPO" "$WORKSPACE" -- --quiet
+    cd "$WORKSPACE"
+fi
 
 # Pre-push hook: refuse main/master.
 HOOK=.git/hooks/pre-push

--- a/scripts/run-watcher.sh
+++ b/scripts/run-watcher.sh
@@ -11,6 +11,7 @@ Usage:
   ./scripts/run-watcher.sh <agent-name>              Start a long-running watcher
   ./scripts/run-watcher.sh --logs <agent-name>       docker logs -f the watcher
   ./scripts/run-watcher.sh --stop <agent-name>       Send SIGTERM and wait for clean exit
+  ./scripts/run-watcher.sh --reset <agent-name>      Stop container AND wipe its volumes
   ./scripts/run-watcher.sh --list                    Show available agent names
   ./scripts/run-watcher.sh --status                  Show running watchers
 
@@ -25,11 +26,20 @@ Environment:
 
   LLAMA_PORT        (optional)  Port the Windows llama-server listens on
                                 (default: 8080).
-  LLAMA_CONTEXT     (optional)  Context window in tokens (default: 32768).
+  LLAMA_CONTEXT     (optional)  Context window in tokens (default: 65536).
+                                Your llama-server must have been started with
+                                at least this many tokens of context (-c flag).
   LLAMA_MAX_TOKENS  (optional)  Per-response cap (default: 8192).
   POLL_INTERVAL     (optional)  Seconds between issue-queue polls (default: 60).
 
   FUCKTORIO_AGENT_IMAGE (optional, default: fucktorio-agent:latest)
+
+Volumes:
+  Each watcher owns two named Docker volumes:
+    fucktorio-workspace-<agent>  (/tmp/workspace — git clone, target/ cache)
+    fucktorio-cargo-<agent>      (~/.cargo/registry — downloaded crates)
+  These survive container recreation and image rebuilds. Use --reset to wipe
+  them when you want a clean start.
 
 Windows-side prerequisites (one-time):
   - Run llama-server bound to 0.0.0.0:<LLAMA_PORT> (not 127.0.0.1).
@@ -43,6 +53,7 @@ Examples:
   ./scripts/run-watcher.sh misia
   ./scripts/run-watcher.sh --logs misia
   ./scripts/run-watcher.sh --stop misia
+  ./scripts/run-watcher.sh --reset misia
 EOF
 }
 
@@ -68,8 +79,44 @@ status() {
     fi
 }
 
-container_name_for() {
-    echo "fucktorio-watcher-$1"
+container_name_for() { echo "fucktorio-watcher-$1"; }
+workspace_volume_for() { echo "fucktorio-workspace-$1"; }
+cargo_volume_for() { echo "fucktorio-cargo-$1"; }
+
+reset_agent() {
+    local name="$1"
+    local container; container="$(container_name_for "$name")"
+    local ws_vol; ws_vol="$(workspace_volume_for "$name")"
+    local cg_vol; cg_vol="$(cargo_volume_for "$name")"
+
+    echo "This will:"
+    echo "  1. Stop ${container} (if running)"
+    echo "  2. Remove the container"
+    echo "  3. Delete volume ${ws_vol} (workspace + target cache)"
+    echo "  4. Delete volume ${cg_vol} (cargo registry)"
+    echo
+    read -rp "Proceed? [y/N] " reply
+    case "$reply" in
+        y|Y|yes|YES) ;;
+        *) echo "aborted."; exit 0 ;;
+    esac
+
+    if docker ps --format '{{.Names}}' | grep -qx "$container"; then
+        echo "stopping ${container}..."
+        docker stop --timeout 30 "$container" >/dev/null
+    fi
+    if docker ps -a --format '{{.Names}}' | grep -qx "$container"; then
+        docker rm "$container" >/dev/null
+    fi
+    for vol in "$ws_vol" "$cg_vol"; do
+        if docker volume ls --format '{{.Name}}' | grep -qx "$vol"; then
+            docker volume rm "$vol" >/dev/null
+            echo "removed volume ${vol}"
+        else
+            echo "volume ${vol} did not exist"
+        fi
+    done
+    echo "reset complete. next launch will cold-clone and cold-compile."
 }
 
 case "${1:-}" in
@@ -98,6 +145,11 @@ case "${1:-}" in
         fi
         echo "sending SIGTERM to ${container} (timeout 30s)..."
         docker stop --timeout 30 "$container"
+        exit 0
+        ;;
+    --reset)
+        [ -n "${2:-}" ] || { echo "error: --reset needs an agent name" >&2; exit 64; }
+        reset_agent "$2"
         exit 0
         ;;
 esac
@@ -133,6 +185,8 @@ if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
 fi
 
 CONTAINER="$(container_name_for "$NAME")"
+WS_VOL="$(workspace_volume_for "$NAME")"
+CG_VOL="$(cargo_volume_for "$NAME")"
 
 # Double-start guard — one watcher per agent name.
 if docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
@@ -160,12 +214,14 @@ docker run -d \
     --name "$CONTAINER" \
     --restart unless-stopped \
     --add-host="llama-host:${WIN_HOST}" \
+    -v "${WS_VOL}:/tmp/workspace" \
+    -v "${CG_VOL}:/home/node/.cargo/registry" \
     -e GH_TOKEN="$GH_TOKEN" \
     -e AGENT_NAME="$NAME" \
     -e AGENT_READY_LABEL="${AGENT_READY_LABEL:-${NAME}-ready}" \
     -e LLAMA_PORT="${LLAMA_PORT:-8080}" \
     -e LLAMA_MODEL="$LLAMA_MODEL" \
-    -e LLAMA_CONTEXT="${LLAMA_CONTEXT:-32768}" \
+    -e LLAMA_CONTEXT="${LLAMA_CONTEXT:-65536}" \
     -e LLAMA_MAX_TOKENS="${LLAMA_MAX_TOKENS:-8192}" \
     -e POLL_INTERVAL="${POLL_INTERVAL:-60}" \
     "$IMAGE" agent-watcher.sh >/dev/null


### PR DESCRIPTION
## Intent

Three related improvements to the agent container now that it's merged and the user is testing with llama.cpp:

1. **Persist the workspace and cargo cache across container/image rebuilds** — previously a rebuild meant a full cold compile.
2. **Ship the dev tools pi actually needs** — language servers, rtk (for trimming command output), and the `lsp-pi` / `pi-rtk` / `pi-subagents` extensions.
3. **Default context window bumped from 32k → 64k** to match what the user's llama-server is actually running with.

## Scope

- **In:**
  - Named volumes per watcher: `fucktorio-workspace-<agent>` → `/tmp/workspace`, `fucktorio-cargo-<agent>` → `~/.cargo/registry`. Survive container recreation AND image rebuilds.
  - `--reset <agent>` verb on `scripts/run-watcher.sh`: stops + removes the container, wipes both volumes, with a confirmation prompt.
  - `scripts/agent-watcher.sh`: reuse-or-clone workspace (checks for existing `.git` dir, `git fetch`es if present, defensively wipes if the remote doesn't match expected).
  - `Dockerfile`: installs `typescript-language-server`, `typescript`, `rust-analyzer` (rustup component), `rtk` (from [rtk-ai/rtk](https://github.com/rtk-ai/rtk) via `cargo install --git`). Sets a user-local npm prefix (`/home/node/.npm-global`) so `pi install npm:...` works as the non-root `node` user.
  - `Dockerfile`: `pi install npm:lsp-pi`, `pi install npm:@sherif-fanous/pi-rtk`, `pi install npm:pi-subagents` — baked into the image's `~/.pi/agent/settings.json`.
  - `docker-entrypoint.sh`: host-mount copy now uses `cp -an` so image-baked settings.json wins; host `auth.json` still layers in.
  - `LLAMA_CONTEXT` default: `32768` → `65536`. Applied in both the entrypoint's `envsubst` and the launcher's env defaults.
  - `docs/agent-container.md`: new "Workspace persistence" and "Baked-in dev tooling" sections, `--reset` usage, `CLAUDE.md` auto-discovery note.

- **Out:**
  - Dynamic language-server management (lsp-pi handles this at runtime).
  - Configuring individual extensions (`pi config` is a TUI — user can invoke it interactively inside the container if they want to toggle things).
  - `pi-rtk` config tuning — uses upstream defaults.

## Verification

- [x] `docker build -t fucktorio-agent:latest .` — clean. `pi list` shows all three extensions installed at `/home/node/.npm-global/lib/node_modules/...`.
- [x] New tools on PATH:
  ```
  $ docker run --rm --entrypoint bash fucktorio-agent:latest -c \
      'which rtk typescript-language-server rust-analyzer && \
       rtk --version && typescript-language-server --version && rust-analyzer --version'
  rtk 0.37.2
  5.1.3
  rust-analyzer 1.95.0
  ```
- [x] `~/.pi/agent/settings.json` contents: `{"packages": ["npm:lsp-pi", "npm:@sherif-fanous/pi-rtk", "npm:pi-subagents"]}`.
- [x] `models.json` renders with `contextWindow: 65536` using the new entrypoint default (no env override needed).
- [x] `cp -an` preserves image settings under a host-mount that tries to clobber with a different `packages` array; host `auth.json` still copies through at `0600` perms.
- [x] `--reset` prompts, stops container, removes both volumes, reports cleanly if volumes didn't exist.
- [x] Watcher workspace reuse: container with an existing `/tmp/workspace/.git` does `git fetch` instead of re-cloning.
- [x] Double-start guard, `--stop`, `--logs`, `--status`, `--list` all still work.
- [x] Banner still shows `backend: llama.cpp (...)` and `mode: watcher (...)` correctly.

Not yet verified — needs a real issue + llama-server:
- [ ] `lsp-pi` actually helps pi navigate the Rust + TS codebase (depends on the extension's own behaviour).
- [ ] `pi-rtk` routes `bash` tool calls through `rtk` as expected.
- [ ] `pi-subagents` lets the model delegate — pi itself doesn't ship subagents, so this is the interesting one.

## Deviations from intent

- pi extensions install needed a user-local npm prefix (`~/.npm-global`) because pi's `npm install -g` delegation can't write to `/usr/local/lib/node_modules` as the non-root `node` user. Added `npm config set prefix` and `PATH` updates to the Dockerfile. Noted for the file I might want to write down later: when running npm globally as a non-root user in Docker, always set a user-local prefix first.
- The watcher's clone step was a simple `rm -rf && clone`, which is wrong once `/tmp/workspace` is a volume (the mountpoint itself can't be rm'd). Rewrote to clear contents and clone into the existing dir.
- `--reset` prompts for confirmation (`read -rp "Proceed? [y/N]"`). Adds one keystroke to the destructive path but avoids `rm -rf`-style regret. If that's annoying for scripted use, easy to add a `-y` flag later.

## Models / contracts touched

None. Still an ops/infra lane; no project abstractions, layout-engine contracts, or recipe models are affected.