### PR TITLE
fix(agent): chown volume mountpoints on first boot

### DIFF
--- a/scripts/agent-watcher.sh
+++ b/scripts/agent-watcher.sh
@@ -29,6 +29,17 @@ on_signal() {
 trap on_signal TERM INT
 
 # ---------------------------------------------------------------------------
+# First-run volume ownership fix. Docker named volumes come up owned by root
+# on their first mount; our `node` user can't write to /tmp/workspace or
+# ~/.cargo/registry until we chown the mount points. Non-recursive is enough —
+# once the top-level dir is node-owned, all future writes are node-owned too.
+# The chown persists in the volume's metadata, so subsequent container
+# starts see an already-node-owned dir and the chown is a no-op.
+# ---------------------------------------------------------------------------
+sudo chown "$(id -u):$(id -g)" "$WORKSPACE" 2>/dev/null || true
+sudo chown "$(id -u):$(id -g)" "$HOME/.cargo/registry" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
 # Workspace setup — clone if cold, otherwise reuse the persisted volume.
 # Volume is /tmp/workspace (a named Docker volume in production); contents
 # survive container recreation, which is the whole point of warm caches.


### PR DESCRIPTION
## Intent

Follow-up to #170. The phase-3 named volumes were landing in a non-working state on first boot — Docker creates volume dirs owned by root, our `node` user can't write to them, so the first clone fails with `Permission denied`. This commit was meant to go out with #170 but I pushed it after the squash-merge and missed the train.

## Scope

- **In:** `scripts/agent-watcher.sh` — two `sudo chown` calls (non-recursive) on `/tmp/workspace` and `~/.cargo/registry` before the clone step. Persists in the volume's metadata, so subsequent starts see an already-node-owned dir and the chown is a no-op.
- **Out:** nothing else; this is a pure bug fix.

## Verification

- [x] Repro reproduced on user's machine: first boot of `./scripts/run-watcher.sh misia` failed with
  ```
  cloning storkme/fucktorio into /tmp/workspace...
  /tmp/workspace/.git: Permission denied
  failed to run git: exit status 1
  ```
- [x] With fix: fresh volume smoke-tested — `drwxr-xr-x 2 root root` → `drwxr-xr-x 2 node node` after chown, `touch /tmp/workspace/.test` succeeds.
- [ ] End-to-end clone (user to verify on their box after rebuild + `--reset`).

## Deviations

None.

## Models / contracts touched

None.