### PR TITLE
feat(agent): default LLAMA_CONTEXT 65536 → 32768

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,7 +50,7 @@ fi
 
 if [ -n "${LLAMA_MODEL:-}" ]; then
     : "${LLAMA_PORT:=8080}"
-    : "${LLAMA_CONTEXT:=65536}"
+    : "${LLAMA_CONTEXT:=32768}"
     : "${LLAMA_MAX_TOKENS:=8192}"
     export LLAMA_PORT LLAMA_MODEL LLAMA_CONTEXT LLAMA_MAX_TOKENS
     mkdir -p "$HOME/.pi/agent"

--- a/docs/agent-container.md
+++ b/docs/agent-container.md
@@ -140,7 +140,7 @@ The launcher auto-detects the WSL-to-Windows gateway via
 | `ISSUE` | one-shot only | — | Positive integer; ignored by the watcher. |
 | `LLAMA_MODEL` | llama backend | — | Model id from `/v1/models` on the server. |
 | `LLAMA_PORT` | no | `8080` | Windows-side llama-server port. |
-| `LLAMA_CONTEXT` | no | `65536` | Context window (tokens). Your llama-server must have been started with at least this much context (`-c` flag). |
+| `LLAMA_CONTEXT` | no | `32768` | Context window (tokens). Your llama-server must have been started with at least this much context (`-c` flag). Scales llama.cpp's KV-cache linearly with RAM — drop to 16384 or 8192 on a tight machine. |
 | `LLAMA_MAX_TOKENS` | no | `8192` | Per-response cap. |
 | `AGENT_READY_LABEL` | no | `${AGENT_NAME}-ready` | Label the watcher polls on. |
 | `POLL_INTERVAL` | no | `60` | Seconds between queue polls. |

--- a/scripts/run-watcher.sh
+++ b/scripts/run-watcher.sh
@@ -26,9 +26,11 @@ Environment:
 
   LLAMA_PORT        (optional)  Port the Windows llama-server listens on
                                 (default: 8080).
-  LLAMA_CONTEXT     (optional)  Context window in tokens (default: 65536).
+  LLAMA_CONTEXT     (optional)  Context window in tokens (default: 32768).
                                 Your llama-server must have been started with
                                 at least this many tokens of context (-c flag).
+                                Scales llama.cpp's KV-cache linearly with RAM;
+                                drop to 16384 or 8192 if the machine is tight.
   LLAMA_MAX_TOKENS  (optional)  Per-response cap (default: 8192).
   POLL_INTERVAL     (optional)  Seconds between issue-queue polls (default: 60).
 
@@ -221,7 +223,7 @@ docker run -d \
     -e AGENT_READY_LABEL="${AGENT_READY_LABEL:-${NAME}-ready}" \
     -e LLAMA_PORT="${LLAMA_PORT:-8080}" \
     -e LLAMA_MODEL="$LLAMA_MODEL" \
-    -e LLAMA_CONTEXT="${LLAMA_CONTEXT:-65536}" \
+    -e LLAMA_CONTEXT="${LLAMA_CONTEXT:-32768}" \
     -e LLAMA_MAX_TOKENS="${LLAMA_MAX_TOKENS:-8192}" \
     -e POLL_INTERVAL="${POLL_INTERVAL:-60}" \
     "$IMAGE" agent-watcher.sh >/dev/null


### PR DESCRIPTION
## Intent

The 64k default from #170 was greedy on RAM. llama.cpp's KV cache scales linearly with context, and on the user's machine 64k crunched memory during real runs.

Halving to 32k as a more conservative default. Users on tighter hardware can override to 16384 or 8192 via env.

## Scope

- **In:** three call sites kept in sync — `docker-entrypoint.sh` envsubst default, `run-watcher.sh` env-forward default + `--help` text, `docs/agent-container.md` env-var table.
- **Out:** `LLAMA_MAX_TOKENS` is unchanged (it's the per-response cap, unrelated to KV-cache RAM).

## Verification

- [x] Grep confirms no `65536` stragglers in the three files.
- [ ] User to confirm RAM usage drops after rebuild + restart.

## Deviations

None.

## Models / contracts touched

None.