### PR TITLE
Add SAT call analyzer and extend stress tests for profiling

### DIFF
--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -649,6 +649,9 @@ impl JunctionStrategy for SatStrategy {
                     .collect()
             })
             .unwrap_or_default();
+        let initial_cost = entities_opt
+            .as_ref()
+            .map(|es| crate::bus::junction_cost::solution_cost(es));
         trace::emit(TraceEvent::SatInvocation {
             seed_x,
             seed_y,
@@ -667,10 +670,12 @@ impl JunctionStrategy for SatStrategy {
             clauses: stats.clauses,
             solve_time_us: stats.solve_time_us,
             entities_raw,
+            initial_cost,
             proposed_entities,
         });
         let mut best = entities_opt?;
-        let mut best_cost = crate::bus::junction_cost::solution_cost(&best);
+        let mut best_cost =
+            initial_cost.expect("entities_opt is Some here, so initial_cost is Some");
 
         // Cost descent: re-solve with a tighter cost cap until either
         // UNSAT (current best is optimal at this cap), wall-clock
@@ -695,6 +700,13 @@ impl JunctionStrategy for SatStrategy {
                 Some(cap),
             );
             let next_sat = next_opt.is_some();
+            let next_cost = next_opt
+                .as_ref()
+                .map(|es| crate::bus::junction_cost::solution_cost(es));
+            let cost_after = match next_cost {
+                Some(c) if c < best_cost => Some(c),
+                _ => None,
+            };
             trace::emit(TraceEvent::SatCostDescent {
                 seed_x,
                 seed_y,
@@ -704,21 +716,20 @@ impl JunctionStrategy for SatStrategy {
                 cap,
                 satisfied: next_sat,
                 solve_time_us: next_stats.solve_time_us,
+                cost_after,
             });
-            match next_opt {
-                Some(ents) => {
-                    let c = crate::bus::junction_cost::solution_cost(&ents);
-                    if c < best_cost {
-                        best = ents;
-                        best_cost = c;
-                    } else {
-                        // Encoder said SAT but cost didn't drop — safety
-                        // bail. Shouldn't happen if weights are in sync
-                        // with `junction_cost::solution_cost`.
-                        break;
-                    }
+            match (next_opt, next_cost) {
+                (Some(ents), Some(c)) if c < best_cost => {
+                    best = ents;
+                    best_cost = c;
                 }
-                None => break,
+                (Some(_), _) => {
+                    // Encoder said SAT but cost didn't drop — safety
+                    // bail. Shouldn't happen if weights are in sync
+                    // with `junction_cost::solution_cost`.
+                    break;
+                }
+                (None, _) => break,
             }
         }
 

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -540,6 +540,11 @@ pub enum TraceEvent {
         cap: u32,
         satisfied: bool,
         solve_time_us: u64,
+        /// New best cost when this descent step improved on the prior
+        /// best. `None` on UNSAT or the safety-bail branch (SAT but cost
+        /// didn't drop). Lets analyzers measure descent deltas and
+        /// detect stalls without re-computing cost.
+        cost_after: Option<u32>,
     },
 
     SatInvocation {
@@ -562,6 +567,11 @@ pub enum TraceEvent {
         clauses: u32,
         solve_time_us: u64,
         entities_raw: usize,
+        /// Cost of the raw SAT solution, before the cost-descent loop
+        /// tightens it. `None` when `satisfied=false`. Analyzers
+        /// compare against the final `cost_after` of the last
+        /// improving `SatCostDescent` event to measure descent savings.
+        initial_cost: Option<u32>,
         /// Entities SAT produced, captured before `prune_dangling_sat_entities`.
         /// Empty when `satisfied=false`. Lets the junction debugger render
         /// the candidate layout — especially useful on walker veto, where

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -908,7 +908,7 @@ fn report_stress_scoreboard(test_name: &str, result: &E2EResult) -> ! {
 /// non-compactable.
 #[test]
 #[ignore]
-#[ntest::timeout(180000)]
+#[ntest::timeout(600000)]
 fn stress_electronic_circuit_30s_from_ore() {
     let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
         .iter().map(|s| s.to_string()).collect();
@@ -929,7 +929,7 @@ fn stress_electronic_circuit_30s_from_ore() {
 /// max_gap=3, max_trunks/band=12.
 #[test]
 #[ignore]
-#[ntest::timeout(180000)]
+#[ntest::timeout(600000)]
 fn stress_advanced_circuit_45s_from_plates() {
     let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "plastic-bar"]
         .iter().map(|s| s.to_string()).collect();
@@ -949,7 +949,7 @@ fn stress_advanced_circuit_45s_from_plates() {
 /// processing-unit requires an AM3 because sulfuric-acid is a fluid input.
 #[test]
 #[ignore]
-#[ntest::timeout(300000)]
+#[ntest::timeout(600000)]
 fn stress_processing_unit_20s_from_plates() {
     let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "plastic-bar", "sulfuric-acid"]
         .iter().map(|s| s.to_string()).collect();
@@ -972,7 +972,7 @@ fn stress_processing_unit_20s_from_plates() {
 /// max_gap=12, max_trunks/band=14.
 #[test]
 #[ignore]
-#[ntest::timeout(180000)]
+#[ntest::timeout(600000)]
 fn stress_electronic_circuit_60s_red_from_ore() {
     let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
         .iter().map(|s| s.to_string()).collect();
@@ -986,6 +986,87 @@ fn stress_electronic_circuit_60s_red_from_ore() {
     ).expect("e2e pipeline");
     assert_produces(&result, "electronic-circuit", 60.0);
     report_stress_scoreboard("stress_electronic_circuit_60s_red_from_ore", &result);
+}
+
+// Electronic-circuit-from-ore rate variants. The 30/s baseline produces
+// lots of 12-15x3 junctions with 22 boundaries; these neighbouring rates
+// let the SAT-call analyzer measure how sensitive the junction-problem
+// distribution is to small rate deltas (22 vs 23) and how it scales
+// (35, 40). Gather with:
+//   FUCKTORIO_DUMP_SNAPSHOTS=1 cargo test --manifest-path \
+//     crates/core/Cargo.toml --test e2e -- --include-ignored stress_
+// then `python scripts/analyze_sat_calls.py --min-solve-us 5000`.
+
+#[test]
+#[ignore]
+#[ntest::timeout(600000)]
+fn stress_electronic_circuit_22s_from_ore() {
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
+        .iter().map(|s| s.to_string()).collect();
+    let result = run_e2e(
+        "stress_electronic_circuit_22s_from_ore",
+        "electronic-circuit",
+        22.0,
+        "assembling-machine-2",
+        Some("transport-belt"),
+        &inputs,
+    ).expect("e2e pipeline");
+    assert_produces(&result, "electronic-circuit", 22.0);
+    report_stress_scoreboard("stress_electronic_circuit_22s_from_ore", &result);
+}
+
+#[test]
+#[ignore]
+#[ntest::timeout(600000)]
+fn stress_electronic_circuit_23s_from_ore() {
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
+        .iter().map(|s| s.to_string()).collect();
+    let result = run_e2e(
+        "stress_electronic_circuit_23s_from_ore",
+        "electronic-circuit",
+        23.0,
+        "assembling-machine-2",
+        Some("transport-belt"),
+        &inputs,
+    ).expect("e2e pipeline");
+    assert_produces(&result, "electronic-circuit", 23.0);
+    report_stress_scoreboard("stress_electronic_circuit_23s_from_ore", &result);
+}
+
+#[test]
+#[ignore]
+#[ntest::timeout(600000)]
+fn stress_electronic_circuit_35s_from_ore() {
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
+        .iter().map(|s| s.to_string()).collect();
+    let result = run_e2e(
+        "stress_electronic_circuit_35s_from_ore",
+        "electronic-circuit",
+        35.0,
+        "assembling-machine-2",
+        Some("transport-belt"),
+        &inputs,
+    ).expect("e2e pipeline");
+    assert_produces(&result, "electronic-circuit", 35.0);
+    report_stress_scoreboard("stress_electronic_circuit_35s_from_ore", &result);
+}
+
+#[test]
+#[ignore]
+#[ntest::timeout(600000)]
+fn stress_electronic_circuit_40s_from_ore() {
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
+        .iter().map(|s| s.to_string()).collect();
+    let result = run_e2e(
+        "stress_electronic_circuit_40s_from_ore",
+        "electronic-circuit",
+        40.0,
+        "assembling-machine-2",
+        Some("transport-belt"),
+        &inputs,
+    ).expect("e2e pipeline");
+    assert_produces(&result, "electronic-circuit", 40.0);
+    report_stress_scoreboard("stress_electronic_circuit_40s_from_ore", &result);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/analyze_sat_calls.py
+++ b/scripts/analyze_sat_calls.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Analyze SAT junction-solver calls across a corpus of .fls snapshots.
+
+Usage
+-----
+    FUCKTORIO_DUMP_SNAPSHOTS=1 cargo test \\
+        --manifest-path crates/core/Cargo.toml --test e2e
+    python scripts/analyze_sat_calls.py
+    python scripts/analyze_sat_calls.py --dir crates/core/target/tmp
+
+The analyzer pulls `SatInvocation` and `SatCostDescent` trace events out of
+every `.fls` file in the target directory and reports:
+
+- per-call stats (count, feasibility, solve-time percentiles, zone size,
+  boundary count),
+- cost-descent stats (iterations used, absolute + relative improvement,
+  time breakdown),
+- raw repeat rate keyed by a content hash of the zone problem. This is
+  the pre-canonicalization floor: if it's already high, canonicalization
+  is probably unnecessary; if it's low, canonicalization is the next
+  lever to try.
+
+Stdlib-only. Runs without a venv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import hashlib
+import json
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+
+DEFAULT_DIR = Path("crates/core/target/tmp")
+MAGIC = b"fls1"
+
+
+def decode_fls(path: Path) -> dict:
+    raw = path.read_bytes()
+    if raw[:4] != MAGIC:
+        raise ValueError(f"{path}: bad magic {raw[:4]!r}")
+    return json.loads(gzip.decompress(base64.b64decode(raw[4:])))
+
+
+def percentiles(values: list[float], ps: tuple[int, ...] = (50, 90, 99)) -> dict[int, float]:
+    if not values:
+        return {p: 0.0 for p in ps}
+    s = sorted(values)
+    out = {}
+    for p in ps:
+        if len(s) == 1:
+            out[p] = s[0]
+            continue
+        k = (len(s) - 1) * p / 100.0
+        lo = int(k)
+        hi = min(lo + 1, len(s) - 1)
+        out[p] = s[lo] + (s[hi] - s[lo]) * (k - lo)
+    return out
+
+
+def fmt_pct_row(label: str, values: list[float], unit: str = "") -> str:
+    if not values:
+        return f"  {label:<28} (no samples)"
+    pct = percentiles(values, (50, 90, 99))
+    return (
+        f"  {label:<28} "
+        f"n={len(values):<6} "
+        f"p50={pct[50]:>8.1f}{unit}  "
+        f"p90={pct[90]:>8.1f}{unit}  "
+        f"p99={pct[99]:>8.1f}{unit}  "
+        f"max={max(values):>8.1f}{unit}"
+    )
+
+
+def canonical_signature(data: dict) -> str:
+    """Hash the zone problem (pre-canonicalization) to measure raw repeat
+    rate. Sorts the boundary and forced_empty lists so field-order doesn't
+    affect the hash, but does NOT rotate/reflect/rename — that's the
+    next step if repeat rate is too low."""
+    boundaries = sorted(
+        (
+            b.get("x"),
+            b.get("y"),
+            b.get("direction"),
+            b.get("item"),
+            b.get("is_input"),
+            b.get("interior"),
+        )
+        for b in data.get("boundaries", [])
+    )
+    forced = sorted(tuple(xy) for xy in data.get("forced_empty", []))
+    sig = {
+        "w": data.get("zone_w"),
+        "h": data.get("zone_h"),
+        "belt_tier": data.get("belt_tier"),
+        "max_reach": data.get("max_reach"),
+        "boundaries": boundaries,
+        "forced_empty": forced,
+    }
+    blob = json.dumps(sig, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def collect(root: Path) -> tuple[list[dict], list[dict]]:
+    """Return (sat_invocations, cost_descents). Each event has its
+    originating `_file` attached for provenance."""
+    invocs: list[dict] = []
+    descents: list[dict] = []
+    for path in sorted(root.glob("*.fls")):
+        try:
+            snap = decode_fls(path)
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            print(f"skip {path.name}: {e}")
+            continue
+        for ev in snap.get("trace", {}).get("events", []):
+            phase = ev.get("phase")
+            data = ev.get("data", {})
+            if phase == "SatInvocation":
+                data["_file"] = path.name
+                invocs.append(data)
+            elif phase == "SatCostDescent":
+                data["_file"] = path.name
+                descents.append(data)
+    return invocs, descents
+
+
+def per_call_stats(invocs: list[dict]) -> None:
+    print("=" * 72)
+    print("PER-CALL STATS")
+    print("=" * 72)
+    print(f"Total SAT calls: {len(invocs)}")
+    files = {i["_file"] for i in invocs}
+    print(f"Unique snapshots contributing: {len(files)}")
+
+    if not invocs:
+        return
+
+    sat_ok = [i for i in invocs if i["satisfied"]]
+    print(f"Feasibility: {len(sat_ok)}/{len(invocs)} = {100 * len(sat_ok) / len(invocs):.1f}%")
+    print()
+
+    print(fmt_pct_row("solve_time (µs)", [i["solve_time_us"] for i in invocs]))
+    print(fmt_pct_row("  (satisfied only, µs)", [i["solve_time_us"] for i in sat_ok]))
+    print(
+        fmt_pct_row(
+            "  (UNSAT only, µs)",
+            [i["solve_time_us"] for i in invocs if not i["satisfied"]],
+        )
+    )
+    print(fmt_pct_row("variables", [i["variables"] for i in invocs]))
+    print(fmt_pct_row("clauses", [i["clauses"] for i in invocs]))
+    print(fmt_pct_row("zone area (tiles)", [i["zone_w"] * i["zone_h"] for i in invocs]))
+    print(fmt_pct_row("boundary count", [len(i.get("boundaries", [])) for i in invocs]))
+    print(fmt_pct_row("forced_empty count", [len(i.get("forced_empty", [])) for i in invocs]))
+    if sat_ok:
+        print(fmt_pct_row("initial_cost (SAT ok)", [i["initial_cost"] for i in sat_ok]))
+    print()
+
+    # Zone-shape histogram (top shapes)
+    shape_counts = Counter((i["zone_w"], i["zone_h"]) for i in invocs)
+    print("Top zone shapes (w × h):")
+    for (w, h), n in shape_counts.most_common(10):
+        print(f"    {w:>3} × {h:<3}  {n:>5}  {100 * n / len(invocs):>5.1f}%")
+    print()
+
+
+def descent_stats(invocs: list[dict], descents: list[dict]) -> None:
+    print("=" * 72)
+    print("COST-DESCENT STATS")
+    print("=" * 72)
+
+    def key(e: dict) -> tuple:
+        return (e["_file"], e["seed_x"], e["seed_y"], e["iter"], e["variant"])
+
+    grouped: dict[tuple, list[dict]] = defaultdict(list)
+    for d in descents:
+        grouped[key(d)].append(d)
+    for steps in grouped.values():
+        steps.sort(key=lambda d: d["descent_iter"])
+
+    sat_ok = [i for i in invocs if i["satisfied"]]
+    with_descent = [i for i in sat_ok if key(i) in grouped]
+    print(f"Total cost-descent events: {len(descents)}")
+    print(
+        f"SAT-feasible calls that entered descent: "
+        f"{len(with_descent)}/{len(sat_ok)} "
+        f"({100 * len(with_descent) / max(1, len(sat_ok)):.1f}%)"
+    )
+    print()
+
+    if not with_descent:
+        return
+
+    iters_used = [len(grouped[key(i)]) for i in with_descent]
+    print(fmt_pct_row("descent iterations used", iters_used))
+
+    improvements_abs: list[int] = []
+    improvements_rel: list[float] = []
+    for i in with_descent:
+        steps = grouped[key(i)]
+        improving = [s for s in steps if s["cost_after"] is not None]
+        if not improving:
+            continue
+        final_cost = improving[-1]["cost_after"]
+        delta = i["initial_cost"] - final_cost
+        improvements_abs.append(delta)
+        if i["initial_cost"]:
+            improvements_rel.append(100.0 * delta / i["initial_cost"])
+
+    print(fmt_pct_row("absolute cost improvement", improvements_abs))
+    print(fmt_pct_row("relative cost improvement", improvements_rel, unit="%"))
+    print()
+
+    # Time breakdown
+    initial_us_sum = sum(i["solve_time_us"] for i in with_descent)
+    descent_us_sum = sum(d["solve_time_us"] for steps in grouped.values() for d in steps)
+    total = initial_us_sum + descent_us_sum
+    if total:
+        print(
+            f"Time breakdown over descent-touching calls: "
+            f"initial solve {initial_us_sum / 1000:.1f} ms "
+            f"({100 * initial_us_sum / total:.1f}%), "
+            f"descent solves {descent_us_sum / 1000:.1f} ms "
+            f"({100 * descent_us_sum / total:.1f}%)."
+        )
+        unsat_descent_us = sum(
+            d["solve_time_us"] for d in descents if d["cost_after"] is None
+        )
+        print(
+            f"  of descent time, {unsat_descent_us / 1000:.1f} ms "
+            f"({100 * unsat_descent_us / max(1, descent_us_sum):.1f}%) "
+            f"was spent on non-improving (UNSAT / stall) attempts."
+        )
+    print()
+
+
+def repeat_stats(invocs: list[dict]) -> None:
+    print("=" * 72)
+    print("REPEAT RATE (raw, pre-canonicalization)")
+    print("=" * 72)
+    if not invocs:
+        return
+
+    sigs: Counter[str] = Counter()
+    example: dict[str, dict] = {}
+    for i in invocs:
+        s = canonical_signature(i)
+        sigs[s] += 1
+        example.setdefault(s, i)
+
+    unique = len(sigs)
+    total = sum(sigs.values())
+    repeated = sum(n for n in sigs.values() if n > 1)
+    print(f"Unique signatures: {unique} / {total} calls")
+    print(f"Calls whose signature recurs (seen >=2x): "
+          f"{repeated} ({100 * repeated / total:.1f}%)")
+    print(f"Cache hit ceiling (calls saved if perfect cache): "
+          f"{total - unique} ({100 * (total - unique) / total:.1f}%)")
+    print()
+
+    # Distribution of repeat counts
+    repeat_hist = Counter(sigs.values())
+    print("Signature occurrence histogram:")
+    for count, n_sigs in sorted(repeat_hist.items()):
+        print(f"    seen {count:>4}×  {n_sigs:>5} signatures  "
+              f"({n_sigs * count:>5} calls)")
+    print()
+
+    print("Top 10 most frequent signatures:")
+    for s, n in sigs.most_common(10):
+        ex = example[s]
+        print(
+            f"    {s}  {n:>4}×  "
+            f"{ex['zone_w']}×{ex['zone_h']}  "
+            f"tier={ex['belt_tier']}  "
+            f"boundaries={len(ex.get('boundaries', []))}  "
+            f"first_seen={ex['_file']}"
+        )
+    print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dir",
+        type=Path,
+        default=DEFAULT_DIR,
+        help=f"Directory of .fls files (default: {DEFAULT_DIR})",
+    )
+    args = parser.parse_args()
+
+    if not args.dir.is_dir():
+        print(f"no such directory: {args.dir}")
+        print("run: FUCKTORIO_DUMP_SNAPSHOTS=1 cargo test "
+              "--manifest-path crates/core/Cargo.toml --test e2e")
+        return 1
+
+    invocs, descents = collect(args.dir)
+    if not invocs and not descents:
+        print(f"no SAT events in {args.dir}")
+        return 1
+
+    per_call_stats(invocs)
+    descent_stats(invocs, descents)
+    repeat_stats(invocs)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_sat_calls.py
+++ b/scripts/analyze_sat_calls.py
@@ -282,6 +282,34 @@ def repeat_stats(invocs: list[dict]) -> None:
     print()
 
 
+def filter_invocs(
+    invocs: list[dict],
+    min_solve_us: int,
+    min_area: int,
+    min_boundaries: int,
+) -> list[dict]:
+    """Keep only calls that look interesting. Filters are AND-ed."""
+    out = []
+    for i in invocs:
+        if i["solve_time_us"] < min_solve_us:
+            continue
+        if i["zone_w"] * i["zone_h"] < min_area:
+            continue
+        if len(i.get("boundaries", [])) < min_boundaries:
+            continue
+        out.append(i)
+    return out
+
+
+def filter_descents(descents: list[dict], kept: set[tuple]) -> list[dict]:
+    """Keep descent events whose parent invocation survived filtering."""
+
+    def key(e: dict) -> tuple:
+        return (e["_file"], e["seed_x"], e["seed_y"], e["iter"], e["variant"])
+
+    return [d for d in descents if key(d) in kept]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -289,6 +317,25 @@ def main() -> int:
         type=Path,
         default=DEFAULT_DIR,
         help=f"Directory of .fls files (default: {DEFAULT_DIR})",
+    )
+    parser.add_argument(
+        "--min-solve-us",
+        type=int,
+        default=0,
+        help="Only include SAT calls with solve_time_us >= this. Use to "
+             "focus on the painful tail and ignore sub-millisecond trivia.",
+    )
+    parser.add_argument(
+        "--min-area",
+        type=int,
+        default=0,
+        help="Only include SAT calls with zone_w * zone_h >= this.",
+    )
+    parser.add_argument(
+        "--min-boundaries",
+        type=int,
+        default=0,
+        help="Only include SAT calls with >= this many boundaries.",
     )
     args = parser.parse_args()
 
@@ -302,6 +349,26 @@ def main() -> int:
     if not invocs and not descents:
         print(f"no SAT events in {args.dir}")
         return 1
+
+    raw_count = len(invocs)
+    if args.min_solve_us or args.min_area or args.min_boundaries:
+
+        def invoc_key(e: dict) -> tuple:
+            return (e["_file"], e["seed_x"], e["seed_y"], e["iter"], e["variant"])
+
+        invocs = filter_invocs(
+            invocs, args.min_solve_us, args.min_area, args.min_boundaries
+        )
+        descents = filter_descents(descents, {invoc_key(i) for i in invocs})
+        print(
+            f"Filters applied: min_solve_us={args.min_solve_us} "
+            f"min_area={args.min_area} min_boundaries={args.min_boundaries}  ->  "
+            f"{len(invocs)}/{raw_count} SAT calls survive"
+        )
+        print()
+        if not invocs:
+            print("nothing to analyze after filtering.")
+            return 0
 
     per_call_stats(invocs)
     descent_stats(invocs, descents)


### PR DESCRIPTION
## Intent

Enable profiling and analysis of SAT junction-solver invocations across test runs. This adds a Python analyzer tool to extract and report statistics on SAT calls (feasibility, solve times, zone sizes, cost-descent improvements) and introduces additional stress-test variants to measure sensitivity to production rate deltas.

## Scope

- **In:**
  - New `scripts/analyze_sat_calls.py`: stdlib-only analyzer that processes `.fls` snapshot files to report per-call stats, cost-descent metrics, and raw repeat rates (pre-canonicalization)
  - Extended `SatInvocation` and `SatCostDescent` trace events with `initial_cost` and `cost_after` fields to enable cost-improvement analysis without re-computation
  - Four new stress-test variants (22s, 23s, 35s, 40s electronic-circuit rates) to measure junction-problem distribution sensitivity
  - Increased timeouts on all stress tests from 180–300s to 600s to accommodate snapshot dumping overhead
  
- **Out:**
  - No changes to core SAT solving logic or junction cost computation
  - Snapshot dumping is opt-in via `FUCKTORIO_DUMP_SNAPSHOTS=1` environment variable

## Verification

- Analyzer runs without external dependencies (stdlib only)
- Trace event schema extended with optional fields; backward-compatible with existing code paths
- Stress tests remain functionally identical; timeout increase is purely for profiling runs
- No changes to production code paths or solver behavior

## Deviations from intent

None.

## Models / contracts touched

`trace.rs`: Extended `SatInvocation` and `SatCostDescent` event schemas with cost tracking fields. These are diagnostic-only and do not affect solver contracts or junction-cost semantics.

https://claude.ai/code/session_01LjEjWj1UiFzSd81DtwgGPa