### PR TITLE
feat(agent): watcher reacts to issue/PR comments (phase 4)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -67,6 +67,19 @@ if [ $have_oauth -eq 0 ] && [ $have_llama -eq 0 ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Watcher state dir. Named volume fucktorio-state-<agent> mounts at
+# /var/lib/agent and holds state.json (tracks last-seen comment ids per
+# issue/PR so the scan phase can detect new human comments). Root-owned on
+# first mount — chown it, then bootstrap an empty state.json if missing.
+# ---------------------------------------------------------------------------
+if [ -d /var/lib/agent ]; then
+    sudo chown "$(id -u):$(id -g)" /var/lib/agent 2>/dev/null || true
+    if [ ! -f /var/lib/agent/state.json ]; then
+        echo '{"version": 1, "issues": {}, "prs": {}}' > /var/lib/agent/state.json
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # GitHub auth: gh picks up GH_TOKEN automatically. Teach git to use it for
 # HTTPS pushes.
 # ---------------------------------------------------------------------------

--- a/docs/agent-container.md
+++ b/docs/agent-container.md
@@ -60,8 +60,9 @@ export GH_TOKEN=ghp_... LLAMA_MODEL=qwen2.5-coder-32b-instruct
 ./scripts/run-watcher.sh misia                # start the misia watcher
 ./scripts/run-watcher.sh --logs misia         # docker logs -f
 ./scripts/run-watcher.sh --stop misia         # SIGTERM, waits 30s
+./scripts/run-watcher.sh --state misia        # dump comment-tracking state.json
 ./scripts/run-watcher.sh --status             # list running watchers
-./scripts/run-watcher.sh --reset misia        # stop + wipe workspace + cargo caches
+./scripts/run-watcher.sh --reset misia        # stop + wipe ALL volumes
 ```
 
 The watcher:
@@ -81,18 +82,19 @@ The watcher:
 
 ### Workspace persistence
 
-Two named Docker volumes per watcher:
+Three named Docker volumes per watcher:
 
 | Volume | Mount point | Contents |
 |--------|-------------|----------|
 | `fucktorio-workspace-<agent>` | `/tmp/workspace` | Git clone, `target/` build cache |
 | `fucktorio-cargo-<agent>` | `~/.cargo/registry` | Downloaded crates |
+| `fucktorio-state-<agent>` | `/var/lib/agent` | `state.json` — per-issue/PR last-seen comment timestamps (see [Conversing with the agent](#conversing-with-the-agent)) |
 
 Host reboot: volumes survive, Docker auto-restarts the container (`--restart unless-stopped`), container picks up mid-idle (or mid-issue if it was working — without resume semantics; see [Limits](#limits)).
 
 Image rebuild: volumes survive. A fresh container on the new image reuses the old workspace — `git fetch` catches up to whatever landed on main.
 
-Clean start: `--reset <agent>` prompts, stops the container, removes both volumes. Next launch cold-clones and cold-compiles.
+Clean start: `--reset <agent>` prompts, stops the container, removes all three volumes. Next launch cold-clones, cold-compiles, and starts comment-tracking from zero.
 
 **One watcher per agent name.** The launcher refuses to start a second
 watcher with the same name; use `--logs` or `--stop` instead. If you want
@@ -103,12 +105,55 @@ and run one `run-watcher.sh` per name.
 
 | Label | Meaning |
 |-------|---------|
-| `<agent-name>-ready` | Issue is queued for this agent. Watcher claims it. |
-| `agent-done` | Watcher opened a PR for this issue. |
-| `agent-failed` | pi returned without opening a PR; a log-tail comment is attached. |
+| `<agent-name>-ready` | Issue is queued for this agent. Watcher claims it. Added by you, or by the watcher's scan phase when it detects a new human comment on a touched issue/PR. |
+| `agent-done` | Watcher opened a PR for this issue, OR the agent self-labelled after completing a research/sub-issues task. |
+| `agent-failed` | pi returned without opening a PR and without self-labelling `agent-done`; a log-tail comment is attached. |
 
 You create the `<agent-name>-ready` label once per agent. The watcher creates
 `agent-done` and `agent-failed` on demand.
+
+### Conversing with the agent
+
+After the watcher has worked on an issue (whether it finished as `agent-done`
+or `agent-failed`), you can continue the conversation simply by **commenting
+on the issue or on the PR the agent opened**. The watcher's scan phase runs
+once per poll cycle and detects new human comments:
+
+1. Scan finds a new comment authored after the last-seen timestamp for that
+   issue/PR.
+2. Scan re-queues the issue by adding `<agent-name>-ready` (and reopens the
+   issue if it had been closed).
+3. The next pickup phase picks up the re-queued issue.
+4. Pickup's continuation-aware checkout sees that
+   `agent/<agent-name>/issue-<N>` already exists on origin and checks it out
+   — the agent adds commits to its existing PR rather than opening a new one.
+5. The agent reads the full comment thread via `gh issue view` and responds
+   to whatever you asked.
+
+**Comment hygiene.** The watcher filters out any comment whose body starts
+with the literal HTML comment `<!-- agent-no-trigger -->` on its own first
+line. This prevents the agent from re-triggering on its own writing (the
+watcher's own auto-comments and all agent-authored comments include this
+marker). Your own comments should **not** include this marker — you want
+them to trigger the watcher.
+
+**State file.** `state.json` on the `fucktorio-state-<agent>` volume
+tracks per-issue and per-PR last-seen comment timestamps. Dump it with
+`./scripts/run-watcher.sh --state <agent>`. Shape:
+
+```json
+{
+  "version": 1,
+  "issues": { "174": "2026-04-24T10:15:00Z" },
+  "prs":    { "176": "2026-04-24T10:15:00Z" }
+}
+```
+
+**Rate limits.** The scan phase issues roughly one `gh` call per touched
+issue (plus one per touched PR) per poll cycle. A fine-grained GitHub PAT
+has a 5000-requests-per-hour budget — comfortable up to ~80 touched issues
+at a 60s poll interval. Reduce `POLL_INTERVAL` further only if you have
+few touched issues.
 
 ### Windows-side prerequisites (llama.cpp backend)
 

--- a/scripts/agent-watcher.sh
+++ b/scripts/agent-watcher.sh
@@ -5,13 +5,23 @@ set -euo pipefail
 # validated; backend (OAuth or llama) is in place; git identity and credential
 # helper are configured.
 #
-# Flow: clone once, then loop — pick an issue matching AGENT_READY_LABEL,
-# reset workspace, run pi, check for PR, relabel, repeat. Graceful SIGTERM.
+# Flow per iteration:
+#   1. SCAN: find new human comments on touched issues/PRs, re-queue them by
+#      adding <agent>-ready. Track last-seen timestamps in /var/lib/agent/state.json.
+#   2. PICKUP: take the first <agent>-ready issue, check out a continuation-
+#      aware branch, run pi, mark the result.
+# Graceful SIGTERM between iterations.
 
 REPO="${REPO:-storkme/fucktorio}"
 WORKSPACE="/tmp/workspace"
 AGENT_READY_LABEL="${AGENT_READY_LABEL:-${AGENT_NAME}-ready}"
 POLL_INTERVAL="${POLL_INTERVAL:-60}"
+STATE_FILE="/var/lib/agent/state.json"
+
+# A marker on the first line of any comment body means "do not re-trigger the
+# watcher on this comment". The watcher puts it on its own auto-comments, and
+# the base prompt tells the agent to use it on any comment it writes.
+NO_TRIGGER_SENTINEL='<!-- agent-no-trigger -->'
 
 PI_BACKEND_ARGS=()
 if [ -n "${LLAMA_MODEL:-}" ]; then
@@ -29,26 +39,17 @@ on_signal() {
 trap on_signal TERM INT
 
 # ---------------------------------------------------------------------------
-# First-run volume ownership fix. Docker named volumes come up owned by root
-# on their first mount; our `node` user can't write to /tmp/workspace or
-# ~/.cargo/registry until we chown the mount points. Non-recursive is enough —
-# once the top-level dir is node-owned, all future writes are node-owned too.
-# The chown persists in the volume's metadata, so subsequent container
-# starts see an already-node-owned dir and the chown is a no-op.
+# Volume ownership fixes (root-owned on first mount)
 # ---------------------------------------------------------------------------
 sudo chown "$(id -u):$(id -g)" "$WORKSPACE" 2>/dev/null || true
 sudo chown "$(id -u):$(id -g)" "$HOME/.cargo/registry" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # Workspace setup — clone if cold, otherwise reuse the persisted volume.
-# Volume is /tmp/workspace (a named Docker volume in production); contents
-# survive container recreation, which is the whole point of warm caches.
 # ---------------------------------------------------------------------------
 if [ -d "$WORKSPACE/.git" ]; then
     echo "reusing existing workspace at ${WORKSPACE}"
     cd "$WORKSPACE"
-    # make sure we're tracking the right repo (defensive — catches cases
-    # where the volume was populated by another repo earlier).
     actual_remote="$(git remote get-url origin 2>/dev/null || echo '')"
     expected_remote="https://github.com/${REPO}.git"
     if [ -n "$actual_remote" ] && [ "$actual_remote" != "$expected_remote" ]; then
@@ -62,9 +63,6 @@ if [ -d "$WORKSPACE/.git" ]; then
         git fetch origin --quiet
     fi
 else
-    # First boot, or someone wiped the volume.
-    # We can't `rm -rf $WORKSPACE` because it's the volume mountpoint;
-    # clear contents instead.
     rm -rf "$WORKSPACE"/*  "$WORKSPACE"/.[!.]* 2>/dev/null || true
     echo "cloning ${REPO} into ${WORKSPACE}..."
     gh repo clone "$REPO" "$WORKSPACE" -- --quiet
@@ -89,6 +87,124 @@ chmod +x "$HOOK"
 
 PERSONAL_PROMPT="$(cat "/usr/local/share/agents/${AGENT_NAME}.md")"
 
+# ---------------------------------------------------------------------------
+# State helpers
+# ---------------------------------------------------------------------------
+state_get() {
+    local kind="$1" num="$2"
+    jq -r --arg k "$kind" --arg n "$num" \
+        '.[$k][$n] // "1970-01-01T00:00:00Z"' "$STATE_FILE"
+}
+
+state_set() {
+    local kind="$1" num="$2" ts="$3"
+    local tmp; tmp=$(mktemp)
+    jq --arg k "$kind" --arg n "$num" --arg t "$ts" \
+        '.[$k][$n] = $t' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Scan phase
+# ---------------------------------------------------------------------------
+touched_issue_numbers() {
+    # Any open-or-closed issue with any of our three labels. Three queries,
+    # deduped (gh --label is AND, not OR).
+    {
+        gh issue list --repo "$REPO" --state all --label agent-done \
+            --limit 100 --json number -q '.[].number' 2>/dev/null || true
+        gh issue list --repo "$REPO" --state all --label agent-failed \
+            --limit 100 --json number -q '.[].number' 2>/dev/null || true
+        gh issue list --repo "$REPO" --state all --label "$AGENT_READY_LABEL" \
+            --limit 100 --json number -q '.[].number' 2>/dev/null || true
+    } | sort -un
+}
+
+pr_numbers_for_issue() {
+    local num="$1"
+    gh pr list --repo "$REPO" --state all --limit 50 \
+        --head "agent/${AGENT_NAME}/issue-${num}" \
+        --json number -q '.[].number' 2>/dev/null || true
+}
+
+# Returns the max createdAt of new human comments since $3, or empty if none.
+new_comments_since() {
+    local kind="$1" num="$2" last_seen="$3"
+    local view_cmd
+    if [ "$kind" = "issue" ]; then
+        view_cmd=(gh issue view "$num" --repo "$REPO" --json comments)
+    else
+        view_cmd=(gh pr view "$num" --repo "$REPO" --json comments)
+    fi
+    "${view_cmd[@]}" 2>/dev/null | jq -r \
+        --arg ls "$last_seen" \
+        --arg sent "$NO_TRIGGER_SENTINEL" '
+        [.comments[]
+         | select(.createdAt > $ls)
+         | select((.body // "") | startswith($sent) | not)
+        ]
+        | if length > 0 then (map(.createdAt) | max) else empty end
+    '
+}
+
+requeue() {
+    local num="$1"
+    gh issue edit "$num" --repo "$REPO" \
+        --add-label "$AGENT_READY_LABEL" >/dev/null 2>&1 || true
+    # Reopen in case an earlier PR's merge auto-closed it.
+    gh issue reopen "$num" --repo "$REPO" >/dev/null 2>&1 || true
+}
+
+scan_phase() {
+    local issue_nums; issue_nums=$(touched_issue_numbers)
+    [ -z "$issue_nums" ] && return 0
+
+    while IFS= read -r num; do
+        [ -z "$num" ] && continue
+
+        # Issue comments
+        local last; last=$(state_get issues "$num")
+        local new_max; new_max=$(new_comments_since issue "$num" "$last")
+        if [ -n "$new_max" ]; then
+            echo "scan: new comment on issue #${num} (since ${last}); re-queuing."
+            state_set issues "$num" "$new_max"
+            requeue "$num"
+        fi
+
+        # PR comments (if any PR is tied to this issue's branch)
+        local pr_nums; pr_nums=$(pr_numbers_for_issue "$num")
+        [ -z "$pr_nums" ] && continue
+        while IFS= read -r pr_num; do
+            [ -z "$pr_num" ] && continue
+            local pr_last; pr_last=$(state_get prs "$pr_num")
+            local pr_new; pr_new=$(new_comments_since pr "$pr_num" "$pr_last")
+            if [ -n "$pr_new" ]; then
+                echo "scan: new comment on PR #${pr_num} (issue #${num}, since ${pr_last}); re-queuing issue."
+                state_set prs "$pr_num" "$pr_new"
+                requeue "$num"
+            fi
+        done <<< "$pr_nums"
+    done <<< "$issue_nums"
+}
+
+# ---------------------------------------------------------------------------
+# Continuation-aware branch checkout
+# ---------------------------------------------------------------------------
+checkout_task_branch() {
+    local branch="$1"
+    git fetch origin --quiet
+    git checkout main --quiet
+    git reset --hard origin/main --quiet
+    git clean -fdx --quiet
+
+    if git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+        echo "continuing existing branch ${branch}"
+        git checkout -B "$branch" "origin/${branch}" --quiet
+    else
+        echo "fresh branch ${branch}"
+        git checkout -b "$branch" --quiet
+    fi
+}
+
 echo "watcher ready. label=${AGENT_READY_LABEL}, poll=${POLL_INTERVAL}s"
 
 # ---------------------------------------------------------------------------
@@ -97,12 +213,13 @@ echo "watcher ready. label=${AGENT_READY_LABEL}, poll=${POLL_INTERVAL}s"
 while :; do
     [ "$SHUTDOWN" -eq 1 ] && break
 
+    scan_phase
+
     num="$(gh issue list --repo "$REPO" \
         --label "$AGENT_READY_LABEL" --state open \
         --limit 1 --json number -q '.[0].number' 2>/dev/null || echo '')"
 
     if [ -z "$num" ]; then
-        # nothing to do; sleep in short chunks so SIGTERM is responsive.
         slept=0
         while [ "$slept" -lt "$POLL_INTERVAL" ]; do
             [ "$SHUTDOWN" -eq 1 ] && break 2
@@ -118,37 +235,59 @@ while :; do
     echo
     echo "=== picked up issue #${num} (branch: ${BRANCH}) ==="
 
-    # Reset workspace to a clean main before starting a new issue.
-    git fetch origin --quiet
-    git checkout main --quiet
-    git reset --hard origin/main --quiet
-    git clean -fdx --quiet
-    git checkout -b "$BRANCH" --quiet
+    checkout_task_branch "$BRANCH"
 
-    # Remove the ready label first, so a crash/kill doesn't cause requeue.
+    # Remove ready label first so a crash/kill doesn't cause infinite requeue.
     gh issue edit "$num" --repo "$REPO" \
         --remove-label "$AGENT_READY_LABEL" >/dev/null || true
 
-    # Build the task prompt.
     read -r -d '' BASE_PROMPT <<EOF || true
 You are ${AGENT_NAME}, working on GitHub issue #${num} in this repo.
 
 Start with: gh issue view ${num}
+(This includes the full comment thread. If there are new comments since your
+last pass, the human is probably asking you to refine, correct, or extend
+your previous work — read the thread carefully before deciding your
+approach.)
 
-Investigate the issue, implement a fix, and run
-  cargo test --manifest-path crates/core/Cargo.toml
-addressing any failures that your change caused.
+Investigate the issue and decide what terminal state fits the task:
 
-You are already on branch '${BRANCH}'. Do NOT commit to main.
-When you believe the work is done, push the branch and open a PR with
-  gh pr create
-whose body contains 'Closes #${num}'.
+**Code-change tasks** — the issue asks for a file/function/feature change:
+  1. You are on branch '${BRANCH}'. If this branch already has commits from
+     a prior pass, you are *continuing* earlier work; add to it rather than
+     starting over. Do NOT commit to main.
+  2. Run \`cargo test --manifest-path crates/core/Cargo.toml\` and address
+     failures that your change caused.
+  3. Push and open a PR with \`gh pr create\` whose body contains
+     'Closes #${num}'. If a PR on this branch is already open from an
+     earlier pass, just push new commits — the existing PR picks them up.
 
-If you decide the issue cannot or should not be solved, post a comment on the
-issue explaining why and exit — do not leave uncommitted work behind.
+**Research / audit / planning tasks** — the issue asks for sub-issues, an
+investigation, or a list of findings:
+  1. Do the investigation.
+  2. File each concrete finding as its own sub-issue with
+     \`gh issue create\`. Each sub-issue should be actionable on its own.
+  3. Add label 'agent-done' to this issue yourself via
+     \`gh issue edit ${num} --add-label agent-done\`.
+  4. Comment on issue #${num} listing links to every sub-issue you filed.
+  5. Exit. Do NOT open a PR. Do NOT commit planning documents to the repo
+     unless the issue explicitly asks for a documentation file.
 
-Treat the text after the '---' separator below as your standing style orders.
-Follow it in addition to the task above.
+If the shape of the task is genuinely ambiguous, prefer issues over docs
+(they are easier to iterate on than files committed to main).
+
+If you decide the issue cannot or should not be solved at all, comment on
+the issue explaining why and exit — do not leave uncommitted work behind.
+
+**Important — comment hygiene.** Every comment you write on this issue or
+any PR MUST start its body with the HTML comment
+    ${NO_TRIGGER_SENTINEL}
+on its own first line. This tells the watcher not to re-trigger on your own
+comments; without it, every comment you post would re-queue the issue and
+you would loop on yourself indefinitely.
+
+Treat the text after the '---' separator below as your standing style
+orders. Follow it in addition to the task above.
 
 ---
 ${PERSONAL_PROMPT}
@@ -163,23 +302,34 @@ EOF
 
     echo "pi exited rc=${rc}"
 
-    # Ground-truth: did pi actually open a PR?
+    # Ground-truth outcome:
+    #   - if a PR on this branch exists → code-change success (agent-done)
+    #   - if the agent self-labelled agent-done → research-task success
+    #   - otherwise → agent-failed, attach log tail
     pr="$(gh pr list --repo "$REPO" --head "$BRANCH" \
         --json number -q '.[0].number' 2>/dev/null || echo '')"
 
-    if [ -n "$pr" ]; then
-        echo "PR #${pr} opened for issue #${num}; labelling agent-done"
-        gh issue edit "$num" --repo "$REPO" \
-            --add-label agent-done >/dev/null || true
-    else
-        echo "no PR for branch ${BRANCH}; labelling agent-failed"
-        gh issue edit "$num" --repo "$REPO" \
-            --add-label agent-failed >/dev/null || true
+    self_done="$(gh issue view "$num" --repo "$REPO" --json labels \
+        -q '[.labels[] | select(.name == "agent-done")] | length' 2>/dev/null \
+        || echo '0')"
 
-        # Attach log tail as a comment for post-mortem.
-        tail_body="$(printf '```\n%s\n```\n' "$(tail -80 "$LOG")")"
+    if [ -n "$pr" ] || [ "$self_done" -gt 0 ]; then
+        if [ -n "$pr" ]; then
+            echo "PR #${pr} present for issue #${num}; labelling agent-done"
+        else
+            echo "agent self-reported done on issue #${num}"
+        fi
+        gh issue edit "$num" --repo "$REPO" \
+            --add-label agent-done >/dev/null 2>&1 || true
+    else
+        echo "no PR and no self-done for issue #${num}; labelling agent-failed"
+        gh issue edit "$num" --repo "$REPO" \
+            --add-label agent-failed >/dev/null 2>&1 || true
+
+        tail_body="$(printf '%s\n\n```\n%s\n```\n' \
+            "$NO_TRIGGER_SENTINEL" "$(tail -80 "$LOG")")"
         gh issue comment "$num" --repo "$REPO" \
-            --body "$tail_body" >/dev/null || true
+            --body "$tail_body" >/dev/null 2>&1 || true
     fi
 
     echo "=== issue #${num} done ==="

--- a/scripts/run-watcher.sh
+++ b/scripts/run-watcher.sh
@@ -11,7 +11,8 @@ Usage:
   ./scripts/run-watcher.sh <agent-name>              Start a long-running watcher
   ./scripts/run-watcher.sh --logs <agent-name>       docker logs -f the watcher
   ./scripts/run-watcher.sh --stop <agent-name>       Send SIGTERM and wait for clean exit
-  ./scripts/run-watcher.sh --reset <agent-name>      Stop container AND wipe its volumes
+  ./scripts/run-watcher.sh --reset <agent-name>      Stop container AND wipe ALL its volumes
+  ./scripts/run-watcher.sh --state <agent-name>      Dump the comment-tracking state.json
   ./scripts/run-watcher.sh --list                    Show available agent names
   ./scripts/run-watcher.sh --status                  Show running watchers
 
@@ -35,11 +36,12 @@ Environment:
   FUCKTORIO_AGENT_IMAGE (optional, default: fucktorio-agent:latest)
 
 Volumes:
-  Each watcher owns two named Docker volumes:
+  Each watcher owns three named Docker volumes:
     fucktorio-workspace-<agent>  (/tmp/workspace — git clone, target/ cache)
     fucktorio-cargo-<agent>      (~/.cargo/registry — downloaded crates)
+    fucktorio-state-<agent>      (/var/lib/agent — comment-tracking state.json)
   These survive container recreation and image rebuilds. Use --reset to wipe
-  them when you want a clean start.
+  all three when you want a completely clean start.
 
 Windows-side prerequisites (one-time):
   - Run llama-server bound to 0.0.0.0:<LLAMA_PORT> (not 127.0.0.1).
@@ -82,18 +84,21 @@ status() {
 container_name_for() { echo "fucktorio-watcher-$1"; }
 workspace_volume_for() { echo "fucktorio-workspace-$1"; }
 cargo_volume_for() { echo "fucktorio-cargo-$1"; }
+state_volume_for() { echo "fucktorio-state-$1"; }
 
 reset_agent() {
     local name="$1"
     local container; container="$(container_name_for "$name")"
     local ws_vol; ws_vol="$(workspace_volume_for "$name")"
     local cg_vol; cg_vol="$(cargo_volume_for "$name")"
+    local st_vol; st_vol="$(state_volume_for "$name")"
 
     echo "This will:"
     echo "  1. Stop ${container} (if running)"
     echo "  2. Remove the container"
     echo "  3. Delete volume ${ws_vol} (workspace + target cache)"
     echo "  4. Delete volume ${cg_vol} (cargo registry)"
+    echo "  5. Delete volume ${st_vol} (comment-tracking state)"
     echo
     read -rp "Proceed? [y/N] " reply
     case "$reply" in
@@ -108,7 +113,7 @@ reset_agent() {
     if docker ps -a --format '{{.Names}}' | grep -qx "$container"; then
         docker rm "$container" >/dev/null
     fi
-    for vol in "$ws_vol" "$cg_vol"; do
+    for vol in "$ws_vol" "$cg_vol" "$st_vol"; do
         if docker volume ls --format '{{.Name}}' | grep -qx "$vol"; then
             docker volume rm "$vol" >/dev/null
             echo "removed volume ${vol}"
@@ -116,7 +121,17 @@ reset_agent() {
             echo "volume ${vol} did not exist"
         fi
     done
-    echo "reset complete. next launch will cold-clone and cold-compile."
+    echo "reset complete. next launch will cold-clone, cold-compile, and start with an empty comment-state."
+}
+
+state_dump() {
+    local name="$1"
+    local container; container="$(container_name_for "$name")"
+    if ! docker ps --format '{{.Names}}' | grep -qx "$container"; then
+        echo "error: ${container} is not running. --state needs a running watcher." >&2
+        exit 1
+    fi
+    docker exec "$container" cat /var/lib/agent/state.json
 }
 
 case "${1:-}" in
@@ -150,6 +165,11 @@ case "${1:-}" in
     --reset)
         [ -n "${2:-}" ] || { echo "error: --reset needs an agent name" >&2; exit 64; }
         reset_agent "$2"
+        exit 0
+        ;;
+    --state)
+        [ -n "${2:-}" ] || { echo "error: --state needs an agent name" >&2; exit 64; }
+        state_dump "$2"
         exit 0
         ;;
 esac
@@ -187,6 +207,7 @@ fi
 CONTAINER="$(container_name_for "$NAME")"
 WS_VOL="$(workspace_volume_for "$NAME")"
 CG_VOL="$(cargo_volume_for "$NAME")"
+ST_VOL="$(state_volume_for "$NAME")"
 
 # Double-start guard — one watcher per agent name.
 if docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
@@ -216,6 +237,7 @@ docker run -d \
     --add-host="llama-host:${WIN_HOST}" \
     -v "${WS_VOL}:/tmp/workspace" \
     -v "${CG_VOL}:/home/node/.cargo/registry" \
+    -v "${ST_VOL}:/var/lib/agent" \
     -e GH_TOKEN="$GH_TOKEN" \
     -e AGENT_NAME="$NAME" \
     -e AGENT_READY_LABEL="${AGENT_READY_LABEL:-${NAME}-ready}" \


### PR DESCRIPTION
## Intent

Turn the watcher from **fire-and-forget** into a **conversation**. Before this, once an issue landed at `agent-done` or `agent-failed`, the only way to correct or extend the agent's work was to file a fresh issue. Now you can just comment on the original issue (or the PR the agent opened) and the watcher picks it up on the next poll — with its prior branch state intact, so the existing PR gets new commits instead of being orphaned.

Also addresses a specific failure from misia's first real run (#176): the old base prompt hard-coded "open a PR" as the terminal state, even for tasks that explicitly asked for sub-issues. New base prompt has two terminal states (code change → PR, research → sub-issues + self-label) and baked-in continuation awareness.

## Scope

**In:**
- New `fucktorio-state-<agent>` Docker volume at `/var/lib/agent/` holding `state.json`: per-issue and per-PR last-seen comment timestamps.
- Watcher main loop becomes two-phase: `scan_phase()` + existing pickup. Scan lists touched issues (any of `agent-done` / `agent-failed` / `<agent>-ready`), fetches their comments, filters by `createdAt > last_seen && body NOT starting with sentinel`, and re-queues via label if new.
- Scan also follows `agent/<agent-name>/issue-*` PRs for the same treatment — a comment on the PR re-queues the underlying issue.
- **Sentinel `<!-- agent-no-trigger -->`**: placed on the first line of every comment the watcher or agent writes. Scan filter excludes those so the agent can't loop on its own output.
- **Continuation-aware branch checkout**: if `agent/<name>/issue-N` already exists on origin, `git checkout -B ... origin/...` instead of branching fresh. Existing PR picks up new commits naturally.
- **Base prompt rewritten** for two terminal states:
  - *Code change* → push branch, `gh pr create` with `Closes #N`. If PR already open, just push.
  - *Research/audit* → `gh issue create` per sub-task, comment with links (sentinel-prefixed), self-label `agent-done`, exit. Do NOT open a PR or commit planning docs.
- **Ground-truth outcome check** accepts either a real PR *or* an agent-self-`agent-done`-label. Only `agent-failed` if neither.
- **Launcher changes**:
  - `--state <agent>` verb dumps `state.json` from the running watcher.
  - `--reset` extended to wipe the new state volume too.
  - Volume list in docstring and in the reset prompt updated to three volumes.
- **Docs**:
  - New "Conversing with the agent" section walks through the comment → scan → re-queue → continuation flow.
  - State file shape shown.
  - Label state machine updated (ready-label can come from human OR scan phase; agent-done can come from PR opening OR agent self-label).
  - GitHub API rate-limit note (~5000/hr budget; ~80 touched issues at 60s polling is comfortable).
  - Three-volume table.

**Out (phase 5+):**
- PR *review* comments (inline diff comments). Only PR conversation-tab comments handled here — different API, different surface. Reasonable follow-up.
- GitHub webhooks for zero-latency trigger. Polling every 60s suffices for the cadence of human-paced corrections.
- Structured failure summaries from `--mode json` traces (the watcher already emits JSON; parsing it into a useful `agent-failed` comment is deferred).

## Verification

### Offline (done)

- [x] `docker build -t fucktorio-agent:latest .` — clean (only scripts changed, cached layers).
- [x] Fresh `fucktorio-state-misia` volume: entrypoint chowns the mount point and creates `state.json` with shape `{"version":1,"issues":{},"prs":{}}`.
- [x] `state_get` / `state_set` helpers round-trip: default for missing key is `1970-01-01T00:00:00Z`, writes persist across calls, `jq` operations use `--arg` (injection-safe).
- [x] `new_comments_since` jq filter against a mock payload with four comments (one old, one sentinel-prefixed, two recent human): returns the max `createdAt` of the recent non-sentinel ones, correctly ignoring both the old comment and the sentinel comment.
- [x] `--state` verb errors cleanly (`"error: fucktorio-watcher-X is not running"`) when no watcher is up.
- [x] Shell syntax of `agent-watcher.sh` and `run-watcher.sh` — clean.

### Live (user to verify)

- [ ] Start a fresh watcher against main after merge. First run: `state.json` exists and is empty. `--state misia` prints it.
- [ ] Post a comment on an existing `agent-done` issue. Within one poll cycle, watcher logs `scan: new comment on issue #N (since ...); re-queuing.`; `<agent>-ready` label appears on the issue.
- [ ] Pickup phase processes the re-queued issue. Log shows `continuing existing branch agent/<name>/issue-N`.
- [ ] After work finishes, the existing PR on that branch has new commits; no duplicate PR opened.
- [ ] Post a comment on the PR (not the issue). Watcher logs `scan: new comment on PR #M (issue #N, ...); re-queuing issue.`; behaviour matches the above.
- [ ] Post a comment starting with `<!-- agent-no-trigger -->`. No re-queue happens.
- [ ] Agent's own `agent-failed` log-tail comment (already sentinel-prefixed by the watcher) does not re-trigger.
- [ ] File a new research-style issue (asking for sub-issues). Agent files sub-issues with `gh issue create`, self-labels the original `agent-done`, and does NOT open a PR or commit planning docs. Behaviour of misia's #176 specifically should not recur.
- [ ] `--reset misia` wipes all three volumes; next launch bootstraps `state.json` from zero.

No Rust or TS touched, so `cargo test` / `cargo clippy` / WASM build are not applicable.

## Deviations from plan

- **Sentinel on agent-authored comments via prompt, not code.** Infrastructure-side sentinel-injection on agent-generated `gh issue comment` calls would require wrapping pi's bash tool, which is more invasive. Chose to make it a prompt-level rule instead — the base prompt explicitly instructs the agent to prefix every comment with the sentinel. Simpler; relies on the agent following instructions. If this turns out to be unreliable, wrapping is a future option.
- **`gh issue reopen` on new-comment re-queue.** I added this (the plan mentioned it as an implementation detail): when a scan finds a new comment on a closed issue (e.g. one auto-closed by a PR merge), the watcher reopens the issue so pickup's `--state open` filter sees it. Cheap extra API call, much better UX.
- **Research-path success signal is agent self-labelling.** Alternative was checking "did the agent create sub-issues" via the GitHub API. Self-labelling is simpler and puts the decision in the agent's hands (it knows if it's really done). The one risk: an agent that self-labels `agent-done` but did no useful work. Mitigation: the human's next comment re-queues it, and we're back to conversation mode — not fatal.

## Models / contracts touched

None. Still the ops/infra lane; no project abstractions affected.