### PR TITLE
Density metric + revised modular production RFP (supersedes #178)

### DIFF
--- a/crates/core/examples/diagnose_junctions.rs
+++ b/crates/core/examples/diagnose_junctions.rs
@@ -364,7 +364,7 @@ fn run_case(label: &str, recipe: &str, rate: f64, machine: &str, inputs: &[&str]
             }
         }
         for (item, ys) in &mut rows_by_item {
-            let mut unique: Vec<i32> = ys.iter().copied().collect();
+            let mut unique: Vec<i32> = ys.to_vec();
             unique.sort_unstable();
             unique.dedup();
             println!("  row:{} ys: {:?}", item, unique);

--- a/crates/core/src/density.rs
+++ b/crates/core/src/density.rs
@@ -1,0 +1,298 @@
+//! Density scoring for bus layouts.
+//!
+//! Given a [`LayoutResult`] and a target aspect ratio, compute how tightly the
+//! layout packs its entities into an axis-aligned bounding rectangle whose
+//! width:height matches the target ratio.
+//!
+//! Filled area counts every entity's full footprint (e.g. a 3×3 assembler
+//! contributes 9 tiles). Only the entities themselves contribute — power-pole
+//! coverage areas, wire connections, and `LayoutResult.connections` are
+//! ignored. Overlap is not expected; if the sum of footprints exceeds the
+//! rectangle area, [`DensityScore::filled_exceeds_rect`] is set so the caller
+//! can surface the anomaly rather than silently clamp.
+
+use crate::common::{machine_size, is_machine_entity};
+use crate::models::{EntityDirection, LayoutResult, PlacedEntity};
+
+/// Axis-aligned footprint (in tiles) of a single entity.
+///
+/// Splitters are 2×1 or 1×2 depending on their flow direction; machines use
+/// [`machine_size`]; beacons are 3×3; everything else is 1×1.
+pub fn entity_footprint(entity: &PlacedEntity) -> (u32, u32) {
+    let name = entity.name.as_str();
+    if is_machine_entity(name) {
+        let s = machine_size(name);
+        return (s, s);
+    }
+    if name == "beacon" {
+        return (3, 3);
+    }
+    if matches!(name, "splitter" | "fast-splitter" | "express-splitter") {
+        return match entity.direction {
+            EntityDirection::North | EntityDirection::South => (2, 1),
+            EntityDirection::East | EntityDirection::West => (1, 2),
+        };
+    }
+    // Belts, underground belts, inserters, poles, pipes, pipe-to-ground, and
+    // any other single-tile entity default to 1×1.
+    (1, 1)
+}
+
+/// Result of scoring a layout against a target aspect ratio.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DensityScore {
+    /// Width of the smallest aspect-ratio-matching rectangle that contains
+    /// every entity footprint.
+    pub rect_width: u32,
+    /// Height of that rectangle.
+    pub rect_height: u32,
+    /// Total area of the rectangle (`rect_width * rect_height`).
+    pub rect_area: u64,
+    /// Sum of entity footprint areas (width × height per entity).
+    pub filled_tiles: u64,
+    /// `rect_area - filled_tiles` (saturating at zero if filled exceeds rect,
+    /// which would indicate overlapping entities).
+    pub empty_tiles: u64,
+    /// `filled_tiles / rect_area` as a fraction in `[0.0, 1.0]` (or above 1.0
+    /// if entities overlap).
+    pub density: f64,
+    /// Content bounding box width — the tight axis-aligned rectangle around
+    /// the actual entity footprints, before aspect-ratio padding.
+    pub content_bbox_width: u32,
+    /// Content bounding box height (tight, pre-padding).
+    pub content_bbox_height: u32,
+    /// Set to `true` if `filled_tiles > rect_area`, which implies overlapping
+    /// entity footprints — a bug in the layout engine worth surfacing.
+    pub filled_exceeds_rect: bool,
+}
+
+impl DensityScore {
+    /// Zero-entity layout score — all fields 0, density 0.
+    pub const EMPTY: DensityScore = DensityScore {
+        rect_width: 0,
+        rect_height: 0,
+        rect_area: 0,
+        filled_tiles: 0,
+        empty_tiles: 0,
+        density: 0.0,
+        content_bbox_width: 0,
+        content_bbox_height: 0,
+        filled_exceeds_rect: false,
+    };
+}
+
+/// Score a layout's tile-packing density against a target aspect ratio.
+///
+/// The aspect ratio is given as `(width, height)` in integer units. Default
+/// usage is `(1, 1)` for a square rectangle. Higher ratios like `(16, 9)`
+/// stretch the rectangle horizontally.
+///
+/// Steps:
+/// 1. Compute the tight content bbox over every entity footprint (each entity
+///    contributes the tiles `[x, x + w) × [y, y + h)` from
+///    [`entity_footprint`]).
+/// 2. Pad one axis outward to match the aspect ratio. The padded side length
+///    is `max(bbox_w * ratio_h, bbox_h * ratio_w)`, scaled back to per-axis
+///    widths. For 1:1 this reduces to `max(bbox_w, bbox_h)` on both axes.
+/// 3. Sum entity footprint areas for the filled count.
+/// 4. Density = filled / rect_area.
+///
+/// Empty layouts yield [`DensityScore::EMPTY`].
+pub fn score_density(layout: &LayoutResult, aspect_ratio: (u32, u32)) -> DensityScore {
+    if layout.entities.is_empty() {
+        return DensityScore::EMPTY;
+    }
+
+    // 1. Tight content bbox over entity footprints.
+    let mut min_x = i32::MAX;
+    let mut min_y = i32::MAX;
+    let mut max_x = i32::MIN;
+    let mut max_y = i32::MIN;
+    let mut filled_tiles: u64 = 0;
+
+    for e in &layout.entities {
+        let (w, h) = entity_footprint(e);
+        let ex0 = e.x;
+        let ey0 = e.y;
+        let ex1 = e.x + w as i32; // exclusive
+        let ey1 = e.y + h as i32; // exclusive
+        if ex0 < min_x { min_x = ex0; }
+        if ey0 < min_y { min_y = ey0; }
+        if ex1 > max_x { max_x = ex1; }
+        if ey1 > max_y { max_y = ey1; }
+        filled_tiles += w as u64 * h as u64;
+    }
+
+    let bbox_w = (max_x - min_x) as u32;
+    let bbox_h = (max_y - min_y) as u32;
+
+    // 2. Pad to match aspect ratio. Guard against a zero-denominator ratio by
+    //    falling back to a 1:1 square.
+    let (rw, rh) = aspect_ratio;
+    let (rect_w, rect_h) = if rw == 0 || rh == 0 {
+        let side = bbox_w.max(bbox_h);
+        (side, side)
+    } else {
+        aspect_padded(bbox_w, bbox_h, rw, rh)
+    };
+
+    let rect_area = rect_w as u64 * rect_h as u64;
+    let empty_tiles = rect_area.saturating_sub(filled_tiles);
+    let density = if rect_area > 0 {
+        filled_tiles as f64 / rect_area as f64
+    } else {
+        0.0
+    };
+    let filled_exceeds_rect = filled_tiles > rect_area;
+
+    DensityScore {
+        rect_width: rect_w,
+        rect_height: rect_h,
+        rect_area,
+        filled_tiles,
+        empty_tiles,
+        density,
+        content_bbox_width: bbox_w,
+        content_bbox_height: bbox_h,
+        filled_exceeds_rect,
+    }
+}
+
+/// Expand `(bbox_w, bbox_h)` to the smallest rectangle with `rw:rh` aspect
+/// that still contains the bbox.
+fn aspect_padded(bbox_w: u32, bbox_h: u32, rw: u32, rh: u32) -> (u32, u32) {
+    // We need w/h == rw/rh with w >= bbox_w and h >= bbox_h.
+    // Let k = max(bbox_w / rw, bbox_h / rh) rounded up. Then w = k*rw, h = k*rh.
+    let k_from_w = div_ceil(bbox_w, rw);
+    let k_from_h = div_ceil(bbox_h, rh);
+    let k = k_from_w.max(k_from_h);
+    (k * rw, k * rh)
+}
+
+fn div_ceil(a: u32, b: u32) -> u32 {
+    if b == 0 { 0 } else { a.div_ceil(b) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{EntityDirection, LayoutResult, PlacedEntity};
+
+    fn belt(x: i32, y: i32) -> PlacedEntity {
+        PlacedEntity {
+            name: "transport-belt".into(),
+            x,
+            y,
+            direction: EntityDirection::East,
+            ..Default::default()
+        }
+    }
+
+    fn assembler(x: i32, y: i32) -> PlacedEntity {
+        PlacedEntity {
+            name: "assembling-machine-2".into(),
+            x,
+            y,
+            direction: EntityDirection::North,
+            ..Default::default()
+        }
+    }
+
+    fn splitter_ns(x: i32, y: i32) -> PlacedEntity {
+        PlacedEntity {
+            name: "splitter".into(),
+            x,
+            y,
+            direction: EntityDirection::North,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_layout_returns_empty_score() {
+        let layout = LayoutResult::default();
+        let s = score_density(&layout, (1, 1));
+        assert_eq!(s, DensityScore::EMPTY);
+    }
+
+    #[test]
+    fn single_belt_is_1x1_square() {
+        let layout = LayoutResult {
+            entities: vec![belt(5, 7)],
+            ..Default::default()
+        };
+        let s = score_density(&layout, (1, 1));
+        assert_eq!(s.content_bbox_width, 1);
+        assert_eq!(s.content_bbox_height, 1);
+        assert_eq!(s.rect_width, 1);
+        assert_eq!(s.rect_height, 1);
+        assert_eq!(s.filled_tiles, 1);
+        assert_eq!(s.empty_tiles, 0);
+        assert!((s.density - 1.0).abs() < 1e-9);
+        assert!(!s.filled_exceeds_rect);
+    }
+
+    #[test]
+    fn assembler_contributes_full_3x3_footprint() {
+        let layout = LayoutResult {
+            entities: vec![assembler(0, 0)],
+            ..Default::default()
+        };
+        let s = score_density(&layout, (1, 1));
+        assert_eq!(s.filled_tiles, 9);
+        assert_eq!(s.rect_width, 3);
+        assert_eq!(s.rect_height, 3);
+        assert!((s.density - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn splitter_north_is_2x1() {
+        let layout = LayoutResult {
+            entities: vec![splitter_ns(10, 20)],
+            ..Default::default()
+        };
+        let s = score_density(&layout, (1, 1));
+        assert_eq!(s.filled_tiles, 2);
+        assert_eq!(s.content_bbox_width, 2);
+        assert_eq!(s.content_bbox_height, 1);
+        assert_eq!(s.rect_width, 2);
+        assert_eq!(s.rect_height, 2); // padded to square
+        assert_eq!(s.empty_tiles, 2);
+    }
+
+    #[test]
+    fn wide_row_of_belts_pads_to_square_for_1to1() {
+        // 10 belts in a row → bbox 10×1, square is 10×10, filled=10, density=0.1.
+        let entities: Vec<PlacedEntity> = (0..10).map(|i| belt(i, 0)).collect();
+        let layout = LayoutResult { entities, ..Default::default() };
+        let s = score_density(&layout, (1, 1));
+        assert_eq!(s.filled_tiles, 10);
+        assert_eq!(s.rect_width, 10);
+        assert_eq!(s.rect_height, 10);
+        assert!((s.density - 0.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aspect_ratio_16_by_9() {
+        // 32×9 bbox fits in 32×18 at 16:9 (ceil(32/16)=2 → 32×18).
+        let entities: Vec<PlacedEntity> = (0..32)
+            .flat_map(|x| (0..9).map(move |y| belt(x, y)))
+            .collect();
+        let layout = LayoutResult { entities, ..Default::default() };
+        let s = score_density(&layout, (16, 9));
+        assert_eq!(s.content_bbox_width, 32);
+        assert_eq!(s.content_bbox_height, 9);
+        assert_eq!(s.rect_width, 32);
+        assert_eq!(s.rect_height, 18);
+    }
+
+    #[test]
+    fn zero_aspect_ratio_falls_back_to_square() {
+        let layout = LayoutResult {
+            entities: vec![belt(0, 0), belt(2, 5)],
+            ..Default::default()
+        };
+        let s = score_density(&layout, (0, 1));
+        assert_eq!(s.rect_width, s.rect_height);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod blueprint;
 pub mod blueprint_parser;
 pub mod bus;
 pub mod common;
+pub mod density;
 pub mod fixture;
 pub mod models;
 pub mod recipe_db;

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -16,6 +16,7 @@ use fucktorio_core::analysis::{self, BlueprintAnalysis};
 use fucktorio_core::blueprint;
 use fucktorio_core::blueprint_parser;
 use fucktorio_core::bus::layout;
+use fucktorio_core::density;
 use fucktorio_core::models::{LayoutResult, SolverResult};
 use fucktorio_core::snapshot::{
     LayoutSnapshot, SnapshotContext, SnapshotParams, SnapshotSource,
@@ -222,6 +223,29 @@ fn run_e2e_with_exclusions(
     // Drain trace events into the result so callers (and dump_snapshot below)
     // can read them without the RAII guard wiping them on drop.
     let trace_events = trace::drain_events();
+
+    // Layout size + density (1:1 square) report — mirrors the
+    // `Layout: N entities, WxH` style already used in diagnostic/stress tests,
+    // and prints for every tier test so the pack-efficiency distribution is
+    // visible at a glance with `--nocapture`.
+    let density_score = density::score_density(&layout, (1, 1));
+    eprintln!(
+        "Layout: {} entities, {}x{}; density: {:.1}% ({}x{} rect, {} filled / {} total tiles)",
+        layout.entities.len(),
+        layout.width,
+        layout.height,
+        density_score.density * 100.0,
+        density_score.rect_width,
+        density_score.rect_height,
+        density_score.filled_tiles,
+        density_score.rect_area,
+    );
+    if density_score.filled_exceeds_rect {
+        eprintln!(
+            "  WARNING: filled tiles ({}) exceeds rect area ({}) — entity footprints overlap",
+            density_score.filled_tiles, density_score.rect_area,
+        );
+    }
 
     let result = E2EResult {
         solver_result,

--- a/docs/rfp-modular-production.md
+++ b/docs/rfp-modular-production.md
@@ -6,10 +6,13 @@
 
 ## Current status
 
-- **Phase**: Draft / brainstorming complete.
-- **Flag state**: both features gated behind off-by-default flags;
-  current behavior is the no-flags path.
-- **Last update**: 2026-04-24 — initial draft from brainstorm.
+- **Phase**: Draft / brainstorming complete, design revised once.
+- **Strategy state**: selectable via `LayoutStrategy` enum;
+  `Pooled` (today's path) is default. `PartitionedPerConsumer` and
+  `PartitionedDecomposed` are first-class peer strategies, not
+  opt-in degradations of the default.
+- **Last update**: 2026-04-24 — revisions from second-pass review
+  (see Decision log).
 
 ## Summary
 
@@ -17,7 +20,7 @@ The current layout engine pools each intermediate item into one shared
 bus lane family and stamps a single balancer at the producer row
 output. This caps the widest producible intermediate at 8 lanes
 (the largest template in `balancer_library.rs`). We propose two
-*optional, composable* strategies, layered behind feature flags:
+*composable* strategies, exposed as selectable layout modes:
 
 1. **Demand-partitioning (outer)** — split a high-demand intermediate
    into one producer module per consumer, sized to that consumer's
@@ -29,9 +32,13 @@ output. This caps the widest producible intermediate at 8 lanes
    expand going up-tree), shard *that* module into ⌈widest / 8⌉
    sibling subtrees, each producing a proportional share.
 
-Both flags default to off. The existing pooled/balancer-stamped path
-stays the baseline until one or both strategies earn the right to
-become default via the kill-criteria checks below.
+Both are exposed as peer variants of a `LayoutStrategy` enum (see
+Design). `Pooled` is the default because it's the current baseline,
+not because it's inherently preferred — the point of this RFP is
+that **different recipes and different user preferences deserve
+different layout shapes**, and modular production gives us a second
+and third shape to offer. The strategy the user selects is the
+strategy we produce; we don't silently upgrade or downgrade.
 
 ## Motivation
 
@@ -59,13 +66,28 @@ cable." This is a real semantic shift in `lane_planner.rs` /
 
 ### Load-bearing assumption
 
-Partitioning works without a pool-balancer because belts are wildly
+Partitioning works without a pool-balancer because belts are
 over-provisioned relative to machine consumption (yellow belt =
 15/s; a single assembler consumes 1–2/s of most ingredients).
 Per-machine timing jitter produces mild lane-to-lane variance in the
-producer's output, but the over-provisioning absorbs it. This
-assumption breaks for speed-module-3'd rows on marginal lanes —
-document it, and watch for it in verification.
+producer's output, but the over-provisioning absorbs it *as long as
+per-lane utilization stays well below saturation*.
+
+**Concrete numeric threshold**: if the proposed partition would put
+any lane above **75% of belt tier capacity** (e.g. >11.25/s on a
+yellow belt, >22.5/s on red, >33.75/s on blue), we assume variance
+will cause starvation. This shows up with speed-module-3'd
+producers, tight partitions where integer belt rounding leaves
+little headroom, or deep chains where intermediate demand is tight
+against belt capacity. The partitioner treats 75% as a hard ceiling:
+if a proposed partition can't stay under it, the partitioner emits
+`TraceEvent::PartitionRejectedByUtilization` and the strategy falls
+back — but because strategy is user-selected rather than
+auto-chosen, "fallback" here means **producing an invalid layout
+with a loud warning**, not silently switching to `Pooled`. The user
+picked `PartitionedPerConsumer`; if the case can't satisfy that
+shape under the utilization rule, that's diagnostic output they need
+to see, not a quiet downgrade.
 
 ## Design
 
@@ -73,9 +95,20 @@ document it, and watch for it in verification.
 
 ```rust
 // crates/core/src/bus/layout.rs
+pub enum LayoutStrategy {
+    /// Current behavior: one shared lane family per item, single
+    /// balancer at the producer row. Capped at 8 lanes.
+    Pooled,
+    /// Phase 1: one lane family per consuming recipe-row, sized to
+    /// that consumer's exact demand, no pool-balancer.
+    PartitionedPerConsumer,
+    /// Phase 2: PartitionedPerConsumer plus subtree sharding when a
+    /// single module's widest upstream recipe still exceeds 8 lanes.
+    PartitionedDecomposed,
+}
+
 pub struct LayoutOptions {
-    pub demand_partition: bool,     // Feature flag — outer pass
-    pub subtree_decompose: bool,    // Feature flag — inner pass
+    pub strategy: LayoutStrategy,   // default: LayoutStrategy::Pooled
     // ... existing options merged in
 }
 
@@ -86,27 +119,49 @@ pub fn build_bus_layout(
 ) -> LayoutResult;
 ```
 
-Both flags default to `false`. With both off, the pipeline is
-byte-identical to today (enforced by a flag-off regression snapshot
-on every e2e test).
+`LayoutStrategy::default() == Pooled`. With the default selected the
+pipeline is byte-identical to today (enforced by a regression
+snapshot on every e2e test).
 
-WASM bindings (`crates/wasm-bindings/src/lib.rs`) expose the flags as
-optional params on `layout()`. The web app (`web/src/ui/sidebar.ts`)
-adds two debug toggles; URL state (`?partition=1&decompose=1`) makes
-links reproduce the experimental mode.
+WASM bindings (`crates/wasm-bindings/src/lib.rs`) expose `strategy`
+as an optional string param on `layout()`. The web app
+(`web/src/ui/sidebar.ts`) gets a strategy dropdown; URL state
+(`?strategy=partitioned-per-consumer`) makes links reproduce the
+selected mode.
+
+### Why an enum, not two booleans
+
+Two key reasons:
+
+1. **Invalid combinations don't exist.** `subtree_decompose=true`
+   with `demand_partition=false` was meaningless; the enum doesn't
+   let you express it.
+2. **Future strategies slot in cleanly.** The `escargio` RFP
+   (folded / spiral layouts) will add `PartitionedFolded` and
+   similar as new variants rather than orthogonal booleans that
+   cartesian-product into sixteen combinations, most of which don't
+   make sense.
+
+The cost is a modest refactor in Phase 0 scaffolding.
 
 ### Phase 0 — shared scaffolding (no behavior change)
 
-The scaffolding both features need is: **the lane planner must be
-able to represent multiple same-item families**. Today
-`LaneFamily` is implicitly one-per-item; downstream code (lane-order
-optimiser, balancer stamper, tap-off router) assumes this.
+The scaffolding the partitioning strategies need is: **the lane
+planner must be able to represent multiple same-item families**.
+Today `LaneFamily` is implicitly one-per-item; downstream code
+(lane-order optimiser, balancer stamper, tap-off router) assumes
+this.
 
-Touch list:
+Phase 0 is split into two independently reviewable sub-phases to
+keep each PR small and reviewable:
 
+**Phase 0a — core scaffolding (~400 LOC):**
+
+- Add `LayoutStrategy` enum + `LayoutOptions.strategy` field.
 - `crates/core/src/bus/lane_planner.rs` — make `LaneFamily`
   identity include a `module_id: u32` alongside the item name. One
-  `module_id=0` per item in the baseline = today's behavior.
+  `module_id=0` per item in the `Pooled` baseline = today's
+  behavior.
 - `crates/core/src/bus/lane_order.rs` — key the exact-search on the
   `(item, module_id)` tuple. The ≤7-family cutoff applies to the
   tuple count, not the item count.
@@ -116,32 +171,82 @@ Touch list:
   tuple; consumer→module mapping defaults to "consumer of item X
   taps the single `(X, 0)` family."
 
-Flag-off behavior must be identical. All 9 non-ignored e2e tests
-stay green with zero snapshot drift.
+**Phase 0b — surface wiring (~200 LOC):**
+
+- Expose `strategy` on WASM bindings (no-op when `Pooled`).
+- Web app strategy dropdown, URL state.
+- Threaded through call sites (examples, tests).
+
+`Pooled`-strategy behavior must be byte-identical to today's.
+All 9 non-ignored e2e tests stay green with zero snapshot drift.
 
 ### Phase 1 — demand-partitioning (outer pass)
 
-When `demand_partition = true`:
+When `strategy == PartitionedPerConsumer` (or
+`PartitionedDecomposed`):
 
-1. For each intermediate item with multiple consumers, allocate one
-   `LaneFamily` per consumer. Each family's lane count is sized to
-   the consumer's exact demand (rounded up to the nearest belt).
-2. Consumer→module mapping is 1:1 (no tap decision — each consumer
+#### Consumer definition
+
+A **consumer** is *one consuming recipe-row*, not one consuming
+machine and not one consuming item. If `advanced-circuit` has
+assemblers split across two rows because of throughput (standard
+`placer.rs` row-splitting for rate), each row is a separate
+consumer. Eight assemblers on a single row count as one consumer.
+This keeps the partition count bounded by recipe-row count (small)
+rather than machine count (potentially large), which is the right
+granularity to make `LaneFamily` splitting meaningful.
+
+#### Algorithm
+
+1. For each intermediate item with K ≥ 1 consuming recipe-rows,
+   allocate K `LaneFamily` instances, one per consumer. Each
+   family's lane count is sized to that consumer's exact demand,
+   rounded up to the nearest belt.
+2. Before allocating, the partitioner checks the utilization
+   threshold (75%, see *Load-bearing assumption*). If any proposed
+   family would violate it, emit
+   `TraceEvent::PartitionRejectedByUtilization` and produce an
+   invalid layout with a loud warning — **do not silently fall back
+   to `Pooled`**, because strategy is user-selected.
+3. Consumer→module mapping is 1:1 (no tap decision — each consumer
    owns its module).
-3. The producer row for item X is split into K sibling rows, one per
-   consumer, each sized to that consumer's demand. Shared upstream
-   ingredients feed all K rows via a simple tee/split (not a
-   balancer — ⌈K / 8⌉ wide, typically 2–3).
-4. No pool-balancer is stamped. If K > 1, no single-family balancer
+4. The producer row for item X is split into K sibling rows, one per
+   consumer, each sized to that consumer's demand.
+5. No pool-balancer is stamped. If K > 1, no single-family balancer
    needs to be wider than the widest single consumer's lane count.
 
-The producer-side belt math:
+#### The shared-upstream distribution — not "just a tee"
 
-- Shared upstream ingredient feeds K rows. The split is `K`
-  outputs, which we emit as a splitter tree. For K ≤ 8 (the common
-  case) this is a single library template.
-- If K > 8, the ingredient's own demand-partitioning recurses
-  naturally: treat the K rows as K consumers.
+Shared upstream ingredients feed all K producer-rows. A symmetric
+K-way splitter tree is *approximately* equal-share only if the tree
+is balanced and the belt compression stays sub-saturation; a
+naive tee is measurably asymmetric on early branches under load.
+Call this what it is: a **small-scale balancer** (K-to-K where K
+≤ 8 in the common case), reusing `balancer_library.rs` templates
+rather than inventing a new splitter-tree primitive. The "no
+pool-balancer" property of Phase 1 is accurate at the *output* of
+the producer module — there's no giant stamped balancer consolidating
+item X from all producers. But the *input* side of a multi-row
+producer still needs a balanced distributor of its shared
+ingredients. This is a smaller balancer (K ≤ 8) and reuses existing
+templates, so it's not an open problem — but the RFP shouldn't
+pretend it isn't there.
+
+If K > 8 on the input distributor, the ingredient's own
+demand-partitioning recurses naturally: treat the K producer-rows
+as K consumers of the ingredient, and the distributor disappears
+into per-consumer lane families one level up. Recursion depth is
+bounded by the recipe dependency depth (≤ ~10 for anything we'll
+see in practice, including processing-unit chains).
+
+#### Fluids
+
+Fluids (petroleum gas, sulfuric acid, lubricant, etc.) stay pooled
+under `PartitionedPerConsumer` and `PartitionedDecomposed`. Pipe
+networks merge freely, there's no per-lane identity to partition
+against, and the whole premise ("one belt lane per consumer")
+doesn't apply. Partitioning only touches solid-item lane families.
+This is an explicit non-goal, not a deferred TODO.
 
 ### Phase 2 — subtree decomposition (inner pass)
 
@@ -164,9 +269,17 @@ widest recipe forces a 2-shard split (6+6), proportional allocation
 produces a 7-from-(6+6) tap that's ugly. This is the case where
 hierarchical balancer composition would win over decomposition.
 
-**Decision**: don't solve it in Phase 2. Log the event
-(`TraceEvent::LumpyShardTap`) so we can count how often it occurs
-in the real corpus, then decide later whether to tackle it.
+**Decision**: don't solve it in Phase 2 proper, but *prototype one
+hierarchical composition during Phase 1* so we have working code to
+pivot to if K2-2 fires. The prototype can be a single hand-authored
+12→12 = 8→8 + 8→8 + inter-mixer template applied to the
+`advanced_circuit` copper-cable case. That de-risks the
+"if decomposition produces too many lumpy taps, we'll just switch
+to hierarchical composition" fallback by making it an actual
+available fallback rather than a hypothetical one. Log the
+`TraceEvent::LumpyShardTap` event from Phase 2 code as planned;
+the prototype lives alongside it, guarded by a separate strategy
+variant (`HierarchicalComposed` — unexposed user-facing for now).
 
 ### Rejected alternatives
 
@@ -183,45 +296,82 @@ in the real corpus, then decide later whether to tackle it.
 ## Kill criteria
 
 Explicit, observable, falsifiable. Act on these, don't rationalize
-around them.
+around them. Kill criteria are correctness- and bounds-focused; they
+do **not** include "strategy X produces more entities than strategy
+Y on case Z" because that's a tradeoff the user opted into, not a
+bug. See *Observables* below for the tradeoff data we report but
+don't gate on.
 
 **Phase 0 (scaffolding):**
 
 - **K0-1**: If any of the 9 non-ignored e2e tests snapshot-drifts
-  with both flags off after Phase 0 lands, the multi-family
+  with `strategy: Pooled` after Phase 0 lands, the multi-family
   abstraction is not clean — abandon and rethink the types.
-- **K0-2**: If the scaffolding needs > ~400 LOC of new code (not
-  counting tests) just to preserve current behavior, the
+- **K0-2**: If Phase 0a scaffolding needs > ~400 LOC of new code
+  (not counting tests) just to preserve current behavior, the
   `module_id` keying is in the wrong place — likely needs to be
-  deeper in `placer.rs` instead of the planner.
+  deeper in `placer.rs` instead of the planner. Phase 0b (UI +
+  WASM wiring) budget is ~200 LOC.
 
 **Phase 1 (partitioning):**
 
-- **K1-1**: If enabling `demand_partition` on a tier2 case that
-  *doesn't need it* (e.g. `tier2_electronic_circuit_from_ore`)
-  produces a layout with > 1.5× the entity count of the flag-off
-  baseline, the partitioning waste is too steep — reconsider the
-  "one module per consumer" rule.
-- **K1-2**: If a consumer row still emits belt-flow validator
-  warnings (starved inserters) with `demand_partition=true` on a
-  correctly-sized partition and balanced external inputs, the
-  "belts are over-provisioned so variance doesn't matter"
-  assumption is false — we need balancers back, possibly scoped per
-  module.
-- **K1-3**: If the flag combination doesn't produce a valid layout
-  for the target failing case (`advanced_circuit` at a rate that
-  currently trips the 8-lane ceiling) within 2 weeks of Phase 1
-  work, the approach isn't unblocking the motivating problem —
+- **K1-1** (correctness on motivating case): If
+  `PartitionedPerConsumer` doesn't produce a **validator-clean**
+  layout for the target failing case (`advanced_circuit` at a rate
+  that currently trips the 8-lane ceiling) within 2 weeks of Phase
+  1 work, the approach isn't unblocking the motivating problem —
   reassess rather than push further.
+- **K1-2** (load-bearing assumption holds): If a consumer row
+  emits belt-flow validator warnings (starved inserters) under
+  `PartitionedPerConsumer` on a correctly-sized partition with
+  balanced external inputs *and* the partitioner's 75%-utilization
+  gate is satisfied, the "belts over-provisioned" assumption is
+  wrong — we need balancers back, scoped per module.
+- **K1-3** (utilization gate is rare-firing): If
+  `TraceEvent::PartitionRejectedByUtilization` fires on > 20% of
+  the stress corpus at default rates, the 75% threshold is too
+  aggressive and is blocking reasonable cases; retune or treat
+  partition-utilization as a per-case concern.
+- **K1-4** (inert on uninvolved cases): If `PartitionedPerConsumer`
+  doesn't produce an **entity-equivalent** layout to `Pooled` on
+  cases with no multi-consumer intermediates (iron-gear-wheel,
+  anything with K=1 for every intermediate), the partitioning code
+  is doing something it shouldn't when it has nothing to do.
+  "Entity-equivalent" = same validator result, same density score,
+  same entity-type counts (not necessarily byte-equal since
+  module_id≠0 paths will traverse different code). K1-4 replaces
+  the previous "<1.5× entity count" kill criterion with a sharper
+  inertness test.
 
 **Phase 2 (decomposition):**
 
-- **K2-1**: If Phase 2 needs > ~300 LOC outside the Phase-0
-  scaffolding, the split between outer/inner passes is wrong.
-- **K2-2**: If `TraceEvent::LumpyShardTap` fires on >30% of the
-  stress corpus runs with decomposition enabled, lumpiness is the
-  common case, not the edge — pivot to hierarchical composition
-  instead of shipping decomposition.
+- **K2-1** (LOC budget): If Phase 2 needs > ~300 LOC outside the
+  Phase-0 scaffolding, the split between outer/inner passes is
+  wrong.
+- **K2-2** (lumpiness common vs rare): If
+  `TraceEvent::LumpyShardTap` fires on > 30% of the stress corpus
+  runs under `PartitionedDecomposed`, lumpiness is the common case
+  not the edge — pivot to the `HierarchicalComposed` prototype (see
+  Phase 1) rather than shipping decomposition as the standard
+  inner-pass strategy.
+
+## Observables (reported, not gated)
+
+These are numbers we want to watch because they describe the
+tradeoff between strategies, not because we want to prevent the
+tradeoff. They're reported per-run in the e2e scoreboards.
+
+- **Entity count per strategy, per tier test.** Expected:
+  `Pooled` ≤ `PartitionedPerConsumer` ≤ `PartitionedDecomposed` on
+  shallow cases (more strategies = more infrastructure); inverted
+  on deep cases that would otherwise fail under `Pooled`.
+- **Density per strategy, per tier test** (1:1 and tight-bbox).
+  The density metric added in the preceding work on this branch
+  picks up the layout-shape tradeoff directly.
+- **`PartitionRejectedByUtilization` events per case.** Feeds K1-3.
+- **`LumpyShardTap` events per case.** Feeds K2-2.
+- **Max family width per case.** Confirms the "no balancer wider
+  than the largest consumer" property holds.
 
 ## Verification plan
 
@@ -229,35 +379,59 @@ Follow the
 [verification protocol](../CLAUDE.md#verification-protocol-for-layout-engine-changes).
 Specifics:
 
-1. **Flag-off regression**: every e2e test asserts snapshot equality
-   with the pre-RFP baseline. Non-negotiable for Phase 0 landing.
-2. **Flag-on golden cases**: add `tier3_advanced_circuit_partitioned`
-   and `tier4_advanced_circuit_decomposed` e2e tests using a rate
-   that requires >8 cable lanes. Assert zero validator warnings.
-3. **Browser verification**: load
-   `?item=advanced-circuit&rate=<high>&partition=1` and
-   eyeball the layout per CLAUDE.md verification protocol. A zero-
-   warning layout that visibly has disconnected belts is a
+1. **Pooled-strategy regression**: every e2e test asserts snapshot
+   equality under `strategy: Pooled` with the pre-RFP baseline.
+   Non-negotiable for Phase 0 landing (gated by K0-1).
+2. **Strategy inertness on uninvolved cases**: for every tier test
+   where every intermediate has K=1 consumer (iron-gear-wheel, any
+   single-consumer chain), assert that `Pooled` and
+   `PartitionedPerConsumer` produce layouts with the **same
+   validator result, same density score, and same entity-type
+   count breakdown**. This is the K1-4 gate — the sharpest
+   available test that the partitioning code path doesn't do
+   anything when it has nothing to do.
+3. **Strategy-on golden cases**: add
+   `tier3_advanced_circuit_partitioned` and
+   `tier4_advanced_circuit_decomposed` e2e tests at rates that
+   require >8 cable lanes. Assert zero validator warnings.
+4. **Per-strategy tier sweep**: for every existing tier test, run
+   under all three strategies and dump entity count + density
+   scores into the scoreboard. These feed the *Observables*
+   section, not kill criteria — we report the tradeoff, not gate
+   on it.
+5. **Browser verification**: load
+   `?item=advanced-circuit&rate=<high>&strategy=partitioned-per-consumer`
+   and eyeball the layout per CLAUDE.md verification protocol. A
+   zero-warning layout that visibly has disconnected belts is a
    validator blind spot, not a success.
-4. **Trace signals**: confirm
-   `ModulePartitioned{item, modules}`, `ShardSplit{item, shards}`,
-   and `LumpyShardTap{item, consumer}` events fire as expected.
-   Absent trace events = the code path isn't exercising.
-5. **Entity-count diff**: for each tier2/tier3 regression case,
-   compare flag-off vs flag-on entity counts. K1-1 requires this
-   stays under 1.5× on cases that don't need partitioning.
+6. **Trace signals**: confirm `ModulePartitioned{item, modules}`,
+   `ShardSplit{item, shards}`, `LumpyShardTap{item, consumer}`,
+   and `PartitionRejectedByUtilization{item, lane_util}` events
+   fire as expected. Absent trace events = the code path isn't
+   exercising.
 
 ## Phasing
 
-Three independently landable PRs:
+Four independently landable PRs:
 
-- **PR 1 — Phase 0 scaffolding**: multi-family-per-item in the lane
-  planner, with `module_id=0` baseline preserving current behavior.
-  Both flags exist in `LayoutOptions` but are unused code paths.
-- **PR 2 — Phase 1 partitioning**: `demand_partition` flag wired
-  through. Tests for flag-on path. Browser toggle + URL state.
-- **PR 3 — Phase 2 decomposition**: `subtree_decompose` flag wired
-  through. Lumpy-tap trace event. Tests for flag-on path.
+- **PR 1 — Phase 0a core scaffolding**: multi-family-per-item in
+  the lane planner, with `module_id=0` per item under
+  `strategy: Pooled` preserving current behavior. `LayoutStrategy`
+  enum + `LayoutOptions.strategy` field added but only `Pooled`
+  arm is reachable.
+- **PR 2 — Phase 0b surface wiring**: WASM binding for
+  `strategy`, web app dropdown, URL state, threaded through call
+  sites. Still no behavior change (non-`Pooled` arms still
+  unreachable or panic!).
+- **PR 3 — Phase 1 partitioning**: `PartitionedPerConsumer` arm
+  wired through. Shared-upstream balancer for multi-row producers.
+  Utilization gate. Fluids-stay-pooled carve-out. Tests for
+  strategy-on path. **Includes** hand-authored `HierarchicalComposed`
+  prototype for the 12→12 case, guarded behind the unexposed
+  variant.
+- **PR 4 — Phase 2 decomposition**: `PartitionedDecomposed` arm
+  wired through. Lumpy-tap trace event. Tests for strategy-on
+  path.
 
 Each PR must pass all kill criteria for its phase before the next
 PR starts.
@@ -266,51 +440,72 @@ PR starts.
 
 Living checklist — update as work progresses.
 
-### Phase 0 — shared scaffolding
+### Phase 0a — core scaffolding
 
-- [ ] Add `LayoutOptions` struct to `crates/core/src/bus/layout.rs`
-      with both flags defaulting to `false`
+- [ ] Add `LayoutStrategy` enum + `LayoutOptions` struct to
+      `crates/core/src/bus/layout.rs` (default `Pooled`)
 - [ ] Thread `LayoutOptions` through `build_bus_layout` call sites
-      (core, wasm-bindings, examples, tests)
+      (core, examples, tests)
 - [ ] Extend `LaneFamily` identity to include `module_id: u32`
-- [ ] Update `lane_order.rs` exact-search to key on `(item, module_id)`
+- [ ] Update `lane_order.rs` exact-search to key on
+      `(item, module_id)`
 - [ ] Update `stamp_family_balancer` to accept the tuple
 - [ ] Update tap-off routing in `templates.rs` for tuple lookup
 - [ ] Add consumer→module mapping defaulting to `(item, 0)`
-- [ ] Verify all 9 e2e tests pass with zero snapshot drift (K0-1)
-- [ ] Verify LOC budget (K0-2)
-- [ ] Expose flags on WASM bindings (no-op when false)
+- [ ] Non-`Pooled` strategy arms panic with "not yet implemented"
+- [ ] Verify all 9 e2e tests pass with zero snapshot drift under
+      `Pooled` (K0-1)
+- [ ] Verify Phase 0a LOC budget ≤ 400 (K0-2)
+
+### Phase 0b — surface wiring
+
+- [ ] Expose `strategy` on WASM bindings
+- [ ] Strategy dropdown in `web/src/ui/sidebar.ts`
+- [ ] URL state: `?strategy=...`
+- [ ] Verify Phase 0b LOC budget ≤ 200
 
 ### Phase 1 — demand-partitioning
 
-- [ ] Add `ModulePartitioned` trace event
+- [ ] Add `ModulePartitioned`,
+      `PartitionRejectedByUtilization` trace events
 - [ ] Implement outer-pass partitioning in `lane_planner.rs`
+      under `strategy == PartitionedPerConsumer`
+- [ ] Wire in 75%-utilization gate; emit rejection event rather
+      than silently fall back
 - [ ] Implement producer-row splitting in `placer.rs`
-- [ ] Implement shared-ingredient tee splitter (≤ 8-wide)
+- [ ] Implement shared-upstream balancer (reuses
+      `balancer_library.rs`, not a new splitter-tree primitive)
+- [ ] Fluids-stay-pooled carve-out in `lane_planner.rs`
+- [ ] **Hand-authored `HierarchicalComposed` prototype** for
+      12→12 = 8→8 + 8→8 + mixer on the `advanced_circuit` copper
+      case; strategy variant is unexposed to UI for now
 - [ ] Add `tier3_advanced_circuit_partitioned` e2e test
-- [ ] Browser UI toggle in `web/src/ui/sidebar.ts`
-- [ ] URL state: `?partition=1`
-- [ ] Verify K1-1 on tier2 cases
-- [ ] Verify K1-2 on tier3 partitioned case
-- [ ] Verify K1-3 on motivating failure case
+- [ ] Per-tier strategy sweep in scoreboards (all 3 strategies ×
+      all tier tests)
+- [ ] Verify K1-1 on motivating failure case
+- [ ] Verify K1-2 on stress corpus
+- [ ] Verify K1-3 utilization gate rate ≤ 20%
+- [ ] Verify K1-4 inertness on single-consumer cases
 
 ### Phase 2 — subtree decomposition
 
 - [ ] Add `ShardSplit` and `LumpyShardTap` trace events
 - [ ] Implement widest-recipe walker
 - [ ] Implement proportional shard allocator
-- [ ] Wire into `demand_partition` outer pass
+- [ ] Wire into `PartitionedDecomposed` outer pass
 - [ ] Add `tier4_advanced_circuit_decomposed` e2e test
-- [ ] Browser URL state: `?decompose=1`
 - [ ] Verify K2-1 LOC budget
 - [ ] Verify K2-2 lumpy-tap rate on stress corpus
+- [ ] If K2-2 fires: promote `HierarchicalComposed` prototype to
+      exposed user-facing variant; archive `PartitionedDecomposed`
 
-### Rollout (post-both-phases)
+### Rollout (post-all-phases)
 
-- [ ] Run full stress corpus with both flags on; compare
-      scoreboards to baseline
-- [ ] Decide per kill criteria: flip defaults, keep as opt-in, or
-      archive this RFP
+- [ ] Run full stress corpus under all strategies; publish
+      per-strategy scoreboards so users can see the tradeoffs
+- [ ] Decide per kill criteria: promote strategies to tier test
+      coverage, keep as opt-in, or archive specific strategy
+      variants
 
 ## Decision log
 
@@ -324,3 +519,55 @@ prevents "why did we drop this?" amnesia.
   (c) "belts over-provisioned" is the load-bearing assumption
   behind dropping the pool-balancer. Both features to land as
   off-by-default flags to keep the current path as baseline.*
+
+- *2026-04-24 (revision pass) — Second-pass review against the draft
+  above produced the following changes:*
+  - *Replaced the two-boolean option surface with a
+    `LayoutStrategy` enum. Motivated by (a) avoiding invalid
+    combinations (`decompose && !partition`), and (b) future
+    strategies (escargio `Folded`) composing cleanly without a
+    cartesian product of flags.*
+  - *Reframed the strategy model: `Pooled`,
+    `PartitionedPerConsumer`, and `PartitionedDecomposed` are
+    **peer citizens**, not degradations or upgrades of a default.
+    The layout engine respects what the user selected; no silent
+    auto-downgrade when a strategy can't satisfy a case — instead
+    produce an invalid layout with a loud diagnostic so the user
+    knows the shape they picked doesn't fit. Rationale: different
+    recipes and different users prefer different shapes, and
+    silently picking the "safe" one hides that tradeoff.*
+  - *Defined "consumer" explicitly as one consuming recipe-row,
+    not one consuming machine or one consuming item. Under-defined
+    in the original draft.*
+  - *Made the "belts over-provisioned" assumption numeric: 75% of
+    belt tier capacity is the utilization ceiling. A dedicated
+    trace event reports violations, which seeds K1-3.*
+  - *Reshaped K1-1 from "entity count < 1.5× on irrelevant cases"
+    to K1-4 "entity-equivalent layout on single-consumer cases".
+    Entity count per strategy becomes an **observable** (reported
+    in scoreboards) not a kill criterion, because the entire point
+    of offering multiple strategies is that users see the
+    tradeoff.*
+  - *Honest about the shared-upstream distributor: it's a
+    small-scale balancer reusing `balancer_library.rs`, not a
+    "simple tee". The "no pool-balancer" claim applies at the
+    output side, not the input side.*
+  - *Fluids explicitly out of scope for partitioning (pipe
+    networks merge freely, no per-lane identity to partition).*
+  - *Added the `HierarchicalComposed` prototype to Phase 1 to
+    de-risk the K2-2 fallback: if decomposition produces too many
+    lumpy taps, we pivot to a strategy that already exists in
+    working code rather than a hypothetical one.*
+  - *Split Phase 0 into 0a (core, ≤400 LOC) and 0b (surface
+    wiring, ≤200 LOC) for reviewability. Previous single budget
+    of 400 LOC was optimistic given the WASM-and-UI-threading
+    costs.*
+  - *Added K1-4 inertness test + snapshot-equality-on-irrelevant-
+    cases verification step. Sharpest available "new code path
+    does nothing when it should do nothing" check.*
+  - *Noted that escargio (folded layouts, separate upcoming RFP)
+    will slot in as additional `LayoutStrategy` variants on top of
+    this scaffolding. The `module_id` keying in Phase 0a should
+    not bake in any row-orientation assumption; a row's
+    `(item, module_id)` identity is orthogonal to its spatial
+    orientation.*

--- a/docs/rfp-modular-production.md
+++ b/docs/rfp-modular-production.md
@@ -1,0 +1,326 @@
+# RFP: Modular production — demand-partitioned modules + subtree decomposition
+
+> **Status**: Draft, not yet accepted. Living document — update the
+> Decision log and Task tracker as work progresses. Kill-criteria are
+> explicit and meant to be acted on.
+
+## Current status
+
+- **Phase**: Draft / brainstorming complete.
+- **Flag state**: both features gated behind off-by-default flags;
+  current behavior is the no-flags path.
+- **Last update**: 2026-04-24 — initial draft from brainstorm.
+
+## Summary
+
+The current layout engine pools each intermediate item into one shared
+bus lane family and stamps a single balancer at the producer row
+output. This caps the widest producible intermediate at 8 lanes
+(the largest template in `balancer_library.rs`). We propose two
+*optional, composable* strategies, layered behind feature flags:
+
+1. **Demand-partitioning (outer)** — split a high-demand intermediate
+   into one producer module per consumer, sized to that consumer's
+   exact demand, wired directly to it. No shared pool, no
+   pool-balancer, and the widest balancer ever needed is bounded by
+   the *largest single consumer's* demand, not the sum.
+2. **Subtree decomposition (inner)** — if a single demand-partitioned
+   module is still wider than 8 lanes (big consumer, or recipe ratios
+   expand going up-tree), shard *that* module into ⌈widest / 8⌉
+   sibling subtrees, each producing a proportional share.
+
+Both flags default to off. The existing pooled/balancer-stamped path
+stays the baseline until one or both strategies earn the right to
+become default via the kill-criteria checks below.
+
+## Motivation
+
+Concrete failing case: `advanced_circuit` at moderate-to-high rates
+needs more copper cable than any 8-lane balancer can feed.
+[`#136`](https://github.com/storkme/fucktorio/issues/136) tracks the
+missing-shape problem. Related: [`#135`](https://github.com/storkme/fucktorio/issues/135)
+(balancer templates oversized) and [`#68`](https://github.com/storkme/fucktorio/issues/68)
+(fluid row 3-tile pitch).
+
+Today the layout engine has no recourse when it hits a >8-lane
+family: it either can't find a template and falls back to a
+degenerate passthrough, or stamps an undersized balancer that leaves
+downstream inserters starved. Both produce bad layouts; neither is
+detectable purely via validator error count.
+
+### Architectural reframe
+
+This change reframes the "bus" from a *shared resource pool*
+(homogenized supply, lane-agnostic tap-off) to a *routing fabric for
+locally-scoped producer→consumer pairs*. The lane still exists, but
+it belongs to a specific consumer rather than to "anyone who wants
+cable." This is a real semantic shift in `lane_planner.rs` /
+`lane_order.rs`, not a balancer swap.
+
+### Load-bearing assumption
+
+Partitioning works without a pool-balancer because belts are wildly
+over-provisioned relative to machine consumption (yellow belt =
+15/s; a single assembler consumes 1–2/s of most ingredients).
+Per-machine timing jitter produces mild lane-to-lane variance in the
+producer's output, but the over-provisioning absorbs it. This
+assumption breaks for speed-module-3'd rows on marginal lanes —
+document it, and watch for it in verification.
+
+## Design
+
+### New option surface
+
+```rust
+// crates/core/src/bus/layout.rs
+pub struct LayoutOptions {
+    pub demand_partition: bool,     // Feature flag — outer pass
+    pub subtree_decompose: bool,    // Feature flag — inner pass
+    // ... existing options merged in
+}
+
+pub fn build_bus_layout(
+    solver: &SolverResult,
+    belt_tier: BeltTier,
+    opts: LayoutOptions,
+) -> LayoutResult;
+```
+
+Both flags default to `false`. With both off, the pipeline is
+byte-identical to today (enforced by a flag-off regression snapshot
+on every e2e test).
+
+WASM bindings (`crates/wasm-bindings/src/lib.rs`) expose the flags as
+optional params on `layout()`. The web app (`web/src/ui/sidebar.ts`)
+adds two debug toggles; URL state (`?partition=1&decompose=1`) makes
+links reproduce the experimental mode.
+
+### Phase 0 — shared scaffolding (no behavior change)
+
+The scaffolding both features need is: **the lane planner must be
+able to represent multiple same-item families**. Today
+`LaneFamily` is implicitly one-per-item; downstream code (lane-order
+optimiser, balancer stamper, tap-off router) assumes this.
+
+Touch list:
+
+- `crates/core/src/bus/lane_planner.rs` — make `LaneFamily`
+  identity include a `module_id: u32` alongside the item name. One
+  `module_id=0` per item in the baseline = today's behavior.
+- `crates/core/src/bus/lane_order.rs` — key the exact-search on the
+  `(item, module_id)` tuple. The ≤7-family cutoff applies to the
+  tuple count, not the item count.
+- `crates/core/src/bus/balancer.rs` — `stamp_family_balancer` takes
+  the tuple; behavior unchanged when `module_id=0` is the only one.
+- `crates/core/src/bus/templates.rs` — tap-off routing looks up by
+  tuple; consumer→module mapping defaults to "consumer of item X
+  taps the single `(X, 0)` family."
+
+Flag-off behavior must be identical. All 9 non-ignored e2e tests
+stay green with zero snapshot drift.
+
+### Phase 1 — demand-partitioning (outer pass)
+
+When `demand_partition = true`:
+
+1. For each intermediate item with multiple consumers, allocate one
+   `LaneFamily` per consumer. Each family's lane count is sized to
+   the consumer's exact demand (rounded up to the nearest belt).
+2. Consumer→module mapping is 1:1 (no tap decision — each consumer
+   owns its module).
+3. The producer row for item X is split into K sibling rows, one per
+   consumer, each sized to that consumer's demand. Shared upstream
+   ingredients feed all K rows via a simple tee/split (not a
+   balancer — ⌈K / 8⌉ wide, typically 2–3).
+4. No pool-balancer is stamped. If K > 1, no single-family balancer
+   needs to be wider than the widest single consumer's lane count.
+
+The producer-side belt math:
+
+- Shared upstream ingredient feeds K rows. The split is `K`
+  outputs, which we emit as a splitter tree. For K ≤ 8 (the common
+  case) this is a single library template.
+- If K > 8, the ingredient's own demand-partitioning recurses
+  naturally: treat the K rows as K consumers.
+
+### Phase 2 — subtree decomposition (inner pass)
+
+When `subtree_decompose = true` (requires `demand_partition = true`
+for the outer framing — they compose, not alternate):
+
+For each partitioned module, walk the upstream subtree. If any
+recipe's required belt count exceeds 8, shard the whole *module*
+into ⌈widest / 8⌉ pieces via proportional demand split. Each shard
+is an independent `LaneFamily` with its own upstream chain (with
+shared external inputs).
+
+Shard allocation rule: equal shares rounded so the widest recipe in
+each shard's subtree is ≤ 8 lanes. One-pass greedy; no search.
+
+### Consumer lumpiness — known failure mode
+
+If a consumer needs 7 lanes and another needs 5, and the item's
+widest recipe forces a 2-shard split (6+6), proportional allocation
+produces a 7-from-(6+6) tap that's ugly. This is the case where
+hierarchical balancer composition would win over decomposition.
+
+**Decision**: don't solve it in Phase 2. Log the event
+(`TraceEvent::LumpyShardTap`) so we can count how often it occurs
+in the real corpus, then decide later whether to tackle it.
+
+### Rejected alternatives
+
+- **Hierarchical balancer composition** (12→12 = two 8→8s + mixer)
+  — preserves single-pool semantics but requires a synthesizer over
+  a composition library we don't have. Preserve as a future option
+  if demand-partitioning's lumpy-tap case becomes common.
+- **Status quo + hand-authored 9+/10+/12+ templates** — doesn't
+  scale past the next ceiling, and `balancer_library.rs` is already
+  the largest file in the repo.
+- **Unbalanced splitter trees for >8** — gives up the "every
+  consumer gets its share" property that makes the bus work.
+
+## Kill criteria
+
+Explicit, observable, falsifiable. Act on these, don't rationalize
+around them.
+
+**Phase 0 (scaffolding):**
+
+- **K0-1**: If any of the 9 non-ignored e2e tests snapshot-drifts
+  with both flags off after Phase 0 lands, the multi-family
+  abstraction is not clean — abandon and rethink the types.
+- **K0-2**: If the scaffolding needs > ~400 LOC of new code (not
+  counting tests) just to preserve current behavior, the
+  `module_id` keying is in the wrong place — likely needs to be
+  deeper in `placer.rs` instead of the planner.
+
+**Phase 1 (partitioning):**
+
+- **K1-1**: If enabling `demand_partition` on a tier2 case that
+  *doesn't need it* (e.g. `tier2_electronic_circuit_from_ore`)
+  produces a layout with > 1.5× the entity count of the flag-off
+  baseline, the partitioning waste is too steep — reconsider the
+  "one module per consumer" rule.
+- **K1-2**: If a consumer row still emits belt-flow validator
+  warnings (starved inserters) with `demand_partition=true` on a
+  correctly-sized partition and balanced external inputs, the
+  "belts are over-provisioned so variance doesn't matter"
+  assumption is false — we need balancers back, possibly scoped per
+  module.
+- **K1-3**: If the flag combination doesn't produce a valid layout
+  for the target failing case (`advanced_circuit` at a rate that
+  currently trips the 8-lane ceiling) within 2 weeks of Phase 1
+  work, the approach isn't unblocking the motivating problem —
+  reassess rather than push further.
+
+**Phase 2 (decomposition):**
+
+- **K2-1**: If Phase 2 needs > ~300 LOC outside the Phase-0
+  scaffolding, the split between outer/inner passes is wrong.
+- **K2-2**: If `TraceEvent::LumpyShardTap` fires on >30% of the
+  stress corpus runs with decomposition enabled, lumpiness is the
+  common case, not the edge — pivot to hierarchical composition
+  instead of shipping decomposition.
+
+## Verification plan
+
+Follow the
+[verification protocol](../CLAUDE.md#verification-protocol-for-layout-engine-changes).
+Specifics:
+
+1. **Flag-off regression**: every e2e test asserts snapshot equality
+   with the pre-RFP baseline. Non-negotiable for Phase 0 landing.
+2. **Flag-on golden cases**: add `tier3_advanced_circuit_partitioned`
+   and `tier4_advanced_circuit_decomposed` e2e tests using a rate
+   that requires >8 cable lanes. Assert zero validator warnings.
+3. **Browser verification**: load
+   `?item=advanced-circuit&rate=<high>&partition=1` and
+   eyeball the layout per CLAUDE.md verification protocol. A zero-
+   warning layout that visibly has disconnected belts is a
+   validator blind spot, not a success.
+4. **Trace signals**: confirm
+   `ModulePartitioned{item, modules}`, `ShardSplit{item, shards}`,
+   and `LumpyShardTap{item, consumer}` events fire as expected.
+   Absent trace events = the code path isn't exercising.
+5. **Entity-count diff**: for each tier2/tier3 regression case,
+   compare flag-off vs flag-on entity counts. K1-1 requires this
+   stays under 1.5× on cases that don't need partitioning.
+
+## Phasing
+
+Three independently landable PRs:
+
+- **PR 1 — Phase 0 scaffolding**: multi-family-per-item in the lane
+  planner, with `module_id=0` baseline preserving current behavior.
+  Both flags exist in `LayoutOptions` but are unused code paths.
+- **PR 2 — Phase 1 partitioning**: `demand_partition` flag wired
+  through. Tests for flag-on path. Browser toggle + URL state.
+- **PR 3 — Phase 2 decomposition**: `subtree_decompose` flag wired
+  through. Lumpy-tap trace event. Tests for flag-on path.
+
+Each PR must pass all kill criteria for its phase before the next
+PR starts.
+
+## Task tracker
+
+Living checklist — update as work progresses.
+
+### Phase 0 — shared scaffolding
+
+- [ ] Add `LayoutOptions` struct to `crates/core/src/bus/layout.rs`
+      with both flags defaulting to `false`
+- [ ] Thread `LayoutOptions` through `build_bus_layout` call sites
+      (core, wasm-bindings, examples, tests)
+- [ ] Extend `LaneFamily` identity to include `module_id: u32`
+- [ ] Update `lane_order.rs` exact-search to key on `(item, module_id)`
+- [ ] Update `stamp_family_balancer` to accept the tuple
+- [ ] Update tap-off routing in `templates.rs` for tuple lookup
+- [ ] Add consumer→module mapping defaulting to `(item, 0)`
+- [ ] Verify all 9 e2e tests pass with zero snapshot drift (K0-1)
+- [ ] Verify LOC budget (K0-2)
+- [ ] Expose flags on WASM bindings (no-op when false)
+
+### Phase 1 — demand-partitioning
+
+- [ ] Add `ModulePartitioned` trace event
+- [ ] Implement outer-pass partitioning in `lane_planner.rs`
+- [ ] Implement producer-row splitting in `placer.rs`
+- [ ] Implement shared-ingredient tee splitter (≤ 8-wide)
+- [ ] Add `tier3_advanced_circuit_partitioned` e2e test
+- [ ] Browser UI toggle in `web/src/ui/sidebar.ts`
+- [ ] URL state: `?partition=1`
+- [ ] Verify K1-1 on tier2 cases
+- [ ] Verify K1-2 on tier3 partitioned case
+- [ ] Verify K1-3 on motivating failure case
+
+### Phase 2 — subtree decomposition
+
+- [ ] Add `ShardSplit` and `LumpyShardTap` trace events
+- [ ] Implement widest-recipe walker
+- [ ] Implement proportional shard allocator
+- [ ] Wire into `demand_partition` outer pass
+- [ ] Add `tier4_advanced_circuit_decomposed` e2e test
+- [ ] Browser URL state: `?decompose=1`
+- [ ] Verify K2-1 LOC budget
+- [ ] Verify K2-2 lumpy-tap rate on stress corpus
+
+### Rollout (post-both-phases)
+
+- [ ] Run full stress corpus with both flags on; compare
+      scoreboards to baseline
+- [ ] Decide per kill criteria: flip defaults, keep as opt-in, or
+      archive this RFP
+
+## Decision log
+
+Append entries. Date them. Don't skip this — it's the part that
+prevents "why did we drop this?" amnesia.
+
+- *2026-04-24 — RFP drafted. Brainstorm preceding this doc
+  established: (a) balancer width is the true constraint, not bus
+  width; (b) demand-partitioning and subtree-decomposition are
+  complementary outer/inner passes sharing a scaffolding layer;
+  (c) "belts over-provisioned" is the load-bearing assumption
+  behind dropping the pool-balancer. Both features to land as
+  off-by-default flags to keep the current path as baseline.*


### PR DESCRIPTION
## Intent

Two related pieces of work land together: (1) a density-scoring metric for layout results as a baseline measurement we can track against in future layout work, and (2) a revised version of the modular-production RFP originally proposed in #178, rethought around a `LayoutStrategy` enum and user-selectable peer strategies. Supersedes #178.

## Scope

- **In:**
  - `crates/core/src/density.rs` — `score_density(&LayoutResult, (u32,u32)) -> DensityScore`, re-exported from `lib.rs`
  - Wired into `crates/core/tests/e2e.rs` so every tier test prints `Layout: N entities, WxH; density: D.D% (RxR rect, F filled / A total tiles)` alongside its existing entity-count reporting
  - `docs/rfp-modular-production.md` — cherry-picked from #178 (preserving original authorship) in one commit, then revised in a follow-up commit so the diff-against-#178 stands on its own for review
  - Revisions: strategy enum instead of two booleans; strategies as peer citizens instead of trust-earning degradations; K1-1 retired → K1-4 inertness test; entity count becomes an observable per-strategy rather than a kill criterion; "belts over-provisioned" made numeric at 75% utilization ceiling; consumer pinned to per-recipe-row; "simple tee" acknowledged as a small balancer reusing `balancer_library.rs`; fluids out-of-scope; hierarchical-composition prototype pulled into Phase 1 to de-risk K2-2; Phase 0 split into 0a/0b with separate LOC budgets
- **Out:**
  - No implementation code for the RFP itself — still design-only, to be split across four follow-up PRs per the phasing plan
  - No escargio RFP — that's a separate upcoming doc that will slot in as additional `LayoutStrategy` variants on top of this scaffolding; called out in the decision log so Phase 0's `module_id` keying stays orientation-agnostic
  - Drive-by clippy fix in `crates/core/examples/diagnose_junctions.rs` from the density commit (one-line, needed to satisfy `-D warnings`)

## Verification

Density metric:

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — all 9 non-ignored e2e tests green; density lines appear under `--nocapture`
- [x] `cargo clippy --manifest-path crates/core/Cargo.toml --all-targets -- -D warnings` — clean
- [ ] WASM rebuild + browser eyeball — N/A, core-only change, density not exposed to WASM in this PR
- [ ] Snapshot inspection — N/A, no layout change

RFP:

- N/A — design document, the artifact is the doc itself

Density numbers captured in the subagent run that landed the metric (reproducible via `cargo test ... -- --nocapture`):

| Test | Density | Rect |
|------|---------|------|
| tier2_ec_splitter_stamp_regression | 47.8% | 36x36 |
| tier3_sulfuric_acid | 39.0% | 10x10 |
| tier1_iron_gear_wheel_20s | 32.6% | 30x30 |
| tier2_ec_20s_from_ore | 20.3% | 111x111 |
| tier1_iron_gear_wheel | 13.8% | 37x37 |
| tier1_iron_gear_wheel_from_ore | 6.9% | 102x102 |

The low scores on `from_ore` variants are aspect-skew driven (long thin layouts padded to square), which is itself useful signal — it's a proxy for "how much would folding help here," which informs the escargio RFP to come.

## Deviations from intent

- The RFP was landed as two commits rather than one: a clean cherry-pick preserving original authorship, then a revision commit on top. Rationale: makes the "what changed from #178" diff reviewable as its own thing without conflating it with the original proposal.
- The drive-by clippy fix in `diagnose_junctions.rs` wasn't planned but was needed to satisfy `cargo clippy --all-targets -- -D warnings` on the density commit's verification step.

## Models / contracts touched

- **New**: `DensityScore` struct and `score_density()` function in `crates/core::density` — a new public surface, but non-invasive (no existing code paths change).
- **Proposed (design-only, not yet implemented)**: `LayoutStrategy` enum and `LayoutOptions.strategy` field as the user-selection surface for bus shape. Captured in the RFP; contract doc updates will accompany Phase 0a's implementation PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvNYmVSoUWfJRW4PcLU2jj)_