### PR TITLE
feat(agent): memory orphan branch + Q&A terminal state

### DIFF
--- a/docs/agent-container.md
+++ b/docs/agent-container.md
@@ -106,7 +106,7 @@ and run one `run-watcher.sh` per name.
 | Label | Meaning |
 |-------|---------|
 | `<agent-name>-ready` | Issue is queued for this agent. Watcher claims it. Added by you, or by the watcher's scan phase when it detects a new human comment on a touched issue/PR. |
-| `agent-done` | Watcher opened a PR for this issue, OR the agent self-labelled after completing a research/sub-issues task. |
+| `agent-done` | Watcher opened a PR for this issue, OR the agent self-labelled after completing a research/sub-issues task, OR the agent self-labelled after answering a question. |
 | `agent-failed` | pi returned without opening a PR and without self-labelling `agent-done`; a log-tail comment is attached. |
 
 You create the `<agent-name>-ready` label once per agent. The watcher creates
@@ -154,6 +154,61 @@ issue (plus one per touched PR) per poll cycle. A fine-grained GitHub PAT
 has a 5000-requests-per-hour budget — comfortable up to ~80 touched issues
 at a 60s poll interval. Reduce `POLL_INTERVAL` further only if you have
 few touched issues.
+
+### Terminal states an agent can pick
+
+The base prompt the watcher hands to pi describes three possible "done"
+shapes. The agent picks whichever fits the task:
+
+| Shape | Terminal state | Typical task |
+|-------|---------------|--------------|
+| Code change | Open/update a PR that says `Closes #N` | "Fix the off-by-one in `foo.rs`" |
+| Research / audit | File sub-issues + comment with links + self-label `agent-done` | "Audit the web app for UX smells and create an issue per finding" |
+| Question / discussion | Reply with a comment + self-label `agent-done` | "Why does the ghost router use negotiated congestion instead of straight A\*?" |
+
+Mixing is allowed when natural — a code-change task that includes a
+question should get both the PR and the answer comment.
+
+### Agent memory
+
+Each agent has an orphan branch `agent-memory/<agent-name>` on the
+repository. Each subdirectory `issue-<N>/` under it is the agent's scratch
+space while working on issue #N — `understanding.md`, `progress.md`, and
+whatever other markdown the agent finds useful. The watcher auto-clones the
+memory branch on startup, mounts it as `/tmp/agent-memory/` inside the
+container, surfaces the per-issue subdirectory to the agent via the base
+prompt, and commits + pushes anything the agent wrote after pi exits.
+
+**Inspect what the agent has been thinking:**
+
+```sh
+git fetch origin agent-memory/misia
+git checkout agent-memory/misia    # from a throwaway clone or worktree
+ls                                  # issue-174/, issue-182/, ...
+cat issue-174/understanding.md
+```
+
+**Manually edit memory** (rare — useful if the agent has formed a wrong
+understanding you want to correct before the next pass):
+
+```sh
+git checkout agent-memory/misia
+# edit issue-<N>/understanding.md
+git commit -am "human: correcting misia's notes on #N"
+git push
+```
+
+Then re-queue the issue (label it `misia-ready`); the next pickup will see
+your edits and build on them.
+
+**Key properties:**
+- Orphan branch — shares no history with `main`, never merged.
+- One branch per agent, covering all issues that agent has touched.
+- Never deleted by `--reset` (the reset wipes the memory clone in the
+  container, but the remote branch is untouched — next container startup
+  re-clones it).
+- Not pushed if the agent didn't write anything to `issue-<N>/` during a
+  pickup.
 
 ### Windows-side prerequisites (llama.cpp backend)
 

--- a/scripts/agent-watcher.sh
+++ b/scripts/agent-watcher.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 
 REPO="${REPO:-storkme/fucktorio}"
 WORKSPACE="/tmp/workspace"
+MEM_DIR="/tmp/agent-memory"
+MEM_BRANCH="agent-memory/${AGENT_NAME}"
 AGENT_READY_LABEL="${AGENT_READY_LABEL:-${AGENT_NAME}-ready}"
 POLL_INTERVAL="${POLL_INTERVAL:-60}"
 STATE_FILE="/var/lib/agent/state.json"
@@ -86,6 +88,77 @@ EOF
 chmod +x "$HOOK"
 
 PERSONAL_PROMPT="$(cat "/usr/local/share/agents/${AGENT_NAME}.md")"
+
+# ---------------------------------------------------------------------------
+# Agent memory — a separate clone at $MEM_DIR tracking an orphan branch
+# (agent-memory/<agent-name>) where the agent writes per-issue notes. The
+# watcher clones/inits it at container start; commits and pushes after each
+# pickup if the agent changed anything in /tmp/agent-memory/issue-<N>/.
+# ---------------------------------------------------------------------------
+setup_memory_dir() {
+    if git -C "$WORKSPACE" ls-remote --exit-code origin \
+        "refs/heads/${MEM_BRANCH}" >/dev/null 2>&1; then
+        echo "using existing memory branch: ${MEM_BRANCH}"
+        rm -rf "$MEM_DIR"
+        git clone --depth 20 --single-branch --branch "$MEM_BRANCH" \
+            "https://github.com/${REPO}.git" "$MEM_DIR" --quiet
+    else
+        echo "initializing new memory branch: ${MEM_BRANCH}"
+        rm -rf "$MEM_DIR"
+        mkdir -p "$MEM_DIR"
+        cd "$MEM_DIR"
+        git init --quiet --initial-branch="$MEM_BRANCH"
+        git remote add origin "https://github.com/${REPO}.git"
+        cat > README.md <<EOF
+# Agent memory: ${AGENT_NAME}
+
+This orphan branch is a durable store of ${AGENT_NAME}'s working memory
+across issues. Each \`issue-<N>/\` subdirectory holds markdown notes the
+agent wrote while working on issue #N. Never merged to main.
+
+Inspect with:
+\`\`\`
+git fetch origin ${MEM_BRANCH}
+git checkout ${MEM_BRANCH}
+\`\`\`
+EOF
+        git add README.md
+        git commit --quiet -m "init agent memory"
+        git push --quiet origin "HEAD:${MEM_BRANCH}"
+        cd "$WORKSPACE"
+    fi
+}
+
+# Commit and push anything the agent changed under /tmp/agent-memory/issue-<N>/.
+# No-op if nothing changed. Best-effort push — a single failure is logged but
+# doesn't block the watcher.
+commit_memory() {
+    local num="$1"
+    local issue_mem_dir="${MEM_DIR}/issue-${num}"
+    if [ ! -d "$issue_mem_dir" ]; then
+        return 0
+    fi
+    (
+        cd "$MEM_DIR"
+        git add "issue-${num}/" 2>/dev/null || true
+        if ! git diff --cached --quiet 2>/dev/null; then
+            git commit --quiet -m "memory: issue #${num} (${AGENT_NAME})"
+            if ! git push --quiet origin "$MEM_BRANCH" 2>&1; then
+                echo "warning: memory push failed; re-sync on next pickup"
+                # Try to reconcile: fetch + rebase + push once more
+                git fetch origin "$MEM_BRANCH" --quiet 2>/dev/null || true
+                git rebase "origin/${MEM_BRANCH}" --quiet 2>/dev/null \
+                    || git rebase --abort 2>/dev/null || true
+                git push --quiet origin "$MEM_BRANCH" 2>/dev/null \
+                    || echo "warning: memory still not pushed; will retry next pickup"
+            else
+                echo "memory committed + pushed for issue #${num}"
+            fi
+        fi
+    )
+}
+
+setup_memory_dir
 
 # ---------------------------------------------------------------------------
 # State helpers
@@ -241,6 +314,10 @@ while :; do
     gh issue edit "$num" --repo "$REPO" \
         --remove-label "$AGENT_READY_LABEL" >/dev/null || true
 
+    # Ensure the per-issue memory dir exists (possibly populated from prior passes).
+    ISSUE_MEM_DIR="${MEM_DIR}/issue-${num}"
+    mkdir -p "$ISSUE_MEM_DIR"
+
     read -r -d '' BASE_PROMPT <<EOF || true
 You are ${AGENT_NAME}, working on GitHub issue #${num} in this repo.
 
@@ -249,6 +326,21 @@ Start with: gh issue view ${num}
 last pass, the human is probably asking you to refine, correct, or extend
 your previous work — read the thread carefully before deciding your
 approach.)
+
+**Working memory** for this issue lives at:
+    ${ISSUE_MEM_DIR}
+
+If that directory has files, they are notes from your past self — read them
+BEFORE you do anything else. You may have partially understood the issue
+before, tried approaches that didn't work, or formed a plan worth continuing.
+When you finish this pass, update (or create) files in that directory so a
+future pass picks up where you left off. Suggested files:
+  understanding.md  — what the issue is actually asking, any constraints
+  progress.md       — what has been attempted, what worked / didn't, next steps
+Feel free to add more files if useful (notes.md, open-questions.md, etc).
+The watcher commits and pushes this directory to a separate 'agent-memory'
+branch after you exit — don't commit it yourself and don't put it in the
+main workspace.
 
 Investigate the issue and decide what terminal state fits the task:
 
@@ -273,8 +365,23 @@ investigation, or a list of findings:
   5. Exit. Do NOT open a PR. Do NOT commit planning documents to the repo
      unless the issue explicitly asks for a documentation file.
 
+**Question / discussion tasks** — the issue (or a comment on it) asks a
+question, requests an explanation, or invites your opinion without asking
+for code changes or sub-issues:
+  1. Read the full comment thread AND the relevant code to form a substantive
+     answer. Prior comments may include earlier exchanges with you; account
+     for them — your comments start with '${NO_TRIGGER_SENTINEL}' so you can
+     recognise them.
+  2. Post a comment on the issue with your answer, starting the body with
+     '${NO_TRIGGER_SENTINEL}' on its own first line.
+  3. Add label 'agent-done' via
+     \`gh issue edit ${num} --add-label agent-done\`.
+  4. Exit. Do NOT open a PR. Do NOT file sub-issues.
+
 If the shape of the task is genuinely ambiguous, prefer issues over docs
-(they are easier to iterate on than files committed to main).
+(they are easier to iterate on than files committed to main). Questions
+that accompany a code-change ask should get a reply comment AND the code
+change — they're not mutually exclusive.
 
 If you decide the issue cannot or should not be solved at all, comment on
 the issue explaining why and exit — do not leave uncommitted work behind.
@@ -301,6 +408,9 @@ EOF
     set -e
 
     echo "pi exited rc=${rc}"
+
+    # Commit and push any memory the agent wrote for this issue.
+    commit_memory "$num"
 
     # Ground-truth outcome:
     #   - if a PR on this branch exists → code-change success (agent-done)


### PR DESCRIPTION
## Intent

Two conversation-supporting additions on top of [#177](https://github.com/storkme/fucktorio/pull/177):

1. **Persistent memory per agent** via an orphan branch `agent-memory/<agent-name>`. The watcher auto-clones (or inits) it, mounts it inside the container as `/tmp/agent-memory/`, and commits anything the agent wrote to `issue-<N>/*.md` after each pickup. Lets an agent form and carry forward an understanding of an issue across multiple passes without cluttering main.
2. **Third terminal state: question / discussion**. If an issue (or a comment on it) asks a question rather than requesting code, the agent now has a legitimate path: reply with a sentinel-prefixed comment, self-label `agent-done`, exit. No PR, no sub-issues. Addresses a gap in phase 4's prompt I caught while thinking about follow-up questions.

## Scope

**In:**
- Watcher sets up `/tmp/agent-memory/` at container start. If `agent-memory/<agent>` exists on origin, shallow-clone it; otherwise `git init --orphan`, add README, initial commit, push.
- Per pickup: `mkdir -p /tmp/agent-memory/issue-<N>/` before pi runs, so the agent sees any prior notes and has a place to write new ones.
- Post pi: `commit_memory` stages `issue-<N>/`, commits + pushes if anything changed. Handles a push-rejection with one fetch+rebase retry, then warns and moves on.
- Base prompt now surfaces the per-issue memory dir with usage guidance (read existing files first; update `understanding.md` + `progress.md` before exiting; file references only, no injection).
- Base prompt gains a third terminal state for question/discussion tasks and an updated "choose the right shape" heuristic that now covers all three paths.
- Docs: "Agent memory" section (how to inspect with `git fetch origin agent-memory/<agent>`, how to manually correct notes); "Terminal states an agent can pick" summary table; label state machine's `agent-done` row includes the Q&A path.

**Out:**
- Memory pruning/archiving when issues are closed. Branch grows unbounded for now; manual cleanup if it ever matters.
- Injecting prior notes into the prompt. The agent reads the files itself (by design — per your call on this).
- Memory per-PR (separate from the issue). Everything is keyed by issue number; PRs are "for" an issue and share its memory dir. Simpler.

## Verification

### Offline (done)

- [x] Build clean; no new tools needed.
- [x] `bash -n scripts/agent-watcher.sh` — clean.
- [x] Grep confirms the new prompt sections are present: "Working memory" (1 hit), "Question / discussion tasks" (1 hit), `setup_memory_dir` (def + call, 2 hits), `commit_memory` (def + call, 2 hits).

### Live (user to verify)

- [ ] First container start with a fresh remote: `git branch -a` (from inside `/tmp/agent-memory`) shows `agent-memory/misia` created; `git log` shows the init commit; `README.md` present; orphan (no connection to main's history).
- [ ] Subsequent container starts: reuses existing `agent-memory/misia` branch via shallow clone.
- [ ] Pickup with the agent writing to `/tmp/agent-memory/issue-N/understanding.md`: `commit_memory` commits + pushes; watcher log reports `memory committed + pushed for issue #N`. Commit visible on `agent-memory/misia` on GitHub.
- [ ] Pickup with the agent writing nothing: no commit; `git log` unchanged on the memory branch.
- [ ] `--reset misia` does not delete the remote `agent-memory/misia` branch. Next container restart re-clones it; memory preserved across resets.
- [ ] Q&A flow: file an issue with just a question; agent replies with a sentinel-prefixed comment and self-labels `agent-done`; no PR, no sub-issues.

## Deviations from plan

- Memory is pushed non-atomically (one commit at a time). If two watchers for the same agent ran simultaneously (not a supported configuration, but conceptually possible), they'd conflict on push. Detection via the single retry; worst case is a warning + slightly-stale local memory. Acceptable for single-watcher-per-agent.
- `commit_memory` uses `--quiet` everywhere and accepts failures on `push`, catching them with a rebase-retry fallback. No hard failure mode; the watcher continues whatever happens. Design choice: memory is additive and lossy-safe; don't block the main work loop on it.

## Models / contracts touched

None. Still the ops/infra lane; no project abstractions affected.