### PR TITLE
fix(web): allow shift+drag selection starting from empty tiles

### DIFF
--- a/web/src/renderer/selection.ts
+++ b/web/src/renderer/selection.ts
@@ -92,10 +92,6 @@ export function createSelectionController(
 
   const onDown = (e: PointerEvent) => {
     if (e.button !== 0 || !e.shiftKey) return;
-    const w = toWorld(e.clientX, e.clientY);
-    const tx = Math.floor(w.x / TILE_PX);
-    const ty = Math.floor(w.y / TILE_PX);
-    if (!tileMap.has(`${tx},${ty}`)) return;
     dragStart = { sx: e.clientX, sy: e.clientY };
     isDragging = false;
   };
@@ -121,11 +117,17 @@ export function createSelectionController(
       redrawBorders(selected);
       onSelectionChange(selected);
     } else if (dragStart !== null) {
-      // Shift was held but drag threshold not reached — Shift+click on empty
-      // space. Clear selection; entity clicks are handled by their own handlers.
-      selected = [];
-      borderG.clear();
-      onSelectionChange([]);
+      // Shift was held but drag threshold not reached — Shift+click.
+      // Only clear selection when clicking on an entity; clicking empty
+      // space is pure navigation and leaves selection untouched.
+      const w = toWorld(e.clientX, e.clientY);
+      const tx = Math.floor(w.x / TILE_PX);
+      const ty = Math.floor(w.y / TILE_PX);
+      if (tileMap.has(`${tx},${ty}`)) {
+        selected = [];
+        borderG.clear();
+        onSelectionChange([]);
+      }
     }
     // Plain click/drag with no Shift: pure navigation — leave selection alone.
     dragStart = null;


### PR DESCRIPTION
<!-- agent-no-trigger -->
🐛 🔧

## Problem

Shift+drag selection doesn't work when starting the drag on an empty tile. This is a regression introduced in #162, which added an early return in `onDown` that only allows shift+drag to start when the pointer-down tile has an entity.

## Fix

1. **Remove the empty-tile check in `onDown`** — shift+drag now starts a selection rectangle from any tile, not just tiles with entities.
2. **Adjust `onUp` click behavior** — shift+click only clears selection when the click lands on an entity. Clicking empty space is treated as pure navigation and leaves the current selection untouched.

This restores the original behavior where shift+drag works from any starting position, while preserving the #162 intent that plain click-drag (no Shift) doesn't clear selection.

Closes #184