### PR TITLE
RFP modular production: review fixes + Phase 0 scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +64,15 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -92,6 +110,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +164,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tsify-next",
  "varisat",
@@ -154,6 +193,16 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -214,6 +263,12 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
@@ -483,6 +538,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +794,12 @@ name = "vec_mut_scan"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ed610a8d5e63d9c0e31300e8fdb55104c5f21e422743a9dc74848fa8317fd2"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -26,3 +26,4 @@ web-time = "1"
 
 [dev-dependencies]
 ntest = "0.9"
+sha2 = "0.10"

--- a/crates/core/examples/capture_ac_am3_ore.rs
+++ b/crates/core/examples/capture_ac_am3_ore.rs
@@ -11,7 +11,7 @@
 //! Prints the cluster seeds the region solver encounters + writes one
 //! fixture per cluster to `$FUCKTORIO_DUMP_REGION_FIXTURE` (when set).
 
-use fucktorio_core::bus::layout::build_bus_layout;
+use fucktorio_core::bus::layout::{build_bus_layout, LayoutOptions};
 use fucktorio_core::solver;
 use rustc_hash::FxHashSet;
 
@@ -34,7 +34,7 @@ fn main() {
                 std::process::exit(1);
             });
 
-    let layout = build_bus_layout(&solver_result, Some("transport-belt"))
+    let layout = build_bus_layout(&solver_result, LayoutOptions::from_belt_tier(Some("transport-belt")))
         .unwrap_or_else(|e| {
             eprintln!("layout failed: {e}");
             std::process::exit(1);

--- a/crates/core/examples/capture_ec_am1_seed_3_8.rs
+++ b/crates/core/examples/capture_ec_am1_seed_3_8.rs
@@ -12,7 +12,7 @@
 //!     cargo run --manifest-path crates/core/Cargo.toml \
 //!     --example capture_ec_am1_seed_3_8 --release
 
-use fucktorio_core::bus::layout::build_bus_layout;
+use fucktorio_core::bus::layout::{build_bus_layout, LayoutOptions};
 use fucktorio_core::solver;
 use rustc_hash::FxHashSet;
 
@@ -39,7 +39,7 @@ fn main() {
                 std::process::exit(1);
             });
 
-    let layout = build_bus_layout(&solver_result, None)
+    let layout = build_bus_layout(&solver_result, LayoutOptions::default())
         .unwrap_or_else(|e| {
             eprintln!("layout failed: {e}");
             std::process::exit(1);

--- a/crates/core/examples/diagnose_junctions.rs
+++ b/crates/core/examples/diagnose_junctions.rs
@@ -10,7 +10,7 @@
 
 use std::collections::BTreeMap;
 
-use fucktorio_core::bus::layout::build_bus_layout_traced;
+use fucktorio_core::bus::layout::{build_bus_layout_traced, LayoutOptions};
 use fucktorio_core::models::{EntityDirection, LayoutRegion, PortIo, RegionKind, RegionPort};
 use fucktorio_core::solver;
 use fucktorio_core::trace::TraceEvent;
@@ -142,7 +142,10 @@ fn run_case(label: &str, recipe: &str, rate: f64, machine: &str, inputs: &[&str]
     let solver_result = solver::solve(recipe, rate, &input_set, machine)
         .expect("solve");
 
-    let layout = build_bus_layout_traced(&solver_result, Some("transport-belt"))
+    let layout = build_bus_layout_traced(
+        &solver_result,
+        LayoutOptions::from_belt_tier(Some("transport-belt")),
+    )
         .expect("layout");
 
     // validate returns Err when errors are found; the issues live inside
@@ -492,7 +495,11 @@ fn run_case_with_belt(
 ) {
     let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
     let solver_result = solver::solve(recipe, rate, &input_set, machine).expect("solve");
-    let layout = build_bus_layout_traced(&solver_result, max_belt_tier).expect("layout");
+    let layout = build_bus_layout_traced(
+        &solver_result,
+        LayoutOptions::from_belt_tier(max_belt_tier),
+    )
+        .expect("layout");
     let issues = match validate::validate(&layout, Some(&solver_result), LayoutStyle::Bus) {
         Ok(issues) => issues,
         Err(e) => e.issues,

--- a/crates/core/examples/dump_layout.rs
+++ b/crates/core/examples/dump_layout.rs
@@ -3,7 +3,7 @@
 //! Usage: cargo run -p fucktorio_core --example dump_layout [recipe] [rate]
 //! Default: iron-gear-wheel 10.0
 
-use fucktorio_core::bus::layout::build_bus_layout;
+use fucktorio_core::bus::layout::{build_bus_layout, LayoutOptions};
 use fucktorio_core::models::LayoutResult;
 use fucktorio_core::solver;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -34,7 +34,7 @@ fn main() {
     }
     println!();
 
-    let layout = match build_bus_layout(&solver_result, None) {
+    let layout = match build_bus_layout(&solver_result, LayoutOptions::default()) {
         Ok(l) => l,
         Err(e) => {
             eprintln!("layout failed: {}", e);

--- a/crates/core/examples/trace_junction.rs
+++ b/crates/core/examples/trace_junction.rs
@@ -24,7 +24,7 @@
 use std::collections::BTreeMap;
 use std::env;
 
-use fucktorio_core::bus::layout::build_bus_layout_traced;
+use fucktorio_core::bus::layout::{build_bus_layout_traced, LayoutOptions};
 use fucktorio_core::solver;
 use fucktorio_core::trace::{BoundarySnapshot, StampedNeighbor, TraceEvent};
 use rustc_hash::FxHashSet;
@@ -66,7 +66,7 @@ fn main() {
         }
     };
 
-    let layout = match build_bus_layout_traced(&solver_result, None) {
+    let layout = match build_bus_layout_traced(&solver_result, LayoutOptions::default()) {
         Ok(l) => l,
         Err(e) => {
             eprintln!("layout failed: {e}");

--- a/crates/core/examples/validate_ac_am3_ore.rs
+++ b/crates/core/examples/validate_ac_am3_ore.rs
@@ -2,7 +2,7 @@
 //! pipeline and report validator error/warning counts. Used to verify
 //! the clustering change doesn't regress the AM3 layout.
 
-use fucktorio_core::bus::layout::build_bus_layout;
+use fucktorio_core::bus::layout::{build_bus_layout, LayoutOptions};
 use fucktorio_core::solver;
 use fucktorio_core::validate::{self, LayoutStyle, Severity};
 use rustc_hash::FxHashSet;
@@ -19,7 +19,7 @@ fn main() {
         solver::solve("advanced-circuit", 5.0, &inputs, "assembling-machine-3")
             .unwrap();
 
-    let layout = build_bus_layout(&solver_result, Some("transport-belt")).unwrap();
+    let layout = build_bus_layout(&solver_result, LayoutOptions::from_belt_tier(Some("transport-belt"))).unwrap();
 
     let issues = match validate::validate(&layout, Some(&solver_result), LayoutStyle::Bus) {
         Ok(v) => v,

--- a/crates/core/src/bus/balancer.rs
+++ b/crates/core/src/bus/balancer.rs
@@ -91,6 +91,24 @@ pub(crate) fn balancer_origin_x(lane_xs: &[i32], output_tiles: &[(i32, i32)]) ->
     lane_xs[0] - output_tiles[0].0
 }
 
+/// Build the `segment_id` string for a stamped balancer.
+///
+/// Under `LayoutStrategy::Pooled` every family has `module_id == 0`,
+/// and the produced string is byte-identical to the pre-RFP format
+/// (`balancer:{item}:{n}x{m}` or `…:{group}` for decomposition). The
+/// `:mod{N}` suffix only appears when partitioning produced multiple
+/// modules per item — see `docs/rfp-modular-production.md`.
+fn format_segment_id(item: &str, module_id: u32, n: u32, m: u32, group: Option<usize>) -> String {
+    let mut s = format!("balancer:{item}:{n}x{m}");
+    if let Some(gi) = group {
+        s.push_str(&format!(":{gi}"));
+    }
+    if module_id != 0 {
+        s.push_str(&format!(":mod{module_id}"));
+    }
+    s
+}
+
 /// Stamp a balancer template at the family's origin position.
 ///
 /// Template entity tiles are offset by the family's stamp origin
@@ -126,7 +144,7 @@ pub(crate) fn stamp_family_balancer(
             origin_x, origin_y, belt_tier, splitter_name, ug_name,
             Some(&family.item),
         );
-        let seg_id = Some(format!("balancer:{}:{}x{}", family.item, n, m));
+        let seg_id = Some(format_segment_id(&family.item, family.module_id, n, m, None));
         for ent in &mut entities {
             ent.segment_id = seg_id.clone();
         }
@@ -161,7 +179,7 @@ pub(crate) fn stamp_family_balancer(
                     sub_origin_x, sub_origin_y, belt_tier, splitter_name, ug_name,
                     Some(&family.item),
                 );
-                let sub_seg = format!("balancer:{}:{}x{}:{}", family.item, sub_n, sub_m, gi);
+                let sub_seg = format_segment_id(&family.item, family.module_id, sub_n, sub_m, Some(gi));
                 for ent in &mut ents {
                     ent.segment_id = Some(sub_seg.clone());
                 }
@@ -184,6 +202,7 @@ mod tests {
     fn test_stamp_family_balancer() {
         let family = LaneFamily {
             item: "iron-plate".to_string(),
+            module_id: 0,
             shape: (1, 2),  // 1 producer, 2 lanes
             producer_rows: vec![0],
             lane_xs: vec![1, 2],

--- a/crates/core/src/bus/lane_planner.rs
+++ b/crates/core/src/bus/lane_planner.rs
@@ -120,6 +120,11 @@ impl BusLane {
 pub struct LaneFamily {
     /// Item name shared by all lanes in this family.
     pub item: String,
+    /// Module index within the item: `0` under `LayoutStrategy::Pooled`
+    /// (one family per item). Phase 1 of `rfp-modular-production`
+    /// distinguishes multiple `(item, module_id)` families per item;
+    /// see the RFP for the partitioning algorithm.
+    pub module_id: u32,
     /// `(N producers, M lanes)` — the balancer shape.
     pub shape: (usize, usize),
     /// Row indices of the N producers feeding into this balancer.
@@ -361,6 +366,7 @@ pub fn plan_bus_lanes(
         }).collect(),
         families: families.iter().map(|f| crate::trace::FamilyInfo {
             item: f.item.clone(),
+            module_id: f.module_id,
             shape: f.shape,
             lane_xs: f.lane_xs.clone(),
             balancer_y_start: f.balancer_y_start,
@@ -529,6 +535,7 @@ fn split_overflowing_lanes(
 
             families.push(LaneFamily {
                 item: lane.item.clone(),
+                module_id: 0,
                 shape,
                 producer_rows: all_producer_rows.to_vec(),
                 lane_xs: Vec::new(),

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -14,6 +14,42 @@ use crate::bus::lane_planner::{
 };
 use crate::bus::placer::{place_rows, RowSpan};
 
+/// Layout strategy. Selects the shape of the bus the engine produces.
+/// See `docs/rfp-modular-production.md` for the rationale.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum LayoutStrategy {
+    /// One shared lane family per item, single balancer at the producer
+    /// row. Capped at 8 lanes per item.
+    #[default]
+    Pooled,
+    /// One lane family per consuming recipe-row, sized to that
+    /// consumer's exact demand, no pool-balancer. Phase 1 (RFP).
+    PartitionedPerConsumer,
+    /// `PartitionedPerConsumer` plus subtree sharding when a single
+    /// module's widest upstream recipe still exceeds 8 lanes. Phase 2.
+    PartitionedDecomposed,
+}
+
+/// Per-call options for `build_bus_layout`. New struct; absorbs the
+/// previous `max_belt_tier` parameter so future per-call options
+/// (strategy, escargio fold parameters, …) attach as additional fields.
+#[derive(Clone, Debug, Default)]
+pub struct LayoutOptions {
+    pub strategy: LayoutStrategy,
+    pub max_belt_tier: Option<String>,
+}
+
+impl LayoutOptions {
+    /// Convenience: keep today's call shape working for tests / examples
+    /// that only care about the belt tier.
+    pub fn from_belt_tier(max_belt_tier: Option<&str>) -> Self {
+        Self {
+            strategy: LayoutStrategy::default(),
+            max_belt_tier: max_belt_tier.map(|s| s.to_string()),
+        }
+    }
+}
+
 /// Convert a SolverResult into a bus-style LayoutResult.
 ///
 /// Returns a LayoutResult with:
@@ -22,8 +58,18 @@ use crate::bus::placer::{place_rows, RowSpan};
 /// - height: maximum y dimension used
 pub fn build_bus_layout(
     solver_result: &SolverResult,
-    max_belt_tier: Option<&str>,
+    opts: LayoutOptions,
 ) -> Result<LayoutResult, String> {
+    match opts.strategy {
+        LayoutStrategy::Pooled => {}
+        LayoutStrategy::PartitionedPerConsumer => {
+            unimplemented!("PartitionedPerConsumer strategy is wired in Phase 1 (rfp-modular-production)");
+        }
+        LayoutStrategy::PartitionedDecomposed => {
+            unimplemented!("PartitionedDecomposed strategy is wired in Phase 2 (rfp-modular-production)");
+        }
+    }
+    let max_belt_tier = opts.max_belt_tier.as_deref();
     // Final product items get EAST-flowing output belts (merge at right side)
     let final_output_items: FxHashSet<String> = solver_result
         .external_outputs
@@ -337,10 +383,10 @@ pub fn build_bus_layout(
 /// them in `LayoutResult.trace`. Zero overhead when using the non-traced entry point.
 pub fn build_bus_layout_traced(
     solver_result: &SolverResult,
-    max_belt_tier: Option<&str>,
+    opts: LayoutOptions,
 ) -> Result<LayoutResult, String> {
     let _guard = crate::trace::start_trace();
-    let mut result = build_bus_layout(solver_result, max_belt_tier)?;
+    let mut result = build_bus_layout(solver_result, opts)?;
     result.trace = Some(crate::trace::drain_events());
     Ok(result)
 }
@@ -350,12 +396,12 @@ pub fn build_bus_layout_traced(
 /// the web app to render pipeline progress live while the engine runs.
 pub fn build_bus_layout_streaming(
     solver_result: &SolverResult,
-    max_belt_tier: Option<&str>,
+    opts: LayoutOptions,
     mut on_event: Box<dyn FnMut(&crate::trace::TraceEvent)>,
 ) -> Result<LayoutResult, String> {
     let _collector_guard = crate::trace::start_trace();
     let _sink_guard = crate::trace::set_sink(Box::new(move |evt| on_event(evt)));
-    let mut result = build_bus_layout(solver_result, max_belt_tier)?;
+    let mut result = build_bus_layout(solver_result, opts)?;
     result.trace = Some(crate::trace::drain_events());
     Ok(result)
 }

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -817,6 +817,11 @@ pub struct LaneInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FamilyInfo {
     pub item: String,
+    /// `0` under `LayoutStrategy::Pooled`. Distinguishes multiple
+    /// `(item, module_id)` families per item under the partitioning
+    /// strategies — see `docs/rfp-modular-production.md`.
+    #[serde(default)]
+    pub module_id: u32,
     pub shape: (usize, usize),
     pub lane_xs: Vec<i32>,
     pub balancer_y_start: i32,

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -196,7 +196,10 @@ fn run_e2e_with_exclusions(
             msg
         })?;
 
-    let layout = layout::build_bus_layout(&solver_result, belt_tier)
+    let layout = layout::build_bus_layout(
+        &solver_result,
+        layout::LayoutOptions::from_belt_tier(belt_tier),
+    )
         .map_err(|e| {
             let msg = format!("layout: {e}");
             dump_partial_snapshot(test_name, &run_params, Some(&solver_result), &msg);
@@ -341,6 +344,97 @@ fn assert_produces(result: &E2EResult, item: &str, min_rate: f64) {
     );
 }
 
+/// Compute a deterministic SHA-256 hash of `layout.entities` over the
+/// structural fields a Phase 0a refactor must preserve under
+/// `LayoutStrategy::Pooled`. Excludes `rate` (Option<f64>) and `items`
+/// (not yet structurally stable across the bus pipeline).
+fn golden_hash(layout: &fucktorio_core::models::LayoutResult) -> String {
+    use sha2::{Digest, Sha256};
+    let mut sorted: Vec<_> = layout.entities.iter().collect();
+    sorted.sort_by(|a, b| {
+        (
+            a.name.as_str(),
+            a.x,
+            a.y,
+            a.direction as u8,
+            a.recipe.as_deref().unwrap_or(""),
+            a.carries.as_deref().unwrap_or(""),
+            a.segment_id.as_deref().unwrap_or(""),
+        )
+            .cmp(&(
+                b.name.as_str(),
+                b.x,
+                b.y,
+                b.direction as u8,
+                b.recipe.as_deref().unwrap_or(""),
+                b.carries.as_deref().unwrap_or(""),
+                b.segment_id.as_deref().unwrap_or(""),
+            ))
+    });
+    let mut hasher = Sha256::new();
+    for e in sorted {
+        hasher.update(e.name.as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(e.x.to_le_bytes());
+        hasher.update(e.y.to_le_bytes());
+        hasher.update([e.direction as u8, e.mirror as u8]);
+        hasher.update(e.recipe.as_deref().unwrap_or("").as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(e.carries.as_deref().unwrap_or("").as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(e.segment_id.as_deref().unwrap_or("").as_bytes());
+        hasher.update(b"\x1e");
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// K0-1 regression gate from `docs/rfp-modular-production.md`. Asserts
+/// that the layout produced under `LayoutStrategy::Pooled` is
+/// byte-identical (over structural fields) to the committed baseline.
+/// To regenerate after an intentional layout change:
+/// `FUCKTORIO_GOLDEN_DUMP=1 cargo test --test e2e -- --nocapture`,
+/// then paste the printed hashes into `GOLDEN_HASHES`.
+fn assert_golden_hash(result: &E2EResult, test_name: &str) {
+    let computed = golden_hash(&result.layout);
+    if std::env::var("FUCKTORIO_GOLDEN_DUMP").is_ok() {
+        eprintln!("    (\"{test_name}\", \"{computed}\"),");
+        return;
+    }
+    let expected = GOLDEN_HASHES
+        .iter()
+        .find(|(name, _)| *name == test_name)
+        .map(|(_, hash)| *hash);
+    match expected {
+        Some(expected) if expected == computed => {}
+        Some(expected) => panic!(
+            "Golden hash mismatch for `{test_name}` (K0-1 regression).\n  \
+             expected: {expected}\n  computed: {computed}\n  \
+             If this is an intentional layout change, regenerate with \
+             FUCKTORIO_GOLDEN_DUMP=1."
+        ),
+        None => panic!(
+            "No golden hash registered for `{test_name}`. \
+             Run `FUCKTORIO_GOLDEN_DUMP=1 cargo test --test e2e -- --nocapture` \
+             to capture. Computed: {computed}"
+        ),
+    }
+}
+
+/// K0-1 byte-equality regression table. Entries are
+/// `(test_name, sha256_hex_of_entities)`. Captured under
+/// `LayoutStrategy::Pooled` on the pre-RFP baseline.
+const GOLDEN_HASHES: &[(&str, &str)] = &[
+    ("tier1_iron_gear_wheel", "c3ad3100d0d4a68befa8b6beb05f200ad25a60b41e89a98e490a61486a958ccd"),
+    ("tier1_iron_gear_wheel_from_ore", "3cd35e7f5cd6a06fb84df10f902b6726f9ce8c6f66d557989fada973c4eacb3b"),
+    ("tier1_iron_gear_wheel_20s", "cb9db5d05c01524432c2f4524e3e8eaa50b8957b8a764622fc9c59dfcc27fffd"),
+    ("tier2_electronic_circuit_from_ore", "b3fdf981f86d7794b0346424123a553436b04628a77d45fb01fc56f9cb2bf044"),
+    ("tier2_electronic_circuit_20s_from_ore", "6187078fcdbfebd265d1417c0b71650951fed4c3d2c216c29801fd5ee2917104"),
+    ("tier2_electronic_circuit_splitter_stamp_regression", "1240c095aece437a4e9268580028625e7521e29e4f5015712dfed2f693c46e9e"),
+    ("tier3_plastic_bar", "6985e6c920c10e4f20ec4c7b18bbb0cde98a6a8c030787e85a3f8ab3618e70fb"),
+    ("tier3_sulfuric_acid", "091765fa6a50b4438137e0500e32eb8378ed22224f9b58843070cb70d6561bcd"),
+    ("tier3_heavy_oil_cracking", "9b7e04e97a65d99c6f001a8e6f67eaf69d348e56417093788cfd19369adb9cd1"),
+];
+
 fn assert_round_trip(result: &E2EResult) {
     // Check entity count and per-entity position/direction/name.
     // Metadata like carries, segment_id, and rate are lost in the blueprint
@@ -401,6 +495,7 @@ fn tier1_iron_gear_wheel() {
     assert_no_warnings(&result);
     assert_produces(&result, "iron-gear-wheel", 10.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier1_iron_gear_wheel");
 }
 
 #[test]
@@ -421,6 +516,7 @@ fn tier1_iron_gear_wheel_from_ore() {
     assert_no_warnings(&result);
     assert_produces(&result, "iron-gear-wheel", 10.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier1_iron_gear_wheel_from_ore");
 }
 
 #[test]
@@ -434,6 +530,7 @@ fn tier1_iron_gear_wheel_20s() {
     assert_no_warnings(&result);
     assert_produces(&result, "iron-gear-wheel", 20.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier1_iron_gear_wheel_20s");
 }
 
 // ---------------------------------------------------------------------------
@@ -518,6 +615,7 @@ fn tier2_electronic_circuit_from_ore() {
     assert_no_warnings_except(&result, &["power"]);
     assert_produces(&result, "electronic-circuit", 10.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier2_electronic_circuit_from_ore");
 }
 
 #[test]
@@ -543,6 +641,7 @@ fn tier2_electronic_circuit_20s_from_ore() {
     assert_no_warnings_except(&result, &["power"]);
     assert_produces(&result, "electronic-circuit", 20.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier2_electronic_circuit_20s_from_ore");
 }
 
 /// Regression test for the splitter-stamp sideload-into-UG-input bug that the
@@ -596,6 +695,7 @@ fn tier2_electronic_circuit_splitter_stamp_regression() {
     );
     // Ensure the layout can actually produce items (no solver/routing failure).
     assert_produces(&result, "electronic-circuit", 10.0);
+    assert_golden_hash(&result, "tier2_electronic_circuit_splitter_stamp_regression");
 }
 
 // ---------------------------------------------------------------------------
@@ -617,6 +717,7 @@ fn tier3_plastic_bar() {
     assert_no_warnings(&result);
     assert_produces(&result, "plastic-bar", 10.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier3_plastic_bar");
 }
 
 #[test]
@@ -652,6 +753,7 @@ fn tier3_sulfuric_acid() {
     assert_no_warnings(&result);
     assert_produces(&result, "sulfuric-acid", 5.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier3_sulfuric_acid");
 }
 
 #[test]
@@ -680,6 +782,7 @@ fn tier3_heavy_oil_cracking() {
     assert_no_warnings(&result);
     assert_produces(&result, "light-oil", 5.0);
     assert_round_trip(&result);
+    assert_golden_hash(&result, "tier3_heavy_oil_cracking");
 }
 
 // ---------------------------------------------------------------------------
@@ -753,7 +856,7 @@ fn diag_validator_timing_from_ore() {
     let inputs: FxHashSet<String> = ["iron-ore"].iter().map(|s| s.to_string()).collect();
     let sr = solver::solve("iron-gear-wheel", 10.0, &inputs, "assembling-machine-2")
         .unwrap_or_else(|e| panic!("solver (iron-gear-wheel from ore): {e}"));
-    let lr = layout::build_bus_layout(&sr, None)
+    let lr = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
         .unwrap_or_else(|e| panic!("layout (iron-gear-wheel from ore): {e}"));
     eprintln!("=== iron-gear-wheel from ore ===");
     eprintln!("Layout: {} entities, {}x{}", lr.entities.len(), lr.width, lr.height);
@@ -763,7 +866,10 @@ fn diag_validator_timing_from_ore() {
     let inputs2: FxHashSet<String> = ["iron-ore", "copper-ore"].iter().map(|s| s.to_string()).collect();
     let sr2 = solver::solve("electronic-circuit", 10.0, &inputs2, "assembling-machine-1")
         .unwrap_or_else(|e| panic!("solver (electronic-circuit from ore): {e}"));
-    let lr2 = layout::build_bus_layout(&sr2, Some("transport-belt"))
+    let lr2 = layout::build_bus_layout(
+        &sr2,
+        layout::LayoutOptions::from_belt_tier(Some("transport-belt")),
+    )
         .unwrap_or_else(|e| panic!("layout (electronic-circuit from ore): {e}"));
     eprintln!("\n=== electronic-circuit from ore ===");
     eprintln!("Layout: {} entities, {}x{}", lr2.entities.len(), lr2.width, lr2.height);
@@ -1467,7 +1573,10 @@ fn diag_ghost_cluster_helper(
         let _guard = trace::start_trace();
         let solver_result = solver::solve(item, rate, inputs, machine)
             .unwrap_or_else(|e| panic!("{test_name}: solver: {e}"));
-        let layout = layout::build_bus_layout(&solver_result, belt_tier)
+        let layout = layout::build_bus_layout(
+            &solver_result,
+            layout::LayoutOptions::from_belt_tier(belt_tier),
+        )
             .unwrap_or_else(|e| panic!("{test_name}: layout: {e}"));
         let trace_events = trace::drain_events();
         let analysis = analysis::analyze(&layout);

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -12,11 +12,24 @@ use fucktorio_core::models::{LayoutResult, PlacedEntity, SolverResult};
 use fucktorio_core::validate::{self, LayoutStyle, ValidationIssue};
 use fucktorio_core::{
     blueprint, blueprint_parser, bus::junction_cost::solution_cost,
-    bus::layout::{build_bus_layout, LayoutOptions}, fixture as fixture_mod, recipe_db, sat, solver,
+    bus::layout::{build_bus_layout, LayoutOptions, LayoutStrategy},
+    fixture as fixture_mod, recipe_db, sat, solver,
 };
 use rustc_hash::FxHashSet;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
+
+/// Build `LayoutOptions` from the optional belt-tier and strategy strings
+/// passed in across the WASM boundary. The TS engine layer validates URL
+/// params, so unknown strategy strings fall back to `Pooled` silently.
+fn layout_options(max_belt_tier: Option<String>, strategy: Option<String>) -> LayoutOptions {
+    let strategy = match strategy.as_deref() {
+        Some("partitioned-per-consumer") => LayoutStrategy::PartitionedPerConsumer,
+        Some("partitioned-decomposed") => LayoutStrategy::PartitionedDecomposed,
+        _ => LayoutStrategy::Pooled,
+    };
+    LayoutOptions { strategy, max_belt_tier }
+}
 
 #[wasm_bindgen]
 pub fn init() {
@@ -51,8 +64,12 @@ pub fn default_machine_for_item(item: &str, fallback: &str) -> String {
 }
 
 #[wasm_bindgen]
-pub fn layout(solver_result: SolverResult, max_belt_tier: Option<String>) -> Result<LayoutResult, JsError> {
-    build_bus_layout(&solver_result, LayoutOptions::from_belt_tier(max_belt_tier.as_deref()))
+pub fn layout(
+    solver_result: SolverResult,
+    max_belt_tier: Option<String>,
+    strategy: Option<String>,
+) -> Result<LayoutResult, JsError> {
+    build_bus_layout(&solver_result, layout_options(max_belt_tier, strategy))
         .map_err(|e| JsError::new(&e))
 }
 
@@ -61,10 +78,14 @@ pub fn layout(solver_result: SolverResult, max_belt_tier: Option<String>) -> Res
 /// routing is the only routing path — the legacy direct router was
 /// deleted; both `layout()` and `layout_traced()` go through it.
 #[wasm_bindgen]
-pub fn layout_traced(solver_result: SolverResult, max_belt_tier: Option<String>) -> Result<LayoutResult, JsError> {
+pub fn layout_traced(
+    solver_result: SolverResult,
+    max_belt_tier: Option<String>,
+    strategy: Option<String>,
+) -> Result<LayoutResult, JsError> {
     fucktorio_core::bus::layout::build_bus_layout_traced(
         &solver_result,
-        LayoutOptions::from_belt_tier(max_belt_tier.as_deref()),
+        layout_options(max_belt_tier, strategy),
     )
     .map_err(|e| JsError::new(&e))
 }
@@ -110,6 +131,7 @@ fn streamable(evt: &fucktorio_core::trace::TraceEvent) -> bool {
 pub fn layout_streaming(
     solver_result: SolverResult,
     max_belt_tier: Option<String>,
+    strategy: Option<String>,
     emit: &js_sys::Function,
 ) -> Result<LayoutResult, JsError> {
     let emit = emit.clone();
@@ -123,7 +145,7 @@ pub fn layout_streaming(
     });
     fucktorio_core::bus::layout::build_bus_layout_streaming(
         &solver_result,
-        LayoutOptions::from_belt_tier(max_belt_tier.as_deref()),
+        layout_options(max_belt_tier, strategy),
         on_event,
     )
     .map_err(|e| JsError::new(&e))

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -12,7 +12,7 @@ use fucktorio_core::models::{LayoutResult, PlacedEntity, SolverResult};
 use fucktorio_core::validate::{self, LayoutStyle, ValidationIssue};
 use fucktorio_core::{
     blueprint, blueprint_parser, bus::junction_cost::solution_cost,
-    bus::layout::build_bus_layout, fixture as fixture_mod, recipe_db, sat, solver,
+    bus::layout::{build_bus_layout, LayoutOptions}, fixture as fixture_mod, recipe_db, sat, solver,
 };
 use rustc_hash::FxHashSet;
 use serde::Serialize;
@@ -52,7 +52,8 @@ pub fn default_machine_for_item(item: &str, fallback: &str) -> String {
 
 #[wasm_bindgen]
 pub fn layout(solver_result: SolverResult, max_belt_tier: Option<String>) -> Result<LayoutResult, JsError> {
-    build_bus_layout(&solver_result, max_belt_tier.as_deref()).map_err(|e| JsError::new(&e))
+    build_bus_layout(&solver_result, LayoutOptions::from_belt_tier(max_belt_tier.as_deref()))
+        .map_err(|e| JsError::new(&e))
 }
 
 /// Traced variant of `layout()`. Returns the same `LayoutResult` plus
@@ -61,8 +62,11 @@ pub fn layout(solver_result: SolverResult, max_belt_tier: Option<String>) -> Res
 /// deleted; both `layout()` and `layout_traced()` go through it.
 #[wasm_bindgen]
 pub fn layout_traced(solver_result: SolverResult, max_belt_tier: Option<String>) -> Result<LayoutResult, JsError> {
-    fucktorio_core::bus::layout::build_bus_layout_traced(&solver_result, max_belt_tier.as_deref())
-        .map_err(|e| JsError::new(&e))
+    fucktorio_core::bus::layout::build_bus_layout_traced(
+        &solver_result,
+        LayoutOptions::from_belt_tier(max_belt_tier.as_deref()),
+    )
+    .map_err(|e| JsError::new(&e))
 }
 
 /// Filter predicate — determines which TraceEvent variants are forwarded to
@@ -119,7 +123,7 @@ pub fn layout_streaming(
     });
     fucktorio_core::bus::layout::build_bus_layout_streaming(
         &solver_result,
-        max_belt_tier.as_deref(),
+        LayoutOptions::from_belt_tier(max_belt_tier.as_deref()),
         on_event,
     )
     .map_err(|e| JsError::new(&e))

--- a/docs/rfp-modular-production.md
+++ b/docs/rfp-modular-production.md
@@ -107,16 +107,19 @@ pub enum LayoutStrategy {
     PartitionedDecomposed,
 }
 
+// New struct. Today's signature is
+// `build_bus_layout(solver_result, max_belt_tier)`; the existing
+// `max_belt_tier` arg folds in here, and future per-call options
+// (e.g. escargio's fold parameters) attach as additional fields.
 pub struct LayoutOptions {
     pub strategy: LayoutStrategy,   // default: LayoutStrategy::Pooled
-    // ... existing options merged in
+    pub max_belt_tier: Option<String>,
 }
 
 pub fn build_bus_layout(
     solver: &SolverResult,
-    belt_tier: BeltTier,
     opts: LayoutOptions,
-) -> LayoutResult;
+) -> Result<LayoutResult, String>;
 ```
 
 `LayoutStrategy::default() == Pooled`. With the default selected the
@@ -214,6 +217,12 @@ granularity to make `LaneFamily` splitting meaningful.
    consumer, each sized to that consumer's demand.
 5. No pool-balancer is stamped. If K > 1, no single-family balancer
    needs to be wider than the widest single consumer's lane count.
+6. The K producer-rows allocated in step 4 are themselves K
+   consumers of every shared upstream ingredient. Step 1 applies
+   recursively up-tree: an ingredient with K' = K consuming
+   producer-rows for item X gets K' lane families of its own. This
+   is what bounds the input distributor's width; see *The
+   shared-upstream distribution* below for the K' > 8 case.
 
 #### The shared-upstream distribution — not "just a tee"
 
@@ -250,8 +259,9 @@ This is an explicit non-goal, not a deferred TODO.
 
 ### Phase 2 — subtree decomposition (inner pass)
 
-When `subtree_decompose = true` (requires `demand_partition = true`
-for the outer framing — they compose, not alternate):
+When `strategy == PartitionedDecomposed`, the outer pass runs
+exactly as `PartitionedPerConsumer` (Phase 1), then the inner pass
+runs over each resulting module:
 
 For each partitioned module, walk the upstream subtree. If any
 recipe's required belt count exceeds 8, shard the whole *module*
@@ -310,17 +320,22 @@ don't gate on.
 - **K0-2**: If Phase 0a scaffolding needs > ~400 LOC of new code
   (not counting tests) just to preserve current behavior, the
   `module_id` keying is in the wrong place — likely needs to be
-  deeper in `placer.rs` instead of the planner. Phase 0b (UI +
-  WASM wiring) budget is ~200 LOC.
+  deeper in `placer.rs` instead of the planner.
+- **K0-3**: If Phase 0b (UI + WASM wiring) needs > ~200 LOC of new
+  code, the strategy plumbing is leaking through too many call
+  sites — `LayoutOptions` is the wrong shape or the WASM binding
+  is exposing internals it shouldn't.
 
 **Phase 1 (partitioning):**
 
-- **K1-1** (correctness on motivating case): If
-  `PartitionedPerConsumer` doesn't produce a **validator-clean**
-  layout for the target failing case (`advanced_circuit` at a rate
-  that currently trips the 8-lane ceiling) within 2 weeks of Phase
-  1 work, the approach isn't unblocking the motivating problem —
-  reassess rather than push further.
+- **K1-1** (correctness on motivating case): Once the
+  `PartitionedPerConsumer` code path is wired and the partitioner's
+  75%-utilization gate is satisfied for the smallest valid
+  partition, the target failing case (`advanced_circuit` at a rate
+  that currently trips the 8-lane ceiling) must produce a
+  **validator-clean** layout. If validator warnings remain on the
+  smallest gate-passing partition, the approach isn't unblocking
+  the motivating problem — reassess rather than push further.
 - **K1-2** (load-bearing assumption holds): If a consumer row
   emits belt-flow validator warnings (starved inserters) under
   `PartitionedPerConsumer` on a correctly-sized partition with
@@ -409,6 +424,14 @@ Specifics:
    and `PartitionRejectedByUtilization{item, lane_util}` events
    fire as expected. Absent trace events = the code path isn't
    exercising.
+7. **`HierarchicalComposed` prototype smoke test**: even though
+   the variant is unexposed in the UI, exercise it via a single
+   `#[ignore]`-able e2e test (or a `#[cfg(test)]`-only entry
+   point) that runs the hand-authored 12→12 = 8→8 + 8→8 + mixer
+   on the `advanced_circuit` copper-cable case. Assert zero
+   validator warnings. The point of the prototype is to be a
+   real, exercised fallback for K2-2 — an unexercised prototype
+   doesn't de-risk anything.
 
 ## Phasing
 
@@ -479,6 +502,9 @@ Living checklist — update as work progresses.
 - [ ] **Hand-authored `HierarchicalComposed` prototype** for
       12→12 = 8→8 + 8→8 + mixer on the `advanced_circuit` copper
       case; strategy variant is unexposed to UI for now
+- [ ] Smoke test for the `HierarchicalComposed` prototype
+      (validator-clean assertion on the 12→12 case) — gates the
+      "real fallback for K2-2" claim
 - [ ] Add `tier3_advanced_circuit_partitioned` e2e test
 - [ ] Per-tier strategy sweep in scoreboards (all 3 strategies ×
       all tier tests)
@@ -571,3 +597,26 @@ prevents "why did we drop this?" amnesia.
     not bake in any row-orientation assumption; a row's
     `(item, module_id)` identity is orthogonal to its spatial
     orientation.*
+
+- *2026-04-24 (review pass) — Third pass against the revised draft.
+  Fixes:*
+  - *Phase 2 section still referenced the pre-revision booleans
+    (`subtree_decompose = true` / `demand_partition = true`).
+    Rewritten in `LayoutStrategy` terms.*
+  - *Code-block `LayoutOptions` was implied to extend an existing
+    struct; clarified that it is new and absorbs today's
+    `max_belt_tier` arg. Function signature corrected to
+    `Result<LayoutResult, String>`.*
+  - *Added K0-3 to gate Phase 0b's ≤200 LOC budget (the task
+    tracker checkbox previously had no kill criterion behind it).*
+  - *Reframed K1-1 from a wall-clock criterion ("within 2 weeks")
+    to a behavioural one (validator warnings on the smallest
+    gate-passing partition). Time-based kill criteria are hard
+    to act on consistently.*
+  - *Made the up-tree recursion of the partitioning algorithm
+    explicit as step 6, instead of leaving it to be inferred from
+    the shared-upstream prose.*
+  - *Added verification step 7 + a task-tracker checkbox for a
+    smoke test of the `HierarchicalComposed` prototype. The
+    prototype's job is to be a real, exercised fallback for
+    K2-2 — an unexercised one doesn't de-risk anything.*

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -173,12 +173,22 @@ function allProducerMachines(): string[] {
   return machinesCache;
 }
 
-function buildLayout(result: SolverResult, maxBeltTier?: string): Promise<LayoutResult> {
-  return call<LayoutResult>({ method: "layout", result, maxBeltTier: maxBeltTier ?? null });
+function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: string): Promise<LayoutResult> {
+  return call<LayoutResult>({
+    method: "layout",
+    result,
+    maxBeltTier: maxBeltTier ?? null,
+    strategy: strategy ?? null,
+  });
 }
 
-function buildLayoutTraced(result: SolverResult, maxBeltTier?: string): Promise<LayoutResult> {
-  return call<LayoutResult>({ method: "layoutTraced", result, maxBeltTier: maxBeltTier ?? null });
+function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?: string): Promise<LayoutResult> {
+  return call<LayoutResult>({
+    method: "layoutTraced",
+    result,
+    maxBeltTier: maxBeltTier ?? null,
+    strategy: strategy ?? null,
+  });
 }
 
 /**
@@ -200,6 +210,7 @@ async function supersedeWorker(): Promise<void> {
 async function buildLayoutStreaming(
   result: SolverResult,
   maxBeltTier: string | undefined,
+  strategy: string | undefined,
   onEvent: (evt: TraceEvent) => void,
 ): Promise<LayoutResult> {
   if (activeStreamingId !== null) {
@@ -229,6 +240,7 @@ async function buildLayoutStreaming(
       method: "layoutStreaming",
       result,
       maxBeltTier: maxBeltTier ?? null,
+      strategy: strategy ?? null,
       traceLogs,
     });
   });

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -6,9 +6,15 @@ export interface FormState {
   inputs: string[];
   /** Max belt tier override, e.g. "transport-belt". null = auto. */
   belt: string | null;
+  /** Layout strategy ("partitioned-per-consumer" | "partitioned-decomposed").
+   * null = pooled (today's default). See `docs/rfp-modular-production.md`. */
+  strategy: string | null;
   /** User-added inputs beyond the DEFAULT_INPUTS list. */
   customInputs: string[];
 }
+
+/** Strategy values accepted on the URL and in `FormState.strategy`. */
+export const KNOWN_STRATEGIES = ["partitioned-per-consumer", "partitioned-decomposed"] as const;
 
 /** Full list of input pills rendered in the sidebar. */
 export const DEFAULT_INPUTS: string[] = [
@@ -48,10 +54,12 @@ export function readUrlState(): FormState {
   const inParam = params.get("in");
   const inputs = inParam ? inParam.split(",").filter((s) => s.length > 0) : DEFAULT_CHECKED_INPUTS;
   const belt = params.get("belt");
+  const rawStrategy = params.get("strategy");
+  const strategy = rawStrategy && (KNOWN_STRATEGIES as readonly string[]).includes(rawStrategy) ? rawStrategy : null;
   const ciParam = params.get("ci");
   const customInputs = ciParam ? ciParam.split(",").filter((s) => s.length > 0) : [];
 
-  return { item, rate, machine, inputs, belt, customInputs };
+  return { item, rate, machine, inputs, belt, strategy, customInputs };
 }
 
 export function writeUrlState(state: Omit<FormState, "machine"> & { machine: string }): void {
@@ -62,6 +70,7 @@ export function writeUrlState(state: Omit<FormState, "machine"> & { machine: str
     state.inputs.length === DEFAULT_CHECKED_INPUTS.length &&
     state.inputs.every((v, i) => v === DEFAULT_CHECKED_INPUTS[i]) &&
     !state.belt &&
+    !state.strategy &&
     state.customInputs.length === 0;
 
   if (isDefault) {
@@ -75,6 +84,7 @@ export function writeUrlState(state: Omit<FormState, "machine"> & { machine: str
   params.set("machine", state.machine);
   params.set("in", state.inputs.join(","));
   if (state.belt) params.set("belt", state.belt);
+  if (state.strategy) params.set("strategy", state.strategy);
   if (state.customInputs.length > 0) params.set("ci", state.customInputs.join(","));
   history.replaceState(null, "", "?" + params.toString());
 }

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -373,6 +373,27 @@ export function renderSidebar(
   });
   targetBody.appendChild(makeField("Belt", beltSelect));
 
+  // Layout strategy. Phase 0b of `rfp-modular-production` ships the
+  // dropdown; the partitioned variants are wired in Phase 1, so they are
+  // disabled here and a tooltip explains why.
+  const strategySelect = document.createElement("select");
+  strategySelect.className = "sb-select";
+  ([
+    ["Pooled (today)", "", false],
+    ["Partitioned per consumer", "partitioned-per-consumer", true],
+    ["Partitioned + decomposed", "partitioned-decomposed", true],
+  ] as const).forEach(([label, value, disabled]) => {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = label;
+    if (disabled) {
+      opt.disabled = true;
+      opt.title = "Wired in Phase 1 of rfp-modular-production";
+    }
+    strategySelect.appendChild(opt);
+  });
+  targetBody.appendChild(makeField("Strategy", strategySelect));
+
   // Rate (numeric with /s suffix)
   const rateRow = document.createElement("div");
   rateRow.className = "sb-field";
@@ -552,6 +573,7 @@ export function renderSidebar(
     if (tag) tag.classList.toggle("active", cb.checked);
   });
   if (urlState.belt) beltSelect.value = urlState.belt;
+  if (urlState.strategy) strategySelect.value = urlState.strategy;
   // Restore custom inputs from URL
   for (const item of urlState.customInputs) {
     if (itemSet.has(item) && !defaultInputSet.has(item) && !customInputs.includes(item)) {
@@ -599,6 +621,7 @@ export function renderSidebar(
       machine: machineSelect.value,
       inputs: checkedDefaults,
       belt: beltSelect.value || null,
+      strategy: strategySelect.value || null,
       customInputs,
     });
 
@@ -630,8 +653,9 @@ export function renderSidebar(
     let layout: LayoutResult;
     try {
       const maxTier = beltSelect.value || undefined;
+      const strategy = strategySelect.value || undefined;
       const onEvent = callbacks.startStreaming();
-      layout = await engine.buildLayoutStreaming(result, maxTier, onEvent);
+      layout = await engine.buildLayoutStreaming(result, maxTier, strategy, onEvent);
     } catch (err) {
       if (gen !== solveGeneration) return;
       const errDiv = document.createElement("div");
@@ -672,6 +696,7 @@ export function renderSidebar(
   rateInput.addEventListener("input", scheduleAutoSolve);
   machineSelect.addEventListener("change", scheduleAutoSolve);
   beltSelect.addEventListener("change", scheduleAutoSolve);
+  strategySelect.addEventListener("change", scheduleAutoSolve);
   checkboxes.forEach((cb) => cb.addEventListener("change", scheduleAutoSolve));
 
   runSolve().catch((err) => console.error("runSolve failed:", err));

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -31,9 +31,9 @@ type Request =
       availableInputs: string[];
       machineEntity: string;
     }
-  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null }
-  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null }
-  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null }
+  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null }
+  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null }
+  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null; strategy: string | null }
   | { id: number; method: "exportBlueprint"; layout: LayoutResult; label: string }
   | {
       id: number;
@@ -99,10 +99,10 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         result = solve(req.targetItem, req.targetRate, req.availableInputs, req.machineEntity);
         break;
       case "layout":
-        result = layout(req.result, req.maxBeltTier ?? undefined);
+        result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined);
         break;
       case "layoutTraced":
-        result = layout_traced(req.result, req.maxBeltTier ?? undefined);
+        result = layout_traced(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined);
         break;
       case "layoutStreaming": {
         const id = req.id;
@@ -145,7 +145,7 @@ self.onmessage = async (e: MessageEvent<Request>) => {
           if (batch.length >= BATCH_SIZE) flushBatch();
         };
         try {
-          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, emit);
+          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, emit);
         } finally {
           flushBatch();
           if (TRACE_LOGS) {


### PR DESCRIPTION
Foundation for `docs/rfp-modular-production.md`. Three commits, intentionally kept separate so review can look at each in isolation:

1. **`docs(rfp): review-pass fixes to modular-production RFP`** — pre-implementation third-pass review of the RFP doc itself. Fixes the leftover boolean syntax in Phase 2 (`subtree_decompose=true` → `LayoutStrategy::PartitionedDecomposed`), clarifies that `LayoutOptions` is new (not extending an existing struct), reframes K1-1 from a wall-clock criterion to a behavioural one, makes the up-tree recursion of the partitioning algorithm explicit, adds K0-3 to gate the Phase 0b LOC budget, and adds verification step 7 + a smoke test for the (later-dropped) HierarchicalComposed prototype.

2. **`feat(bus): Phase 0a scaffolding — LayoutStrategy + module_id`** — type-level scaffolding for the partitioning strategies, byte-identical Pooled behaviour:
   - `LayoutStrategy { Pooled (default), PartitionedPerConsumer, PartitionedDecomposed }` enum + `LayoutOptions { strategy, max_belt_tier }` struct.
   - `build_bus_layout`, `_traced`, `_streaming` take `LayoutOptions` instead of `Option<&str>`. All 10 call sites (tests, examples, WASM bindings) updated. WASM bindings construct `LayoutOptions` internally — no JS-visible change in this commit.
   - `LaneFamily.module_id: u32` (always 0 under Pooled). `FamilyInfo` trace mirror with `#[serde(default)]`.
   - `stamp_family_balancer` segment-id format gains `:mod{N}` suffix only when `module_id != 0`, so under Pooled it's byte-identical to today.
   - **K0-1** snapshot-equality regression check added to `tests/e2e.rs` via SHA-256 of layout entities and a committed `GOLDEN_HASHES` table covering all 9 non-ignored e2e tests. Regenerate with `FUCKTORIO_GOLDEN_DUMP=1 cargo test --test e2e -- --nocapture`.
   - **K0-2** Phase 0a LOC budget: net +89 LOC excluding tests + `Cargo.lock`.

3. **`feat(web): Phase 0b surface wiring — strategy dropdown + URL state`** — exposes `LayoutStrategy` to the web app:
   - WASM `layout`, `layout_traced`, `layout_streaming` accept `strategy: Option<String>`.
   - TS engine + worker thread `strategy?: string` to the WASM call.
   - `FormState.strategy` + `?strategy=…` URL param, validated against a `KNOWN_STRATEGIES` whitelist.
   - Sidebar gains a "Strategy" dropdown next to "Belt". Non-Pooled options are disabled with a "Wired in Phase 1" tooltip rather than letting users hit the `unimplemented!()` panic.
   - **K0-3** Phase 0b LOC budget: net +69 LOC.

## Verification

- 387 unit + 9 e2e + ancillary tests pass.
- `cargo clippy --all-targets -- -D warnings` clean on `core` and `wasm-bindings`.
- TS type-check clean on touched files.
- Live `wasm-pack` browser verification deferred — wasm-pack not installed in the agent env. The WASM crate type-checks cleanly with the host toolchain; behaviour change under `LayoutStrategy::Pooled` is zero by construction.

## What's NOT in this PR

- The actual partitioning algorithm — `Phase 1` PR (stacked on top of this branch).
- Any UI exposure of the non-`Pooled` strategy options as enabled — they remain disabled until Phase 1 wires the algorithm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dyy5o9EH5tsavTZLPHjX9p)_