### PR TITLE
Timeline view follow-up: clearer labels, time-weighted fill, optimize phase

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -34,6 +34,7 @@ import { spawnRegionFlash } from "./renderer/improvementAnimation";
 import { createStreamingRenderer, type StreamingRendererHandle } from "./renderer/streamingRenderer";
 import { createTimelineScrubber, type TimelineScrubberHandle } from "./ui/timelineScrubber";
 import "./ui/timelineScrubber.css";
+import { attachBusyOverlay } from "./ui/busyOverlay";
 import { logLayoutStats } from "./ui/layoutTimingLog";
 
 const MACHINE_SLUGS = [
@@ -549,6 +550,11 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     (virtualMs) => streamingHandle?.seekTo(virtualMs),
   );
 
+  // Spinner that appears in the top-right while the WASM worker is
+  // busy. Covers the gap between "click solve" and the first trace
+  // event arriving (before the timeline scrubber has anything to show).
+  attachBusyOverlay(container);
+
   const snapshotMode = createSnapshotMode({
     sidebarEl: document.getElementById("sidebar"),
     getSidebarCtrl: () => sidebarCtrl,
@@ -614,6 +620,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     if (!hasSatZones) return;
 
     optimizeInFlight = true;
+    timelineScrubber.markOptimizeState("active");
 
     // Tear down selection so renderLayout's removeChildren doesn't
     // orphan its overlays as we restamp tiles during the drain.
@@ -738,6 +745,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       solverDone = true;
       if (rafId !== null) cancelAnimationFrame(rafId);
       optimizeInFlight = false;
+      timelineScrubber.markOptimizeState("done");
       if (lastLayout) {
         selectionCtrl = createSelectionController(
           app.canvas,
@@ -901,7 +909,10 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
           viewportFitted = true;
         }
       }
-      streamingHandle?.onEvent(evt, (m) => timelineScrubber.noteMilestone(m.id));
+      streamingHandle?.onEvent(evt, (m) => {
+        if (!streamingHandle) return;
+        timelineScrubber.noteMilestone(m, streamingHandle.getTimeRange());
+      });
     };
   }
 

--- a/web/src/renderer/streamingRenderer.ts
+++ b/web/src/renderer/streamingRenderer.ts
@@ -163,11 +163,11 @@ export type MilestoneId =
   | "ghost_routes"
   | "committed_routes"
   | "junctions"
-  | "poles";
+  | "poles"
+  | "optimizing";
 
 export interface Milestone {
   id: MilestoneId;
-  label: string;
   /** Absolute virtual ms when this milestone's trigger event first arrived. */
   virtualMs: number;
 }
@@ -195,14 +195,6 @@ export interface StreamingRendererHandle {
   /** Milestones recorded so far, sorted by virtualMs. */
   getMilestones(): Milestone[];
 }
-
-const MILESTONE_LABELS: Record<MilestoneId, string> = {
-  machines: "Machines",
-  ghost_routes: "Ghost Routes",
-  committed_routes: "Committed Routes",
-  junctions: "Junctions",
-  poles: "Poles",
-};
 
 // ---------------------------------------------------------------------------
 // Main factory
@@ -274,7 +266,7 @@ export function createStreamingRenderer(
     // the chip at the first one is misleading.
     const existing = milestones.get(id);
     const isNew = !existing;
-    const m: Milestone = { id, label: MILESTONE_LABELS[id], virtualMs: at };
+    const m: Milestone = { id, virtualMs: at };
     milestones.set(id, m);
     // Only fire the live-mode callback once, the first time we see
     // this milestone — so the scrubber's progress bar advances one

--- a/web/src/ui/timelineScrubber.css
+++ b/web/src/ui/timelineScrubber.css
@@ -53,6 +53,18 @@
   background: rgba(86, 156, 214, 0.25);
 }
 
+/* Pulsing chip for the post-stream auto-optimize phase. We can't show
+ * scrub-bar progress for it (no virtual-ms timestamps), so the chip
+ * itself signals "still working" until markOptimizeState("done"). */
+.timeline-scrubber .ts-chip--in-progress {
+  animation: ts-chip-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes ts-chip-pulse {
+  0%, 100% { color: #888; }
+  50% { color: #d4d4d4; }
+}
+
 /* Tick mark dropping into the track */
 .timeline-scrubber .ts-chip::after {
   content: "";

--- a/web/src/ui/timelineScrubber.ts
+++ b/web/src/ui/timelineScrubber.ts
@@ -21,30 +21,44 @@ const MIN_DURATION_MS_FOR_SCRUB = 200;
 
 /** Ordered list of every milestone the streaming renderer can produce.
  *  We render chips for all of them in live mode; if a layout doesn't
- *  produce one (e.g. no junctions), that chip stays un-reached. */
+ *  produce one (e.g. no junctions), that chip stays un-reached.
+ *
+ *  `optimizing` is special — it's not driven by the trace stream but by
+ *  the post-stream auto-optimize pass, so its chip is hidden until
+ *  `markOptimizeState()` is called. */
 const MILESTONE_ORDER: MilestoneId[] = [
   "machines",
   "ghost_routes",
   "committed_routes",
   "junctions",
   "poles",
+  "optimizing",
 ];
 
 const MILESTONE_LABELS: Record<MilestoneId, string> = {
   machines: "Machines",
-  ghost_routes: "Ghost Routes",
-  committed_routes: "Committed Routes",
-  junctions: "Junctions",
-  poles: "Poles",
+  ghost_routes: "Belt routes",
+  committed_routes: "Belts placed",
+  junctions: "Crossings",
+  poles: "Power poles",
+  optimizing: "Optimizing",
 };
 
 export interface TimelineScrubberHandle {
   /** Live mode: mark this milestone as reached. Advances progress. */
-  noteMilestone(id: MilestoneId): void;
+  /** Live mode: mark this milestone as reached. Advances the progress
+   *  fill proportionally to `currentRange` (virtual-ms time-weighted),
+   *  not the milestone count. */
+  noteMilestone(milestone: Milestone, currentRange: { firstMs: number; lastMs: number }): void;
   /** Flip to scrub mode. `range` is the [firstMs, lastMs] virtual window;
    *  `milestones` is the list of milestones with their absolute virtual-ms
    *  timestamps. Milestones get positioned proportionally along the bar. */
   arm(range: { firstMs: number; lastMs: number }, milestones: Milestone[]): void;
+  /** Show / update the post-stream "Optimizing" chip:
+   *    - "active": chip pulses (auto-optimize in progress)
+   *    - "done":   chip becomes reached (optimize finished)
+   *    - "idle":   chip hidden (no optimize ran or layout reset) */
+  markOptimizeState(state: "active" | "done" | "idle"): void;
   /** Go back to empty-live state, hide the bar. */
   reset(): void;
   destroy(): void;
@@ -86,6 +100,11 @@ export function createTimelineScrubber(
     chip.className = "ts-chip";
     chip.dataset["milestone"] = id;
     chip.textContent = MILESTONE_LABELS[id];
+    // Optimizing chip is hidden until the auto-optimize pass actually
+    // runs (signalled by `markOptimizeState`). Without this, live mode
+    // would show 6 evenly-spaced chips even when the layout has no SAT
+    // zones and optimize will be skipped.
+    if (id === "optimizing") chip.style.display = "none";
     chipsRow.appendChild(chip);
     chips.set(id, chip);
   }
@@ -109,14 +128,20 @@ export function createTimelineScrubber(
     activeChipId = id;
   }
 
-  function noteMilestone(id: MilestoneId): void {
+  function noteMilestone(milestone: Milestone, currentRange: { firstMs: number; lastMs: number }): void {
     if (armed) return; // ignore during scrub mode — bar is user-controlled
+    const id = milestone.id;
     reached.add(id);
     chips.get(id)?.classList.add("ts-chip--reached");
     setActiveChip(id);
-    // Progress fill: fraction of MILESTONE_ORDER reached.
-    const idx = MILESTONE_ORDER.indexOf(id);
-    setFillToFraction((idx + 1) / MILESTONE_ORDER.length);
+    // Progress fill: where this milestone sits in the current virtual-ms
+    // range. Long phases (e.g. junction solving) get more of the bar than
+    // short ones (e.g. row placement), instead of every chip getting an
+    // even 1/Nth slice. `lastMs` keeps growing as new events arrive, so
+    // earlier milestones' fractions settle as the stream progresses.
+    const span = Math.max(1, currentRange.lastMs - currentRange.firstMs);
+    const frac = (milestone.virtualMs - currentRange.firstMs) / span;
+    setFillToFraction(Math.min(1, Math.max(0, frac)));
     root.classList.add("ts-visible");
   }
 
@@ -266,7 +291,11 @@ export function createTimelineScrubber(
       .map((id) => {
         const el = chips.get(id);
         if (!el || el.style.display === "none") return null;
-        const originalFrac = milestoneByFrac.find((m) => m.id === id)?.frac ?? 0;
+        // `optimizing` isn't in milestoneByFrac (no virtual-ms timestamp);
+        // it always sits at the right edge of the bar.
+        const originalFrac = id === "optimizing"
+          ? 1.0
+          : milestoneByFrac.find((m) => m.id === id)?.frac ?? 0;
         return { el, originalFrac };
       })
       .filter((x): x is { el: HTMLDivElement; originalFrac: number } => x !== null);
@@ -300,12 +329,39 @@ export function createTimelineScrubber(
     // Restore chips to even-spaced live-mode layout.
     chipsRow.style.justifyContent = "space-between";
     chipsRow.style.position = "";
-    for (const chip of chips.values()) {
+    for (const [id, chip] of chips) {
       chip.style.position = "";
       chip.style.transform = "";
       chip.style.left = "";
-      chip.style.display = "";
-      chip.classList.remove("ts-chip--reached", "ts-chip--active");
+      // Optimizing stays hidden until auto-optimize actually runs.
+      chip.style.display = id === "optimizing" ? "none" : "";
+      chip.classList.remove("ts-chip--reached", "ts-chip--active", "ts-chip--in-progress");
+    }
+  }
+
+  function markOptimizeState(state: "active" | "done" | "idle"): void {
+    const chip = chips.get("optimizing");
+    if (!chip) return;
+    chip.classList.remove("ts-chip--in-progress", "ts-chip--reached");
+    if (state === "idle") {
+      chip.style.display = "none";
+      return;
+    }
+    chip.style.display = "";
+    // Always show the bar — covers the rare case where the stream was
+    // too short to arm and reset() hid everything, but optimize still
+    // runs and we want the user to see *something*.
+    root.classList.add("ts-visible");
+    if (armed) {
+      chip.style.position = "absolute";
+      chip.style.transform = "translateX(-50%)";
+      chip.style.left = "100%";
+      requestAnimationFrame(resolveChipCollisions);
+    }
+    if (state === "active") {
+      chip.classList.add("ts-chip--in-progress");
+    } else if (state === "done") {
+      chip.classList.add("ts-chip--reached");
     }
   }
 
@@ -316,5 +372,5 @@ export function createTimelineScrubber(
     root.remove();
   }
 
-  return { noteMilestone, arm, reset, destroy };
+  return { noteMilestone, arm, markOptimizeState, reset, destroy };
 }


### PR DESCRIPTION
## Summary

Follow-up to the #186 investigation, addressing the four sub-issues it produced. All changes are in `web/src/` — UI only, no Rust touched.

- **#187 — Relabel chips.** `Ghost Routes` / `Committed Routes` / `Junctions` / `Poles` → `Belt routes` / `Belts placed` / `Crossings` / `Power poles`. Drops a duplicate (and unused) `MILESTONE_LABELS` map in `streamingRenderer.ts` along with the dead `Milestone.label` field.
- **#188 — Time-weighted progress fill.** `noteMilestone()` now positions the fill by `(virtualMs - firstMs) / (lastMs - firstMs)` instead of `(idx + 1) / N`. A 4-second junction solve no longer gets the same 20% slice as a 50ms row-placement phase. `lastMs` keeps growing as the stream progresses, so earlier milestones' fractions settle naturally.
- **#189 — `Optimizing` chip on the timeline.** A 6th milestone chip is hidden by default and surfaced only when `runAutoOptimize` actually runs (i.e. the layout has SAT crossing zones). It pulses while the optimize pass is in flight, then becomes "reached" when it completes. Sits at `frac=1.0` in scrub mode, doesn't snap (auto-optimize isn't part of the trace stream — there's no virtualMs to seek to), and doesn't extend the scrub range. The user can still scrub the layout reveal during optimize.
- **#190 — Wire up `attachBusyOverlay`.** The spinner module existed but was never imported. Now called from `main.ts` during app setup so the top-right `computing…` indicator actually appears during long solves and the auto-optimize pass.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — bundle builds (only the pre-existing >500 kB chunk warning)
- [x] Loaded `?item=electronic-circuit&rate=10&belt=express-transport-belt` in a browser; timeline shows the new labels, time-weighted positions, and the post-stream `Optimizing` chip lights up + becomes reached. Screenshot in conversation.
- [ ] Visual confirmation of `busyOverlay` during a long solve — couldn't trigger a slow-enough solve in the test recipe; safe by inspection (one-line wire-up of an already-tested module).

Closes #186
Closes #187
Closes #188
Closes #189
Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)