### PR TITLE
perf(web): cache entity-layer instructions, silence icon warns

### DIFF
--- a/docs/web-render-perf-investigation.md
+++ b/docs/web-render-perf-investigation.md
@@ -1,0 +1,223 @@
+# Web app render performance investigation — 2026-04
+
+Snapshot of findings from a Chrome DevTools trace captured while loading
+`?item=processing-unit&rate=2&machine=assembling-machine-3&in=iron-plate,copper-plate,steel-plate,stone,coal,water,crude-oil,iron-ore,copper-ore`.
+The trace covered ~5.5 s of wall-clock time on the dev server.
+
+The investigation was triggered by a "things feel sluggish" report. The headline
+finding is that **the engine work is not the problem** — it lands cleanly off the
+main thread and finishes in tens of milliseconds. The sluggishness comes from
+PixiJS rendering at full speed continuously, even when nothing in the scene is
+changing. This doc captures the trace methodology, the steady-state numbers,
+and the option space for future work, so the next person who picks up this
+thread can skip the discovery phase.
+
+## Summary of findings
+
+| Where the time goes (5.46 s window) | ms | % |
+|---|---|---|
+| Idle | 2,047 | 38 |
+| Pixi `_tick` → render loop (continuous, scene-static) | 2,574 | 47 |
+| V8 program / module / GC overhead | ~500 | 9 |
+
+Most of the rendering time is downstream of one root cause: **the Pixi ticker
+runs every frame regardless of whether the scene changed.** With thousands of
+`Graphics` children in the entity layer (each entity is its own Graphics
+object), even an unchanged scene costs ~10 ms/frame to re-collect, re-batch,
+and re-submit to WebGL.
+
+After the initial render settles (~2 s in), CPU usage holds steady at
+**~135 ms per 200 ms wall-clock, ~65–75% of one core, on a static scene**.
+
+## Pipeline timing
+
+Decomposing the trace by 200 ms bucket on the main thread:
+
+| Time | Main-thread CPU | What's happening |
+|---|---|---|
+| 0–600 ms | ~165 ms | boot, Vite module loading |
+| **600–1000 ms** | **~30 ms total** | **main thread idle while worker solves+lays out** |
+| 1000–1200 ms | 104 ms | Pixi `app.init()` (54 ms blocking) + first stream events |
+| 1200–1400 ms | 213 ms | initial layout render (one 145 ms rAF, see below) |
+| 1400–2000 ms | ~270 ms | streaming commits + sidebar build |
+| **2000–5400 ms** | **~135 ms / 200 ms** | **steady state — pure Pixi waste** |
+
+Worker total CPU across the entire 5.4 s trace was **~55 ms**, with the longest
+single task being a 5.6 ms WASM compile. The actual solve+layout for
+`processing-unit @ rate=2` from raw inputs is sub-frame fast in WASM. The
+`engine.worker.ts` handoff is correct; the user's mental model of "heavy stuff
+runs in a worker" holds.
+
+## The three notable single events
+
+**The 143 ms initial-render frame** (around +1271 ms): one rAF spent ~91 ms in
+`collectRenderables*` walking the scene graph and ~91 ms in
+`_buildInstructions` rebuilding the GPU command list. That's first-render
+fixed cost — Pixi has to traverse and batch every entity once. Not a steady-
+state problem, but it does block input for ~9 frames at 60 Hz.
+
+**A 54 ms `RunMicrotasks` at +1115 ms** turned out to be Pixi's `app.init()`:
+12 ms `getExtensions`, 9.5 ms `initFromContext`, 9.2 ms `createContext`. WebGL
+context creation is synchronous and not really our problem to fix, but it's
+worth knowing about.
+
+**A 45 ms `HandlePostMessage` at +1218 ms** was the streaming renderer
+processing a `PhaseSnapshot/rows_placed` event from the worker:
+`worker.onmessage` → `streamingRenderer.onEvent` → `handlePhaseSnapshot` →
+`commitTransient` → `drawEntityGraphic`. With `BATCH_SIZE = 8` in
+[`engine.worker.ts`](../web/src/workers/engine.worker.ts), each batch holds
+the main thread for tens of ms. During the streaming phase, the user sees
+~10 small stalls.
+
+## How to reproduce the methodology
+
+1. Open DevTools → Performance, click record.
+2. Load a heavy URL (the `processing-unit @ rate=2` link above is good).
+3. Stop after the layout settles + you've moved the mouse around a bit.
+4. Save the trace as `Trace-*.json.gz`.
+5. Decompress with `gunzip -c Trace-*.json.gz > trace.json`.
+6. Use `jq` to extract:
+   - All `traceEvents` and group by category.
+   - `FireAnimationFrame` events with `dur > 0` to measure rAF cadence.
+   - `RunTask` events on the main thread (`tid` matches `CrRendererMain`)
+     bucketed by time to show CPU pressure.
+7. To get a CPU profile, filter for `name == "ProfileChunk" and id == "0x1"`
+   (where 0x1 is the main thread's profile id from the matching `Profile`
+   event), concatenate the `nodes` arrays and reconstruct sample timestamps
+   from `ts + cumsum(timeDeltas)`. Aggregate self-time and total time per
+   node, walking parents to get inclusive cost.
+
+The Node script template that worked well for this trace lives in the analysis
+notes; the gist is:
+
+```js
+const samples = [];
+for (const c of chunks) {
+  let t = c.ts;
+  for (let i = 0; i < c.samples.length; i++) {
+    t += c.deltas[i] || 0;
+    samples.push({ ts: t, nodeId: c.samples[i] });
+  }
+}
+samples.sort((a, b) => a.ts - b.ts);
+for (let i = 0; i < samples.length - 1; i++) samples[i].dur = samples[i+1].ts - samples[i].ts;
+// then aggregate self-time per nodeId, walk parent chain for total time
+```
+
+## Pitfalls in the trace
+
+- **18 dedicated worker threads** show up but only one (the
+  `fucktorio-engine` worker) does meaningful work. The other 17 spin up and
+  die in 1–5 ms each, all within a 25 ms burst at +484 ms. They look
+  alarming but they're not from our code — most likely a Chrome extension's
+  content scripts or Vite dev-server scaffolding. Confirm by checking
+  `wasm_events` and `RunTask` totals per thread before chasing this.
+- **rAF count looks doubled.** ~210 rAFs/s vs the expected 60–120 Hz refresh
+  rate. The median rAF is 33 µs (no-op) and the heavy ones (5–12 ms) come at
+  ~60/s, so there are two ticker loops scheduling: Pixi's app ticker plus
+  pixi-viewport's deceleration plugin (which keeps requesting frames even
+  when at rest). After render-on-demand lands, this number should drop to
+  approximately zero outside of interactions.
+- **`_setProgram` taking ~190 ms self-time** suggests batch breaks from
+  shader switches (Graphics → Sprite → Graphics → ...). Worth investigating
+  *if* render-on-demand alone doesn't restore the desired feel; otherwise
+  it's premature.
+
+## Option space for fixes
+
+In rough order of impact-vs-effort:
+
+### 1. Render-on-demand (~65% steady-state CPU → ~0%)
+
+`web/src/renderer/app.ts`:
+
+```ts
+await app.init({ ..., autoStart: false, sharedTicker: false });
+```
+
+Then `app.render()` once after `renderLayout`, and on viewport `moved` /
+`zoomed` / `decelerate` events. While interactions are active,
+`app.ticker.start()`; when they settle, `app.ticker.stop()`. pixi-viewport
+emits the events.
+
+Per-feature tickers (`phaseAnimation`, `streamingRenderer`,
+`improvementAnimation`, `issuesDialog` pulse) all currently rely on the
+ticker being live; each one will need to either keep the ticker alive while
+it has work or call `app.render()` explicitly after each tick.
+
+This is a real architectural change — single PR, but with reach.
+
+### 2. Mark static layers as render groups (already landed)
+
+```ts
+entityLayer.isRenderGroup = true;
+```
+
+Pixi v8 caches the GPU instruction buffer for descendants. Transform / alpha
+mutations on children still render correctly without invalidating the cache.
+Adding / removing children (e.g. `renderLayout`'s `removeChildren()` +
+re-add) does invalidate, so this only helps in steady state, not during
+layout commit. Already merged as part of this investigation.
+
+### 3. Yield while building the scene
+
+`renderLayout` builds all entity Graphics in one synchronous pass
+(`entities.ts:980`). For the 143 ms first-render hit, chunk this with
+`await scheduler.yield()` so the work spreads across 5–10 frames. The user
+sees layout fade in instead of a single hard pause. Smaller change than (1),
+but the win is "fewer dropped frames during commit," not "feels snappier
+later."
+
+### 4. OffscreenCanvas — move all of Pixi to a worker
+
+The big lift. Pixi v8 supports it. Rendering, scene graph, batching, GL state
+all move off-main-thread. The main thread keeps input handling, DOM updates
+(sidebar/inspector), and forwards events to the render worker. Eliminates the
+steady-state main-thread cost completely.
+
+Browser support is broad (Chrome, Edge, Firefox 105+, Safari 16.4+). Cost is
+substantial: `app.ts` and the entire `renderer/` directory move into a new
+worker; events have to be serialized across the boundary; the inspector +
+sidebar code that reads scene state needs a request/response bridge. Not
+worth attempting until (1) is in place and shown insufficient.
+
+### 5. Pre-built geometry in the engine worker
+
+For each entity, generate vertex data (positions, colours, UVs) in the
+engine worker and `postMessage` with `transfer:[buffer]` for zero-copy. Main
+thread feeds it into a single `Mesh` per visual class instead of one
+`Graphics` per entity. Drops the per-entity allocation cost during commit
+and shrinks the scene graph from "thousands of children" to "a few meshes."
+
+Lossy: per-entity alpha for hover would need uniforms or a separate dim
+overlay shape. Probably worth it once (1) is shipping; not a near-term move.
+
+## Smaller wins worth knowing about
+
+- **Missing-icon warns** (already landed): `Assets.get` warns when the key
+  isn't cached, and each warn captures a stack trace. We saw 13 warns during
+  initial render. Fixed by checking `Cache.has(key)` before `Assets.get`.
+  See `tryGetTexture()` in `entities.ts`.
+- **Per-machine `new TextStyle(...)` allocations** in `entities.ts:760, 784`
+  rebuild text style state for every machine. Hoist to module scope as a
+  constant or memoise per `(fontSize, fill)` tuple. Modest win.
+- **`improveRegionStreaming` uses `BATCH_SIZE = 1`** in
+  `engine.worker.ts:178`. Fine while improvements come in slowly, but if
+  optimisation ever speeds up this becomes the bottleneck.
+
+## Ground rules for future trace analysis
+
+- Decompress traces somewhere outside the repo (e.g. `/tmp/perf-trace/`)
+  — uncompressed traces are tens of MB and we don't want them tracked.
+- Always check whether the user's selected breadcrumb covers the whole trace
+  or just a window — `metadata.modifications.initialBreadcrumb.window` has
+  the µs range. Quoting numbers across the wrong window is the #1 way to
+  mislead yourself.
+- The CPU profile lives in `ProfileChunk` events keyed by `tid` + `id`. The
+  `tid` on the chunks themselves is the *profiler* thread, not the sampled
+  thread; match against the `tid` of the parent `Profile` event to find the
+  main thread.
+- Don't trust "X ms in `executeInstructions`" alone. Always also check
+  whether the scene graph mutated (look at `removeChildren` / `addChild`
+  in self-time) — re-rendering a static scene has different fixes from
+  re-building one.

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -187,6 +187,12 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   setupSnapshotDropZone(container, (snap) => snapshotMode.load(snap));
 
   const entityLayer = new Container();
+  // Cache the entity layer's GPU instruction buffer across frames. The static
+  // bus layout (thousands of Graphics) doesn't change between renders, so
+  // re-walking the scene graph and rebuilding draw calls every frame is
+  // pure waste. Add/remove operations (renderLayout commit, overlay toggle)
+  // invalidate the group; transform / alpha changes on children don't.
+  entityLayer.isRenderGroup = true;
   viewport.addChild(entityLayer);
   // SAT-zone detail overlay sits above the entity layer so the bbox,
   // boundary bars, and item icons always read on top of the belts.

--- a/web/src/renderer/entities.ts
+++ b/web/src/renderer/entities.ts
@@ -1,4 +1,4 @@
-import { Assets, Container, Graphics, Sprite, Text, TextStyle, Texture } from "pixi.js";
+import { Assets, Cache, Container, Graphics, Sprite, Text, TextStyle, Texture } from "pixi.js";
 import type { LayoutResult, PlacedEntity, EntityDirection } from "../engine";
 import {
   buildBeltGraph,
@@ -705,7 +705,7 @@ function drawMachine(entity: PlacedEntity): Graphics {
   // Entity-frame sprites are designed so (0,0) = top-left of footprint at 1x.
   // To scale 1.5x around the footprint centre, offset by -0.25 * footprint size.
   const spriteScale = 1.5;
-  const frameTexture = Assets.get<Texture>(`${import.meta.env.BASE_URL}entity-frames/${entity.name}.png`);
+  const frameTexture = tryGetTexture(`${import.meta.env.BASE_URL}entity-frames/${entity.name}.png`);
   if (frameTexture) {
     const sprite = new Sprite(frameTexture);
     const baseScale = TILE_PX / ENTITY_FRAME_TILE_PX;
@@ -716,7 +716,7 @@ function drawMachine(entity: PlacedEntity): Graphics {
     sprite.y = -ph * (spriteScale - 1) / 2;
     g.addChild(sprite);
   } else {
-    const iconTexture = Assets.get<Texture>(`${import.meta.env.BASE_URL}icons/${entity.name}.png`);
+    const iconTexture = tryGetTexture(`${import.meta.env.BASE_URL}icons/${entity.name}.png`);
     if (iconTexture) {
       const sprite = new Sprite(iconTexture);
       const iconSize = Math.min(pw, ph) * 0.8 * spriteScale;
@@ -754,7 +754,7 @@ function drawMachine(entity: PlacedEntity): Graphics {
     const dropShadow = { color: 0x000000, alpha: 1, blur: 2, distance: 0 };
 
     // Header: recipe icon + nice name + rate — centred
-    const recipeIcon = Assets.get<Texture>(`${import.meta.env.BASE_URL}icons/${entity.recipe}.png`);
+    const recipeIcon = tryGetTexture(`${import.meta.env.BASE_URL}icons/${entity.recipe}.png`);
     const label = niceName(entity.recipe);
     const rateStr = entity.rate != null ? ` ${entity.rate.toFixed(1)}/s` : "";
     const headerStyle = new TextStyle({
@@ -783,7 +783,7 @@ function drawMachine(entity: PlacedEntity): Graphics {
     // Flow rows: icon + item name + rate — centred
     const flowStyle = new TextStyle({ fontSize: 8, fill: 0xcccccc, dropShadow });
     const renderFlow = (item: string, rate: number, prefix: string) => {
-      const fIcon = Assets.get<Texture>(`${import.meta.env.BASE_URL}icons/${item}.png`);
+      const fIcon = tryGetTexture(`${import.meta.env.BASE_URL}icons/${item}.png`);
       const fText = new Text({ text: `${prefix}${niceName(item)} ${rate.toFixed(1)}/s`, style: flowStyle });
       const fIconSz = 10;
       const rowW = (fIcon ? fIconSz + 2 : 0) + fText.width;
@@ -841,6 +841,15 @@ export async function initEntityIcons(slugs: string[]): Promise<void> {
 export async function preloadCarriesIcons(slugs: string[]): Promise<void> {
   const base = import.meta.env.BASE_URL;
   await Promise.allSettled(slugs.map((s) => Assets.load(`${base}icons/${s}.png`)));
+}
+
+/** `Assets.get` warns when called with a key that wasn't loaded — and recipe /
+ * entity slugs frequently have no PNG (multi-output recipes, fluid-only outputs,
+ * entity frames not yet generated). Hot draw paths call this thousands of times
+ * per layout, so the warns add real cost (each one captures a stack trace for
+ * the inspector). Check the cache first; callers already null-check the result. */
+function tryGetTexture(path: string): Texture | null {
+  return Cache.has(path) ? (Assets.get<Texture>(path) ?? null) : null;
 }
 
 // Chain highlight controller returned by renderLayout
@@ -1205,7 +1214,7 @@ export function renderLayout(
         showIcon = (ex + ey) % 5 === 0;
       }
       if (showIcon) {
-        const iconTex = Assets.get<Texture>(`${import.meta.env.BASE_URL}icons/${entity.carries}.png`);
+        const iconTex = tryGetTexture(`${import.meta.env.BASE_URL}icons/${entity.carries}.png`);
         if (iconTex) {
           const ICON_SZ = 14;
           const bgR = ICON_SZ * 0.7;


### PR DESCRIPTION
## Intent

Two small wins from a Chrome DevTools trace investigation. The trace was
captured loading `processing-unit @ rate=2` from raw inputs and showed
that, in steady state on a static layout, **Pixi's render loop was
eating ~65% of one core re-walking the scene graph and rebuilding the
GPU command buffer every frame**.

Full findings — methodology, numbers, option space for bigger fixes —
are documented in [`docs/web-render-perf-investigation.md`](../tree/perf-render-on-demand-prep/docs/web-render-perf-investigation.md).
This PR lands the two changes that don't require rearchitecting the app
loop.

## Scope

- **In:**
  - `entityLayer.isRenderGroup = true` so Pixi caches the layer's
    instruction buffer between frames. Transform / alpha mutations on
    children still render correctly without invalidating; only
    `addChild` / `removeChild` does. Static layouts pay the rebuild
    cost ~once per layout commit instead of every frame.
  - New `tryGetTexture()` helper in `entities.ts` that checks
    `Cache.has(key)` before calling `Assets.get`. Pixi warns (with a
    captured stack trace) when a key isn't in cache — and recipe slugs
    frequently don't have icons (multi-output recipes, fluid-only
    outputs, entity frames not yet generated). Hot draw paths called
    `Assets.get` thousands of times per layout, so the warns added real
    cost on top of the noise.
- **Out:**
  - **Render-on-demand** (stop the ticker outside of interactions). This
    is the bigger win (~65% steady-state CPU → ~0%) but it has reach
    across multiple per-feature tickers and needs visual verification
    in the browser. Held for a follow-up PR. Documented as option (1)
    in the investigation doc.
  - OffscreenCanvas / pre-built geometry — both are real options if the
    above isn't enough, but neither is justified yet. Documented as
    options (4) and (5).

## Verification

- [x] `npx tsc --noEmit` from `web/` — three pre-existing errors in
      `engine.worker.ts` (signatures lag the WASM bindings on `main`);
      no new errors from this PR. Confirmed by stashing the diff and
      re-running.
- [ ] WASM rebuild + browser eyeball — **not done**. The changes are
      type-safe and isolated, but PIXI render-group semantics around
      hover dimming (which mutates `g.alpha` on every entity in
      `entities.ts:1244-1256`) is exactly the kind of thing that can
      surprise. Worth a quick pass at the dev server before merging.
- N/A: Rust-side checks — no engine changes.

## Deviations from intent

None. The two changes shipped are exactly what was discussed.

## Models / contracts touched

None. Adds `docs/web-render-perf-investigation.md` as a reference
document; no contract changes.