### PR TITLE
RFP modular production: K1-2 + K1-3 stress test (re-PR onto main, second stacked-merge mishap)

### DIFF
--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -1300,6 +1300,93 @@ fn check_stress_scoreboard(test_name: &str, result: &E2EResult, baseline: Stress
     );
 }
 
+/// Baseline for `LayoutStrategy::PartitionedPerConsumer` runs of stress
+/// cases. Adds the K1-2 / K1-3 ceilings on top of `StressBaseline`'s
+/// pass-fail mechanism. See `docs/rfp-modular-production.md`.
+struct PartitionedStressBaseline {
+    /// `StressBaseline.max_errors`-equivalent for the partitioned run.
+    max_errors_partitioned: usize,
+    /// `StressBaseline.max_warnings`-equivalent for the partitioned run.
+    /// **K1-2**: should ideally be ≤ the Pooled `max_warnings` baseline.
+    /// If the partitioned run introduces new starvation warnings while
+    /// the 75% utilization gate isn't tripping, the "belts
+    /// over-provisioned" load-bearing assumption is wrong.
+    max_warnings_partitioned: usize,
+    /// **K1-3 per-test**: maximum allowed
+    /// `TraceEvent::PartitionRejectedByUtilization` events. `0` means
+    /// the partitioner is comfortable with this case at this rate.
+    /// Across the corpus, the RFP wants this to fire on ≤ 20% of
+    /// cases at default rates — tracked by a separate corpus-level
+    /// summary.
+    max_partition_rejections: usize,
+}
+
+/// Pooled-and-partitioned scoreboard: runs the stress case under both
+/// strategies, prints both scoreboards, and asserts both baselines.
+/// The partitioned-side assertions cover K1-2 (no new starvation)
+/// and K1-3 per-test (rejection-event ceiling).
+fn check_partitioned_stress_scoreboard(
+    test_name: &str,
+    pooled_result: &E2EResult,
+    partitioned_result: &E2EResult,
+    pooled_baseline: StressBaseline,
+    partitioned_baseline: PartitionedStressBaseline,
+) {
+    use fucktorio_core::trace::TraceEvent;
+
+    eprintln!("\n=== {test_name} :: Pooled ===");
+    check_stress_scoreboard(test_name, pooled_result, pooled_baseline);
+
+    let partitioned_warnings = partitioned_result.issues.iter()
+        .filter(|i| i.severity == Severity::Warning)
+        .count();
+    let partitioned_errors = partitioned_result.issues.iter()
+        .filter(|i| i.severity == Severity::Error)
+        .count();
+    let partition_rejections = partitioned_result.trace_events.iter()
+        .filter(|evt| matches!(evt, TraceEvent::PartitionRejectedByUtilization { .. }))
+        .count();
+    let module_partitions = partitioned_result.trace_events.iter()
+        .filter(|evt| matches!(evt, TraceEvent::ModulePartitioned { .. }))
+        .count();
+
+    eprintln!("\n=== {test_name} :: PartitionedPerConsumer ===");
+    eprintln!(
+        "  entities={} {}x{}",
+        partitioned_result.layout.entities.len(),
+        partitioned_result.layout.width,
+        partitioned_result.layout.height,
+    );
+    eprintln!("  module_partitioned events: {module_partitions}");
+    eprintln!("  partition_rejected events: {partition_rejections}");
+    eprintln!("  errors: {partitioned_errors} (baseline ≤ {})", partitioned_baseline.max_errors_partitioned);
+    eprintln!("  warnings: {partitioned_warnings} (baseline ≤ {})", partitioned_baseline.max_warnings_partitioned);
+
+    assert!(
+        partitioned_errors <= partitioned_baseline.max_errors_partitioned,
+        "{test_name}: PartitionedPerConsumer errors regressed: got {partitioned_errors}, \
+         baseline allows ≤ {}. If intentional, update the baseline (and tighten when fewer \
+         errors result).",
+        partitioned_baseline.max_errors_partitioned,
+    );
+    assert!(
+        partitioned_warnings <= partitioned_baseline.max_warnings_partitioned,
+        "{test_name}: K1-2 — PartitionedPerConsumer warnings regressed: got {partitioned_warnings}, \
+         baseline allows ≤ {}. If the 75%-utilization gate isn't tripping (see \
+         partition_rejected events), this means the 'belts over-provisioned' assumption from \
+         the RFP is failing on this case.",
+        partitioned_baseline.max_warnings_partitioned,
+    );
+    assert!(
+        partition_rejections <= partitioned_baseline.max_partition_rejections,
+        "{test_name}: K1-3 — partition_rejected events regressed: got {partition_rejections}, \
+         baseline allows ≤ {}. The 75%-utilization gate is tripping more than expected for this \
+         case — either the partitioner is being asked to handle a too-tight case, or the gate \
+         threshold needs retuning.",
+        partitioned_baseline.max_partition_rejections,
+    );
+}
+
 /// Baseline (Phase 1, 2026-04-11): entities=11232, warnings=0, zones_solved=19,
 /// bands=3 (1 crossing, 2 non-crossing), total_gap_tiles=33, mean_gap=11.00,
 /// max_gap=15, max_trunks/band=20. Note: the "non-crossing" bands here are
@@ -1350,6 +1437,86 @@ fn stress_advanced_circuit_45s_from_plates() {
         "stress_advanced_circuit_45s_from_plates",
         &result,
         StressBaseline { max_errors: usize::MAX, max_warnings: usize::MAX },
+    );
+}
+
+/// **K1-2 / K1-3 stress case** from `docs/rfp-modular-production.md`.
+/// advanced-circuit @ 5/s exercises the partitioner — copper-cable is
+/// consumed by both `electronic-circuit` and `advanced-circuit`
+/// recipes (K=2). Runs the case under both `Pooled` and
+/// `PartitionedPerConsumer` and asserts the K1-2 / K1-3 properties.
+///
+/// Baselines (probed 2026-04-25, blue belt = auto):
+/// - Pooled: 0 warnings, 3 errors. The errors are pre-existing
+///   #64-bound layout issues — Pooled can't avoid them at this rate.
+/// - PartitionedPerConsumer: 0 errors, 41 warnings,
+///   1 PartitionRejectedByUtilization event.
+///
+/// The single rejection event is *expected*: at AC=5/s the EC
+/// module's copper-cable demand (30/s ÷ 2 blue lanes = 15/s per lane)
+/// is ~89% of per-side capacity, above the 75% gate (11.25/s
+/// ceiling). The partitioner correctly flags it; this is the K1-3
+/// mechanism working — not a violation.
+///
+/// What this gates:
+///   - **K1-2**: warnings under `PartitionedPerConsumer` stay
+///     bounded (≤ 50 here, room for #64 jitter). If the count
+///     blows up while the gate isn't tripping more than expected,
+///     the "belts over-provisioned" assumption is failing.
+///   - **K1-3 per-test**: rejection events stay at 1 (the EC
+///     module's borderline rate). If we see > 1, the gate fired
+///     for an additional module — investigate.
+///   - **Phase 1 strict win**: PartitionedPerConsumer drops Pooled's
+///     3 errors to 0.
+///
+/// Corpus-level K1-3 (≤ 20% of cases trip the gate at default
+/// rates) needs more K>1 cases over time; this test contributes one.
+///
+/// Run with `cargo test --test e2e
+/// stress_advanced_circuit_partitioned_5s_from_plates -- --nocapture`.
+#[test]
+#[ntest::timeout(600000)]
+fn stress_advanced_circuit_partitioned_5s_from_plates() {
+    use fucktorio_core::bus::layout::LayoutStrategy;
+
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "coal", "crude-oil", "water"]
+        .iter().map(|s| s.to_string()).collect();
+    let pooled = run_e2e_with_strategy(
+        "stress_advanced_circuit_partitioned_5s_from_plates",
+        "advanced-circuit",
+        5.0,
+        "assembling-machine-2",
+        None,
+        &inputs,
+        LayoutStrategy::Pooled,
+    ).expect("Pooled e2e pipeline");
+    let partitioned = run_e2e_with_strategy(
+        "stress_advanced_circuit_partitioned_5s_from_plates",
+        "advanced-circuit",
+        5.0,
+        "assembling-machine-2",
+        None,
+        &inputs,
+        LayoutStrategy::PartitionedPerConsumer,
+    ).expect("PartitionedPerConsumer e2e pipeline");
+    assert_produces(&pooled, "advanced-circuit", 5.0);
+    assert_produces(&partitioned, "advanced-circuit", 5.0);
+    check_partitioned_stress_scoreboard(
+        "stress_advanced_circuit_partitioned_5s_from_plates",
+        &pooled,
+        &partitioned,
+        StressBaseline { max_errors: 3, max_warnings: 0 },
+        PartitionedStressBaseline {
+            max_errors_partitioned: 0,
+            // 41 warnings probed; 50 leaves slack for #64 jitter.
+            // Tighten when #64 (lane-throughput false-positives) is
+            // resolved separately.
+            max_warnings_partitioned: 50,
+            // 1 rejection: EC module hits 89% of per-side capacity
+            // on blue belt at AC=5/s. Documented as expected
+            // behavior, not a violation. See doc-comment above.
+            max_partition_rejections: 1,
+        },
     );
 }
 


### PR DESCRIPTION
## What happened

Same shape as PR #199's recovery — PR #200 was merged 17 seconds after PR #199, with PR #200's base set to `claude/rfp-mp-phase-1-onto-main` (PR #199's branch). By the time PR #200's merge fired, PR #199 had already squashed to main and its source branch was orphaned. So PR #200's content (`PartitionedStressBaseline`, `check_partitioned_stress_scoreboard`, `stress_advanced_circuit_partitioned_5s_from_plates`) landed on the orphaned branch, never reached main.

Confirmed via `grep -c "PartitionedStressBaseline" tests/e2e.rs` on `origin/main` → 0 matches.

## What this PR does

Cherry-picks `e695af1` (PR #200's squash commit on the orphaned branch) onto a fresh branch off current `main`. Conflict in `tests/e2e.rs` because main now has the squashed versions of Phase 1 (PR #199 → `9fbe8bc`) and stress baselines (PR #197 → `590811c`) at slightly different file positions than the un-squashed cherry-picked version expected. Resolution was mechanical: take the incoming side at both conflict points (which insert new helpers/tests before the closing `}` of the previous function — both halves agreed on what was already present, the conflict was just the insertion point).

Net diff matches PR #200's intent: 1 file changed, 167 insertions, 0 deletions.

## Verification

- `cargo test -p fucktorio_core` (release): 392 unit + **18** e2e tests pass (was 17 on current main: +1 from this commit). 14 ignored (timeout-bound; unchanged).
- `cargo clippy --all-targets -- -D warnings` clean on `core` and `wasm-bindings`.
- New `stress_advanced_circuit_partitioned_5s_from_plates` test runs in 1.89s release.

## Behavior unchanged

This PR adds a verification test only. **No production code paths change.** The `StressBaseline` and `check_stress_scoreboard` infrastructure was already on main from PR #197; this just adds the partitioned-strategy assertion struct + helper + the one test that exercises K1-2 / K1-3 at the K=2 advanced-circuit case.

## Cleanup after this lands

- Delete `claude/rfp-mp-phase-1-onto-main` (orphaned, content already on main).
- Delete `claude/rfp-mp-phase-1-stress-verification` (orphaned, content in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dyy5o9EH5tsavTZLPHjX9p)_