### PR TITLE
perf(web): bring render-on-demand onto main (re-merge of #202)

### DIFF
--- a/docs/web-render-perf-investigation.md
+++ b/docs/web-render-perf-investigation.md
@@ -147,6 +147,96 @@ it has work or call `app.render()` explicitly after each tick.
 
 This is a real architectural change — single PR, but with reach.
 
+#### Implementation plan
+
+Two abstractions in `web/src/renderer/app.ts`, exported both via the
+`AppContext` and as module-level functions (so per-feature ticker users
+can `import { beginAnimating, endAnimating } from "../renderer/app"`
+without changing function signatures):
+
+```ts
+// Coalesced one-shot render. Multiple calls in the same task collapse
+// into one. Use after one-shot scene mutations.
+export function requestRender(): void;
+
+// Refcounted ticker control. Use around sustained animations.
+export function beginAnimating(): void;
+export function endAnimating(): void;
+```
+
+Inside `createApp`, wire the viewport's events to keep the ticker open
+during interactions:
+
+| Event | Action |
+|---|---|
+| `moved`, `zoomed` | `requestRender()` |
+| `drag-start`, `pinch-start`, `snap-start`, `snap-zoom-start`, `bounce-x-start`, `bounce-y-start` | `beginAnimating()` |
+| `drag-end`, `pinch-end`, `snap-end`, `snap-zoom-end`, `bounce-x-end`, `bounce-y-end` | `endAnimating()` |
+| Window `resize` | `requestRender()` |
+
+Wheel emits `wheel-start` but no matching end; `moved`/`zoomed` cover
+the resulting motion.
+
+In `web/src/main.ts`, every code path that mutates the visible scene
+needs a `requestRender()` afterwards. The choke points:
+
+| Site | Why |
+|---|---|
+| End of `renderLayoutOnCanvas` (after overlay updates + `entityLayer.alpha` reset) | Initial layout commit |
+| Each `renderLayout(...)` call site (5 total) | Re-render with new entities |
+| End of `updateValidationOverlay`, `updateRegionOverlay`, `updateGhostTilesOverlay`, `updateTraceOverlay` (all return paths) | Overlay add/remove |
+| `junctionDebugger.onChange` callback (sets `entityLayer.alpha`) | SAT-zone dim toggle |
+| `inspector.onPinChange` (mutates `pinHighlight`) | Pin highlight |
+| `soloRegionsCb.addEventListener("change", ...)` both branches | Solo-region dim |
+| Wrap the `HighlightController` returned from every `renderLayout` so each method auto-`requestRender()`s | Hover dim path (called from `inspector.ts`) |
+
+Per-feature ticker users — convert each to call `beginAnimating()` when
+they `app.ticker.add(tick)` and `endAnimating()` when they
+`app.ticker.remove(tick)`:
+
+| File | Lifecycle notes |
+|---|---|
+| `web/src/renderer/streamingRenderer.ts` | tick added at start, removed in `cancel()` and `finish()`; track a local `tickerActive` boolean to avoid double-end |
+| `web/src/renderer/phaseAnimation.ts` | tick added at start, removed when complete or via `cancel()` / `finish()`; **early-return when `scheduled.length === 0` must skip `app.ticker.add` entirely**, otherwise the begin has no matching end |
+| `web/src/renderer/improvementAnimation.ts` | tick added on flash spawn, removed when faded out |
+| `web/src/ui/issuesDialog.ts` (pulse) | `pulseCircle` adds, `clearPulse` removes |
+
+Each removal path also needs a `requestRender()` so the final state is
+painted (e.g. fade-out finishing `alpha = 0` for the flash, alpha back to
+the resting value for pulse markers).
+
+#### Failure mode and verification
+
+The failure mode is "the canvas appears frozen until I move the mouse
+or pan." That happens when a mutation occurs but no `requestRender()`
+follows. Type-check, tests, and lint do not catch this. The only
+reliable verification is exercising every interaction at the dev server.
+
+Verification checklist for the PR:
+
+- Initial load: layout renders, sidebar populates, all overlays settle.
+- Pan / zoom / pinch: smooth motion during, no continued rendering
+  after motion settles.
+- Hover an entity: highlight appears immediately, dim applies to
+  others, clears immediately when mouse leaves.
+- Toggle each overlay (validation, regions, ghost tiles): each appears
+  and disappears immediately.
+- "Solo regions" mode: dim applies on enable, restores on disable.
+- Pin a tile via the inspector: highlight ring renders.
+- SAT zone selection: dim applies, edit mode dims further;
+  deselection restores both.
+- Streaming layout (load a fresh URL): transient previews + ghost
+  routes appear progressively, settle into final layout.
+- Phase animation (corpus / parsed blueprint): entities fade in
+  staggered.
+- Auto-optimize: region flashes during the optimize phase.
+- Validation pulse: clicking an issue in the panel pulses its marker.
+- Timeline scrub: drag the scrubber backwards/forwards through phases.
+
+**Anti-test: leave the page idle and watch DevTools Performance.** Main
+thread CPU should drop to near zero. If it doesn't, something is
+calling `beginAnimating()` without a matching `endAnimating()`.
+
 ### 2. Mark static layers as render groups (already landed)
 
 ```ts

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,7 +2,7 @@ import { Container, Graphics } from "pixi.js";
 import { createApp, WORLD_SIZE } from "./renderer/app";
 import { drawGrid, updateGrid } from "./renderer/grid";
 import { drawGraph } from "./renderer/graph";
-import { initEntityIcons, preloadCarriesIcons, renderLayout, setItemColoring, itemColor, TILE_PX } from "./renderer/entities";
+import { initEntityIcons, preloadCarriesIcons, renderLayout, setItemColoring, itemColor, TILE_PX, type HighlightController } from "./renderer/entities";
 import { createSelectionController, type SelectionController } from "./renderer/selection";
 import { renderSidebar } from "./ui/sidebar";
 import { initCorpusPanel } from "./ui/corpus";
@@ -101,7 +101,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   if (sidebar) sidebar.style.display = "";
   container.style.display = "";
 
-  const { app, viewport } = await createApp(container);
+  const { app, viewport, requestRender, beginAnimating, endAnimating } = await createApp(container);
   const gridGfx = drawGrid(viewport);
   drawGraph(viewport, null);
 
@@ -164,10 +164,12 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         // If the user deselects the zone while editing, exit cleanly.
         if (satEditor.isActive()) satEditor.exit();
       }
+      requestRender();
     },
     onEditRequested: (state) => {
       entityLayer.alpha = 0.2;
       satEditor.enter(state);
+      requestRender();
     },
   });
 
@@ -204,11 +206,13 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   viewport.addChild(pinHighlight);
   inspector.onPinChange((tile) => {
     pinHighlight.clear();
-    if (!tile) return;
-    const px = tile.x * TILE_PX;
-    const py = tile.y * TILE_PX;
-    pinHighlight.setStrokeStyle({ width: 2, color: 0x80c8ff, alpha: 0.95 });
-    pinHighlight.rect(px - 2, py - 2, TILE_PX + 4, TILE_PX + 4).stroke();
+    if (tile) {
+      const px = tile.x * TILE_PX;
+      const py = tile.y * TILE_PX;
+      pinHighlight.setStrokeStyle({ width: 2, color: 0x80c8ff, alpha: 0.95 });
+      pinHighlight.rect(px - 2, py - 2, TILE_PX + 4, TILE_PX + 4).stroke();
+    }
+    requestRender();
   });
   viewport.moveCenter(WORLD_SIZE / 2, WORLD_SIZE / 2);
 
@@ -219,6 +223,18 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   function onHover(entity: PlacedEntity | null): void {
     hoveredEntity = entity;
     inspector.onHover(entity, entity?.x, entity?.y);
+  }
+
+  // Wraps a HighlightController so highlight changes (alpha mutations + the
+  // overlay graphic) trigger render requests. Used at every renderLayout
+  // call site below — the returned controller is what we pass to inspector.
+  function wrapHighlight(ctrl: HighlightController): HighlightController {
+    return {
+      highlightItem: (item) => { ctrl.highlightItem(item); requestRender(); },
+      highlightBeltNetwork: (e) => { ctrl.highlightBeltNetwork(e); requestRender(); },
+      clearHighlight: () => { ctrl.clearHighlight(); requestRender(); },
+      chainKey: ctrl.chainKey,
+    };
   }
 
   // --- Sidebar toggles ---
@@ -313,16 +329,20 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       if (pointer >= reveals.length) {
         done = true;
         app.ticker.remove(tick);
+        endAnimating();
       }
     };
 
     app.ticker.add(tick);
+    beginAnimating();
     return {
       cancel() {
         if (done) return;
         done = true;
         app.ticker.remove(tick);
+        endAnimating();
         for (const r of reveals) for (const g of r.gfx) g.alpha = 1;
+        requestRender();
       },
     };
   }
@@ -356,7 +376,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         entityLayer, onHover, onSelect,
         (entity, gfx) => { gfxMap.set(entityKey(entity), gfx); },
       );
-      inspector.setHighlightController(ctrl);
+      inspector.setHighlightController(wrapHighlight(ctrl));
+      requestRender();
 
       // Animate only consecutive forward steps (N → N+1); jumps and backward stays instant.
       if (phaseIndex === prevPhaseIndexForAnim + 1 && prevSnapshotEntityList.length > 0) {
@@ -372,12 +393,14 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       prevPhaseIndexForAnim = -1;
       if (lastLayout) {
         const ctrl = renderLayout(lastLayout, entityLayer, onHover, onSelect);
-        inspector.setHighlightController(ctrl);
+        inspector.setHighlightController(wrapHighlight(ctrl));
+        requestRender();
       }
     }
 
     if (!debugCb.checked || !lastLayout?.trace?.length) {
       stepThrough.update();
+      requestRender();
       return;
     }
     const events = phaseIndex < 0
@@ -393,6 +416,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       },
     );
     stepThrough.update();
+    requestRender();
   }
 
   let valOverlayLayer: Container | null = null;
@@ -446,10 +470,12 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
     if (!debugCb.checked || !valCb.checked || !lastLayout) {
       issuesDialog.populate(cachedValidationIssues ?? [], debugCb.checked, valCb.checked);
+      requestRender();
       return;
     }
     if (!cachedValidationIssues || cachedValidationIssues.length === 0) {
       issuesDialog.populate([], debugCb.checked, valCb.checked);
+      requestRender();
       return;
     }
     const result = renderValidationOverlay(
@@ -463,6 +489,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     valCircleMap = result.circleMap;
     issuesDialog.setCircleMap(valCircleMap);
     issuesDialog.populate(cachedValidationIssues, debugCb.checked, valCb.checked);
+    requestRender();
   }
 
   function updateGhostTilesOverlay(): void {
@@ -471,14 +498,21 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       ghostTilesLayer.destroy({ children: true });
       ghostTilesLayer = null;
     }
-    if (!debugCb.checked || !ghostTilesCb.checked || !lastLayout) return;
+    if (!debugCb.checked || !ghostTilesCb.checked || !lastLayout) {
+      requestRender();
+      return;
+    }
     const layer = renderGhostTilesOverlay(lastLayout.trace);
-    if (!layer) return;
+    if (!layer) {
+      requestRender();
+      return;
+    }
     ghostTilesLayer = layer;
     // Attach below the entity layer so belts/machines read on top of
     // the cyan wash. `addChildAt(layer, 0)` puts it at the bottom of
     // the viewport's z-order.
     viewport.addChildAt(ghostTilesLayer, 0);
+    requestRender();
   }
 
   function updateRegionOverlay(): void {
@@ -494,7 +528,10 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     }
     regionHitTest = null;
     junctionHitTest = null;
-    if (!debugCb.checked || !regionsCb?.checked || !lastLayout) return;
+    if (!debugCb.checked || !regionsCb?.checked || !lastLayout) {
+      requestRender();
+      return;
+    }
 
     if (lastLayout.regions && lastLayout.regions.length > 0) {
       const detailed = renderRegionOverlayDetailed(lastLayout);
@@ -514,6 +551,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         entityLayer.addChild(junctionOverlayLayer);
       }
     }
+    requestRender();
   }
 
   // --- Item color legend (bottom-left) ---
@@ -681,6 +719,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         h: imp.zone_h,
       });
       renderLayout(lastLayout, entityLayer, undefined, undefined);
+      requestRender();
     };
 
     const drainDone = (): boolean => solverDone && queue.length === 0;
@@ -741,6 +780,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       (window as unknown as { __layout?: LayoutResult }).__layout = finalLayout;
       // Final authoritative redraw with the committed layout.
       renderLayout(finalLayout, entityLayer, undefined, undefined);
+      requestRender();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.includes("superseded")) {
@@ -998,7 +1038,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         ctrl = renderLayout(layout, entityLayer, onHover, onSelect);
       }
     }
-    inspector.setHighlightController(ctrl);
+    inspector.setHighlightController(wrapHighlight(ctrl));
     inspector.setTileContext(buildTileContext(layout.trace));
     inspector.clearPin();
     selectionCtrl = createSelectionController(app.canvas, viewport, entityLayer, layout, onSelectionChange);
@@ -1020,6 +1060,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     if (soloRegionsActive) {
       entityLayer.alpha = 0.12;
     }
+    requestRender();
 
     // Auto-optimize: kick off the round-robin pass after the initial
     // render has been painted. rAF gives PixiJS one tick to commit the
@@ -1146,6 +1187,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     });
 
     soloRegionsCb.addEventListener("change", () => {
+      const finish = (): void => requestRender();
       if (soloRegionsCb.checked) {
         soloRegionsActive = true;
         soloSavedState = {
@@ -1171,6 +1213,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
         entityLayer.alpha = 0.12;
         updateRegionOverlay();
+        finish();
       } else {
         soloRegionsActive = false;
         if (soloSavedState) {
@@ -1192,6 +1235,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
           soloSavedState = null;
         }
+        finish();
       }
     });
 

--- a/web/src/renderer/app.ts
+++ b/web/src/renderer/app.ts
@@ -1,4 +1,4 @@
-import { Application } from "pixi.js";
+import { Application, UPDATE_PRIORITY } from "pixi.js";
 import { Viewport } from "pixi-viewport";
 
 export const WORLD_SIZE = 3200;
@@ -6,15 +6,71 @@ export const WORLD_SIZE = 3200;
 export interface AppContext {
   app: Application;
   viewport: Viewport;
+  /**
+   * Schedule a single render on the next microtask. Multiple calls within
+   * the same task coalesce into one render. Use for one-shot scene mutations
+   * (renderLayout commits, hover dim changes, overlay toggles).
+   */
+  requestRender: () => void;
+  /**
+   * Mark the start of a sustained animation that wants the ticker running
+   * every frame. Pairs with `endAnimating()`. Internal counter — overlapping
+   * animations are safe as long as each begin matches exactly one end.
+   * Use for ticker-driven animations (per-feature `app.ticker.add(tick)`
+   * call sites, viewport drag/pinch/decelerate inertia).
+   */
+  beginAnimating: () => void;
+  /** Pair with `beginAnimating()`. Stops the ticker when the counter hits 0. */
+  endAnimating: () => void;
+}
+
+// --- Module-scoped re-exports ---
+//
+// Per-feature ticker users (streamingRenderer, phaseAnimation, improvementAnimation,
+// issuesDialog) take `app: Application` rather than the full AppContext, but they
+// still need to start/stop the ticker as part of their lifecycle. Rather than
+// thread the controls through every function signature, we expose them as
+// module-scoped functions populated by `createApp`. They are no-ops if invoked
+// before `createApp` has run — which shouldn't happen in practice but means a
+// stray import won't blow up at module load time.
+
+let _requestRender: (() => void) | null = null;
+let _beginAnimating: (() => void) | null = null;
+let _endAnimating: (() => void) | null = null;
+
+export function requestRender(): void {
+  _requestRender?.();
+}
+
+export function beginAnimating(): void {
+  _beginAnimating?.();
+}
+
+export function endAnimating(): void {
+  _endAnimating?.();
 }
 
 export async function createApp(container: HTMLElement): Promise<AppContext> {
   const app = new Application();
+  // `autoStart: false` stops Pixi from rendering on every rAF. We drive
+  // renders explicitly via `requestRender()` for one-shot mutations and via
+  // `beginAnimating()` / `endAnimating()` for sustained animations. See
+  // `docs/web-render-perf-investigation.md` for the trace evidence.
   await app.init({
     resizeTo: container,
     background: 0x1e1e1e,
     antialias: true,
+    autoStart: false,
+    sharedTicker: false,
   });
+
+  // `autoStart: true` would have wired this for us; we have to do it
+  // ourselves. Without it, the ticker runs custom ticks (alpha animations,
+  // viewport plugin updates) but never paints — so during streaming layout
+  // commit and per-feature animations the scene mutates invisibly. LOW
+  // priority puts the render after every other tick, so each tick's state
+  // changes show up in the same frame.
+  app.ticker.add(() => app.render(), null, UPDATE_PRIORITY.LOW);
 
   container.appendChild(app.canvas);
 
@@ -32,9 +88,90 @@ export async function createApp(container: HTMLElement): Promise<AppContext> {
 
   app.stage.addChild(viewport);
 
+  // --- Render-on-demand controls ---
+
+  let pendingRender = false;
+  const requestRenderImpl = (): void => {
+    if (pendingRender) return;
+    pendingRender = true;
+    queueMicrotask(() => {
+      pendingRender = false;
+      app.render();
+    });
+  };
+
+  let activeAnimations = 0;
+  const beginAnimatingImpl = (): void => {
+    if (activeAnimations === 0) app.ticker.start();
+    activeAnimations++;
+  };
+  const endAnimatingImpl = (): void => {
+    if (activeAnimations === 0) {
+      // Defensive: shouldn't happen if pairs are balanced, but if a *-end
+      // event fires without a matching *-start (e.g. plugin lifecycle
+      // edge case) we don't want to underflow.
+      return;
+    }
+    activeAnimations--;
+    if (activeAnimations === 0) app.ticker.stop();
+  };
+
+  // Wire the module-scoped re-exports. After this returns, the standalone
+  // `requestRender` / `beginAnimating` / `endAnimating` exports become live.
+  _requestRender = requestRenderImpl;
+  _beginAnimating = beginAnimatingImpl;
+  _endAnimating = endAnimatingImpl;
+
+  // --- Viewport interaction wiring ---
+  //
+  // `moved` / `zoomed` fire after every position/zoom change (during drag,
+  // pinch, decelerate, snap). Coalesced by the requestRender microtask.
+  // For sustained motion that needs the viewport's plugins to update each
+  // frame, we hold the ticker open via *-start / *-end event pairs.
+  viewport.on("moved", requestRenderImpl);
+  viewport.on("zoomed", requestRenderImpl);
+
+  const interactionStarts = [
+    "drag-start",
+    "pinch-start",
+    "snap-start",
+    "snap-zoom-start",
+    "bounce-x-start",
+    "bounce-y-start",
+  ] as const;
+  const interactionEnds = [
+    "drag-end",
+    "pinch-end",
+    "snap-end",
+    "snap-zoom-end",
+    "bounce-x-end",
+    "bounce-y-end",
+  ] as const;
+  for (const e of interactionStarts) {
+    (viewport as unknown as { on: (e: string, fn: () => void) => void }).on(e, beginAnimatingImpl);
+  }
+  for (const e of interactionEnds) {
+    (viewport as unknown as { on: (e: string, fn: () => void) => void }).on(e, endAnimatingImpl);
+  }
+  // Wheel emits `wheel-start` but no matching end (it's a one-shot per
+  // scroll). `moved`/`zoomed` already trigger requestRender, so no extra
+  // wiring needed for plain wheel zoom. Decelerate-after-drag is handled
+  // by drag-end → moved-end via the `bounce`/`snap` chain.
+
   window.addEventListener("resize", () => {
     viewport.resize(container.clientWidth, container.clientHeight, WORLD_SIZE, WORLD_SIZE);
+    requestRenderImpl();
   });
 
-  return { app, viewport };
+  // Render once after init so the canvas isn't blank until something else
+  // triggers a render.
+  requestRenderImpl();
+
+  return {
+    app,
+    viewport,
+    requestRender: requestRenderImpl,
+    beginAnimating: beginAnimatingImpl,
+    endAnimating: endAnimatingImpl,
+  };
 }

--- a/web/src/renderer/improvementAnimation.ts
+++ b/web/src/renderer/improvementAnimation.ts
@@ -5,6 +5,7 @@
 import { Graphics, type Application } from "pixi.js";
 import type { Viewport } from "pixi-viewport";
 import { TILE_PX } from "./entities";
+import { beginAnimating, endAnimating } from "./app";
 
 const FLASH_COLOR = 0x40c0e0;
 
@@ -29,6 +30,7 @@ export function spawnRegionFlash(
     if (remaining <= 0) {
       app.ticker.remove(tick);
       flashG.destroy();
+      endAnimating();
       return;
     }
     flashG.clear();
@@ -37,4 +39,5 @@ export function spawnRegionFlash(
       .fill({ color: FLASH_COLOR, alpha: 0.55 * remaining });
   };
   app.ticker.add(tick);
+  beginAnimating();
 }

--- a/web/src/renderer/phaseAnimation.ts
+++ b/web/src/renderer/phaseAnimation.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Application, Container, Graphics } from "pixi.js";
+import { beginAnimating, endAnimating, requestRender } from "./app";
 import type { LayoutResult, PlacedEntity } from "../wasm-pkg/fucktorio_wasm";
 import { renderLayout, type HighlightController } from "./entities";
 
@@ -228,16 +229,24 @@ export function renderLayoutPhaseAnimated(
     if (pointer >= scheduled.length) {
       done = true;
       app.ticker.remove(tick);
+      endAnimating();
     }
   };
 
-  app.ticker.add(tick);
+  // Skip the ticker entirely if there's nothing to animate. Otherwise
+  // `beginAnimating` would be called without a matching `endAnimating`.
+  if (!done) {
+    app.ticker.add(tick);
+    beginAnimating();
+  }
 
   const handle: PhaseAnimationHandle = {
     cancel() {
       if (cancelled || done) return;
       cancelled = true;
       app.ticker.remove(tick);
+      endAnimating();
+      requestRender();
     },
     finish() {
       if (cancelled || done) return;
@@ -246,6 +255,8 @@ export function renderLayoutPhaseAnimated(
       }
       done = true;
       app.ticker.remove(tick);
+      endAnimating();
+      requestRender();
     },
     isDone() {
       return done || cancelled;

--- a/web/src/renderer/streamingRenderer.ts
+++ b/web/src/renderer/streamingRenderer.ts
@@ -54,6 +54,7 @@ import {
   type DrawContext,
   type HighlightController,
 } from "./entities";
+import { beginAnimating, endAnimating, requestRender } from "./app";
 
 // ---------------------------------------------------------------------------
 // Timings
@@ -709,6 +710,8 @@ export function createStreamingRenderer(
   };
 
   app.ticker.add(tick);
+  beginAnimating();
+  let tickerActive = true;
 
   // -------------------------------------------------------------------------
   // Event dispatcher
@@ -780,6 +783,7 @@ export function createStreamingRenderer(
       if (cancelled) return;
       cancelled = true;
       app.ticker.remove(tick);
+      if (tickerActive) { endAnimating(); tickerActive = false; }
       committedLayer.removeChildren();
       ghostLayer.removeChildren();
       clusterOverlay.clear();
@@ -788,11 +792,13 @@ export function createStreamingRenderer(
       transientByTile.clear();
       ghostClusters.length = 0;
       reveals = null;
+      requestRender();
     },
 
     finish(layout: LayoutResult): HighlightController {
       // Tear down the live-phase ticker — scrub alpha is now imperative.
       app.ticker.remove(tick);
+      if (tickerActive) { endAnimating(); tickerActive = false; }
 
       // `renderLayout` calls `container.removeChildren()` which wipes
       // committedLayer, ghostLayer, clusterOverlay, and every transient

--- a/web/src/ui/issuesDialog.ts
+++ b/web/src/ui/issuesDialog.ts
@@ -3,6 +3,7 @@ import type { Viewport } from "pixi-viewport";
 import type { Graphics } from "pixi.js";
 import { VALIDATION_CIRCLE_ALPHA } from "../renderer/validationOverlay";
 import { TILE_PX } from "../renderer/entities";
+import { beginAnimating, endAnimating, requestRender } from "../renderer/app";
 import "./issuesDialog.css";
 
 export interface ValidationIssueItem {
@@ -89,7 +90,9 @@ export function createIssuesDialog(
     if (activePulse) {
       for (const m of activePulse.markers) m.alpha = VALIDATION_CIRCLE_ALPHA;
       app.ticker.remove(activePulse.tickerFn);
+      endAnimating();
       activePulse = null;
+      requestRender();
     }
   }
 
@@ -109,6 +112,7 @@ export function createIssuesDialog(
       }
     };
     app.ticker.add(tickerFn);
+    beginAnimating();
     activePulse = { markers, tickerFn };
   }
 


### PR DESCRIPTION
## Intent

Re-lands the render-on-demand work from #202 onto \`main\`. #202 was
merged into its base branch (\`perf-render-on-demand-prep\`) but never
propagated forward to \`main\` when #198 was squash-merged, leaving the
render-on-demand changes stranded on a side branch.

This PR cherry-picks the squash commit (\`8945a83\`) of #202 directly
onto current \`main\`, so the diff here is identical to what was already
reviewed and merged in #202 — no new code.

## Scope

- **In:** Identical content to #202: render-on-demand abstractions in
  \`app.ts\`, mutation-site wiring in \`main.ts\`, ticker conversions for
  \`streamingRenderer\`, \`phaseAnimation\`, \`improvementAnimation\`,
  \`issuesDialog\` pulse, the auto-render hook fix, and the doc
  expansion.
- **Out:** Nothing new.

## Verification

- [x] \`npx tsc --noEmit\` from \`web/\` passes.
- [x] Diff matches #202's squash commit.
- [ ] Local browser eyeball — already done in #202's review cycle by
      the human; this PR adds no new code beyond that.

## Deviations from intent

None — this is a re-merge to fix the missed forward-merge.

## Models / contracts touched

None new.