### PR TITLE
feat(bus,web): stream bus trunks, balancers, mergers, poles for progressive reveal

### DIFF
--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -150,6 +150,7 @@ pub fn route_bus_ghost(
             continue;
         }
 
+        let lane_start = entities.len();
         let x = lane.x;
         let belt_name = belt_entity_for_rate(lane.rate * 2.0, max_belt_tier);
         let trunk_seg_id = Some(format!("trunk:{}", lane.item));
@@ -201,6 +202,17 @@ pub fn route_bus_ghost(
                 pre_ghost_belts.insert((x, tap_y));
             }
         }
+
+        // Stream the per-lane tap-off batch so the live renderer can reveal
+        // it progressively instead of dumping it via the bus_routed safety net.
+        if entities.len() > lane_start {
+            crate::trace::emit(crate::trace::TraceEvent::TrunkBeltCommitted {
+                item: lane.item.clone(),
+                lane_x: lane.x,
+                is_fluid: false,
+                entities: entities[lane_start..].to_vec(),
+            });
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -236,6 +248,17 @@ pub fn route_bus_ghost(
                 hard.insert((sx, sy));
                 fluid_reservations.remove(&(sx, sy));
             }
+        }
+        // Stream sibling of BalancerStamped — carries the entity batch so
+        // the live renderer can reveal the cascade progressively. Emitted
+        // before extend() so the event clones the entity list once and the
+        // extend consumes the original.
+        if !balancer_ents.is_empty() {
+            crate::trace::emit(crate::trace::TraceEvent::BalancerCommitted {
+                item: fam.item.clone(),
+                shape: fam.shape,
+                entities: balancer_ents.clone(),
+            });
         }
         entities.extend(balancer_ents);
     }
@@ -278,6 +301,7 @@ pub fn route_bus_ghost(
         if lane.is_fluid {
             continue;
         }
+        let lane_start = entities.len();
         let x = lane.x;
         let belt_name = belt_entity_for_rate(lane.rate * 2.0, max_belt_tier);
         let trunk_seg_id = Some(format!("trunk:{}", lane.item));
@@ -351,6 +375,15 @@ pub fn route_bus_ghost(
                     .push(tile);
             }
         }
+        // Stream the per-lane trunk-segment batch.
+        if entities.len() > lane_start {
+            crate::trace::emit(crate::trace::TraceEvent::TrunkBeltCommitted {
+                item: lane.item.clone(),
+                lane_x: lane.x,
+                is_fluid: false,
+                entities: entities[lane_start..].to_vec(),
+            });
+        }
     }
     // Sort each synth path so tiles are ordered top-to-bottom (ascending y).
     for path in trunk_synth_paths.values_mut() {
@@ -386,6 +419,7 @@ pub fn route_bus_ghost(
         if !lane.is_fluid {
             continue;
         }
+        let lane_start = entities.len();
         let x = lane.x;
         let trunk_seg_id = Some(format!("trunk:{}", lane.item));
 
@@ -651,6 +685,15 @@ pub fn route_bus_ghost(
                     hard.insert(tile);
                 }
             }
+        }
+        // Stream the per-lane fluid-trunk batch.
+        if entities.len() > lane_start {
+            crate::trace::emit(crate::trace::TraceEvent::TrunkBeltCommitted {
+                item: lane.item.clone(),
+                lane_x: lane.x,
+                is_fluid: true,
+                entities: entities[lane_start..].to_vec(),
+            });
         }
     }
 
@@ -2182,6 +2225,14 @@ pub fn route_bus_ghost(
                 rows: output_rows.clone(),
                 merge_y: max_y,
             });
+            // Stream sibling of OutputMerged — carries the merger entity batch
+            // so the live renderer can reveal them progressively.
+            if !merge_ents.is_empty() {
+                crate::trace::emit(crate::trace::TraceEvent::OutputMergerCommitted {
+                    item: item.clone(),
+                    entities: merge_ents.clone(),
+                });
+            }
             entities.extend(merge_ents);
             max_y = max_y.max(merge_end_y);
             merge_max_x = merge_max_x.max(item_merge_x);

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -275,6 +275,14 @@ pub fn build_bus_layout(
             count: poles.len(),
             strategy: pole_strategy.to_string(),
         });
+        // Stream sibling of PolesPlaced — carries the pole entity batch so
+        // the live renderer can reveal them progressively instead of dumping
+        // them via the poles_placed PhaseSnapshot safety net.
+        if !poles.is_empty() {
+            crate::trace::emit(crate::trace::TraceEvent::PolesCommitted {
+                entities: poles.clone(),
+            });
+        }
         crate::trace::emit(crate::trace::TraceEvent::PhaseComplete {
             phase: "poles_placed".into(),
             entity_count: poles.len(),

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -158,6 +158,26 @@ pub enum TraceEvent {
         y_end: i32,
         template_found: bool,
     },
+    /// Stream sibling of `BalancerStamped` — carries the actual entity batch
+    /// so the live renderer can reveal a balancer cascade progressively
+    /// instead of dumping it via the `bus_routed` safety net at the end.
+    BalancerCommitted {
+        item: String,
+        shape: (usize, usize),
+        entities: Vec<PlacedEntity>,
+    },
+    /// One emission per per-lane stamp pass during Steps 2 (tap-off
+    /// splitters and continue-belts), 3.5 (solid trunk segments), and 3.6
+    /// (fluid trunks). `is_fluid` distinguishes the source step but the
+    /// renderer treats them uniformly. Each lane therefore emits two events
+    /// for solid lanes (Step 2 and Step 3.5) and one event for fluid lanes
+    /// (Step 3.6).
+    TrunkBeltCommitted {
+        item: String,
+        lane_x: i32,
+        is_fluid: bool,
+        entities: Vec<PlacedEntity>,
+    },
     LaneRouted {
         item: String,
         x: i32,
@@ -180,6 +200,13 @@ pub enum TraceEvent {
         rows: Vec<usize>,
         merge_y: i32,
     },
+    /// Stream sibling of `OutputMerged` — carries the merger entity batch
+    /// (belts + splitters with `merger:{item}` segment id) so the live
+    /// renderer can reveal them progressively.
+    OutputMergerCommitted {
+        item: String,
+        entities: Vec<PlacedEntity>,
+    },
     MergerBlockPlaced {
         item: String,
         lanes: usize,
@@ -191,6 +218,11 @@ pub enum TraceEvent {
     PolesPlaced {
         count: usize,
         strategy: String,
+    },
+    /// Stream sibling of `PolesPlaced` — carries the pole entity batch so
+    /// the live renderer can reveal them progressively.
+    PolesCommitted {
+        entities: Vec<PlacedEntity>,
     },
 
     // Phase boundary markers

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -118,6 +118,14 @@ fn streamable(evt: &fucktorio_core::trace::TraceEvent) -> bool {
             | T::JunctionSolved { .. }
             | T::SatInvocation { .. }
             | T::SatImprovement { .. }
+            // Stream siblings of metadata-only stamp events. Without these,
+            // bus trunks, balancers, output mergers, and poles surface only
+            // via the bus_routed / poles_placed PhaseSnapshot safety nets
+            // and slam onto the canvas all at once at the end of layout.
+            | T::TrunkBeltCommitted { .. }
+            | T::BalancerCommitted { .. }
+            | T::OutputMergerCommitted { .. }
+            | T::PolesCommitted { .. }
     )
 }
 

--- a/web/src/renderer/streamingRenderer.ts
+++ b/web/src/renderer/streamingRenderer.ts
@@ -461,16 +461,20 @@ export function createStreamingRenderer(
     }
   }
 
-  function handleGhostSpecCommitted(data: {
-    spec_key: string;
-    entities: PlacedEntity[];
-  }): void {
+  /** Reveal a batch of entities with a NW→SE staggered fade-in. Used by
+   *  `GhostSpecCommitted` (per-spec ghost route commits) and the silent-stamp
+   *  stream events (`TrunkBeltCommitted`, `BalancerCommitted`,
+   *  `OutputMergerCommitted`, `PolesCommitted`) — all of which want the same
+   *  treatment: pre-populate the draw context for turn detection, then
+   *  commit each entity at a staggered timestamp. */
+  function commitEntitiesStaggered(entities: PlacedEntity[]): void {
+    if (entities.length === 0) return;
     const now = clock();
     // Populate draw ctx with every entity in this batch up-front so
     // turn detection sees sideload neighbours when rendering each belt.
-    for (const e of data.entities) addEntityToDrawContext(e, drawCtx);
+    for (const e of entities) addEntityToDrawContext(e, drawCtx);
     // Sort entities by their path position (approximately) via NW→SE.
-    const sorted = [...data.entities].sort((a, b) => {
+    const sorted = [...entities].sort((a, b) => {
       const dy = (a.y ?? 0) - (b.y ?? 0);
       if (dy !== 0) return dy;
       return (a.x ?? 0) - (b.x ?? 0);
@@ -484,6 +488,13 @@ export function createStreamingRenderer(
     // keep their ghost belt at ~50% alpha — the eye-candy feedback
     // "something still flows here". When a junction cluster covers
     // those tiles later, `handleJunctionCommitted` fades them out.
+  }
+
+  function handleGhostSpecCommitted(data: {
+    spec_key: string;
+    entities: PlacedEntity[];
+  }): void {
+    commitEntitiesStaggered(data.entities);
   }
 
   function handleJunctionCommitted(data: {
@@ -765,6 +776,15 @@ export function createStreamingRenderer(
           zone_w: number;
           zone_h: number;
         });
+        break;
+      // Stream-sibling events for entities that the engine previously stamped
+      // silently. They all carry an `entities` batch that we reveal with the
+      // same NW→SE stagger as `GhostSpecCommitted`.
+      case "TrunkBeltCommitted":
+      case "BalancerCommitted":
+      case "OutputMergerCommitted":
+      case "PolesCommitted":
+        commitEntitiesStaggered((evt.data as { entities: PlacedEntity[] }).entities);
         break;
       default:
         break;


### PR DESCRIPTION
## Intent

Fixes the "blasts all the rest of the lanes in one go" jank described in
\`docs/web-render-perf-investigation.md\`. The engine previously stamped
several entity classes (bus trunks, balancer cascades, output mergers,
power poles) into the layout accumulator without emitting any
\`TraceEvent\`, so they surfaced only at the very end via the
\`bus_routed\` / \`poles_placed\` \`PhaseSnapshot\` safety-net handlers in the
streaming renderer — appearing all at once over a clipped 900 ms
stagger that \`streamingHandle.finish()\` raced.

This PR adds streaming events for every silent-stamp path so the live
renderer reveals each batch progressively. The safety nets become
no-ops, and the \`finish()\` race is resolved as a side effect (no
in-flight stagger left to clip).

Plan: \`/home/stork/.claude/plans/velvety-jingling-grove.md\`.

## Scope

- **In:**
  - 4 new \`TraceEvent\` variants (\`TrunkBeltCommitted\`,
    \`BalancerCommitted\`, \`OutputMergerCommitted\`, \`PolesCommitted\`)
    sitting alongside their metadata-only siblings.
  - 6 \`trace::emit(...)\` call-sites in \`crates/core/src/bus/\` covering
    every \`entities.push/extend\` site that wasn't already being
    streamed via \`GhostSpecCommitted\` / \`JunctionCommitted\`.
  - WASM streamable filter updated.
  - Frontend dispatch through a shared \`commitEntitiesStaggered\`
    helper extracted from the existing \`handleGhostSpecCommitted\`.
- **Out:**
  - Cluster outline rectangles (\`GhostClusterSolved\`) — still useful
    for debugging; user wants to keep them.
  - Timeline-scrubber milestones for the new events. Cheap follow-up.

## Verification

- [x] \`cargo test --manifest-path crates/core/Cargo.toml\` — 416 tests pass.
- [x] \`cargo clippy --manifest-path crates/core/Cargo.toml --tests -- -D warnings\` — clean (pre-existing warnings in unrelated files weren't touched).
- [x] \`wasm-pack build crates/wasm-bindings --target web --out-dir "\$(pwd)/web/src/wasm-pkg"\` — clean rebuild; new variants land in the generated \`.d.ts\`.
- [x] \`cd web && npx tsc --noEmit\` — clean.
- [ ] Browser eyeball at dev server, URL \`?item=processing-unit&rate=2&machine=assembling-machine-3&in=iron-plate,copper-plate,steel-plate,stone,coal,water,crude-oil,iron-ore,copper-ore\`. Expected progression:
  - machines + row belts reveal (existing)
  - poles dot in
  - tap-off splitters appear at trunk columns
  - balancer cascades reveal
  - trunk segments fill between taps
  - fluid trunks reveal
  - ghost routes commit (existing)
  - junctions resolve (existing)
  - output mergers reveal at bottom-right
  - **no big "blast" at the end**

## Deviations from intent

None. The implementation matches the plan exactly.

## Models / contracts touched

\`TraceEvent\` enum in \`crates/core/src/trace.rs\` — additive only;
existing variants are unchanged. The streaming event union in the
generated TS bindings is automatically updated.

E2e tests in \`crates/core/tests/\` use open \`match\` arms over
\`TraceEvent\`, so adding variants is non-breaking — confirmed by the
green test run.