### PR TITLE
perf(web): kill redundant pan renders + grid fades in as the canvas

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -103,6 +103,11 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   const { app, viewport, requestRender, beginAnimating, endAnimating } = await createApp(container);
   const gridGfx = drawGrid(viewport);
+  // Tracks whether the grid has been animated in. Once revealed it stays
+  // visible across subsequent layout loads — only the dimensions are
+  // updated. The fade is a "this is the canvas" signal, shown once per
+  // session.
+  let gridRevealed = false;
   drawGraph(viewport, null);
 
   debugState.create();
@@ -944,21 +949,104 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     drawGraph(viewport, null);
     streamingHandle = createStreamingRenderer(entityLayer, app, onHover, onSelect);
     let viewportFitted = false;
+    let gridReveal: ReturnType<typeof startGridReveal> | null = null;
     return (evt) => {
+      const phase = (evt as { phase?: string }).phase;
       // On the first PhaseSnapshot, pan+zoom to frame the layout so streaming
-      // entities are visible. Subsequent snaps don't re-pan (user may have moved).
-      if (!viewportFitted && (evt as { phase?: string }).phase === "PhaseSnapshot") {
+      // entities are visible, and start drawing the grid as the "canvas" the
+      // entities will be placed on. Subsequent PhaseSnapshots resize the grid
+      // (the bus phase grows the layout sideways and downward) but don't
+      // re-pan (user may have moved) and don't re-trigger the fade-in.
+      if (phase === "PhaseSnapshot") {
         const d = (evt as { phase: string; data: { width: number; height: number } }).data;
         if (d.width > 0 && d.height > 0) {
-          viewport.fit(true, d.width * TILE_PX * 1.15, d.height * TILE_PX * 1.25);
-          viewport.moveCenter(d.width * TILE_PX / 2, d.height * TILE_PX / 2);
-          viewportFitted = true;
+          if (!viewportFitted) {
+            viewport.fit(true, d.width * TILE_PX * 1.15, d.height * TILE_PX * 1.25);
+            viewport.moveCenter(d.width * TILE_PX / 2, d.height * TILE_PX / 2);
+            viewportFitted = true;
+          }
+          if (!gridReveal) {
+            gridReveal = startGridReveal(d.width + 2, d.height + 2);
+          } else {
+            gridReveal.resize(d.width + 2, d.height + 2);
+          }
+          // First-fade-in is owned by the gridReveal handle; subsequent
+          // layout loads skip the fade and just resize. The flag flips
+          // when the fade animation finishes.
         }
       }
       streamingHandle?.onEvent(evt, (m) => {
         if (!streamingHandle) return;
         timelineScrubber.noteMilestone(m, streamingHandle.getTimeRange());
       });
+    };
+  }
+
+  /** Reveal the grid as a top-to-bottom wipe. Returns a handle that can
+   *  resize the target dimensions mid-animation (the bus-routed phase grows
+   *  the layout). When the wipe completes, switches to imperative redraws
+   *  on resize so subsequent PhaseSnapshots are cheap. */
+  function startGridReveal(
+    initialW: number,
+    initialH: number,
+  ): { cancel(): void; resize(w: number, h: number): void } {
+    let w = initialW;
+    let h = initialH;
+    let done = false;
+
+    // Fast path: the grid was already revealed once in this session. Just
+    // redraw at the new size — no fade, no flicker.
+    if (gridRevealed) {
+      updateGrid(gridGfx, w, h);
+      requestRender();
+      done = true;
+      return {
+        cancel: () => {},
+        resize(newW, newH) {
+          updateGrid(gridGfx, newW, newH);
+          requestRender();
+        },
+      };
+    }
+
+    const FADE_MS = 250;
+    const start = performance.now();
+    gridGfx.alpha = 1;
+    updateGrid(gridGfx, w, h, 0);
+    const tick = (): void => {
+      if (done) return;
+      const t = Math.min(1, (performance.now() - start) / FADE_MS);
+      updateGrid(gridGfx, w, h, t);
+      requestRender();
+      if (t >= 1) {
+        done = true;
+        gridRevealed = true;
+        app.ticker.remove(tick);
+        endAnimating();
+      }
+    };
+    app.ticker.add(tick);
+    beginAnimating();
+    return {
+      cancel(): void {
+        if (done) return;
+        done = true;
+        gridRevealed = true;
+        app.ticker.remove(tick);
+        endAnimating();
+        updateGrid(gridGfx, w, h);
+        requestRender();
+      },
+      resize(newW: number, newH: number): void {
+        w = newW;
+        h = newH;
+        // While animating, the next tick redraws at the new size with the
+        // current reveal fraction. After completion, redraw fully.
+        if (done) {
+          updateGrid(gridGfx, w, h);
+          requestRender();
+        }
+      },
     };
   }
 

--- a/web/src/renderer/app.ts
+++ b/web/src/renderer/app.ts
@@ -91,7 +91,15 @@ export async function createApp(container: HTMLElement): Promise<AppContext> {
   // --- Render-on-demand controls ---
 
   let pendingRender = false;
+  let activeAnimations = 0;
   const requestRenderImpl = (): void => {
+    // If the ticker is running, the auto-render hook above will paint this
+    // frame already — scheduling a microtask render on top of that just
+    // doubles the cost. During pan/drag/animations we get pointermove +
+    // viewport.on("moved") events firing at ~60Hz; without this guard, each
+    // one queues an extra full app.render() (≈30ms on a 3000-entity layout)
+    // on top of the ticker's own per-frame render.
+    if (activeAnimations > 0) return;
     if (pendingRender) return;
     pendingRender = true;
     queueMicrotask(() => {
@@ -100,7 +108,6 @@ export async function createApp(container: HTMLElement): Promise<AppContext> {
     });
   };
 
-  let activeAnimations = 0;
   const beginAnimatingImpl = (): void => {
     if (activeAnimations === 0) app.ticker.start();
     activeAnimations++;

--- a/web/src/renderer/grid.ts
+++ b/web/src/renderer/grid.ts
@@ -11,19 +11,42 @@ export function drawGrid(viewport: Viewport): Graphics {
   return g;
 }
 
-export function updateGrid(g: Graphics, widthTiles: number, heightTiles: number): void {
+/** Draw the grid lines covering `widthTiles × heightTiles`.
+ *
+ *  `revealFraction` (default 1) clips the drawing to the top portion of the
+ *  grid, drawing only down to `heightTiles × TILE_SIZE × revealFraction`.
+ *  Used by the streaming-layout fade-in to wipe the grid in top-to-bottom
+ *  on first reveal. Pass 1 for a fully-drawn grid. */
+export function updateGrid(
+  g: Graphics,
+  widthTiles: number,
+  heightTiles: number,
+  revealFraction: number = 1,
+): void {
   g.clear();
   if (widthTiles <= 0 || heightTiles <= 0) return;
+  const t = Math.max(0, Math.min(1, revealFraction));
+  if (t === 0) return;
   const pw = widthTiles * TILE_SIZE;
   const ph = heightTiles * TILE_SIZE;
+  const visibleH = ph * t;
+  // Vertical lines — clip each to the revealed height.
   for (let i = 0; i <= widthTiles; i++) {
     const x = i * TILE_SIZE;
     const major = i % 10 === 0;
-    g.moveTo(x, 0).lineTo(x, ph).stroke({ width: major ? 1.5 : 1, color: major ? MAJOR_COLOR : MINOR_COLOR });
+    g.moveTo(x, 0).lineTo(x, visibleH).stroke({
+      width: major ? 1.5 : 1,
+      color: major ? MAJOR_COLOR : MINOR_COLOR,
+    });
   }
+  // Horizontal lines — only draw those whose y has been revealed.
   for (let j = 0; j <= heightTiles; j++) {
     const y = j * TILE_SIZE;
+    if (y > visibleH) break;
     const major = j % 10 === 0;
-    g.moveTo(0, y).lineTo(pw, y).stroke({ width: major ? 1.5 : 1, color: major ? MAJOR_COLOR : MINOR_COLOR });
+    g.moveTo(0, y).lineTo(pw, y).stroke({
+      width: major ? 1.5 : 1,
+      color: major ? MAJOR_COLOR : MINOR_COLOR,
+    });
   }
 }


### PR DESCRIPTION
## Intent

Two related changes from a fresh perf trace
(\`Trace-20260425T135149.json.gz\`, ~9s of post-layout panning + mouse
movement on \`processing-unit @ rate=2\`):

1. **Kill the double-render during interaction.** The trace showed
   ~95ms tasks firing every ~100ms (i.e. CPU pinned at near 100%
   during pan), each containing **three** \`app.render()\` calls:
   one from the ticker's auto-render hook, two from \`requestRender\`
   microtasks fired by rapid \`pointermove\` events. With 2892
   entities each render is ~30ms; rendering 3x per task explains the
   pin. Fix: \`requestRender\` is now a no-op while the ticker is
   running — the auto-render hook will paint anyway. One-shot renders
   (overlay toggles, hover dim post-settle) still go through the
   microtask path.
2. **Grid fades in as the canvas, not as a final flash.** Previously
   \`updateGrid\` was called at the end of \`renderLayoutOnCanvas\`,
   *after* every entity was on screen — the grid blasted in over a
   fully-rendered factory. Now the streaming-event handler in
   \`main.ts\` sizes the grid as soon as the first \`PhaseSnapshot\`
   arrives (carries dimensions), and animates a 250ms top-to-bottom
   wipe with \`updateGrid\` taking a \`revealFraction\` parameter.
   Subsequent layout loads in the same session skip the fade and just
   resize — the canvas is established once.

## Scope

- **In:**
  - \`web/src/renderer/app.ts\`: 1-line guard in \`requestRender\`.
  - \`web/src/renderer/grid.ts\`: \`updateGrid\` gains a
    \`revealFraction\` parameter, default 1 (existing call sites
    unaffected).
  - \`web/src/main.ts\`: \`startStreaming\` hooks \`PhaseSnapshot\`
    events to size + animate the grid; new \`startGridReveal\` helper
    handles the wipe and exposes a \`resize()\` method for in-flight
    dimension updates.
- **Out:**
  - The \`hitTestMoveRecursive\` cost (~370ms self-time across 9s in
    the trace). Pixi's pointer hit-test walks all 2892 entity Graphics
    on every \`pointermove\`. Worth chasing in a follow-up — likely
    fixable by replacing per-entity hit-tests with a direct
    tile-coordinate lookup using the layout entities — but bigger
    surgery and not in the critical path now.
  - Reducing per-render cost itself (~30ms with cached render-group
    instructions). That's a deeper refactor (single-mesh batching,
    ParticleContainer, etc.) — the dedup gets us most of the win for
    much less work.

## Verification

- [x] \`npx tsc --noEmit\` clean.
- [ ] Browser eyeball — please verify:
  1. **Pan is responsive**: load processing-unit @ rate=2, wait for
     layout, drag the canvas around. Should feel smooth instead of
     pinned. DevTools Performance during pan should show roughly half
     the render frequency vs before this PR.
  2. **Grid wipes in top-to-bottom** at the start of the streaming
     phase, before any entities reveal.
  3. **Loading a second layout** (change recipe) just resizes the
     grid — no re-fade, no flicker.
  4. **Non-streaming paths still work** — try loading a corpus entry
     or pasting a blueprint string. The grid should appear at full
     opacity (the existing \`renderLayoutOnCanvas\` updateGrid call
     fires at fraction=1).

## Deviations from intent

User asked for "fast fade in from top to bottom" — implemented as 250ms
wipe by progressively drawing the grid lines. The Pixi-mask alternative
was an option but redrawing the lines is simpler and the cost is
negligible (~230 lines).

## Models / contracts touched

\`updateGrid\` signature gained an optional \`revealFraction\` parameter.
Default value preserves prior behavior so existing callers (the
non-streaming path in \`renderLayoutOnCanvas\`) work unchanged.