### PR TITLE
perf(web): tile-based hover detection (drops per-pointermove scene-walk)

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,7 +2,7 @@ import { Container, Graphics } from "pixi.js";
 import { createApp, WORLD_SIZE } from "./renderer/app";
 import { drawGrid, updateGrid } from "./renderer/grid";
 import { drawGraph } from "./renderer/graph";
-import { initEntityIcons, preloadCarriesIcons, renderLayout, setItemColoring, itemColor, TILE_PX, type HighlightController } from "./renderer/entities";
+import { initEntityIcons, preloadCarriesIcons, renderLayout, setItemColoring, itemColor, TILE_PX, MACHINE_SIZES, SPLITTER_ENTITIES, splitterCompanionOffset, type HighlightController } from "./renderer/entities";
 import { createSelectionController, type SelectionController } from "./renderer/selection";
 import { renderSidebar } from "./ui/sidebar";
 import { initCorpusPanel } from "./ui/corpus";
@@ -195,6 +195,10 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   // pure waste. Add/remove operations (renderLayout commit, overlay toggle)
   // invalidate the group; transform / alpha changes on children don't.
   entityLayer.isRenderGroup = true;
+  // Disable Pixi's recursive hit-testing on the entity layer. Hover detection
+  // is now done via tileEntityMap in the canvas pointermove handler; per-entity
+  // Pixi events are no longer registered for hover (only click via onSelect).
+  entityLayer.eventMode = "none";
   viewport.addChild(entityLayer);
   // SAT-zone detail overlay sits above the entity layer so the bbox,
   // boundary bars, and item icons always read on top of the belts.
@@ -223,6 +227,36 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   function onHover(entity: PlacedEntity | null): void {
     hoveredEntity = entity;
     inspector.onHover(entity, entity?.x, entity?.y);
+  }
+
+  // Tile→entity map for canvas-level hover detection. Rebuilt whenever the
+  // layout changes (see rebuildTileEntityMap calls). Replaces per-entity Pixi
+  // pointer events to avoid the hitTestMoveRecursive scene-walk on every
+  // pointermove.
+  let tileEntityMap: Map<string, PlacedEntity> = new Map();
+
+  function rebuildTileEntityMap(layout: LayoutResult): void {
+    const m = new Map<string, PlacedEntity>();
+    for (const e of layout.entities) {
+      const x = e.x ?? 0;
+      const y = e.y ?? 0;
+      const sz = MACHINE_SIZES[e.name];
+      if (sz) {
+        const [w, h] = sz;
+        for (let dy = 0; dy < h; dy++) {
+          for (let dx = 0; dx < w; dx++) {
+            m.set(`${x + dx},${y + dy}`, e);
+          }
+        }
+      } else if (SPLITTER_ENTITIES.has(e.name)) {
+        m.set(`${x},${y}`, e);
+        const [cdx, cdy] = splitterCompanionOffset(e.direction);
+        m.set(`${x + cdx},${y + cdy}`, e);
+      } else {
+        m.set(`${x},${y}`, e);
+      }
+    }
+    tileEntityMap = m;
   }
 
   // Wraps a HighlightController so highlight changes (alpha mutations + the
@@ -614,6 +648,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       inspector.clearPin();
       inspector.setTileContext(null);
       lastLayout = null;
+      tileEntityMap = new Map();
       cachedValidationIssues = null;
       drawGraph(viewport, null);
       viewport.moveCenter(WORLD_SIZE / 2, WORLD_SIZE / 2);
@@ -777,6 +812,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         waitForDrain();
       });
       lastLayout = finalLayout;
+      rebuildTileEntityMap(finalLayout);
       (window as unknown as { __layout?: LayoutResult }).__layout = finalLayout;
       // Final authoritative redraw with the committed layout.
       renderLayout(finalLayout, entityLayer, undefined, undefined);
@@ -815,11 +851,16 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     // the coord line stays visible even when a lane/row/ghost overlay
     // has installed a tooltip override.
     inspector.setCursorTile(tx, ty);
+    // Tile-based hover detection — replaces per-entity Pixi pointer events.
+    // Look up the entity at this tile and fire onHover only on change.
+    const found = tileEntityMap.get(`${tx},${ty}`) ?? null;
+    if (found !== hoveredEntity) onHover(found);
     if (!hoveredEntity) inspector.onHover(null, tx, ty);
   });
 
   app.canvas.addEventListener("pointerleave", () => {
     inspector.setCursorTile(null);
+    if (hoveredEntity) onHover(null);
   });
 
   // Click handling for SAT regions + junction zones. Junction click
@@ -991,6 +1032,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   function renderLayoutOnCanvas(layout: LayoutResult): void {
     lastLayout = layout;
+    rebuildTileEntityMap(layout);
     (window as unknown as { __layout?: LayoutResult }).__layout = layout;
     logLayoutStats(layout);
     stepThrough.reset();

--- a/web/src/renderer/entities.ts
+++ b/web/src/renderer/entities.ts
@@ -163,7 +163,7 @@ export function itemColor(item: string | undefined): number {
 }
 
 // [width, height] in tiles for multi-tile entities
-const MACHINE_SIZES: Record<string, [number, number]> = {
+export const MACHINE_SIZES: Record<string, [number, number]> = {
   "assembling-machine-1": [3, 3],
   "assembling-machine-2": [3, 3],
   "assembling-machine-3": [3, 3],
@@ -205,7 +205,7 @@ const BELT_ENTITIES = new Set(
   Object.keys(BELT_COLORS).filter((k) => !k.includes("underground") && !k.includes("splitter"))
 );
 const UG_BELT_ENTITIES = new Set(Object.keys(BELT_COLORS).filter((k) => k.includes("underground")));
-const SPLITTER_ENTITIES = new Set(Object.keys(BELT_COLORS).filter((k) => k.includes("splitter")));
+export const SPLITTER_ENTITIES = new Set(Object.keys(BELT_COLORS).filter((k) => k.includes("splitter")));
 const PIPE_ENTITIES = new Set(["pipe", "pipe-to-ground"]);
 const POLE_ENTITIES = new Set(["medium-electric-pole", "small-electric-pole"]);
 
@@ -230,7 +230,7 @@ function dirVec(dir?: EntityDirection): [number, number] {
 }
 
 /** Companion tile offset for a splitter's 2×1 footprint. */
-function splitterCompanionOffset(dir?: EntityDirection): [number, number] {
+export function splitterCompanionOffset(dir?: EntityDirection): [number, number] {
   switch (dir) {
     case "South":
     case "North":
@@ -989,7 +989,9 @@ export function drawUgTunnelStripe(
 export function renderLayout(
   layout: LayoutResult,
   container: Container,
-  onHover?: (entity: PlacedEntity | null) => void,
+  // onHover is accepted for call-site compatibility but no longer wired to
+  // per-entity Pixi events. Hover detection is now tile-based in main.ts.
+  _onHover?: (entity: PlacedEntity | null) => void,
   onSelect?: (entity: PlacedEntity | null) => void,
   onEntityRendered?: (entity: PlacedEntity, graphics: Graphics[]) => void,
   /** Extra entities that are NOT drawn but DO participate in `detectBeltTurn`
@@ -1173,14 +1175,12 @@ export function renderLayout(
     g.x = (entity.x ?? 0) * TILE_PX;
     g.y = (entity.y ?? 0) * TILE_PX;
 
-    // Make every entity interactive for hover + click
-    g.eventMode = "static";
-    g.cursor = "pointer";
-    if (onHover) {
-      g.on("pointerenter", () => onHover(entity));
-      g.on("pointerleave", () => onHover(null));
-    }
+    // Make every entity interactive for click; hover is handled via tile-lookup
+    // in the canvas pointermove handler (see main.ts) to avoid the per-frame
+    // scene-walk cost of per-entity Pixi pointer events.
     if (onSelect) {
+      g.eventMode = "static";
+      g.cursor = "pointer";
       g.on("click", () => onSelect(entity));
     }
 


### PR DESCRIPTION
## Intent

A profiling trace (`Trace-20260425T135149.json.gz`) showed `hitTestMoveRecursive` consuming ~368ms of self-time over a 9s pan/hover session. The cause: every entity Graphics had `eventMode = "static"` plus `pointerenter`/`pointerleave` listeners, so every `pointermove` triggered a full ~3000-node Pixi scene-walk.

## Scope

**In:**
- `entityLayer.eventMode = "none"` — short-circuits the scene-walk entirely; Pixi never descends into entity children for hit-testing.
- Per-entity `pointerenter`/`pointerleave` events removed from `renderLayout`. The `onHover` parameter is kept (renamed `_onHover`) for call-site compatibility with streaming renderer, phase animation, and snapshot paths — those callers are untouched.
- `tileEntityMap: Map<string, PlacedEntity>` built once per layout change, covers multi-tile machines (w×h) and 2-tile splitters.
- Canvas `pointermove` handler updated to look up `tileEntityMap` and call `onHover` only when the hovered entity changes.
- `pointerleave` handler updated to fire `onHover(null)` when the cursor exits the canvas.

**Out:**
- Callers of `renderLayout` / `createStreamingRenderer` that pass `onHover` are not cleaned up (they just pass a now-ignored arg). That refactor would touch 6+ files for zero behavioral gain.
- `validationOverlay.ts`, `traceOverlay.ts` overlay elements still use per-element Pixi events for their own tooltips — those are a separate, much smaller set of Graphics and not part of the hot path.

## Verification

- [x] `cd web && node_modules/.bin/tsc --noEmit` — no new errors (pre-existing `any` and missing wasm-pkg errors unchanged from `origin/main`)
- [ ] `cargo test --manifest-path crates/core/Cargo.toml` — Rust untouched; skipped for scope
- [ ] Browser eyeball — **not run by the agent**; per-frame cost during pan should drop noticeably. User to validate.

## Deviations from intent

None. The `onHover` parameter is renamed to `_onHover` rather than removed, which avoids touching streaming/phase-animation callers. This was the explicitly approved alternative approach.

## Models / contracts touched

None. Pure rendering performance change; no layout engine, game mechanics, or pipeline contracts affected.