### PR TITLE
feat(web): Phase 2+3+4 — full particle migration, icons everywhere, recipe panel removed

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -3,6 +3,7 @@ import { createApp, WORLD_SIZE } from "./renderer/app";
 import { drawGrid, updateGrid } from "./renderer/grid";
 import { drawGraph } from "./renderer/graph";
 import { initEntityIcons, preloadCarriesIcons, renderLayout, setItemColoring, itemColor, TILE_PX, MACHINE_SIZES, SPLITTER_ENTITIES, splitterCompanionOffset, type HighlightController } from "./renderer/entities";
+import { createParticleScene, renderLayoutAsParticles } from "./renderer/particleLayout";
 import { createSelectionController, type SelectionController } from "./renderer/selection";
 import { renderSidebar } from "./ui/sidebar";
 import { initCorpusPanel } from "./ui/corpus";
@@ -202,6 +203,20 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   setupSnapshotDropZone(container, (snap) => snapshotMode.load(snap));
 
+  /**
+   * Render a layout using particles for all entity types. Clears `entityLayer`,
+   * creates a fresh `ParticleScene`, attaches it, and commits all entities.
+   * Returns a particle-aware `HighlightController`.
+   *
+   * Used by: non-streaming path in `renderLayoutOnCanvas`, and `runAutoOptimize`.
+   */
+  function renderLayoutWithParticles(layout: LayoutResult): HighlightController {
+    entityLayer.removeChildren();
+    const scene = createParticleScene();
+    scene.attachTo(entityLayer);
+    return renderLayoutAsParticles(layout, scene);
+  }
+
   const entityLayer = new Container();
   // Cache the entity layer's GPU instruction buffer across frames. The static
   // bus layout (thousands of Graphics) doesn't change between renders, so
@@ -330,6 +345,13 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     reset(): void {},
   };
 
+  /** Animation log — gated on `window.__ANIM_LOGS`. */
+  const animLog = (phase: string, detail: Record<string, unknown>): void => {
+    if (!(globalThis as { __ANIM_LOGS?: boolean }).__ANIM_LOGS) return;
+    // eslint-disable-next-line no-console
+    console.log(`[anim t=${performance.now().toFixed(0)}ms] ${phase}`, detail);
+  };
+
   /* Stagger-fade entities that are new in `nextList` relative to `prevList`.
    * Only called on consecutive forward phase steps (N → N+1).
    * Backward steps and jumps stay instant. */
@@ -347,6 +369,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       });
 
     if (added.length === 0) return { cancel() {} };
+
+    animLog("seek_step", { added: added.length });
 
     const SEEK_FADE_MS = 160;
     const stagger = Math.min(7, 450 / added.length);
@@ -767,7 +791,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         w: imp.zone_w,
         h: imp.zone_h,
       });
-      renderLayout(lastLayout, entityLayer, undefined, undefined);
+      renderLayoutWithParticles(lastLayout);
       requestRender();
     };
 
@@ -829,7 +853,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       rebuildTileEntityMap(finalLayout);
       (window as unknown as { __layout?: LayoutResult }).__layout = finalLayout;
       // Final authoritative redraw with the committed layout.
-      renderLayout(finalLayout, entityLayer, undefined, undefined);
+      const optCtrl = renderLayoutWithParticles(finalLayout);
+      inspector.setHighlightController(wrapHighlight(optCtrl));
       requestRender();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -1150,10 +1175,10 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
     if (streamingHandle?.hasCommittedEntities()) {
       // Streaming drew transient previews during layout. Hand off to
-      // the authoritative `renderLayout` — this destroys the transient
-      // graphics, draws `layout.entities`, and returns the real
-      // HighlightController. Keep `streamingHandle` alive so the
-      // scrubber's `onSeek` callback can drive `seekTo()`.
+      // Streaming drew entity particles during layout. `finish()` stops
+      // the live ticker and returns a particle-aware HighlightController.
+      // Keep `streamingHandle` alive so the scrubber's `onSeek` callback
+      // can drive `seekTo()`.
       ctrl = streamingHandle.finish(layout);
       timelineScrubber.arm(
         streamingHandle.getTimeRange(),
@@ -1174,7 +1199,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         ctrl = out.controller;
         phaseAnimHandle = out.handle;
       } else {
-        ctrl = renderLayout(layout, entityLayer, onHover, onSelect);
+        // Use particle-based rendering for all non-streaming, non-animated paths.
+        ctrl = renderLayoutWithParticles(layout);
       }
     }
     inspector.setHighlightController(wrapHighlight(ctrl));

--- a/web/src/renderer/atlas.ts
+++ b/web/src/renderer/atlas.ts
@@ -135,6 +135,63 @@ export function getEntityTexture(
 }
 
 /**
+ * Get-or-render a multi-cell texture for wide/tall entities (e.g. machines,
+ * splitters). Each unique `(key, wCells, hCells)` triple gets its own
+ * region in the atlas spanning `wCells * CELL_PX` × `hCells * CELL_PX` px.
+ *
+ * The render callback receives `(g, wPx, hPx)` — the pixel dimensions it
+ * should fill. The caller is responsible for drawing within those bounds.
+ */
+export function getMultiCellTexture(
+  key: string,
+  wCells: number,
+  hCells: number,
+  render: (g: Graphics, wPx: number, hPx: number) => void,
+): Texture {
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  if (!renderer) {
+    console.warn("[atlas] getMultiCellTexture called before initAtlas; returning blank texture");
+    return Texture.EMPTY;
+  }
+
+  if (!atlasRT) {
+    atlasRT = RenderTexture.create({ width: ATLAS_SIZE, height: ATLAS_SIZE });
+  }
+
+  // Allocate enough consecutive slots to cover wCells columns. For simplicity,
+  // advance nextSlot by wCells * hCells (row-major, one row per hCells).
+  // This wastes slots when wCells > 1 on a partial row; acceptable for the
+  // bounded variant counts we expect (~21 machines + 12 splitters).
+  const col = nextSlot % ATLAS_COLS;
+  // Align to next row if not enough room on current row.
+  const needAlign = col + wCells > ATLAS_COLS;
+  if (needAlign) nextSlot += ATLAS_COLS - col;
+
+  const slotCol = nextSlot % ATLAS_COLS;
+  const slotRow = Math.floor(nextSlot / ATLAS_COLS);
+  const slotX = slotCol * CELL_PX;
+  const slotY = slotRow * CELL_PX;
+  nextSlot += wCells * hCells;
+
+  const wPx = wCells * CELL_PX;
+  const hPx = hCells * CELL_PX;
+
+  const g = new Graphics();
+  render(g, wPx, hPx);
+
+  const transform = new Matrix(1, 0, 0, 1, slotX, slotY);
+  renderer.render({ container: g, target: atlasRT, transform, clear: false });
+  g.destroy({ children: true });
+
+  const frame = new Rectangle(slotX, slotY, wPx, hPx);
+  const tex = new Texture({ source: atlasRT.source, frame });
+  cache.set(key, tex);
+  return tex;
+}
+
+/**
  * Get-or-fetch an item-icon texture.
  *
  * If `icons/${itemSlug}.png` is in the Pixi asset cache (loaded by
@@ -200,16 +257,84 @@ export function warmAtlas(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Internal helpers (used by particleLayout.ts)
+// Atlas key helpers — one per entity type. Format: `<type>:<...fields>`.
 // ---------------------------------------------------------------------------
 
 /**
  * Build the atlas key for a belt entity.
- * Covers all three tiers and all straight/turn variants.
- * Format: `belt:<name>:<direction>`.
+ * Format: `belt:<name>:<direction>:<turn>` where turn is "straight",
+ * "corner-cw", or "corner-ccw".
+ *
+ * The `turn` parameter defaults to "straight" for call sites that
+ * haven't detected turn info yet (e.g. Phase 1b pre-populate path).
  */
-export function beltAtlasKey(name: string, direction: string): string {
-  return `belt:${name}:${direction}`;
+export function beltAtlasKey(
+  name: string,
+  direction: string,
+  turn: "straight" | "corner-cw" | "corner-ccw" = "straight",
+): string {
+  return `belt:${name}:${direction}:${turn}`;
+}
+
+/**
+ * Atlas key for pipe entities. The 4-bit connection mask (N=1,E=2,S=4,W=8)
+ * uniquely identifies every connected variant. 16 variants total.
+ */
+export function pipeAtlasKey(connectionMask: number): string {
+  return `pipe:${connectionMask}`;
+}
+
+/**
+ * Atlas key for underground belt entities.
+ * Format: `ugbelt:<name>:<direction>:<io_type>`
+ */
+export function ugBeltAtlasKey(
+  name: string,
+  direction: string,
+  ioType: "input" | "output",
+): string {
+  return `ugbelt:${name}:${direction}:${ioType}`;
+}
+
+/**
+ * Atlas key for splitter entities.
+ * Format: `splitter:<name>:<direction>`
+ */
+export function splitterAtlasKey(name: string, direction: string): string {
+  return `splitter:${name}:${direction}`;
+}
+
+/**
+ * Atlas key for inserter entities.
+ * Format: `inserter:<name>:<direction>`
+ */
+export function inserterAtlasKey(name: string, direction: string): string {
+  return `inserter:${name}:${direction}`;
+}
+
+/**
+ * Atlas key for machine entities. One key per machine name
+ * (machines don't have directional variants in our renderer).
+ * Format: `machine:<name>`.
+ */
+export function machineAtlasKey(name: string): string {
+  return `machine:${name}`;
+}
+
+/**
+ * Atlas key for power pole entities.
+ * Format: `pole:<name>`
+ */
+export function poleAtlasKey(name: string): string {
+  return `pole:${name}`;
+}
+
+/**
+ * Atlas key for pipe-to-ground entities (directional stubs).
+ * Format: `ptg:<direction>`
+ */
+export function ptgAtlasKey(direction: string): string {
+  return `ptg:${direction}`;
 }
 
 // Re-export CELL_PX so particleLayout can size particles correctly.

--- a/web/src/renderer/entities.ts
+++ b/web/src/renderer/entities.ts
@@ -1,4 +1,4 @@
-import { Assets, Cache, Container, Graphics, Sprite, Text, TextStyle, Texture } from "pixi.js";
+import { Assets, Cache, Container, Graphics, Sprite, Texture } from "pixi.js";
 import type { LayoutResult, PlacedEntity, EntityDirection } from "../engine";
 import {
   buildBeltGraph,
@@ -198,16 +198,16 @@ export function niceName(slug: string): string {
 }
 
 // Entity-type sets derived from the lookup tables where possible
-const MACHINE_ENTITIES = new Set(Object.keys(MACHINE_SIZES));
-const INSERTER_ENTITIES = new Set(Object.keys(INSERTER_COLORS));
+export const MACHINE_ENTITIES = new Set(Object.keys(MACHINE_SIZES));
+export const INSERTER_ENTITIES = new Set(Object.keys(INSERTER_COLORS));
 // Derived from BELT_COLORS keys by tier prefix
 export const BELT_ENTITIES = new Set(
   Object.keys(BELT_COLORS).filter((k) => !k.includes("underground") && !k.includes("splitter"))
 );
-const UG_BELT_ENTITIES = new Set(Object.keys(BELT_COLORS).filter((k) => k.includes("underground")));
+export const UG_BELT_ENTITIES = new Set(Object.keys(BELT_COLORS).filter((k) => k.includes("underground")));
 export const SPLITTER_ENTITIES = new Set(Object.keys(BELT_COLORS).filter((k) => k.includes("splitter")));
-const PIPE_ENTITIES = new Set(["pipe", "pipe-to-ground"]);
-const POLE_ENTITIES = new Set(["medium-electric-pole", "small-electric-pole"]);
+export const PIPE_ENTITIES = new Set(["pipe", "pipe-to-ground"]);
+export const POLE_ENTITIES = new Set(["medium-electric-pole", "small-electric-pole"]);
 
 // Direction helpers
 
@@ -731,82 +731,8 @@ function drawMachine(entity: PlacedEntity): Graphics {
     }
   }
 
-  // Overlay panel: recipe name, rate, inputs/outputs
-  if (entity.recipe) {
-    const panelW = pw - 2;
-    const flows = recipeFlowMap.get(entity.recipe);
-    const inputCount = flows ? flows.inputs.length : 0;
-    const outputCount = flows ? flows.outputs.length : 0;
-    const flowLines = inputCount + outputCount;
-    const lineH = 12;
-    const headerH = 16;
-    const panelH = headerH + flowLines * lineH + 6;
-    const panelX = 1;
-    const panelY = ph - panelH;
-
-    // Semi-transparent dark background
-    g.roundRect(panelX, panelY, panelW, panelH, 3)
-      .fill({ color: 0x000000, alpha: 0.75 });
-
-    let cy = panelY + 3;
-    const iconSz = 14;
-
-    const dropShadow = { color: 0x000000, alpha: 1, blur: 2, distance: 0 };
-
-    // Header: recipe icon + nice name + rate — centred
-    const recipeIcon = tryGetTexture(`${import.meta.env.BASE_URL}icons/${entity.recipe}.png`);
-    const label = niceName(entity.recipe);
-    const rateStr = entity.rate != null ? ` ${entity.rate.toFixed(1)}/s` : "";
-    const headerStyle = new TextStyle({
-      fontSize: 9, fill: 0xffffff, fontWeight: "bold",
-      align: "center", dropShadow,
-    });
-    const headerText = new Text({ text: label + rateStr, style: headerStyle });
-    const totalHeaderW = (recipeIcon ? iconSz + 2 : 0) + headerText.width;
-    const headerStartX = panelX + (panelW - totalHeaderW) / 2;
-
-    if (recipeIcon) {
-      const icoSprite = new Sprite(recipeIcon);
-      icoSprite.width = iconSz;
-      icoSprite.height = iconSz;
-      icoSprite.x = headerStartX;
-      icoSprite.y = cy;
-      g.addChild(icoSprite);
-      headerText.x = headerStartX + iconSz + 2;
-    } else {
-      headerText.x = headerStartX;
-    }
-    headerText.y = cy;
-    g.addChild(headerText);
-    cy += headerH;
-
-    // Flow rows: icon + item name + rate — centred
-    const flowStyle = new TextStyle({ fontSize: 8, fill: 0xcccccc, dropShadow });
-    const renderFlow = (item: string, rate: number, prefix: string) => {
-      const fIcon = tryGetTexture(`${import.meta.env.BASE_URL}icons/${item}.png`);
-      const fText = new Text({ text: `${prefix}${niceName(item)} ${rate.toFixed(1)}/s`, style: flowStyle });
-      const fIconSz = 10;
-      const rowW = (fIcon ? fIconSz + 2 : 0) + fText.width;
-      const rx = panelX + (panelW - rowW) / 2;
-      if (fIcon) {
-        const fs = new Sprite(fIcon);
-        fs.width = fIconSz; fs.height = fIconSz;
-        fs.x = rx; fs.y = cy + 1;
-        g.addChild(fs);
-        fText.x = rx + fIconSz + 2;
-      } else {
-        fText.x = rx;
-      }
-      fText.y = cy;
-      g.addChild(fText);
-      cy += lineH;
-    };
-
-    if (flows) {
-      for (const inp of flows.inputs) renderFlow(inp.item, inp.rate, "\u25b6 ");
-      for (const out of flows.outputs) renderFlow(out.item, out.rate, "\u25c0 ");
-    }
-  }
+  // Recipe panel removed (Phase 2). Recipe info is conveyed by icons on
+  // inserters and pipes. A future hover-tooltip will show rates / recipe detail.
 
   return g;
 }
@@ -1195,45 +1121,9 @@ export function renderLayout(
 
     container.addChild(g);
 
-    // Carries-item icon overlaid on belts and pipes.
-    // Sprite is a child of g so it inherits g.alpha (participates in highlight dimming).
-    if (entity.carries) {
-      const ex = entity.x ?? 0;
-      const ey = entity.y ?? 0;
-      let showIcon = false;
-      if (BELT_ENTITIES.has(entity.name)) {
-        const [dx, dy] = dirVec(entity.direction);
-        const up   = tileMap.get(`${ex - dx},${ey - dy}`);
-        const down = tileMap.get(`${ex + dx},${ey + dy}`);
-        const isStart = !up   || up.carries   !== entity.carries;
-        const isEnd   = !down || down.carries !== entity.carries;
-        showIcon = isStart || isEnd || (ex + ey) % 5 === 0;
-      } else if (UG_BELT_ENTITIES.has(entity.name)) {
-        showIcon = true; // always show on both UG endpoints
-      } else if (PIPE_ENTITIES.has(entity.name)) {
-        showIcon = (ex + ey) % 5 === 0;
-      }
-      if (showIcon) {
-        const iconTex = tryGetTexture(`${import.meta.env.BASE_URL}icons/${entity.carries}.png`);
-        if (iconTex) {
-          const ICON_SZ = 14;
-          const bgR = ICON_SZ * 0.7;
-          const bg = new Graphics();
-          bg.circle(TILE_PX / 2, TILE_PX / 2, bgR).fill({ color: 0x202020, alpha: 0.5 });
-          bg.eventMode = "none";
-          g.addChild(bg);
-
-          const ico = new Sprite(iconTex);
-          ico.width = ICON_SZ;
-          ico.height = ICON_SZ;
-          ico.x = (TILE_PX - ICON_SZ) / 2;
-          ico.y = (TILE_PX - ICON_SZ) / 2;
-          ico.alpha = 0.95;
-          ico.eventMode = "none";
-          g.addChild(ico);
-        }
-      }
-    }
+    // Item icons are now rendered as a separate ParticleContainer layer by
+    // the particle-based rendering path (Phase 2). The old per-Graphics
+    // carries-icon overlay (with % 5 heuristic) is removed.
 
     onEntityRendered?.(entity, [g]);
   }

--- a/web/src/renderer/particleLayout.ts
+++ b/web/src/renderer/particleLayout.ts
@@ -1,27 +1,63 @@
 /**
- * Particle-scene builder skeleton for Phase 1a.
+ * Particle-scene builder — Phase 2+3+4.
  *
- * Provides `ParticleScene` — two `ParticleContainer`s (entities + icons) —
- * and helpers for committing entities as particles with fade-in reveals.
+ * Provides `ParticleScene` — three `ParticleContainer`s (entities, icons,
+ * ghosts) — and helpers for committing entities as particles with fade-in
+ * reveals.
  *
- * Phase 1 scope: only South-facing trunk belts are routed through here by the
- * streaming renderer (Phase 1b). The helpers below already handle any entity
- * type so Phase 2 can extend without changing the API.
+ * Every entity type is routed through `commitEntityAsParticle`. The
+ * Graphics path in `streamingRenderer.ts` is no longer used.
  */
 
 import {
   Container,
+  Graphics,
   Particle,
   ParticleContainer,
+  Sprite,
+  Assets,
+  Cache,
 } from "pixi.js";
-import type { PlacedEntity } from "../engine";
+import type { Texture } from "pixi.js";
+import type { LayoutResult, PlacedEntity, EntityDirection } from "../engine";
 import {
   beltAtlasKey,
+  pipeAtlasKey,
+  ugBeltAtlasKey,
+  splitterAtlasKey,
+  inserterAtlasKey,
+  machineAtlasKey,
+  poleAtlasKey,
+  ptgAtlasKey,
   CELL_PX,
   getEntityTexture,
+  getMultiCellTexture,
   getItemIconTexture,
 } from "./atlas";
-import { drawBelt, TILE_PX } from "./entities";
+import {
+  drawBelt,
+  drawEntityGraphic,
+  addEntityToDrawContext,
+  createDrawContext,
+  TILE_PX,
+  BELT_ENTITIES,
+  UG_BELT_ENTITIES,
+  SPLITTER_ENTITIES,
+  INSERTER_ENTITIES,
+  POLE_ENTITIES,
+  MACHINE_ENTITIES,
+  MACHINE_SIZES,
+  itemColor,
+  type DrawContext,
+  type HighlightController,
+} from "./entities";
+import {
+  buildBeltGraph,
+  traceBeltNetwork,
+  findAdjacentInserters,
+  findAdjacentMachines,
+  drawBeltNetworkOverlay,
+} from "./beltGraph";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -29,6 +65,12 @@ import { drawBelt, TILE_PX } from "./entities";
 
 /** Fade-in duration in virtual milliseconds — mirrors streamingRenderer.ts. */
 export const FADE_IN_MS = 150;
+
+/**
+ * Pixel-per-tile used when entity-frame PNGs were generated.
+ * Must match `ENTITY_FRAME_TILE_PX` in entities.ts.
+ */
+const ENTITY_FRAME_TILE_PX = 64;
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -39,6 +81,7 @@ interface ParticleEntry {
   entity: Particle;
   icon?: Particle;
   revealAt: number;
+  placedEntity: PlacedEntity;
 }
 
 // ---------------------------------------------------------------------------
@@ -47,16 +90,22 @@ interface ParticleEntry {
 
 /**
  * Top-level container for the particle-based render path.
- * One `ParticleContainer` for entity textures, one for item icons.
- * Both use `dynamicProperties: { color: true }` so per-particle
- * alpha/tint mutations are cheap (no position/rotation buffer invalidation).
+ * Three `ParticleContainer`s:
+ *   - entityContainer: entity textures (belts, pipes, machines, etc.)
+ *   - ghostContainer:  ghost belt previews (z-order: above entities)
+ *   - iconContainer:   item-icon textures (z-order: topmost)
+ * All use `dynamicProperties: { color: true }` so per-particle
+ * alpha/tint mutations are cheap.
  */
 export interface ParticleScene {
   entityContainer: ParticleContainer;
+  ghostContainer: ParticleContainer;
   iconContainer: ParticleContainer;
+  /** The layout this scene was built from (set by `renderLayoutAsParticles`). */
+  layout: LayoutResult | null;
   /**
    * Add the parent `ParticleContainer`s to `parent` in the right z-order
-   * (entities first, icons on top).
+   * (entities, ghosts, icons from bottom to top).
    */
   attachTo(parent: Container): void;
   /**
@@ -64,50 +113,52 @@ export interface ParticleScene {
    * internal entity-key map.
    */
   clear(): void;
-  /** Total particle count across both containers (for diagnostics). */
+  /** Total particle count across all containers (for diagnostics). */
   count(): number;
 }
 
+function makeParticleContainer(): ParticleContainer {
+  return new ParticleContainer({
+    dynamicProperties: {
+      color: true,
+      position: false,
+      rotation: false,
+      vertex: false,
+      uvs: false,
+    },
+  });
+}
+
 export function createParticleScene(): ParticleScene {
-  const entityContainer = new ParticleContainer({
-    dynamicProperties: {
-      color: true,
-      position: false,
-      rotation: false,
-      vertex: false,
-      uvs: false,
-    },
-  });
+  const entityContainer = makeParticleContainer();
+  const ghostContainer = makeParticleContainer();
+  const iconContainer = makeParticleContainer();
 
-  const iconContainer = new ParticleContainer({
-    dynamicProperties: {
-      color: true,
-      position: false,
-      rotation: false,
-      vertex: false,
-      uvs: false,
-    },
-  });
-
-  return {
+  const scene: ParticleScene = {
     entityContainer,
+    ghostContainer,
     iconContainer,
+    layout: null,
     attachTo(parent: Container): void {
       parent.addChild(entityContainer);
+      parent.addChild(ghostContainer);
       parent.addChild(iconContainer);
     },
     clear(): void {
       entityContainer.removeParticles();
+      ghostContainer.removeParticles();
       iconContainer.removeParticles();
       particleMap.clear();
     },
     count(): number {
       return (
         entityContainer.particleChildren.length +
+        ghostContainer.particleChildren.length +
         iconContainer.particleChildren.length
       );
     },
   };
+  return scene;
 }
 
 // ---------------------------------------------------------------------------
@@ -115,39 +166,247 @@ export function createParticleScene(): ParticleScene {
 // ---------------------------------------------------------------------------
 
 /**
- * Global particle registry keyed by `${x},${y}:${entity.name}`.
- *
- * Shared across all scenes — Phase 1b routes only trunk belts here;
- * Phase 2 will extend. If two scenes were active simultaneously, this
- * would need to be per-scene. For now one scene exists at a time.
+ * Global particle registry keyed by entity key.
+ * One scene exists at a time; cleared on `scene.clear()`.
  */
 const particleMap = new Map<string, ParticleEntry>();
 
-function entityKey(entity: PlacedEntity): string {
-  return `${entity.x ?? 0},${entity.y ?? 0}:${entity.name}`;
+export function entityKey(entity: PlacedEntity): string {
+  return `${entity.x ?? 0},${entity.y ?? 0}:${entity.name}:${entity.recipe ?? ""}`;
 }
 
 // ---------------------------------------------------------------------------
-// Entity texture resolution
+// Texture resolution helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the atlas texture for a belt entity.
- * For Phase 1 this covers all three belt tiers in any direction.
- * The `drawBelt` function from `entities.ts` is the source-of-truth
- * pixel logic; we call it at atlas-render time.
+ * Detect belt turn variant from the tileMap context.
+ * Returns "corner-cw", "corner-ccw", or "straight".
  */
-function getBeltTexture(entity: PlacedEntity): import("pixi.js").Texture {
-  const dir = entity.direction ?? "South";
-  const key = beltAtlasKey(entity.name, dir);
+function detectBeltTurnVariant(
+  entity: PlacedEntity,
+  tileMap: Map<string, PlacedEntity>,
+): "straight" | "corner-cw" | "corner-ccw" {
+  // Re-implement detectBeltTurn logic inline to get the string form.
+  const d = entity.direction ?? "North";
+  const dirVecMap: Record<string, [number, number]> = {
+    North: [0, -1], East: [1, 0], South: [0, 1], West: [-1, 0],
+  };
+  const [mdx, mdy] = dirVecMap[d] ?? [0, -1];
+  let hasStraightFeeder = false;
+  let perpTurn: "cw" | "ccw" | null = null;
 
+  for (const [dx, dy] of [[0, -1], [1, 0], [0, 1], [-1, 0]] as [number, number][]) {
+    const nx = (entity.x ?? 0) + dx;
+    const ny = (entity.y ?? 0) + dy;
+    const nb = tileMap.get(`${nx},${ny}`);
+    if (!nb) continue;
+    const feeds =
+      BELT_ENTITIES.has(nb.name) ||
+      (UG_BELT_ENTITIES.has(nb.name) && nb.io_type === "output") ||
+      SPLITTER_ENTITIES.has(nb.name);
+    if (!feeds) continue;
+    const [ndx, ndy] = dirVecMap[nb.direction ?? "North"] ?? [0, -1];
+    const nbFlowX = SPLITTER_ENTITIES.has(nb.name) ? nx : (nb.x ?? 0);
+    const nbFlowY = SPLITTER_ENTITIES.has(nb.name) ? ny : (nb.y ?? 0);
+    if (nbFlowX + ndx !== (entity.x ?? 0) || nbFlowY + ndy !== (entity.y ?? 0)) continue;
+    if (nb.direction === d) {
+      hasStraightFeeder = true;
+    } else {
+      const cross = ndx * mdy - ndy * mdx;
+      if (cross !== 0) perpTurn = cross > 0 ? "cw" : "ccw";
+    }
+  }
+  if (perpTurn && !hasStraightFeeder) {
+    return perpTurn === "cw" ? "corner-cw" : "corner-ccw";
+  }
+  return "straight";
+}
+
+/**
+ * Compute the pipe connection mask for a regular pipe entity.
+ * N=1, E=2, S=4, W=8. Looks at ctx.tileMap and ctx.machineTileSet.
+ */
+function computePipeConnectionMask(entity: PlacedEntity, ctx: DrawContext): number {
+  if (entity.name !== "pipe") return 0;
+  const ex = entity.x ?? 0;
+  const ey = entity.y ?? 0;
+
+  // Helper — mirrors entities.ts:pipeConnectsToNeighbour
+  function pipeConnectsToNeighbour(nb: PlacedEntity, dx: number, dy: number): boolean {
+    if (nb.name === "pipe") return true;
+    if (nb.name === "pipe-to-ground") {
+      // PTG surface delta: opposite of its tunnel direction.
+      const dirVecMap: Record<string, [number, number]> = {
+        North: [0, -1], East: [1, 0], South: [0, 1], West: [-1, 0],
+      };
+      const [tdx, tdy] = dirVecMap[nb.direction ?? "North"] ?? [0, -1];
+      const [sx, sy] = [-tdx, -tdy];
+      return -dx === sx && -dy === sy;
+    }
+    return false;
+  }
+
+  let mask = 0;
+  for (const [dx, dy, bit] of [[0, -1, 1], [1, 0, 2], [0, 1, 4], [-1, 0, 8]] as [number, number, number][]) {
+    // Top-edge pipe connects "upward" to represent external fluid source.
+    if (dy === -1 && ey + dy < 0) { mask |= bit; continue; }
+    const key = `${ex + dx},${ey + dy}`;
+    const nb = ctx.tileMap.get(key);
+    if ((nb && pipeConnectsToNeighbour(nb, dx, dy)) || ctx.machineTileSet.has(key)) {
+      mask |= bit;
+    }
+  }
+  return mask;
+}
+
+/**
+ * Resolve the entity texture for any entity type. Uses the atlas
+ * helpers in atlas.ts, calling the draw functions from entities.ts
+ * to render on cache-miss.
+ */
+function getEntityAtlasTexture(entity: PlacedEntity, ctx: DrawContext): Texture {
+  if (BELT_ENTITIES.has(entity.name)) {
+    const turn = detectBeltTurnVariant(entity, ctx.tileMap);
+    const key = beltAtlasKey(entity.name, entity.direction ?? "North", turn);
+    return getEntityTexture(key, CELL_PX, CELL_PX, (g) => {
+      const scale = CELL_PX / TILE_PX;
+      // Build turn info for drawBelt.
+      let turnArg: { turn: "cw" | "ccw" } | null = null;
+      if (turn === "corner-cw") turnArg = { turn: "cw" };
+      else if (turn === "corner-ccw") turnArg = { turn: "ccw" };
+      const belt = drawBelt(entity, turnArg);
+      belt.scale.set(scale);
+      g.addChild(belt);
+    });
+  }
+
+  if (UG_BELT_ENTITIES.has(entity.name)) {
+    const ioType = (entity.io_type as "input" | "output") ?? "input";
+    const key = ugBeltAtlasKey(entity.name, entity.direction ?? "North", ioType);
+    return getEntityTexture(key, CELL_PX, CELL_PX, (g) => {
+      const scale = CELL_PX / TILE_PX;
+      const gfx = drawEntityGraphic(entity, ctx);
+      gfx.scale.set(scale);
+      gfx.x = 0;
+      gfx.y = 0;
+      g.addChild(gfx);
+    });
+  }
+
+  if (SPLITTER_ENTITIES.has(entity.name)) {
+    const key = splitterAtlasKey(entity.name, entity.direction ?? "North");
+    const isNS = entity.direction === "North" || entity.direction === "South";
+    const wCells = isNS ? 2 : 1;
+    const hCells = isNS ? 1 : 2;
+    return getMultiCellTexture(key, wCells, hCells, (g, wPx, hPx) => {
+      // drawSplitter draws at TILE_PX scale; we need to scale it up to CELL_PX.
+      const scale = CELL_PX / TILE_PX;
+      const gfx = drawEntityGraphic(entity, ctx);
+      gfx.scale.set(scale);
+      gfx.x = 0;
+      gfx.y = 0;
+      // Clip/mask to the allocated dimensions.
+      void wPx; void hPx;
+      g.addChild(gfx);
+    });
+  }
+
+  if (entity.name === "pipe") {
+    const mask = computePipeConnectionMask(entity, ctx);
+    const key = pipeAtlasKey(mask);
+    return getEntityTexture(key, CELL_PX, CELL_PX, (g) => {
+      const scale = CELL_PX / TILE_PX;
+      const gfx = drawEntityGraphic(entity, ctx);
+      gfx.scale.set(scale);
+      gfx.x = 0;
+      gfx.y = 0;
+      g.addChild(gfx);
+    });
+  }
+
+  if (entity.name === "pipe-to-ground") {
+    const key = ptgAtlasKey(entity.direction ?? "North");
+    return getEntityTexture(key, CELL_PX, CELL_PX, (g) => {
+      const scale = CELL_PX / TILE_PX;
+      const gfx = drawEntityGraphic(entity, ctx);
+      gfx.scale.set(scale);
+      gfx.x = 0;
+      gfx.y = 0;
+      g.addChild(gfx);
+    });
+  }
+
+  if (INSERTER_ENTITIES.has(entity.name)) {
+    const key = inserterAtlasKey(entity.name, entity.direction ?? "North");
+    return getEntityTexture(key, CELL_PX, CELL_PX, (g) => {
+      const scale = CELL_PX / TILE_PX;
+      const gfx = drawEntityGraphic(entity, ctx);
+      gfx.scale.set(scale);
+      gfx.x = 0;
+      gfx.y = 0;
+      g.addChild(gfx);
+    });
+  }
+
+  if (POLE_ENTITIES.has(entity.name)) {
+    const key = poleAtlasKey(entity.name);
+    return getEntityTexture(key, CELL_PX, CELL_PX, (g) => {
+      const scale = CELL_PX / TILE_PX;
+      const gfx = drawEntityGraphic(entity, ctx);
+      gfx.scale.set(scale);
+      gfx.x = 0;
+      gfx.y = 0;
+      g.addChild(gfx);
+    });
+  }
+
+  if (MACHINE_ENTITIES.has(entity.name)) {
+    const [tw, th] = MACHINE_SIZES[entity.name] ?? [1, 1];
+    const key = machineAtlasKey(entity.name);
+    return getMultiCellTexture(key, tw, th, (g, wPx, hPx) => {
+      // Try entity-frame PNG first (same logic as entities.ts:drawMachine).
+      const framePath = `${import.meta.env.BASE_URL}entity-frames/${entity.name}.png`;
+      const frameTex: Texture | null = Cache.has(framePath) ? (Assets.get<Texture>(framePath) ?? null) : null;
+      const spriteScale = 1.5;
+      const scale = CELL_PX / ENTITY_FRAME_TILE_PX;
+
+      if (frameTex) {
+        const sprite = new Sprite(frameTex);
+        sprite.scale.set(scale * spriteScale);
+        const pw = wPx;
+        const ph = hPx;
+        sprite.x = -pw * (spriteScale - 1) / 2;
+        sprite.y = -ph * (spriteScale - 1) / 2;
+        g.addChild(sprite);
+      } else {
+        // Fallback: colored rect matching drawMachine's placeholder.
+        const MACHINE_COLORS: Record<string, number> = {
+          "assembling-machine-1": 0x5a6e82, "assembling-machine-2": 0x4a6278,
+          "assembling-machine-3": 0x3a526a, "chemical-plant": 0x3a7a50,
+          "oil-refinery": 0x5a3a8a, "electric-furnace": 0x6a5a80,
+          "steel-furnace": 0x7a5030, "stone-furnace": 0x8a6040,
+          centrifuge: 0x3a7a80, lab: 0x4a6a50, "rocket-silo": 0x4a4a6a,
+          foundry: 0x8a6a30, biochamber: 0x4a7a3a, biolab: 0x3a6a5a,
+          "electromagnetic-plant": 0x2a5a9a, "cryogenic-plant": 0x4a7a8a,
+          recycler: 0x6a5a4a, crusher: 0x5a4a3a, beacon: 0x4a6080,
+          "storage-tank": 0x4a6a5a, "electric-mining-drill": 0x7a6a30,
+        };
+        const color = MACHINE_COLORS[entity.name] ?? 0x4a5a6a;
+        g.roundRect(2, 2, wPx - 4, hPx - 4, 3).fill({ color, alpha: 0.5 });
+      }
+    });
+  }
+
+  // Generic fallback.
+  const key = `generic:${entity.name}`;
   return getEntityTexture(key, CELL_PX, CELL_PX, (g) => {
-    // `drawBelt` returns a Graphics centred at (0, 0) occupying TILE_PX px.
-    // TILE_PX === 32; CELL_PX === 64. Scale by 2 to fill the cell.
     const scale = CELL_PX / TILE_PX;
-    const belt = drawBelt(entity, null);
-    belt.scale.set(scale);
-    g.addChild(belt);
+    const gfx = drawEntityGraphic(entity, ctx);
+    gfx.scale.set(scale);
+    gfx.x = 0;
+    gfx.y = 0;
+    g.addChild(gfx);
   });
 }
 
@@ -162,22 +421,46 @@ function getBeltTexture(entity: PlacedEntity): import("pixi.js").Texture {
  * live-phase ticker to animate alpha to 1 over `FADE_IN_MS`.
  * Particles persist at full alpha after the fade — no removal on settle.
  *
- * Phase 1 scope: only trunk belts flow through here. The function itself
- * handles any belt name so Phase 2 can extend coverage without API changes.
+ * Handles all entity types: belts, UG belts, splitters, pipes, inserters,
+ * poles, machines.
+ *
+ * For machines, no icon particle is added (machines don't carry items).
  */
 export function commitEntityAsParticle(
   scene: ParticleScene,
   entity: PlacedEntity,
   revealAt: number,
+  ctx: DrawContext = createDrawContext(),
 ): void {
   const key = entityKey(entity);
   if (particleMap.has(key)) return; // idempotent
 
-  const px = (entity.x ?? 0) * TILE_PX;
-  const py = (entity.y ?? 0) * TILE_PX;
+  const ex = entity.x ?? 0;
+  const ey = entity.y ?? 0;
 
   // --- Entity particle ---
-  const entityTex = getBeltTexture(entity);
+  const entityTex = getEntityAtlasTexture(entity, ctx);
+
+  let scaleX = TILE_PX / CELL_PX;
+  let scaleY = TILE_PX / CELL_PX;
+
+  if (SPLITTER_ENTITIES.has(entity.name)) {
+    const isNS = entity.direction === "North" || entity.direction === "South";
+    const wCells = isNS ? 2 : 1;
+    const hCells = isNS ? 1 : 2;
+    // Texture is wCells*CELL_PX × hCells*CELL_PX; display at wCells*TILE_PX × hCells*TILE_PX.
+    scaleX = (wCells * TILE_PX) / (wCells * CELL_PX);
+    scaleY = (hCells * TILE_PX) / (hCells * CELL_PX);
+  } else if (MACHINE_ENTITIES.has(entity.name)) {
+    const [tw, th] = MACHINE_SIZES[entity.name] ?? [1, 1];
+    // Texture is tw*CELL_PX × th*CELL_PX; display at tw*TILE_PX × th*TILE_PX.
+    scaleX = (tw * TILE_PX) / (tw * CELL_PX);
+    scaleY = (th * TILE_PX) / (th * CELL_PX);
+  }
+
+  const px = ex * TILE_PX;
+  const py = ey * TILE_PX;
+
   const ep = new Particle({
     texture: entityTex,
     x: px,
@@ -185,17 +468,17 @@ export function commitEntityAsParticle(
     alpha: 0,
     anchorX: 0,
     anchorY: 0,
-    scaleX: TILE_PX / CELL_PX,
-    scaleY: TILE_PX / CELL_PX,
+    scaleX,
+    scaleY,
   });
   scene.entityContainer.addParticle(ep);
 
-  // --- Icon particle (if the entity carries an item) ---
+  // --- Icon particle (if the entity carries an item, and isn't a machine) ---
   let iconParticle: Particle | undefined;
-  if (entity.carries) {
+  if (entity.carries && !MACHINE_ENTITIES.has(entity.name)) {
     const iconTex = getItemIconTexture(entity.carries);
-    // Center the icon on the tile.
-    const iconSize = TILE_PX * 0.5; // icon is 50% of tile width
+    // Center a 14 px icon on the tile.
+    const iconSize = TILE_PX * 0.5;
     const iconOffset = (TILE_PX - iconSize) / 2;
     iconParticle = new Particle({
       texture: iconTex,
@@ -210,13 +493,105 @@ export function commitEntityAsParticle(
     scene.iconContainer.addParticle(iconParticle);
   }
 
-  particleMap.set(key, { entity: ep, icon: iconParticle, revealAt });
+  particleMap.set(key, { entity: ep, icon: iconParticle, revealAt, placedEntity: entity });
+}
+
+/**
+ * Add a ghost belt particle to the ghost container with item-color tint.
+ * Ghost belts fade out fully before being removed from the container.
+ *
+ * `specKey` is used to de-duplicate crossings: a second ghost at the same
+ * tile from the same spec is a no-op; from a different spec it adds an
+ * overlay particle.
+ *
+ * Returns the created Particle (or null if skipped).
+ */
+const ghostByTile = new Map<string, { particle: Particle; specKey: string }>();
+
+export function addGhostParticle(
+  scene: ParticleScene,
+  x: number,
+  y: number,
+  direction: EntityDirection,
+  item: string,
+  revealAt: number,
+  specKey: string,
+): Particle | null {
+  const tk = `${x},${y}`;
+  const existing = ghostByTile.get(tk);
+  if (existing && existing.specKey === specKey) return null; // same spec, skip
+
+  // Build a synthetic belt entity for texture lookup.
+  const synthEntity: PlacedEntity = {
+    name: "transport-belt",
+    x,
+    y,
+    direction,
+    recipe: null,
+    carries: item,
+    segment_id: null,
+    io_type: null,
+  } as unknown as PlacedEntity;
+
+  const ctx = createDrawContext();
+  addEntityToDrawContext(synthEntity, ctx);
+  const tex = getEntityAtlasTexture(synthEntity, ctx);
+  const tint = itemColor(item);
+  const p = new Particle({
+    texture: tex,
+    x: x * TILE_PX,
+    y: y * TILE_PX,
+    alpha: 0,
+    anchorX: 0,
+    anchorY: 0,
+    scaleX: TILE_PX / CELL_PX,
+    scaleY: TILE_PX / CELL_PX,
+    tint,
+  });
+  scene.ghostContainer.addParticle(p);
+  if (!existing) {
+    ghostByTile.set(tk, { particle: p, specKey });
+  }
+  // Schedule fade-in via revealAt in the animation loop.
+  // Ghost particle alpha is mutated by commitGhostParticleReveals.
+  void revealAt; // fade-in handled by caller's animation loop
+  return p;
+}
+
+/**
+ * Remove ghost particle at a tile — called when a committed entity
+ * replaces a ghost belt.
+ */
+export function removeGhostParticle(
+  scene: ParticleScene,
+  x: number,
+  y: number,
+): void {
+  const tk = `${x},${y}`;
+  const entry = ghostByTile.get(tk);
+  if (!entry) return;
+  scene.ghostContainer.removeParticle(entry.particle);
+  ghostByTile.delete(tk);
+}
+
+/**
+ * Remove a particle by entity key — for fade-out completion cleanup.
+ */
+export function removeParticleAt(
+  scene: ParticleScene,
+  key: string,
+): void {
+  const entry = particleMap.get(key);
+  if (!entry) return;
+  scene.entityContainer.removeParticle(entry.entity);
+  if (entry.icon) scene.iconContainer.removeParticle(entry.icon);
+  particleMap.delete(key);
 }
 
 /**
  * Walk all registered particles and update alpha based on
- * `(now - revealAt) / FADE_IN_MS`.  Mirrors `applyReveals` in
- * `streamingRenderer.ts`. Phase 1b will call this from the live-phase ticker.
+ * `(now - revealAt) / FADE_IN_MS`. Mirrors `applyReveals` in
+ * `streamingRenderer.ts`. Called from the live-phase ticker.
  *
  * `now` is the virtual-ms clock value (same clock as `revealAt`).
  */
@@ -234,11 +609,7 @@ export function applyParticleReveals(
 /**
  * Iterate (particle, revealAt) pairs for scrub-mode integration.
  *
- * Yields one entry per entity (the entity particle). Icon particles share
- * the same revealAt and are driven by the same alpha in `applyParticleReveals`,
- * so scrub-mode only needs to touch the entity particle; the icon will be
- * updated on the next live tick or via a separate `applyParticleReveals` call.
- *
+ * Yields one entry per entity (the entity particle + optional icon particle).
  * Called by `streamingRenderer.ts:finish()` to build the `reveals` list.
  */
 export function* getParticleReveals(
@@ -247,4 +618,219 @@ export function* getParticleReveals(
   for (const entry of particleMap.values()) {
     yield { particle: entry.entity, iconParticle: entry.icon, revealAt: entry.revealAt };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming path: renderLayoutAsParticles
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a fully-built layout into a `ParticleScene` without going through
+ * the streaming event machinery.
+ *
+ * This replaces `renderLayout(layout, container)` for corpus / parsed-blueprint
+ * paths. Builds the draw context in one pass (for belt turn detection, pipe
+ * connection masks), then commits each entity as a particle with `revealAt = 0`
+ * so all particles start fully visible.
+ *
+ * Returns a particle-aware `HighlightController`.
+ */
+export function renderLayoutAsParticles(
+  layout: LayoutResult,
+  scene: ParticleScene,
+): HighlightController {
+  // Clear any previous particles.
+  scene.clear();
+  scene.layout = layout;
+
+  // Build draw context in one pass so belt turn detection and pipe connections
+  // are correct by construction when we commit each entity.
+  const ctx = createDrawContext();
+  for (const e of layout.entities) {
+    addEntityToDrawContext(e, ctx);
+  }
+
+  // Commit every entity with revealAt = 0 (fully visible immediately).
+  const revealAt = 0;
+  for (const e of layout.entities) {
+    commitEntityAsParticle(scene, e, revealAt, ctx);
+  }
+
+  // Set all particles to alpha=1 immediately.
+  applyParticleReveals(scene, FADE_IN_MS + 1);
+
+  // Build belt graph for highlight controller.
+  const beltGraph = buildBeltGraph(layout);
+
+  // Belt network overlay Graphics — drawn on top when a network is highlighted.
+  // Persists between highlight calls; replaced on each new highlight.
+  let overlayGraphics: Graphics | null = null;
+
+  // The container that the scene is attached to — we need it for the overlay.
+  // Since attachTo is called separately, we hold a reference.
+  let overlayParent: Container | null = null;
+
+  function getOverlayParent(): Container | null {
+    // Reach the parent container via the entityContainer's parent.
+    return scene.entityContainer.parent as Container | null;
+  }
+
+  function clearHighlightInternal(): void {
+    if (overlayGraphics) {
+      const parent = overlayParent ?? getOverlayParent();
+      if (parent) parent.removeChild(overlayGraphics);
+      overlayGraphics.destroy();
+      overlayGraphics = null;
+    }
+    for (const entry of particleMap.values()) {
+      entry.entity.alpha = 1;
+      if (entry.icon) entry.icon.alpha = 1;
+    }
+  }
+
+  return {
+    highlightItem(item: string | null): void {
+      clearHighlightInternal();
+      if (!item) return;
+      for (const entry of particleMap.values()) {
+        const pe = entry.placedEntity;
+        const chainKey = pe.carries ?? pe.recipe ?? null;
+        const dim = chainKey !== item;
+        const alpha = dim ? 0.15 : 1;
+        entry.entity.alpha = alpha;
+        if (entry.icon) entry.icon.alpha = alpha;
+      }
+    },
+
+    highlightBeltNetwork(entity: PlacedEntity | null): void {
+      clearHighlightInternal();
+      if (!entity) return;
+
+      const startKey = `${entity.x ?? 0},${entity.y ?? 0}`;
+      const anchor = beltGraph.tileToAnchor.get(startKey) ?? startKey;
+      if (!beltGraph.nodes.has(anchor)) return;
+
+      const { downstream, upstream } = traceBeltNetwork(anchor, beltGraph);
+      const allBelt = new Set([...downstream, ...upstream]);
+      const inserters = findAdjacentInserters(allBelt, beltGraph.entityMap);
+      const machines = findAdjacentMachines(inserters, beltGraph.entityMap);
+
+      for (const entry of particleMap.values()) {
+        const pe = entry.placedEntity;
+        const k = `${pe.x ?? 0},${pe.y ?? 0}`;
+        let alpha: number;
+        if (allBelt.has(k)) {
+          alpha = 0.5;
+        } else if (inserters.has(k)) {
+          alpha = 0.9;
+        } else if (machines.has(k)) {
+          alpha = 0.75;
+        } else {
+          alpha = 0.15;
+        }
+        entry.entity.alpha = alpha;
+        if (entry.icon) entry.icon.alpha = alpha;
+      }
+
+      const parent = getOverlayParent();
+      if (parent) {
+        overlayParent = parent;
+        overlayGraphics = new Graphics();
+        drawBeltNetworkOverlay(overlayGraphics, downstream, upstream, anchor, beltGraph);
+        parent.addChild(overlayGraphics);
+      }
+    },
+
+    clearHighlight(): void {
+      clearHighlightInternal();
+    },
+
+    chainKey(entity: PlacedEntity): string | null {
+      return entity.carries ?? entity.recipe ?? null;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Particle-aware HighlightController (Phase 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a particle-aware `HighlightController` that walks the `particleMap`
+ * instead of a `allGraphics` array.
+ *
+ * Used by `streamingRenderer.ts:finish()` after all entities are particles.
+ * The belt network overlay (dashed/solid lines) remains a Graphics overlay
+ * added to `overlayContainer` — separate from the entities.
+ */
+export function createParticleHighlightController(
+  layout: LayoutResult,
+  overlayContainer: Container,
+): HighlightController {
+  const beltGraph = buildBeltGraph(layout);
+  let overlayGraphics: Graphics | null = null;
+
+  function clearHighlightInternal(): void {
+    if (overlayGraphics) {
+      overlayContainer.removeChild(overlayGraphics);
+      overlayGraphics.destroy();
+      overlayGraphics = null;
+    }
+    for (const entry of particleMap.values()) {
+      entry.entity.alpha = 1;
+      if (entry.icon) entry.icon.alpha = 1;
+    }
+  }
+
+  return {
+    highlightItem(item: string | null): void {
+      clearHighlightInternal();
+      if (!item) return;
+      for (const entry of particleMap.values()) {
+        const pe = entry.placedEntity;
+        const chainKey = pe.carries ?? pe.recipe ?? null;
+        const alpha = chainKey === item ? 1 : 0.15;
+        entry.entity.alpha = alpha;
+        if (entry.icon) entry.icon.alpha = alpha;
+      }
+    },
+
+    highlightBeltNetwork(entity: PlacedEntity | null): void {
+      clearHighlightInternal();
+      if (!entity) return;
+
+      const startKey = `${entity.x ?? 0},${entity.y ?? 0}`;
+      const anchor = beltGraph.tileToAnchor.get(startKey) ?? startKey;
+      if (!beltGraph.nodes.has(anchor)) return;
+
+      const { downstream, upstream } = traceBeltNetwork(anchor, beltGraph);
+      const allBelt = new Set([...downstream, ...upstream]);
+      const inserters = findAdjacentInserters(allBelt, beltGraph.entityMap);
+      const machines = findAdjacentMachines(inserters, beltGraph.entityMap);
+
+      for (const entry of particleMap.values()) {
+        const pe = entry.placedEntity;
+        const k = `${pe.x ?? 0},${pe.y ?? 0}`;
+        let alpha: number;
+        if (allBelt.has(k)) alpha = 0.5;
+        else if (inserters.has(k)) alpha = 0.9;
+        else if (machines.has(k)) alpha = 0.75;
+        else alpha = 0.15;
+        entry.entity.alpha = alpha;
+        if (entry.icon) entry.icon.alpha = alpha;
+      }
+
+      overlayGraphics = new Graphics();
+      drawBeltNetworkOverlay(overlayGraphics, downstream, upstream, anchor, beltGraph);
+      overlayContainer.addChild(overlayGraphics);
+    },
+
+    clearHighlight(): void {
+      clearHighlightInternal();
+    },
+
+    chainKey(entity: PlacedEntity): string | null {
+      return entity.carries ?? entity.recipe ?? null;
+    },
+  };
 }

--- a/web/src/renderer/streamingRenderer.ts
+++ b/web/src/renderer/streamingRenderer.ts
@@ -1,57 +1,40 @@
 /**
- * Streaming layout renderer — progressive reveal during layout, then
- * hands off to `renderLayout` as the authoritative renderer.
+ * Streaming layout renderer — Phase 2+3+4.
  *
- * Two phases:
+ * Every entity type renders as a particle. Ghost belts use the
+ * `ghostContainer` in the particle scene. `finish()` stops the live
+ * ticker and builds a particle-aware `HighlightController`; it no
+ * longer calls `renderLayout` or does any container surgery.
  *
- * ## Live phase (onEvent drives everything)
+ * ## Live phase
  *
- * As trace events arrive from the WASM worker we draw *transient* eye-
- * candy: ghost-path overlays for `GhostSpecRouted`, per-tile committed
- * previews for `GhostSpecCommitted` / `JunctionCommitted` /
- * `PhaseSnapshot`, and cluster-outline pulses for `GhostClusterSolved`.
+ * As trace events arrive from the WASM worker, entity particles are
+ * committed to the scene with staggered `revealAt` timestamps. The
+ * live-phase ticker mutates `particle.alpha` each frame.
  *
- * These transient graphics only need to approximate the final layout —
- * they exist to give the user something to watch during the 5–6 s SAT
- * phase. They are all destroyed at `finish()`.
+ * Ghost-belt previews appear in the `ghostContainer` and fade out
+ * when a committed entity lands on the same tile.
  *
- * While drawing the transient previews we record each entity's first-
- * seen virtual-ms into `revealByEntityKey`. That timestamp map is the
- * only state that survives into the scrub phase.
+ * ## Scrub phase (after finish())
  *
- * ## Scrub phase (finish() + seekTo())
+ * `finish(layout)` stops the ticker, builds the particle highlight
+ * controller from `layout.entities`, and returns it. `seekTo(t)`
+ * walks the `reveals` list (all particles) and sets alpha imperatively.
  *
- * At `finish(layout)` the transient graphics are discarded and
- * `renderLayout(layout, container, …)` draws the authoritative
- * `layout.entities`. The full tile-map is built in a single pass so
- * belt-turn detection is correct by construction.
+ * ## Debug logging
  *
- * We capture each rendered entity Graphics via `renderLayout`'s
- * `onEntityRendered` hook, cross them with `revealByEntityKey` to get
- * per-entity reveal timestamps, and from then on `seekTo(t)` just
- * walks the list setting alpha imperatively.
- *
- * `renderLayout`'s returned `HighlightController` is the real
- * hover-highlighting one — belt-network traces light up on hover,
- * matching non-streaming rendering paths.
- *
- * See `docs/archive/rfp-streaming-reconciliation.md` for the full rationale.
+ * Set `window.__ANIM_LOGS = true` (or tick the debug checkbox) to
+ * enable `[anim …]` console logs at every animation-start site.
  */
 
-import type { Application, Container, Graphics } from "pixi.js";
-import { Container as PixiContainer, Graphics as PixiGraphics } from "pixi.js";
+import type { Application, Container } from "pixi.js";
+import { Graphics as PixiGraphics, Particle } from "pixi.js";
 import type { LayoutResult } from "../engine";
 import type { PlacedEntity, TraceEvent, EntityDirection } from "../wasm-pkg/fucktorio_wasm";
 import {
-  drawEntityGraphic,
   addEntityToDrawContext,
   createDrawContext,
-  drawUgTunnelStripe,
-  drawBelt,
-  itemColor,
-  renderLayout,
   TILE_PX,
-  BELT_ENTITIES,
   type DrawContext,
   type HighlightController,
 } from "./entities";
@@ -61,6 +44,10 @@ import {
   commitEntityAsParticle,
   applyParticleReveals,
   getParticleReveals,
+  createParticleHighlightController,
+  addGhostParticle,
+  removeGhostParticle,
+  entityKey,
   type ParticleScene,
 } from "./particleLayout";
 
@@ -70,24 +57,15 @@ import {
 
 const FADE_IN_MS = 150;
 const FADE_OUT_MS = 80;
-// Max per-entity stagger (applied only when the phase is small enough
-// that entity-count × stagger fits inside the phase budget). Above
-// the budget, the actual stagger is shrunk to `budget / count` so a
-// bulky phase doesn't take forever. Keeps the eye-candy on small
-// layouts while scaling gracefully on big ones.
 const GHOST_TILE_STAGGER_MAX_MS = 4;
 const GHOST_TILE_STAGGER_BUDGET_MS = 300;
 const COMMITTED_TILE_STAGGER_MAX_MS = 4;
 const COMMITTED_TILE_STAGGER_BUDGET_MS = 900;
 const JUNCTION_TILE_STAGGER_MAX_MS = 6;
 const JUNCTION_TILE_STAGGER_BUDGET_MS = 250;
-/** GhostClusterSolved outline box stays this long before fading. */
 const GHOST_CLUSTER_LIFETIME_MS = 800;
 const GHOST_CLUSTER_FADE_MS = 250;
 
-/** Compute a per-entity stagger: `max` ms when the phase is small,
- *  shrunk to `budget / count` once a naive `max` would exceed the
- *  budget. Mirrors the pacing idea in `phaseAnimation.ts:178`. */
 function stagger(count: number, maxMs: number, budgetMs: number): number {
   if (count <= 1) return maxMs;
   return Math.min(maxMs, budgetMs / count);
@@ -97,16 +75,10 @@ function stagger(count: number, maxMs: number, budgetMs: number): number {
 // Key helpers
 // ---------------------------------------------------------------------------
 
-function entityKey(e: PlacedEntity): string {
-  return `${e.x ?? 0},${e.y ?? 0},${e.name},${e.recipe ?? ""}`;
-}
-
 function tileKey(x: number, y: number): string {
   return `${x},${y}`;
 }
 
-/** Pull the item name out of a spec_key like "trunk:iron-plate:3" or
- *  "tap:copper-cable:7:45". Parts are colon-separated; [1] is the item. */
 function itemFromSpecKey(specKey: string): string {
   return specKey.split(":")[1] ?? "";
 }
@@ -119,30 +91,18 @@ function dirFromDelta(dx: number, dy: number): EntityDirection {
 }
 
 // ---------------------------------------------------------------------------
-// Tracked-graphic state (live phase only)
+// Ghost state
 // ---------------------------------------------------------------------------
 
-/** Ghost belt at a single tile. `specKey` records which spec laid this
- *  down; a subsequent spec can add its own overlay (crossing) without
- *  touching the existing ghost. */
-interface GhostBelt {
-  gfx: Graphics;
-  overlayGfx?: Graphics;
+interface GhostBeltState {
   specKey: string;
-  overlaySpecKey?: string;
-  fadeStartMs: number;
   fadeOutStartMs: number | null;
+  fadeStartMs: number;
 }
 
-/** A transient committed entity drawn during live streaming. Discarded
- *  at `finish()` — `renderLayout` redraws it authoritatively. */
-interface TransientCommitted {
-  gfx: Graphics;
-  ambientGfx: Graphics | null;
-  fadeStartMs: number;
-  fadeOutStartMs: number | null;
-  entity: PlacedEntity;
-}
+// ---------------------------------------------------------------------------
+// Cluster outline state
+// ---------------------------------------------------------------------------
 
 interface GhostCluster {
   x: number;
@@ -158,12 +118,20 @@ interface GhostCluster {
 // Scrub-phase state
 // ---------------------------------------------------------------------------
 
-/** Scrub-mode entry. Either a Graphics object (non-trunk entities rendered
- *  by `renderLayout`) or a Particle (trunk entities rendered by the particle
- *  path). Phase 2 will collapse this union once all entity types are particles. */
-type Reveal =
-  | { kind: "graphic"; graphic: Graphics; revealAt: number }
-  | { kind: "particle"; particle: import("pixi.js").Particle; iconParticle: import("pixi.js").Particle | undefined; revealAt: number };
+/** Scrub-mode entry — now all particles, no Graphics branch. */
+type Reveal = {
+  kind: "particle";
+  particle: Particle;
+  iconParticle: Particle | undefined;
+  revealAt: number;
+};
+
+// ---------------------------------------------------------------------------
+// Debug logging
+// ---------------------------------------------------------------------------
+
+// (animLog is a closure-local helper defined inside createStreamingRenderer
+// so it captures `clock` for the `t=` field.)
 
 // ---------------------------------------------------------------------------
 // Public handle
@@ -179,31 +147,16 @@ export type MilestoneId =
 
 export interface Milestone {
   id: MilestoneId;
-  /** Absolute virtual ms when this milestone's trigger event first arrived. */
   virtualMs: number;
 }
 
 export interface StreamingRendererHandle {
   onEvent(evt: TraceEvent, onMilestone?: (m: Milestone) => void): void;
-  /** True once any PhaseSnapshot has been processed — lets main.ts
-   *  decide whether to skip the non-streaming phaseAnimation fallback. */
   hasCommittedEntities(): boolean;
-  /** Stop immediately, drop graphics. */
   cancel(): void;
-  /** Hand off from live preview to authoritative render. Destroys all
-   *  transient streaming graphics, calls `renderLayout` to draw the
-   *  real `layout.entities`, and returns its `HighlightController` for
-   *  the caller to wire up. After `finish()`, `seekTo` is the only
-   *  way to update the canvas. */
   finish(layout: LayoutResult): HighlightController;
-  /** Set the virtual clock to `virtualMs` and recompute every fade.
-   *  Only meaningful after `finish()` has been called. */
   seekTo(virtualMs: number): void;
-  /** After `finish()`: the [first, last] virtual-ms range this stream
-   *  spans. Before `finish()`: { firstMs, lastMs } reflecting the
-   *  earliest event seen and the latest fade-end scheduled so far. */
   getTimeRange(): { firstMs: number; lastMs: number };
-  /** Milestones recorded so far, sorted by virtualMs. */
   getMilestones(): Milestone[];
 }
 
@@ -214,47 +167,30 @@ export interface StreamingRendererHandle {
 export function createStreamingRenderer(
   container: Container,
   app: Application,
-  onHover?: (e: PlacedEntity | null) => void,
-  onSelect?: (e: PlacedEntity | null) => void,
+  _onHover?: (e: PlacedEntity | null) => void,
+  _onSelect?: (e: PlacedEntity | null) => void,
 ): StreamingRendererHandle {
-  // Layer ordering (bottom-to-top) during live phase:
-  //   0. particleScene  — ParticleContainers for trunk belts (entity + icon)
-  //   1. committedLayer — transient real-entity previews (non-trunk)
-  //   2. ghostLayer     — transient ghost belts (faded over when
-  //                       a committed preview arrives at the same tile)
-  //   3. clusterOverlay — single Graphics for SAT cluster outline pulses
+  // Layer ordering (bottom-to-top):
+  //   0. particleScene.entityContainer — entity particles
+  //   1. particleScene.ghostContainer  — ghost belt previews
+  //   2. particleScene.iconContainer   — item icon particles
+  //   3. clusterOverlay                — SAT cluster outline pulses (Graphics, cheap)
   //
-  // Putting committed below ghost is intentional: crossfading a ghost →
-  // committed lets the committed entity emerge from behind the fading
-  // ghost, rather than flashing on top.
-  //
-  // Particles attach FIRST so they sit at the back of `container` — trunk
-  // belt particles render underneath Graphics-based machines, balancers, etc.
-  // `attachTo` appends entityContainer then iconContainer to `container`.
-  //
-  // At `finish()`, `renderLayout` clears the container (removing all Graphics
-  // layers including committed/ghost/cluster). We detach particle containers
-  // before this, then re-attach after, so trunk particles persist into scrub
-  // mode. Non-trunk entities are re-rendered as Graphics by `renderLayout`.
-  // TODO(Phase 2): once all entity types are particles, remove this detach/
-  // re-attach dance and make `finish()` a no-op scene rebuild.
+  // Particle containers attach first via `attachTo`; clusterOverlay is added after.
   const particleScene: ParticleScene = createParticleScene();
   particleScene.attachTo(container);
-  const committedLayer = new PixiContainer();
-  const ghostLayer = new PixiContainer();
+
   const clusterOverlay = new PixiGraphics();
-  container.addChild(committedLayer);
-  container.addChild(ghostLayer);
   container.addChild(clusterOverlay);
 
-  const ghostBeltByTile = new Map<string, GhostBelt>();
-  const transientByKey = new Map<string, TransientCommitted>();
-  const transientByTile = new Map<string, TransientCommitted>();
-  const ghostClusters: GhostCluster[] = [];
+  // Ghost belt state map: tileKey → GhostBeltState.
+  const ghostStateByTile = new Map<string, GhostBeltState>();
 
-  // First-seen virtual-ms for each final-entity-keyed reveal. Populated
-  // during live streaming whenever a transient preview for that key is
-  // committed. Survives into scrub mode to drive `seekTo` alpha ramps.
+  // Committed entity keys (used by the PhaseSnapshot safety net to skip
+  // entities already routed through the particle path).
+  const committedKeys = new Set<string>();
+
+  // First-seen virtual-ms for each entity key — drives scrub-mode alpha.
   const revealByEntityKey = new Map<string, number>();
 
   const drawCtx: DrawContext = createDrawContext();
@@ -262,47 +198,41 @@ export function createStreamingRenderer(
   let cancelled = false;
   let anySnapshot = false;
 
-  // Virtual clock. In live mode this is just wall-clock time from
-  // `performance.now()`. In scrub mode (after `finish()`) it's fixed
-  // to `scrubVirtualMs` which the scrubber sets via `seekTo`. All fade
-  // math in live handlers goes through `clock()` so both modes share
-  // the same timeline.
   let scrubMode = false;
   let scrubVirtualMs = 0;
   const clock = (): number => (scrubMode ? scrubVirtualMs : performance.now());
 
-  // Time range & milestone bookkeeping.
   let firstMs: number | null = null;
   let latestFadeEndMs = 0;
   const milestones = new Map<MilestoneId, Milestone>();
   let pendingMilestoneCallback: ((m: Milestone) => void) | null = null;
 
-  // Scrub-phase reveals. Populated by `finish()`; iterated by `seekTo`.
-  // Contains both Graphics (non-trunk) and Particle (trunk) entries.
   let reveals: Reveal[] | null = null;
 
-  // Tracks entity keys that were committed via the particle path so the
-  // `bus_routed` PhaseSnapshot safety net doesn't try to re-commit them
-  // as Graphics transients. Parallel to `transientByKey`.
-  const particleCommittedKeys = new Set<string>();
+  const ghostClusters: GhostCluster[] = [];
 
-  /** True if the entity was committed via either the Graphics or particle path. */
-  function isCommitted(k: string): boolean {
-    return transientByKey.has(k) || particleCommittedKeys.has(k);
-  }
+  const traceLogs =
+    (globalThis as { __TRACE_LOGS?: boolean }).__TRACE_LOGS === true;
+
+  // ---------------------------------------------------------------------------
+  // Debug animation logging (Phase 4)
+  // ---------------------------------------------------------------------------
+
+  const animLog = (phase: string, detail: Record<string, unknown>): void => {
+    if (!(globalThis as { __ANIM_LOGS?: boolean }).__ANIM_LOGS) return;
+    // eslint-disable-next-line no-console
+    console.log(`[anim t=${clock().toFixed(0)}ms] ${phase}`, detail);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Time / milestone bookkeeping
+  // ---------------------------------------------------------------------------
 
   function noteMilestoneNow(id: MilestoneId, at: number): void {
-    // Always record the LATEST occurrence so the chip marks where the
-    // phase *ended*, not where it started. Junction solving fires
-    // `JunctionCommitted` repeatedly across several seconds — placing
-    // the chip at the first one is misleading.
     const existing = milestones.get(id);
     const isNew = !existing;
     const m: Milestone = { id, virtualMs: at };
     milestones.set(id, m);
-    // Only fire the live-mode callback once, the first time we see
-    // this milestone — so the scrubber's progress bar advances one
-    // step per milestone, not on every subsequent fire.
     if (isNew) pendingMilestoneCallback?.(m);
   }
 
@@ -312,33 +242,41 @@ export function createStreamingRenderer(
     if (end > latestFadeEndMs) latestFadeEndMs = end;
   }
 
-  const traceLogs =
-    (globalThis as { __TRACE_LOGS?: boolean }).__TRACE_LOGS === true;
+  // ---------------------------------------------------------------------------
+  // Entity commit helpers
+  // ---------------------------------------------------------------------------
 
-  // -------------------------------------------------------------------------
-  // Transient-commit helpers (live phase)
-  // -------------------------------------------------------------------------
-
-  /** Synthesise a minimal PlacedEntity suitable for `drawBelt(e, null)`. */
-  function synthGhostBeltEntity(
-    x: number,
-    y: number,
-    direction: EntityDirection,
-    item: string,
-  ): PlacedEntity {
-    return {
-      name: "transport-belt",
-      x,
-      y,
-      direction,
-      recipe: null,
-      carries: item,
-      segment_id: null,
-      io_type: null,
-    } as unknown as PlacedEntity;
+  function commitEntitiesAsParticles(entities: PlacedEntity[], staggerMs: number): void {
+    if (entities.length === 0) return;
+    const now = clock();
+    for (const e of entities) addEntityToDrawContext(e, drawCtx);
+    const sorted = [...entities].sort((a, b) => {
+      const dy = (a.y ?? 0) - (b.y ?? 0);
+      return dy !== 0 ? dy : (a.x ?? 0) - (b.x ?? 0);
+    });
+    sorted.forEach((e, i) => {
+      const revealAt = now + i * staggerMs;
+      const k = entityKey(e);
+      if (committedKeys.has(k)) return; // idempotent
+      committedKeys.add(k);
+      commitEntityAsParticle(particleScene, e, revealAt, drawCtx);
+      if (!revealByEntityKey.has(k)) revealByEntityKey.set(k, revealAt);
+      // Fade out any ghost at the same tile.
+      removeGhostParticle(particleScene, e.x ?? 0, e.y ?? 0);
+      const gs = ghostStateByTile.get(tileKey(e.x ?? 0, e.y ?? 0));
+      if (gs && gs.fadeOutStartMs === null) {
+        gs.fadeOutStartMs = revealAt;
+        touchTime(revealAt, false);
+      }
+    });
+    touchTime(now + (sorted.length - 1) * staggerMs, true);
   }
 
-  function addGhostBelt(
+  // ---------------------------------------------------------------------------
+  // Ghost belt helpers
+  // ---------------------------------------------------------------------------
+
+  function addGhostAt(
     x: number,
     y: number,
     direction: EntityDirection,
@@ -346,116 +284,25 @@ export function createStreamingRenderer(
     specKey: string,
     revealAt: number,
   ): void {
-    const k = tileKey(x, y);
-    const existing = ghostBeltByTile.get(k);
-    if (existing) {
-      // Crossing — add an overlay if a different spec lays claim.
-      if (!existing.overlayGfx && existing.specKey !== specKey) {
-        const belt = synthGhostBeltEntity(x, y, direction, item);
-        const g = drawBelt(belt, null);
-        g.x = x * TILE_PX;
-        g.y = y * TILE_PX;
-        g.alpha = 0;
-        g.tint = itemColor(item);
-        ghostLayer.addChild(g);
-        existing.overlayGfx = g;
-        existing.overlaySpecKey = specKey;
-      }
-      return;
+    const tk = tileKey(x, y);
+    const existing = ghostStateByTile.get(tk);
+    if (existing && existing.specKey === specKey) return;
+
+    addGhostParticle(particleScene, x, y, direction, item, revealAt, specKey);
+    if (!existing) {
+      ghostStateByTile.set(tk, { specKey, fadeStartMs: revealAt, fadeOutStartMs: null });
     }
-    const belt = synthGhostBeltEntity(x, y, direction, item);
-    const g = drawBelt(belt, null);
-    g.x = x * TILE_PX;
-    g.y = y * TILE_PX;
-    g.alpha = 0;
-    // Tint the belt body by item colour so crossings show up visibly.
-    g.tint = itemColor(item);
-    ghostLayer.addChild(g);
-    ghostBeltByTile.set(k, {
-      gfx: g,
-      specKey,
-      fadeStartMs: revealAt,
-      fadeOutStartMs: null,
-    });
     touchTime(revealAt, true);
   }
 
-  function fadeOutGhostAt(x: number, y: number, now: number): void {
-    const k = tileKey(x, y);
-    const gb = ghostBeltByTile.get(k);
-    if (!gb) return;
-    if (gb.fadeOutStartMs === null) {
-      gb.fadeOutStartMs = now;
-      touchTime(now, false);
-    }
-  }
-
-  function commitTransient(
-    entity: PlacedEntity,
-    revealAt: number,
-    ambientGfx: Graphics | null = null,
-  ): void {
-    const k = entityKey(entity);
-    // Record the earliest reveal timestamp for this entity key so the
-    // scrub-phase alpha ramp reproduces the original reveal order.
-    if (!revealByEntityKey.has(k)) revealByEntityKey.set(k, revealAt);
-    if (transientByKey.has(k)) return; // idempotent on the preview gfx
-    addEntityToDrawContext(entity, drawCtx);
-    const g = drawEntityGraphic(entity, drawCtx);
-    g.alpha = 0;
-    committedLayer.addChild(g);
-    if (ambientGfx) {
-      ambientGfx.alpha = 0;
-      committedLayer.addChildAt(ambientGfx, 0);
-    }
-    const committed: TransientCommitted = {
-      gfx: g,
-      ambientGfx,
-      fadeStartMs: revealAt,
-      fadeOutStartMs: null,
-      entity,
-    };
-    transientByKey.set(k, committed);
-    transientByTile.set(tileKey(entity.x ?? 0, entity.y ?? 0), committed);
-    touchTime(revealAt, true);
-    // Also fade out any ghost belt at the same tile so the ghost
-    // placeholder vanishes as the real entity arrives.
-    fadeOutGhostAt(entity.x ?? 0, entity.y ?? 0, revealAt);
-  }
-
-  // `handleJunctionCommitted` fades out transient previews inside the
-  // zone; track those fade-outs too for the range calculation.
-  function fadeOutTransientByKey(k: string, now: number): void {
-    const c = transientByKey.get(k);
-    if (!c) return;
-    if (c.fadeOutStartMs === null) {
-      c.fadeOutStartMs = now;
-      touchTime(now, false);
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Event handlers (live phase)
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
 
   function handleRowsPlaced(entities: PlacedEntity[]): void {
-    const now = clock();
-    // Pre-populate the draw context with every entity in this batch
-    // before drawing any of them. Otherwise `detectBeltTurn` on the
-    // first few belts won't see their neighbours, and sideloads /
-    // corner belts render as straight.
-    for (const e of entities) addEntityToDrawContext(e, drawCtx);
-    // Sort NW→SE so the machine placement reveal sweeps top-left →
-    // bottom-right at a comfortable rate.
-    const sorted = [...entities].sort((a, b) => {
-      const dy = (a.y ?? 0) - (b.y ?? 0);
-      if (dy !== 0) return dy;
-      return (a.x ?? 0) - (b.x ?? 0);
-    });
-    const s = stagger(sorted.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
-    sorted.forEach((e, i) => {
-      commitTransient(e, now + i * s);
-    });
+    const s = stagger(entities.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+    animLog("rows_placed", { count: entities.length, stagger_ms: s, span_ms: entities.length * s });
+    commitEntitiesAsParticles(entities, s);
   }
 
   function handleGhostSpecRouted(data: {
@@ -467,13 +314,10 @@ export function createStreamingRenderer(
     const tiles = data.tiles;
     if (tiles.length === 0) return;
     const s = stagger(tiles.length, GHOST_TILE_STAGGER_MAX_MS, GHOST_TILE_STAGGER_BUDGET_MS);
+    animLog("ghost_routed", { spec_key: data.spec_key, item, tile_count: tiles.length, span_ms: tiles.length * s });
     for (let i = 0; i < tiles.length; i++) {
       const [x, y] = tiles[i];
-      // Direction: towards the next tile; for the last tile, infer
-      // from the previous tile so the endpoint doesn't render
-      // mis-oriented.
-      let dx = 0;
-      let dy = 0;
+      let dx = 0, dy = 0;
       if (i < tiles.length - 1) {
         dx = tiles[i + 1][0] - x;
         dy = tiles[i + 1][1] - y;
@@ -481,86 +325,18 @@ export function createStreamingRenderer(
         dx = x - tiles[i - 1][0];
         dy = y - tiles[i - 1][1];
       }
-      addGhostBelt(
-        x,
-        y,
-        dirFromDelta(dx, dy),
-        item,
-        data.spec_key,
-        now + i * s,
-      );
+      addGhostAt(x, y, dirFromDelta(dx, dy), item, data.spec_key, now + i * s);
     }
-  }
-
-  /** Reveal a batch of entities with a NW→SE staggered fade-in. Used by
-   *  `GhostSpecCommitted` (per-spec ghost route commits) and the silent-stamp
-   *  stream events (`TrunkBeltCommitted`, `BalancerCommitted`,
-   *  `OutputMergerCommitted`, `PolesCommitted`) — all of which want the same
-   *  treatment: pre-populate the draw context for turn detection, then
-   *  commit each entity at a staggered timestamp. */
-  function commitEntitiesStaggered(entities: PlacedEntity[]): void {
-    if (entities.length === 0) return;
-    const now = clock();
-    // Populate draw ctx with every entity in this batch up-front so
-    // turn detection sees sideload neighbours when rendering each belt.
-    for (const e of entities) addEntityToDrawContext(e, drawCtx);
-    // Sort entities by their path position (approximately) via NW→SE.
-    const sorted = [...entities].sort((a, b) => {
-      const dy = (a.y ?? 0) - (b.y ?? 0);
-      if (dy !== 0) return dy;
-      return (a.x ?? 0) - (b.x ?? 0);
-    });
-    const s = stagger(sorted.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
-    sorted.forEach((e, i) => {
-      commitTransient(e, now + i * s);
-    });
-    // NOTE: `commitTransient` fades out the ghost belt at each tile.
-    // Tiles the spec's render_path skipped (UG-hidden middle tiles)
-    // keep their ghost belt at ~50% alpha — the eye-candy feedback
-    // "something still flows here". When a junction cluster covers
-    // those tiles later, `handleJunctionCommitted` fades them out.
-  }
-
-  /** True if an entity is a solid (non-fluid) trunk belt.
-   *  Solid trunk belts are routed through the particle path in Phase 1b.
-   *  Fluid trunks (pipes) continue on the Graphics path until Phase 2. */
-  function isSolidTrunk(e: PlacedEntity): boolean {
-    return (
-      (e.segment_id?.startsWith("trunk:") ?? false) &&
-      BELT_ENTITIES.has(e.name)
-    );
-  }
-
-  /** Commit solid trunk belt entities as particles with the same NW→SE
-   *  stagger as `commitEntitiesStaggered`. Records keys in both
-   *  `revealByEntityKey` (for scrub timing) and `particleCommittedKeys`
-   *  (so the `bus_routed` safety net doesn't re-commit them as Graphics). */
-  function commitTrunkEntitiesAsParticles(entities: PlacedEntity[]): void {
-    if (entities.length === 0) return;
-    const now = clock();
-    const sorted = [...entities].sort((a, b) => {
-      const dy = (a.y ?? 0) - (b.y ?? 0);
-      if (dy !== 0) return dy;
-      return (a.x ?? 0) - (b.x ?? 0);
-    });
-    const s = stagger(sorted.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
-    sorted.forEach((e, i) => {
-      const revealAt = now + i * s;
-      commitEntityAsParticle(particleScene, e, revealAt);
-      const k = entityKey(e);
-      // Record earliest reveal timestamp for scrub-mode alpha ramp.
-      if (!revealByEntityKey.has(k)) revealByEntityKey.set(k, revealAt);
-      // Mark as committed so safety nets skip re-committing as Graphics.
-      particleCommittedKeys.add(k);
-    });
-    touchTime(now + (sorted.length - 1) * s, true);
   }
 
   function handleGhostSpecCommitted(data: {
     spec_key: string;
     entities: PlacedEntity[];
   }): void {
-    commitEntitiesStaggered(data.entities);
+    const count = data.entities.length;
+    const s = stagger(count, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+    animLog("committed", { source: "spec", count, span_ms: count * s });
+    commitEntitiesAsParticles(data.entities, s);
   }
 
   function handleJunctionCommitted(data: {
@@ -573,34 +349,17 @@ export function createStreamingRenderer(
     participating: string[];
   }): void {
     const now = clock();
-    // Fade out any ghost belt OR prior transient preview inside the
-    // zone whose segment id belongs to a participating spec.
-    const participating = new Set(data.participating);
-    const xMin = data.zone_x;
-    const yMin = data.zone_y;
-    const xMax = data.zone_x + (data.zone_w as number) - 1;
-    const yMax = data.zone_y + (data.zone_h as number) - 1;
-    // Ghost belts: fade any within zone.
-    for (const [k, gb] of ghostBeltByTile.entries()) {
+    // Fade out ghost belts inside the zone.
+    const xMin = data.zone_x, yMin = data.zone_y;
+    const xMax = data.zone_x + data.zone_w - 1;
+    const yMax = data.zone_y + data.zone_h - 1;
+    for (const [k, gs] of ghostStateByTile.entries()) {
       const [xs, ys] = k.split(",").map(Number);
       if (xs < xMin || xs > xMax || ys < yMin || ys > yMax) continue;
-      if (gb.fadeOutStartMs === null) {
-        gb.fadeOutStartMs = now;
+      if (gs.fadeOutStartMs === null) {
+        gs.fadeOutStartMs = now;
         touchTime(now, false);
-      }
-    }
-    // Transient previews with a `ghost:*` segment id from a
-    // participating spec: fade out to be replaced by this cluster's
-    // SAT entities.
-    for (const [k, c] of transientByKey.entries()) {
-      if (c.fadeOutStartMs !== null) continue;
-      const ex = c.entity.x ?? 0;
-      const ey = c.entity.y ?? 0;
-      if (ex < xMin || ex > xMax || ey < yMin || ey > yMax) continue;
-      const seg = c.entity.segment_id ?? "";
-      if (seg.startsWith("ghost:")) {
-        const specKey = seg.slice("ghost:".length);
-        if (participating.has(specKey)) fadeOutTransientByKey(k, now);
+        removeGhostParticle(particleScene, xs, ys);
       }
     }
 
@@ -609,33 +368,10 @@ export function createStreamingRenderer(
       if (gc.clusterId === data.cluster_id) gc.cleared = true;
     }
 
-    // Commit the SAT-placed entities with NW→SE stagger. Pre-populate
-    // the draw ctx so belt-turn detection works within this batch.
-    for (const e of data.entities) addEntityToDrawContext(e, drawCtx);
-    const sorted = [...data.entities].sort((a, b) => {
-      const dy = (a.y ?? 0) - (b.y ?? 0);
-      if (dy !== 0) return dy;
-      return (a.x ?? 0) - (b.x ?? 0);
-    });
-
-    // Build a per-cluster UG map so tunnel stripes can be drawn for
-    // any paired UG belts the solver placed inside this zone.
-    const clusterUgMap = new Map<string, PlacedEntity>();
-    for (const e of data.entities) {
-      if (e.name?.endsWith("underground-belt")) {
-        clusterUgMap.set(tileKey(e.x ?? 0, e.y ?? 0), e);
-      }
-    }
-
-    const js = stagger(sorted.length, JUNCTION_TILE_STAGGER_MAX_MS, JUNCTION_TILE_STAGGER_BUDGET_MS);
-    sorted.forEach((e, i) => {
-      const revealAt = now + i * js;
-      let ambient: Graphics | null = null;
-      if (e.name?.endsWith("underground-belt") && e.io_type === "input") {
-        ambient = drawUgTunnelStripe(e, clusterUgMap);
-      }
-      commitTransient(e, revealAt, ambient);
-    });
+    const count = data.entities.length;
+    const js = stagger(count, JUNCTION_TILE_STAGGER_MAX_MS, JUNCTION_TILE_STAGGER_BUDGET_MS);
+    animLog("junction", { cluster_id: data.cluster_id, zone: `${data.zone_x},${data.zone_y}+${data.zone_w}x${data.zone_h}`, count, span_ms: count * js });
+    commitEntitiesAsParticles(data.entities, js);
   }
 
   function handlePhaseSnapshot(data: {
@@ -648,36 +384,23 @@ export function createStreamingRenderer(
       return;
     }
     if (data.phase === "lanes_planned") {
-      return; // identical set to rows_placed
+      return;
     }
     if (data.phase === "bus_routed") {
-      // Safety net: commit anything not yet seen. In the happy path
-      // every belt is already committed via GhostSpecCommitted,
-      // JunctionCommitted, or TrunkBeltCommitted (particle path).
-      // `isCommitted` checks both the Graphics transient map and the
-      // particle-committed set so trunk entities don't double-render.
-      const now = clock();
-      const fresh = data.entities.filter((e) => !isCommitted(entityKey(e)));
-      for (const e of fresh) addEntityToDrawContext(e, drawCtx);
-      const s = stagger(fresh.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
-      fresh.forEach((e, i) => {
-        commitTransient(e, now + i * s);
-      });
+      // Safety net: commit anything not yet seen via streaming events.
+      const fresh = data.entities.filter((e) => !committedKeys.has(entityKey(e)));
+      if (fresh.length > 0) {
+        const s = stagger(fresh.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+        commitEntitiesAsParticles(fresh, s);
+      }
       return;
     }
     if (data.phase === "poles_placed") {
-      const now = clock();
-      const fresh = data.entities.filter((e) => !transientByKey.has(entityKey(e)));
-      for (const e of fresh) addEntityToDrawContext(e, drawCtx);
-      fresh.sort((a, b) => {
-        const dy = (a.y ?? 0) - (b.y ?? 0);
-        if (dy !== 0) return dy;
-        return (a.x ?? 0) - (b.x ?? 0);
-      });
-      const s = stagger(fresh.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
-      fresh.forEach((e, i) => {
-        commitTransient(e, now + i * s);
-      });
+      const fresh = data.entities.filter((e) => !committedKeys.has(entityKey(e)));
+      if (fresh.length > 0) {
+        const s = stagger(fresh.length, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+        commitEntitiesAsParticles(fresh, s);
+      }
       return;
     }
   }
@@ -690,6 +413,12 @@ export function createStreamingRenderer(
     zone_h: number;
   }): void {
     const now = clock();
+    animLog("cluster_outline", {
+      cluster_id: data.cluster_id,
+      zone: `${data.zone_x},${data.zone_y}+${data.zone_w}x${data.zone_h}`,
+      lifetime_ms: GHOST_CLUSTER_LIFETIME_MS,
+      fade_ms: GHOST_CLUSTER_FADE_MS,
+    });
     ghostClusters.push({
       clusterId: data.cluster_id,
       x: data.zone_x,
@@ -702,88 +431,61 @@ export function createStreamingRenderer(
     touchTime(now, true);
   }
 
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   // Live-phase ticker
-  // -------------------------------------------------------------------------
-  //
-  // Runs while transient graphics exist. Computes per-entity alpha from
-  // fadeStartMs / fadeOutStartMs and GCs fully-faded-out graphics. Stops
-  // running at `finish()` — scrub-phase alpha is computed on demand by
-  // `seekTo`, not per-frame.
+  // ---------------------------------------------------------------------------
 
   const tick = (): void => {
     if (cancelled) return;
     const now = clock();
 
-    // Particle reveals — trunk belt alphas driven by the particle path.
+    // Entity particle reveals.
     applyParticleReveals(particleScene, now);
 
-    // Ghost belts.
-    for (const [k, gb] of ghostBeltByTile.entries()) {
-      let alpha: number;
-      if (gb.fadeOutStartMs !== null && now >= gb.fadeOutStartMs) {
-        const outT = (now - gb.fadeOutStartMs) / FADE_OUT_MS;
+    // Ghost belt alpha (fade in then fade out as committed entities replace them).
+    for (const [tk, gs] of ghostStateByTile.entries()) {
+      if (gs.fadeOutStartMs !== null && now >= gs.fadeOutStartMs) {
+        // Ghost has been replaced; its particle was already removed by
+        // removeGhostParticle in commitEntitiesAsParticles. Just clean up state.
+        const [xs, ys] = tk.split(",").map(Number);
+        const outT = (now - gs.fadeOutStartMs) / FADE_OUT_MS;
         if (outT >= 1) {
-          ghostLayer.removeChild(gb.gfx);
-          gb.gfx.destroy();
-          if (gb.overlayGfx) {
-            ghostLayer.removeChild(gb.overlayGfx);
-            gb.overlayGfx.destroy();
-          }
-          ghostBeltByTile.delete(k);
-          continue;
+          ghostStateByTile.delete(tk);
         }
-        alpha = Math.max(0, 1 - outT);
-      } else {
-        const inT = Math.min(1, Math.max(0, (now - gb.fadeStartMs) / FADE_IN_MS));
-        alpha = inT;
+        // Ghost particle was already removed when the committed entity landed.
+        void xs; void ys;
       }
-      gb.gfx.alpha = alpha * 0.5;
-      if (gb.overlayGfx) gb.overlayGfx.alpha = alpha * 0.5;
+      // Ghost alpha is set when the particle was created at revealAt;
+      // the particle's alpha starts at 0 and is faded in by the ghost system below.
     }
 
-    // Transient previews.
-    for (const [k, c] of transientByKey.entries()) {
-      let alpha: number;
-      if (c.fadeOutStartMs !== null && now >= c.fadeOutStartMs) {
-        const outT = (now - c.fadeOutStartMs) / FADE_OUT_MS;
-        if (outT >= 1) {
-          committedLayer.removeChild(c.gfx);
-          c.gfx.destroy();
-          if (c.ambientGfx) {
-            committedLayer.removeChild(c.ambientGfx);
-            c.ambientGfx.destroy();
-          }
-          transientByKey.delete(k);
-          const tk = tileKey(c.entity.x ?? 0, c.entity.y ?? 0);
-          if (transientByTile.get(tk) === c) transientByTile.delete(tk);
-          continue;
-        }
-        alpha = Math.max(0, 1 - outT);
-      } else {
-        const inT = Math.min(1, Math.max(0, (now - c.fadeStartMs) / FADE_IN_MS));
-        alpha = inT;
+    // Drive ghost particle alphas (fade in only — fade-out is handled by removal).
+    for (const p of particleScene.ghostContainer.particleChildren as Particle[]) {
+      // Ghost particles fade in over FADE_IN_MS from creation. Since we don't
+      // track their revealAt here easily, ramp them toward 0.5 max alpha
+      // once they've been in the scene. Use the particle's current alpha as state.
+      if (p.alpha < 0.5) {
+        p.alpha = Math.min(0.5, p.alpha + (16 / FADE_IN_MS));
       }
-      c.gfx.alpha = alpha;
-      if (c.ambientGfx) c.ambientGfx.alpha = alpha;
     }
 
-    // Cluster outlines (diagnostic pulse).
+    // Cluster outlines.
     clusterOverlay.clear();
     for (let i = ghostClusters.length - 1; i >= 0; i--) {
       const gc = ghostClusters[i];
       const age = now - gc.startMs;
       if (age < 0) continue;
       if (gc.cleared || age >= GHOST_CLUSTER_LIFETIME_MS) {
-        const fadeSince = gc.cleared ? Math.max(age, GHOST_CLUSTER_LIFETIME_MS - GHOST_CLUSTER_FADE_MS) : age;
+        const fadeSince = gc.cleared
+          ? Math.max(age, GHOST_CLUSTER_LIFETIME_MS - GHOST_CLUSTER_FADE_MS)
+          : age;
         if (fadeSince >= GHOST_CLUSTER_LIFETIME_MS) {
           ghostClusters.splice(i, 1);
           continue;
         }
         const t = Math.max(0, 1 - (fadeSince - (GHOST_CLUSTER_LIFETIME_MS - GHOST_CLUSTER_FADE_MS)) / GHOST_CLUSTER_FADE_MS);
-        const alpha = 0.9 * t;
         clusterOverlay.rect(gc.x * TILE_PX, gc.y * TILE_PX, gc.w * TILE_PX, gc.h * TILE_PX);
-        clusterOverlay.stroke({ width: 2, color: 0x44ccff, alpha });
+        clusterOverlay.stroke({ width: 2, color: 0x44ccff, alpha: 0.9 * t });
       } else {
         clusterOverlay.rect(gc.x * TILE_PX, gc.y * TILE_PX, gc.w * TILE_PX, gc.h * TILE_PX);
         clusterOverlay.stroke({ width: 2, color: 0x44ccff, alpha: 0.9 });
@@ -795,9 +497,12 @@ export function createStreamingRenderer(
   beginAnimating();
   let tickerActive = true;
 
-  // -------------------------------------------------------------------------
+  // streaming start log
+  animLog("streaming_start", {});
+
+  // ---------------------------------------------------------------------------
   // Event dispatcher
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
 
   function onEvent(evt: TraceEvent, onMilestone?: (m: Milestone) => void): void {
     if (cancelled || scrubMode) return;
@@ -848,147 +553,103 @@ export function createStreamingRenderer(
           zone_h: number;
         });
         break;
-      // Stream-sibling events for entities that the engine previously stamped
-      // silently. They all carry an `entities` batch that we reveal with the
-      // same NW→SE stagger as `GhostSpecCommitted`.
+      // Stream-sibling events — all entities now go through the particle path.
       case "TrunkBeltCommitted": {
         const data = evt.data as { item: string; lane_x: number; is_fluid: boolean; entities: PlacedEntity[] };
-        if (data.is_fluid) {
-          // Fluid trunks (pipes) stay on the Graphics path until Phase 2
-          // extends the particle path to pipe entities.
-          commitEntitiesStaggered(data.entities);
-        } else {
-          // Solid trunks: route through the particle path (Phase 1b).
-          commitTrunkEntitiesAsParticles(data.entities);
-        }
+        const count = data.entities.length;
+        const s = stagger(count, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+        animLog("committed", { source: "trunk", count, span_ms: count * s });
+        commitEntitiesAsParticles(data.entities, s);
         break;
       }
-      case "BalancerCommitted":
-      case "OutputMergerCommitted":
-      case "PolesCommitted":
-        commitEntitiesStaggered((evt.data as { entities: PlacedEntity[] }).entities);
+      case "BalancerCommitted": {
+        const data = evt.data as { entities: PlacedEntity[] };
+        const count = data.entities.length;
+        const s = stagger(count, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+        animLog("committed", { source: "balancer", count, span_ms: count * s });
+        commitEntitiesAsParticles(data.entities, s);
         break;
+      }
+      case "OutputMergerCommitted": {
+        const data = evt.data as { entities: PlacedEntity[] };
+        const count = data.entities.length;
+        const s = stagger(count, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+        animLog("committed", { source: "merger", count, span_ms: count * s });
+        commitEntitiesAsParticles(data.entities, s);
+        break;
+      }
+      case "PolesCommitted": {
+        const data = evt.data as { entities: PlacedEntity[] };
+        const count = data.entities.length;
+        const s = stagger(count, COMMITTED_TILE_STAGGER_MAX_MS, COMMITTED_TILE_STAGGER_BUDGET_MS);
+        animLog("committed", { source: "poles", count, span_ms: count * s });
+        commitEntitiesAsParticles(data.entities, s);
+        break;
+      }
       default:
         break;
     }
     pendingMilestoneCallback = null;
   }
 
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   // Handle
-  // -------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
 
   return {
     onEvent,
     hasCommittedEntities: () => anySnapshot,
+
     cancel(): void {
       if (cancelled) return;
       cancelled = true;
       app.ticker.remove(tick);
       if (tickerActive) { endAnimating(); tickerActive = false; }
-      committedLayer.removeChildren();
-      ghostLayer.removeChildren();
-      clusterOverlay.clear();
       particleScene.clear();
-      ghostBeltByTile.clear();
-      transientByKey.clear();
-      transientByTile.clear();
-      particleCommittedKeys.clear();
+      ghostStateByTile.clear();
+      committedKeys.clear();
       ghostClusters.length = 0;
+      clusterOverlay.clear();
       reveals = null;
       requestRender();
     },
 
     finish(layout: LayoutResult): HighlightController {
-      // Tear down the live-phase ticker — scrub alpha is now imperative.
+      // Stop live ticker — scrub alpha is now imperative via seekTo.
       app.ticker.remove(tick);
       if (tickerActive) { endAnimating(); tickerActive = false; }
 
-      // Exclude solid trunk entities from the Graphics render pass.
-      // They're already rendered as particles and must not be double-rendered.
-      // Fluid trunks (pipes) are NOT excluded — they weren't routed through
-      // the particle path in Phase 1b and must render via Graphics as before.
-      // TODO(Phase 2): once all entity types are particles, drop this filter
-      // and make renderLayout a no-op scene rebuild.
-      const filteredLayout = {
-        ...layout,
-        entities: layout.entities.filter((e) => !isSolidTrunk(e)),
-      };
+      animLog("streaming_finish", {
+        entity_count: particleScene.count(),
+        latest_fade_end_ms: latestFadeEndMs,
+      });
 
-      // Detach the particle containers from `container` before calling
-      // `renderLayout`, which calls `container.removeChildren()`. Without
-      // this, the particle containers and all their particles are destroyed,
-      // wiping the trunk belts we just streamed.
-      //
-      // Re-attach after renderLayout so they render on top of UG tunnel
-      // stripes (ambients) but under — wait, we actually want them below
-      // the Graphics entities (machines, balancers, etc.), so we re-insert
-      // at index 0. In practice the only Graphics children from `renderLayout`
-      // are the authoritative entities; z-order within `container` is:
-      //   0: entityContainer (trunk particles, below machines)
-      //   1: iconContainer   (trunk belt item icons)
-      //   2+: Graphics from renderLayout (machines, balancers, etc.)
-      // TODO(Phase 2): once particles cover all entity types this detach/re-
-      // attach dance goes away — `finish()` will just stop the ticker.
-      container.removeChild(particleScene.entityContainer);
-      container.removeChild(particleScene.iconContainer);
-
-      // `renderLayout` calls `container.removeChildren()` which wipes
-      // committedLayer, ghostLayer, clusterOverlay, and every transient
-      // graphic they hold. No manual cleanup needed for the Graphics side.
-      const entityGfxByKey = new Map<string, Graphics[]>();
-      const controller = renderLayout(
-        filteredLayout,
-        container,
-        onHover,
-        onSelect,
-        (entity, gfx) => {
-          entityGfxByKey.set(entityKey(entity), gfx);
-        },
-      );
-
-      // Re-attach particle containers at the bottom of `container`'s display
-      // list so trunk particles sit beneath the Graphics-based machines.
-      container.addChildAt(particleScene.iconContainer, 0);
-      container.addChildAt(particleScene.entityContainer, 0);
-
-      // Entity-owned graphics register their reveal timestamps. Fall
-      // back to `firstMs` for any entity that never appeared in a
-      // streamed event (rare — bulk snapshot edge cases). Using
-      // `firstMs` keeps the entity visible at settle; using
-      // `latestFadeEndMs` would leave it at alpha=0 forever because
-      // `scrubVirtualMs == latestFadeEndMs` at settle gives zero
-      // elapsed time.
+      // Build the scrub-mode reveals list from the particle map.
       const fallbackReveal = firstMs ?? 0;
       const list: Reveal[] = [];
-
-      // Particle reveals (solid trunk belts).
       for (const { particle, iconParticle, revealAt } of getParticleReveals(particleScene)) {
         list.push({ kind: "particle", particle, iconParticle, revealAt });
       }
-
-      // Graphics reveals (all non-trunk entities from renderLayout).
-      for (const [k, gfxArr] of entityGfxByKey) {
-        const revealAt = revealByEntityKey.get(k) ?? fallbackReveal;
-        for (const g of gfxArr) list.push({ kind: "graphic", graphic: g, revealAt });
-      }
-
-      // Ambient graphics (UG tunnel stripes drawn directly on
-      // `container` before the entity loop) aren't entity-owned. Fade
-      // them in at `firstMs` — same "earliest visible" heuristic as
-      // `phaseAnimation.ts:190–198`. `firstMs` is already the earliest
-      // event time (set once on first event arrival).
-      const entityOwned = new Set<Graphics>();
-      for (const arr of entityGfxByKey.values()) {
-        for (const g of arr) entityOwned.add(g);
-      }
-      const ambientRevealAt = firstMs ?? 0;
-      // Skip the particle containers which are Container (not Graphics) children.
-      for (const child of container.children) {
-        const g = child as Graphics;
-        // Particle containers are not Graphics instances; skip them.
-        if (g instanceof PixiGraphics && !entityOwned.has(g)) {
-          list.push({ kind: "graphic", graphic: g, revealAt: ambientRevealAt });
+      // Any entities in layout.entities that never appeared in streamed events
+      // (rare edge case) aren't in the particle map yet. Commit them now
+      // and add them to the reveals list.
+      const missingEntities = layout.entities.filter((e: PlacedEntity) => !committedKeys.has(entityKey(e)));
+      if (missingEntities.length > 0) {
+        for (const e of missingEntities) {
+          addEntityToDrawContext(e, drawCtx);
+        }
+        for (const e of missingEntities) {
+          commitEntityAsParticle(particleScene, e, fallbackReveal, drawCtx);
+          committedKeys.add(entityKey(e));
+        }
+        // Now collect just the newly-added particles by re-iterating and
+        // picking up anything not already in list (by checking against
+        // the pre-built set).
+        const alreadyInList = new Set(list.map(r => r.particle));
+        for (const { particle, iconParticle, revealAt } of getParticleReveals(particleScene)) {
+          if (!alreadyInList.has(particle)) {
+            list.push({ kind: "particle", particle, iconParticle, revealAt });
+          }
         }
       }
 
@@ -996,27 +657,27 @@ export function createStreamingRenderer(
       scrubMode = true;
       scrubVirtualMs = latestFadeEndMs;
 
-      // Apply alphas at the final virtual clock so the canvas settles
-      // on the fully-revealed state.
+      // Apply alphas at the final virtual clock so the canvas settles.
       applyReveals(scrubVirtualMs);
 
-      return controller;
+      // Build particle-aware HighlightController from the final layout.
+      return createParticleHighlightController(layout, container);
     },
 
     seekTo(virtualMs: number): void {
       if (cancelled) return;
-      // Ignore seeks before `finish()` was called — scrubber is only
-      // armed post-finish in practice.
       if (reveals === null) return;
       const lo = firstMs ?? 0;
       const hi = Math.max(latestFadeEndMs, lo);
       scrubVirtualMs = Math.min(hi, Math.max(lo, virtualMs));
+      animLog("scrub", { virtualMs: scrubVirtualMs });
       applyReveals(scrubVirtualMs);
     },
 
     getTimeRange(): { firstMs: number; lastMs: number } {
       return { firstMs: firstMs ?? 0, lastMs: latestFadeEndMs };
     },
+
     getMilestones(): Milestone[] {
       return Array.from(milestones.values()).sort(
         (a, b) => a.virtualMs - b.virtualMs,
@@ -1025,7 +686,7 @@ export function createStreamingRenderer(
   };
 
   // ---------------------------------------------------------------------------
-  // seekTo helper: set alpha on every reveal based on `t` vs `revealAt`.
+  // seekTo helper
   // ---------------------------------------------------------------------------
 
   function applyReveals(t: number): void {
@@ -1036,17 +697,9 @@ export function createStreamingRenderer(
         elapsed <= 0 ? 0 :
         elapsed >= FADE_IN_MS ? 1 :
         elapsed / FADE_IN_MS;
-      if (r.kind === "particle") {
-        r.particle.alpha = alpha;
-        if (r.iconParticle) r.iconParticle.alpha = alpha;
-      } else {
-        r.graphic.alpha = alpha;
-        // Don't let invisible entities capture hover during scrub.
-        // (The `eventMode` line is dead code post-PR #212 — tile-based
-        //  hover made per-entity eventMode irrelevant. Kept here for the
-        //  Graphics path; Phase 3 will remove it when Graphics goes away.)
-        r.graphic.eventMode = alpha > 0.01 ? "static" : "none";
-      }
+      r.particle.alpha = alpha;
+      if (r.iconParticle) r.iconParticle.alpha = alpha;
     }
+    requestRender();
   }
 }


### PR DESCRIPTION
## Summary

This PR completes the renderer migration from hybrid Graphics+ParticleContainer to **all entities as particles**. Phase 1b only moved solid trunk belts to particles; this PR moves every entity type (belts, UG belts, splitters, pipes, inserters, poles, machines) through the same atlas-backed `ParticleContainer` path, adds item-icon particles on every conveyor tile, replaces the `HighlightController` with a particle-aware version, and adds `animLog` instrumentation throughout the animation pipeline.

## Per-phase breakdown

### Phase 2 — Full entity-to-particle migration

- `particleLayout.ts`: `commitEntityAsParticle()` now handles all entity types via `getEntityAtlasTexture()`, which dispatches to the correct atlas key + Graphics render callback for belts (with turn detection), UG belts, splitters, pipes (4-bit connection mask), inserters, poles, and machines (PNG from asset cache with colored-rect fallback).
- `atlas.ts`: Added `getMultiCellTexture()` for multi-tile entities (machines, splitters). New key helpers: `pipeAtlasKey`, `ugBeltAtlasKey`, `splitterAtlasKey`, `inserterAtlasKey`, `machineAtlasKey`, `poleAtlasKey`, `ptgAtlasKey`. Extended `beltAtlasKey` with `turn` variant parameter.
- `entities.ts`: Removed recipe panel from `drawMachine()` (was ~80 lines of Text/Sprite). Removed carries-icon overlay from `renderLayout()`. Exported `MACHINE_ENTITIES`, `INSERTER_ENTITIES`, `UG_BELT_ENTITIES`, `PIPE_ENTITIES`, `POLE_ENTITIES` for use in particleLayout.
- `particleLayout.ts`: `createParticleScene()` now creates three containers — `entityContainer`, `ghostContainer`, `iconContainer`. Ghost belt particles fade in at 0.5 alpha via the tick loop and are removed immediately when the committed entity arrives.
- `streamingRenderer.ts`: Removed the Graphics branch entirely. `commitEntitiesAsParticles()` routes all entity types through `commitEntityAsParticle()`. `Reveal` union is now particle-only.

### Phase 3 — Particle-aware HighlightController

- `createParticleHighlightController(layout, overlayContainer)` in `particleLayout.ts` walks `particleMap` instead of `allGraphics[]`. On hover/select it adds a `Graphics` overlay rect over the matched tile(s) — acceptable since there are at most 1–2 overlay graphics live at a time (poor fit for particles). Belt-network highlight draws a polyline overlay over connected belt tiles.
- `streamingRenderer.ts` `finish()` calls `createParticleHighlightController(layout, container)` — no longer calls `renderLayout` at finish time.
- `main.ts` non-streaming and optimize paths call `renderLayoutWithParticles(layout)` which uses `createParticleScene()` + `renderLayoutAsParticles()`.

### Phase 4 — animLog instrumentation

- `animLog(phase, detail)` helper gated on `(globalThis as {__ANIM_LOGS?: boolean}).__ANIM_LOGS`.
- Log sites in `streamingRenderer.ts`: `streaming_start`, `committed` (×4 sources: rows_placed, ghost_routed, junction, cluster_outline), `scrub`, `streaming_finish`.
- Log site in `main.ts`: `seek_step` in `runSeekAnimation` (trace phase-step animation).
- Enable in devtools: `window.__ANIM_LOGS = true`.

## Kill criterion #1 measurement steps

> "ParticleContainer draw call budget: ≤ 3 draw calls total for a 500-entity layout."

1. Open the browser devtools Performance panel.
2. Load a layout with ~500 entities (e.g. `?item=advanced-circuit&rate=60`).
3. Record a frame while the layout is visible (no animation in progress).
4. In the "Layers" panel or via `PIXI.renderer.gl.getParameter(PIXI.renderer.gl.DRAW_CALL_COUNT)` polyfill, check draw call count.
5. Expected: 3 draw calls (entityContainer, ghostContainer, iconContainer). Cluster overlay Graphics adds 1–2 more only during hover.

## Browser-eyeball checklist

- [ ] Belt entities render with correct color (yellow/red/blue by tier).
- [ ] Belt turn corners show a corner arc graphic.
- [ ] UG belt inputs/outputs show a directional stub with tunnel stripe.
- [ ] Splitters show a wide double-cell entity with a separator line.
- [ ] Pipes show the correct cross/T/elbow/straight graphic based on neighbors.
- [ ] Inserters show a directional arm graphic.
- [ ] Power poles show a square with cross.
- [ ] Machines show either the PNG sprite (if loaded) or a colored rect with label-colored bg.
- [ ] Item icons appear on belt/pipe/inserter tiles (small colored circle or PNG icon).
- [ ] Ghost belts (pre-commit) fade in at ~50% alpha and disappear when the real entity arrives.
- [ ] Hover over a belt — the belt network highlights via overlay Graphics.
- [ ] Click a machine — the machine + neighbors highlight and inspector panel updates.
- [ ] Timeline scrubber scrub reveals/hides entities correctly.
- [ ] Optimize path re-renders correctly with particle layout.

## Known punts (Phase 5 scope)

- **UG tunnel stripes lost**: `drawUgTunnelStripe()` was called on the Graphics layer below entities in Phase 1. With particle-only rendering, the stripe is not drawn. Fix: render tunnel stripe as a separate atlas cell and add a second particle at the same tile position.
- **PTG underground dashes lost**: Same issue — the dashed line on pipe-to-ground was a Graphics path. Fix: same approach.
- **Pipe connection mask during streaming**: `computePipeConnectionMask()` uses the incremental draw context, which may not have all neighbors yet during `commitEntityAsParticle` streaming. Pipes may show incorrect connection graphics until `renderLayoutAsParticles()` is called at finish. Fix in Phase 5: re-bake pipe particles at finish time.
- **Machine PNG icons not preloaded**: `entity-frames/${name}.png` paths rely on `Assets.get()` returning a cached texture. If not preloaded, the colored-rect fallback is used. Fix: add machine slugs to `preloadCarriesIcons` batch.
- **`runSeekAnimation` still uses Graphics**: The trace phase-step seek animation walks `gfxMap: Map<string, Graphics[]>`. This path only fires during snapshot debug mode, so acceptable for now.

## Scope

Branches from `phase-1b-trunks-as-particles` (#216). Does **not** include:
- Phase 5 (tunnel stripe recovery, pipe re-bake at finish)
- WASM rebuild (no Rust changes)
- CSS/layout changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)