### PR TITLE
perf(web): bump atlas CELL_PX 64→128 for crisper textures at zoom

### DIFF
--- a/web/src/renderer/atlas.ts
+++ b/web/src/renderer/atlas.ts
@@ -3,7 +3,7 @@
  *
  * One module-scoped RenderTexture is allocated lazily on the first
  * `getEntityTexture` call. Atlas slots are assigned on a simple
- * 64×64 grid; `nextSlot` walks left-to-right, top-to-bottom.
+ * 128×128 grid; `nextSlot` walks left-to-right, top-to-bottom.
  * ~250 unique entity variants fit comfortably in 4096×4096.
  *
  * Renderer access: `initAtlas(renderer)` must be called from `app.ts`
@@ -30,16 +30,16 @@ import { itemColor } from "./entities";
 
 /**
  * Atlas texture size in pixels.
- * 4096×4096 holds 4096 × (4096 / CELL_PX) = 4096 entries at 64 px cells.
+ * 4096×4096 holds (4096 / CELL_PX)² = 1024 entries at 128 px cells.
  * If the GPU cannot allocate at this size, halve to 2048×2048 and document.
  */
 const ATLAS_SIZE = 4096;
 
 /** Cell size in pixels — each entity variant occupies one cell. */
-const CELL_PX = 64;
+const CELL_PX = 128;
 
 /** Total columns of cells in the atlas. */
-const ATLAS_COLS = ATLAS_SIZE / CELL_PX; // 64
+const ATLAS_COLS = ATLAS_SIZE / CELL_PX; // 32
 
 /** Lazily allocated atlas RenderTexture. Null until first `getEntityTexture` call. */
 let atlasRT: RenderTexture | null = null;


### PR DESCRIPTION
## Summary

- Bumps `CELL_PX` from 64 to 128 in `web/src/renderer/atlas.ts` — single constant change, all other code references it via `CELL_PX`.
- Provides 4× supersampling instead of 2×, so belt and icon textures stay crisp at up to 4× canvas zoom rather than going fuzzy past 2×.
- Atlas capacity: (4096/128)² = 1024 cells — still well above the ~250 entity variants in use.
- Largest multi-cell entity (3×3 machine): 3×128 = 384 px; fits fine in a 4096 px atlas row.

## Icon PNG size finding

`web/public/icons/iron-plate.png` (and the rest of the icon set) are **64×64 px**. With `CELL_PX = 128` the atlas cell is now larger than the source PNG, so scaling up falls on the PNG sampler rather than the atlas — icons will be upscaled 2× during atlasing. This limits the benefit for icons to whatever was already in the 64×64 source. Higher-res Factorio assets (128×128) would unlock full crispness for icons; left as a follow-up.

## Test plan

- [x] `cd web && npx tsc --noEmit` — clean
- [ ] User eyeball: open the app, zoom in past 2×, verify belt textures are noticeably crisper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>