### PR TITLE
feat(web): distance-based focus highlight (replace dashed-overlay belt network)

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -214,7 +214,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     entityLayer.removeChildren();
     const scene = createParticleScene();
     scene.attachTo(entityLayer);
-    return renderLayoutAsParticles(layout, scene);
+    return renderLayoutAsParticles(layout, scene, app);
   }
 
   const entityLayer = new Container();

--- a/web/src/renderer/connectivityGraph.ts
+++ b/web/src/renderer/connectivityGraph.ts
@@ -1,0 +1,356 @@
+/**
+ * Connectivity graph for distance-based focus highlighting.
+ *
+ * Builds a single undirected adjacency list across every entity type:
+ * belts, underground belts, splitters, inserters, machines, pipes, and
+ * pipe-to-ground pairs. BFS over this graph produces per-entity hop
+ * distances from a hovered entity.
+ *
+ * Build once per layout (cache in the highlight controller). O(N*4)
+ * where N = entity count — well under 10 ms for 3000-entity layouts.
+ */
+
+import type { LayoutResult, PlacedEntity, EntityDirection } from "../engine";
+import {
+  BELT_ENTITIES,
+  UG_BELT_ENTITIES,
+  SPLITTER_ENTITIES,
+  INSERTER_ENTITIES,
+  MACHINE_ENTITIES,
+  MACHINE_SIZES,
+  PIPE_ENTITIES,
+} from "./entities";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Entity key: `"x,y:name:recipe"` — matches `entityKey()` in particleLayout.ts */
+export type EntityKey = string;
+
+/** Undirected adjacency list. Each key maps to the keys of its neighbours. */
+export type ConnectivityGraph = Map<EntityKey, EntityKey[]>;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function tk(x: number, y: number): string {
+  return `${x},${y}`;
+}
+
+function eKey(e: PlacedEntity): EntityKey {
+  return `${e.x ?? 0},${e.y ?? 0}:${e.name}:${e.recipe ?? ""}`;
+}
+
+function dirVec(dir?: EntityDirection): [number, number] {
+  switch (dir) {
+    case "East":  return [1, 0];
+    case "South": return [0, 1];
+    case "West":  return [-1, 0];
+    default:      return [0, -1]; // North
+  }
+}
+
+function addEdge(graph: ConnectivityGraph, a: EntityKey, b: EntityKey): void {
+  if (a === b) return;
+  let la = graph.get(a);
+  if (!la) { la = []; graph.set(a, la); }
+  if (!la.includes(b)) la.push(b);
+
+  let lb = graph.get(b);
+  if (!lb) { lb = []; graph.set(b, lb); }
+  if (!lb.includes(a)) lb.push(a);
+}
+
+/** Coord → entity key for entities of all types (anchor tile only). */
+function buildTileIndex(
+  layout: LayoutResult,
+): Map<string, EntityKey> {
+  const idx = new Map<string, EntityKey>();
+  for (const e of layout.entities) {
+    const x = e.x ?? 0;
+    const y = e.y ?? 0;
+    const k = eKey(e);
+    idx.set(tk(x, y), k);
+
+    // Splitters occupy 2 tiles perpendicular to travel direction.
+    if (SPLITTER_ENTITIES.has(e.name)) {
+      const isNS = e.direction === "North" || e.direction === "South";
+      idx.set(tk(x + (isNS ? 1 : 0), y + (isNS ? 0 : 1)), k);
+    }
+
+    // Multi-tile machines: every tile maps back to the anchor key.
+    if (MACHINE_ENTITIES.has(e.name)) {
+      const [w, h] = MACHINE_SIZES[e.name] ?? [1, 1];
+      for (let dy = 0; dy < h; dy++) {
+        for (let dx = 0; dx < w; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          idx.set(tk(x + dx, y + dy), k);
+        }
+      }
+    }
+  }
+  return idx;
+}
+
+// ---------------------------------------------------------------------------
+// Graph construction
+// ---------------------------------------------------------------------------
+
+const MAX_UG_DIST = 9;
+
+/**
+ * Build a full connectivity graph for `layout`.
+ * Every entity is a node. Edges are undirected (weight 1 per hop).
+ *
+ * Edge types (both directions added):
+ *   belt → adjacent belt (straight + sideload)
+ *   belt → UG output pairing
+ *   splitter → its output/input belts
+ *   inserter ↔ belt (on either pickup or drop tile)
+ *   inserter ↔ machine (on the other side of the inserter, regular or long-handed)
+ *   pipe ↔ adjacent pipe (4-way)
+ *   pipe-to-ground → paired exit (same axis, opposite direction)
+ *   machine ↔ adjacent pipe (fluid port tiles — any adjacent pipe counts)
+ */
+export function buildConnectivityGraph(layout: LayoutResult): ConnectivityGraph {
+  const graph: ConnectivityGraph = new Map();
+  const tileIdx = buildTileIndex(layout);
+
+  // Ensure every entity has a node (even with no edges — isolated poles etc.)
+  for (const e of layout.entities) {
+    const k = eKey(e);
+    if (!graph.has(k)) graph.set(k, []);
+  }
+
+  // Full entity list keyed by anchor tile for scanning neighbours.
+  const entityByTile = new Map<string, PlacedEntity>();
+  for (const e of layout.entities) {
+    entityByTile.set(tk(e.x ?? 0, e.y ?? 0), e);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pass: belt / UG / splitter edges
+  // ---------------------------------------------------------------------------
+  const OFFSETS: [number, number][] = [[0, -1], [1, 0], [0, 1], [-1, 0]];
+
+  for (const e of layout.entities) {
+    const x = e.x ?? 0;
+    const y = e.y ?? 0;
+    const k = eKey(e);
+    const [dx, dy] = dirVec(e.direction);
+
+    if (BELT_ENTITIES.has(e.name)) {
+      // 1a. Forward neighbour (downstream).
+      const fk = tileIdx.get(tk(x + dx, y + dy));
+      if (fk) addEdge(graph, k, fk);
+
+      // 1b. Backward neighbour (upstream = tile in reverse direction).
+      const bk = tileIdx.get(tk(x - dx, y - dy));
+      if (bk) addEdge(graph, k, bk);
+
+      // 1c. Sideload inputs: belts on perpendicular sides whose flow direction
+      //     points at this tile.
+      for (const [ox, oy] of OFFSETS) {
+        if ((ox === dx && oy === dy) || (ox === -dx && oy === -dy)) continue; // skip inline
+        const nb = entityByTile.get(tk(x + ox, y + oy));
+        if (!nb) continue;
+        if (!BELT_ENTITIES.has(nb.name) && !UG_BELT_ENTITIES.has(nb.name) && !SPLITTER_ENTITIES.has(nb.name)) continue;
+        const [ndx, ndy] = dirVec(nb.direction);
+        // nb flows into this tile?
+        // For a splitter the active tile is the neighbour tile itself (x+ox, y+oy);
+        // for a regular belt it's the belt's anchor position.
+        const srcX = SPLITTER_ENTITIES.has(nb.name) ? x + ox : (nb.x ?? 0);
+        const srcY = SPLITTER_ENTITIES.has(nb.name) ? y + oy : (nb.y ?? 0);
+        if (srcX + ndx === x && srcY + ndy === y) {
+          addEdge(graph, k, eKey(nb));
+        }
+      }
+    } else if (UG_BELT_ENTITIES.has(e.name)) {
+      if (e.io_type === "input") {
+        // Scan forward for the matching UG output.
+        for (let dist = 1; dist <= MAX_UG_DIST; dist++) {
+          const te = entityByTile.get(tk(x + dx * dist, y + dy * dist));
+          if (!te) continue;
+          if (UG_BELT_ENTITIES.has(te.name) && te.name === e.name && te.io_type === "input" && te.direction === e.direction) break; // blocked
+          if (UG_BELT_ENTITIES.has(te.name) && te.name === e.name && te.io_type === "output" && te.direction === e.direction) {
+            addEdge(graph, k, eKey(te));
+            break;
+          }
+        }
+      } else {
+        // UG output → forward neighbour (like a regular belt).
+        const fk = tileIdx.get(tk(x + dx, y + dy));
+        if (fk) addEdge(graph, k, fk);
+      }
+
+      // Also connect to adjacent belts that feed into this UG.
+      for (const [ox, oy] of OFFSETS) {
+        const nb = entityByTile.get(tk(x + ox, y + oy));
+        if (!nb) continue;
+        if (!BELT_ENTITIES.has(nb.name) && !SPLITTER_ENTITIES.has(nb.name)) continue;
+        const [ndx, ndy] = dirVec(nb.direction);
+        if ((nb.x ?? 0) + ndx === x && (nb.y ?? 0) + ndy === y) {
+          addEdge(graph, k, eKey(nb));
+        }
+      }
+    } else if (SPLITTER_ENTITIES.has(e.name)) {
+      // Splitter occupies 2 tiles. Its 2 output tiles are in the forward direction
+      // from both halves.
+      const isNS = e.direction === "North" || e.direction === "South";
+      const [sdx, sdy] = isNS ? [1, 0] : [0, 1];
+      for (const [ox, oy] of [[0, 0], [sdx, sdy]] as [number, number][]) {
+        const outK = tileIdx.get(tk(x + ox + dx, y + oy + dy));
+        if (outK && outK !== k) addEdge(graph, k, outK);
+        const inK = tileIdx.get(tk(x + ox - dx, y + oy - dy));
+        if (inK && inK !== k) addEdge(graph, k, inK);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pass: inserter ↔ belt / machine
+  // ---------------------------------------------------------------------------
+  for (const e of layout.entities) {
+    if (!INSERTER_ENTITIES.has(e.name)) continue;
+    const x = e.x ?? 0;
+    const y = e.y ?? 0;
+    const k = eKey(e);
+    const [dx, dy] = dirVec(e.direction);
+
+    // Inserter direction: `direction` points from pickup to drop.
+    // Pickup side: behind the inserter (opposite of direction).
+    // Drop side: in front (direction).
+    // Long-handed: pickup is 2 tiles behind, drop is 2 tiles ahead.
+    const isLong = e.name === "long-handed-inserter";
+    const reach = isLong ? 2 : 1;
+
+    const pickupK = tileIdx.get(tk(x - dx * reach, y - dy * reach));
+    const dropK   = tileIdx.get(tk(x + dx * reach, y + dy * reach));
+
+    if (pickupK) addEdge(graph, k, pickupK);
+    if (dropK)   addEdge(graph, k, dropK);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pass: pipe ↔ adjacent pipe / pipe-to-ground pairing
+  // ---------------------------------------------------------------------------
+  const MAX_PTG_DIST = 10;
+
+  for (const e of layout.entities) {
+    if (!PIPE_ENTITIES.has(e.name)) continue;
+    const x = e.x ?? 0;
+    const y = e.y ?? 0;
+    const k = eKey(e);
+
+    if (e.name === "pipe") {
+      // Connect to all 4 neighbours that are pipe or pipe-to-ground surface side.
+      for (const [ox, oy] of OFFSETS) {
+        const nb = entityByTile.get(tk(x + ox, y + oy));
+        if (!nb) continue;
+        if (nb.name === "pipe") {
+          addEdge(graph, k, eKey(nb));
+        } else if (nb.name === "pipe-to-ground") {
+          // Only connect on the PTG's surface side.
+          // PTG tunnel direction = nb.direction; surface side is opposite.
+          // The pipe (at x,y) reaches nb via offset [ox,oy].
+          // Connection is valid iff the pipe is on the PTG's surface side:
+          //   direction from PTG to pipe = (-ox,-oy) must equal surface delta = (-tdx,-tdy)
+          //   => ox == tdx && oy == tdy  (where [tdx,tdy] = dirVec(nb.direction))
+          const [tdx, tdy] = dirVec(nb.direction);
+          if (ox === tdx && oy === tdy) {
+            addEdge(graph, k, eKey(nb));
+          }
+        } else if (MACHINE_ENTITIES.has(nb.name)) {
+          // Machine fluid port — any adjacent machine counts as connected.
+          const nbK = tileIdx.get(tk(nb.x ?? 0, nb.y ?? 0));
+          if (nbK) addEdge(graph, k, nbK);
+        }
+      }
+    } else if (e.name === "pipe-to-ground") {
+      if (e.io_type === "input") {
+        // Scan forward for matching output.
+        const [dx, dy] = dirVec(e.direction);
+        for (let dist = 2; dist <= MAX_PTG_DIST; dist++) {
+          const te = entityByTile.get(tk(x + dx * dist, y + dy * dist));
+          if (!te) continue;
+          if (te.name !== "pipe-to-ground") continue;
+          const [tdx, tdy] = dirVec(te.direction);
+          // Pair: opposite direction (output coming back).
+          if (te.io_type === "output" && tdx === -dx && tdy === -dy) {
+            addEdge(graph, k, eKey(te));
+            break;
+          }
+          break; // any other PTG blocks the tunnel
+        }
+      }
+      // Also connect to adjacent pipe on surface side.
+      const [dx, dy] = dirVec(e.direction);
+      const surfNb = entityByTile.get(tk(x - dx, y - dy));
+      if (surfNb && surfNb.name === "pipe") {
+        addEdge(graph, k, eKey(surfNb));
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pass: machine ↔ adjacent pipe (fluid connections from machine side)
+  // ---------------------------------------------------------------------------
+  for (const e of layout.entities) {
+    if (!MACHINE_ENTITIES.has(e.name)) continue;
+    const x = e.x ?? 0;
+    const y = e.y ?? 0;
+    const k = eKey(e);
+    const [mw, mh] = MACHINE_SIZES[e.name] ?? [1, 1];
+
+    // Check the perimeter of the machine footprint for adjacent pipes.
+    for (let dy = 0; dy < mh; dy++) {
+      for (let dx = 0; dx < mw; dx++) {
+        for (const [ox, oy] of OFFSETS) {
+          const nx = x + dx + ox;
+          const ny = y + dy + oy;
+          // Only consider tiles outside the machine footprint.
+          if (nx >= x && nx < x + mw && ny >= y && ny < y + mh) continue;
+          const nb = entityByTile.get(tk(nx, ny));
+          if (!nb) continue;
+          if (PIPE_ENTITIES.has(nb.name)) {
+            addEdge(graph, k, eKey(nb));
+          }
+        }
+      }
+    }
+  }
+
+  return graph;
+}
+
+// ---------------------------------------------------------------------------
+// BFS
+// ---------------------------------------------------------------------------
+
+/**
+ * BFS from `start` over `graph`. Returns a map of entity key → hop distance.
+ * Unreachable nodes are absent from the map.
+ */
+export function bfsDistances(
+  graph: ConnectivityGraph,
+  start: EntityKey,
+): Map<EntityKey, number> {
+  const dist = new Map<EntityKey, number>();
+  if (!graph.has(start)) return dist;
+  dist.set(start, 0);
+  const queue: EntityKey[] = [start];
+  let head = 0;
+  while (head < queue.length) {
+    const cur = queue[head++];
+    const d = dist.get(cur)!;
+    for (const nb of graph.get(cur) ?? []) {
+      if (!dist.has(nb)) {
+        dist.set(nb, d + 1);
+        queue.push(nb);
+      }
+    }
+  }
+  return dist;
+}

--- a/web/src/renderer/particleLayout.ts
+++ b/web/src/renderer/particleLayout.ts
@@ -11,14 +11,13 @@
 
 import {
   Container,
-  Graphics,
   Particle,
   ParticleContainer,
   Sprite,
   Assets,
   Cache,
 } from "pixi.js";
-import type { Texture } from "pixi.js";
+import type { Application, Ticker, Texture } from "pixi.js";
 import type { LayoutResult, PlacedEntity, EntityDirection } from "../engine";
 import {
   beltAtlasKey,
@@ -51,13 +50,8 @@ import {
   type DrawContext,
   type HighlightController,
 } from "./entities";
-import {
-  buildBeltGraph,
-  traceBeltNetwork,
-  findAdjacentInserters,
-  findAdjacentMachines,
-  drawBeltNetworkOverlay,
-} from "./beltGraph";
+import { buildConnectivityGraph, bfsDistances, type EntityKey } from "./connectivityGraph";
+import { beginAnimating, endAnimating, requestRender } from "./app";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -71,6 +65,39 @@ export const FADE_IN_MS = 150;
  * Must match `ENTITY_FRAME_TILE_PX` in entities.ts.
  */
 const ENTITY_FRAME_TILE_PX = 64;
+
+// ---------------------------------------------------------------------------
+// Highlight animation constants
+// ---------------------------------------------------------------------------
+
+/** Minimum alpha for dimmed-but-reachable entities (configurable). */
+const HIGHLIGHT_FLOOR = 0.2;
+
+/** Minimum effective max-distance so tiny graphs don't squash their gradient. */
+const HIGHLIGHT_MIN_EFFECTIVE_MAX = 5;
+
+/** Fade-in (raise alpha) duration in ms — sharp ease-out-cubic pop. */
+const HIGHLIGHT_FADE_IN_MS = 100;
+
+/** Fade-out (lower alpha) duration in ms — gentle linear fade. */
+const HIGHLIGHT_FADE_OUT_MS = 200;
+
+// ---------------------------------------------------------------------------
+// Highlight animation types
+// ---------------------------------------------------------------------------
+
+const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+const easeLinear = (t: number): number => t;
+
+interface HighlightAnimation {
+  entityParticle: Particle;
+  iconParticle: Particle | undefined;
+  startAlpha: number;
+  targetAlpha: number;
+  startTime: number;
+  duration: number;
+  ease: (t: number) => number;
+}
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -639,6 +666,154 @@ export function* getParticleReveals(
 }
 
 // ---------------------------------------------------------------------------
+// Shared highlight animation engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a shared highlight animation engine that drives per-particle
+ * alpha transitions.  One instance is created per highlight controller
+ * and registers a single ticker callback while animations are active.
+ *
+ * @param ticker  The Pixi Application ticker (app.ticker).
+ */
+function createHighlightAnimator(ticker: Ticker) {
+  const animations = new Map<EntityKey, HighlightAnimation>();
+  let tickerActive = false;
+
+  function startTicker(): void {
+    if (tickerActive) return;
+    tickerActive = true;
+    ticker.add(tick);
+    beginAnimating();
+  }
+
+  function stopTicker(): void {
+    if (!tickerActive) return;
+    tickerActive = false;
+    ticker.remove(tick);
+    endAnimating();
+  }
+
+  function tick(): void {
+    const now = performance.now();
+    let anyActive = false;
+
+    for (const [key, anim] of animations) {
+      const elapsed = now - anim.startTime;
+      const t = Math.min(1, elapsed / anim.duration);
+      const eased = anim.ease(t);
+      const alpha = anim.startAlpha + (anim.targetAlpha - anim.startAlpha) * eased;
+
+      anim.entityParticle.alpha = alpha;
+      if (anim.iconParticle) anim.iconParticle.alpha = alpha;
+
+      if (t >= 1) {
+        animations.delete(key);
+      } else {
+        anyActive = true;
+      }
+    }
+
+    if (!anyActive) {
+      stopTicker();
+    }
+    requestRender();
+  }
+
+  /**
+   * Schedule a transition for one entity's particles.
+   * If a transition is already in flight, captures current interpolated alpha
+   * as the new start, then retargets to `targetAlpha`.
+   */
+  function animateTo(
+    key: EntityKey,
+    entityParticle: Particle,
+    iconParticle: Particle | undefined,
+    targetAlpha: number,
+  ): void {
+    const existing = animations.get(key);
+    const now = performance.now();
+
+    // Current actual alpha (interpolated if in-flight, otherwise the particle's value).
+    let currentAlpha: number;
+    if (existing) {
+      const elapsed = now - existing.startTime;
+      const t = Math.min(1, elapsed / existing.duration);
+      currentAlpha = existing.startAlpha + (existing.targetAlpha - existing.startAlpha) * existing.ease(t);
+    } else {
+      currentAlpha = entityParticle.alpha;
+    }
+
+    if (Math.abs(currentAlpha - targetAlpha) < 0.001) {
+      // Already at target — no animation needed.
+      animations.delete(key);
+      entityParticle.alpha = targetAlpha;
+      if (iconParticle) iconParticle.alpha = targetAlpha;
+      return;
+    }
+
+    const raising = targetAlpha > currentAlpha;
+    animations.set(key, {
+      entityParticle,
+      iconParticle,
+      startAlpha: currentAlpha,
+      targetAlpha,
+      startTime: now,
+      duration: raising ? HIGHLIGHT_FADE_IN_MS : HIGHLIGHT_FADE_OUT_MS,
+      ease: raising ? easeOutCubic : easeLinear,
+    });
+
+    startTicker();
+  }
+
+  /** Cancel all in-flight animations and set everything to `alpha`. */
+  function cancelAll(alpha: number): void {
+    animations.clear();
+    for (const entry of particleMap.values()) {
+      entry.entity.alpha = alpha;
+      if (entry.icon) entry.icon.alpha = alpha;
+    }
+    stopTicker();
+    requestRender();
+  }
+
+  /** Stop ticker and drop all state — call on controller destroy. */
+  function destroy(): void {
+    animations.clear();
+    stopTicker();
+  }
+
+  return { animateTo, cancelAll, destroy };
+}
+
+// ---------------------------------------------------------------------------
+// Shared per-entity alpha computation from BFS distances
+// ---------------------------------------------------------------------------
+
+function computeTargetAlphas(
+  distances: Map<EntityKey, number>,
+): Map<EntityKey, number> {
+  // Find actual max distance.
+  let actualMax = 0;
+  for (const d of distances.values()) {
+    if (d > actualMax) actualMax = d;
+  }
+  const effectiveMax = Math.max(actualMax, HIGHLIGHT_MIN_EFFECTIVE_MAX);
+
+  const targets = new Map<EntityKey, number>();
+  for (const [key, d] of distances) {
+    const alpha = HIGHLIGHT_FLOOR + (1 - HIGHLIGHT_FLOOR) * (1 - d / effectiveMax);
+    targets.set(key, alpha);
+  }
+  return targets;
+}
+
+/** Build entity key (tile-only, for connectivity graph lookup). */
+function tileEntityKey(e: PlacedEntity): EntityKey {
+  return `${e.x ?? 0},${e.y ?? 0}:${e.name}:${e.recipe ?? ""}`;
+}
+
+// ---------------------------------------------------------------------------
 // Non-streaming path: renderLayoutAsParticles
 // ---------------------------------------------------------------------------
 
@@ -656,6 +831,7 @@ export function* getParticleReveals(
 export function renderLayoutAsParticles(
   layout: LayoutResult,
   scene: ParticleScene,
+  app?: Application,
 ): HighlightController {
   // Clear any previous particles.
   scene.clear();
@@ -677,90 +853,55 @@ export function renderLayoutAsParticles(
   // Set all particles to alpha=1 immediately.
   applyParticleReveals(scene, FADE_IN_MS + 1);
 
-  // Build belt graph for highlight controller.
-  const beltGraph = buildBeltGraph(layout);
+  // Build connectivity graph for distance-based focus.
+  const connGraph = buildConnectivityGraph(layout);
 
-  // Belt network overlay Graphics — drawn on top when a network is highlighted.
-  // Persists between highlight calls; replaced on each new highlight.
-  let overlayGraphics: Graphics | null = null;
-
-  // The container that the scene is attached to — we need it for the overlay.
-  // Since attachTo is called separately, we hold a reference.
-  let overlayParent: Container | null = null;
-
-  function getOverlayParent(): Container | null {
-    // Reach the parent container via the beltContainer's parent.
-    return scene.beltContainer.parent as Container | null;
+  // If no app was provided (legacy call sites), fall back to non-animated behaviour.
+  if (!app) {
+    return createLegacyHighlightController();
   }
 
-  function clearHighlightInternal(): void {
-    if (overlayGraphics) {
-      const parent = overlayParent ?? getOverlayParent();
-      if (parent) parent.removeChild(overlayGraphics);
-      overlayGraphics.destroy();
-      overlayGraphics = null;
-    }
+  const animator = createHighlightAnimator(app.ticker);
+
+  function applyDistances(distances: Map<EntityKey, number>): void {
+    const targets = computeTargetAlphas(distances);
     for (const entry of particleMap.values()) {
-      entry.entity.alpha = 1;
-      if (entry.icon) entry.icon.alpha = 1;
+      const key = tileEntityKey(entry.placedEntity);
+      const target = targets.get(key) ?? HIGHLIGHT_FLOOR;
+      animator.animateTo(key, entry.entity, entry.icon, target);
     }
   }
 
   return {
     highlightItem(item: string | null): void {
-      clearHighlightInternal();
+      animator.cancelAll(1);
       if (!item) return;
       for (const entry of particleMap.values()) {
         const pe = entry.placedEntity;
         const chainKey = pe.carries ?? pe.recipe ?? null;
-        const dim = chainKey !== item;
-        const alpha = dim ? 0.15 : 1;
-        entry.entity.alpha = alpha;
-        if (entry.icon) entry.icon.alpha = alpha;
+        const target = chainKey === item ? 1 : 0.15;
+        const key = tileEntityKey(pe);
+        animator.animateTo(key, entry.entity, entry.icon, target);
       }
     },
 
     highlightBeltNetwork(entity: PlacedEntity | null): void {
-      clearHighlightInternal();
-      if (!entity) return;
-
-      const startKey = `${entity.x ?? 0},${entity.y ?? 0}`;
-      const anchor = beltGraph.tileToAnchor.get(startKey) ?? startKey;
-      if (!beltGraph.nodes.has(anchor)) return;
-
-      const { downstream, upstream } = traceBeltNetwork(anchor, beltGraph);
-      const allBelt = new Set([...downstream, ...upstream]);
-      const inserters = findAdjacentInserters(allBelt, beltGraph.entityMap);
-      const machines = findAdjacentMachines(inserters, beltGraph.entityMap);
-
-      for (const entry of particleMap.values()) {
-        const pe = entry.placedEntity;
-        const k = `${pe.x ?? 0},${pe.y ?? 0}`;
-        let alpha: number;
-        if (allBelt.has(k)) {
-          alpha = 0.5;
-        } else if (inserters.has(k)) {
-          alpha = 0.9;
-        } else if (machines.has(k)) {
-          alpha = 0.75;
-        } else {
-          alpha = 0.15;
-        }
-        entry.entity.alpha = alpha;
-        if (entry.icon) entry.icon.alpha = alpha;
+      if (!entity) {
+        animator.cancelAll(1);
+        return;
       }
-
-      const parent = getOverlayParent();
-      if (parent) {
-        overlayParent = parent;
-        overlayGraphics = new Graphics();
-        drawBeltNetworkOverlay(overlayGraphics, downstream, upstream, anchor, beltGraph);
-        parent.addChild(overlayGraphics);
-      }
+      const startKey = tileEntityKey(entity);
+      const distances = bfsDistances(connGraph, startKey);
+      applyDistances(distances);
     },
 
     clearHighlight(): void {
-      clearHighlightInternal();
+      // Animate everything back to 1.0 with the fade-out (linear) curve.
+      // animateTo picks the correct easing automatically (lowering alpha → linear).
+      for (const entry of particleMap.values()) {
+        const key = tileEntityKey(entry.placedEntity);
+        animator.animateTo(key, entry.entity, entry.icon, 1);
+      }
     },
 
     chainKey(entity: PlacedEntity): string | null {
@@ -770,30 +911,11 @@ export function renderLayoutAsParticles(
 }
 
 // ---------------------------------------------------------------------------
-// Particle-aware HighlightController (Phase 3)
+// Legacy (non-animated) fallback controller — used when no app is available
 // ---------------------------------------------------------------------------
 
-/**
- * Build a particle-aware `HighlightController` that walks the `particleMap`
- * instead of a `allGraphics` array.
- *
- * Used by `streamingRenderer.ts:finish()` after all entities are particles.
- * The belt network overlay (dashed/solid lines) remains a Graphics overlay
- * added to `overlayContainer` — separate from the entities.
- */
-export function createParticleHighlightController(
-  layout: LayoutResult,
-  overlayContainer: Container,
-): HighlightController {
-  const beltGraph = buildBeltGraph(layout);
-  let overlayGraphics: Graphics | null = null;
-
-  function clearHighlightInternal(): void {
-    if (overlayGraphics) {
-      overlayContainer.removeChild(overlayGraphics);
-      overlayGraphics.destroy();
-      overlayGraphics = null;
-    }
+function createLegacyHighlightController(): HighlightController {
+  function clearAll(): void {
     for (const entry of particleMap.values()) {
       entry.entity.alpha = 1;
       if (entry.icon) entry.icon.alpha = 1;
@@ -802,7 +924,7 @@ export function createParticleHighlightController(
 
   return {
     highlightItem(item: string | null): void {
-      clearHighlightInternal();
+      clearAll();
       if (!item) return;
       for (const entry of particleMap.values()) {
         const pe = entry.placedEntity;
@@ -812,43 +934,90 @@ export function createParticleHighlightController(
         if (entry.icon) entry.icon.alpha = alpha;
       }
     },
+    highlightBeltNetwork(): void {
+      // No-op in legacy mode (no app = no animation, and overlay is removed).
+    },
+    clearHighlight(): void {
+      clearAll();
+    },
+    chainKey(entity: PlacedEntity): string | null {
+      return entity.carries ?? entity.recipe ?? null;
+    },
+  };
+}
 
-    highlightBeltNetwork(entity: PlacedEntity | null): void {
-      clearHighlightInternal();
-      if (!entity) return;
+// ---------------------------------------------------------------------------
+// Particle-aware HighlightController (streaming path)
+// ---------------------------------------------------------------------------
 
-      const startKey = `${entity.x ?? 0},${entity.y ?? 0}`;
-      const anchor = beltGraph.tileToAnchor.get(startKey) ?? startKey;
-      if (!beltGraph.nodes.has(anchor)) return;
+/**
+ * Build a particle-aware `HighlightController` with distance-based focus
+ * dimming and smooth alpha animations.
+ *
+ * Used by `streamingRenderer.ts:finish()` after all entities are particles.
+ * The dashed/solid Graphics overlay is removed — distance-based dimming
+ * replaces it entirely.
+ *
+ * @param layout  The final layout (used to build the connectivity graph).
+ * @param app     The Pixi Application (provides the ticker for animation).
+ */
+export function createParticleHighlightController(
+  layout: LayoutResult,
+  app: Application,
+): HighlightController & { destroy(): void } {
+  const connGraph = buildConnectivityGraph(layout);
+  const animator = createHighlightAnimator(app.ticker);
 
-      const { downstream, upstream } = traceBeltNetwork(anchor, beltGraph);
-      const allBelt = new Set([...downstream, ...upstream]);
-      const inserters = findAdjacentInserters(allBelt, beltGraph.entityMap);
-      const machines = findAdjacentMachines(inserters, beltGraph.entityMap);
+  function applyDistanceFocus(entity: PlacedEntity): void {
+    const startKey = tileEntityKey(entity);
+    const distances = bfsDistances(connGraph, startKey);
+    const targets = computeTargetAlphas(distances);
 
+    for (const entry of particleMap.values()) {
+      const key = tileEntityKey(entry.placedEntity);
+      const target = targets.get(key) ?? HIGHLIGHT_FLOOR;
+      animator.animateTo(key, entry.entity, entry.icon, target);
+    }
+  }
+
+  return {
+    highlightItem(item: string | null): void {
+      animator.cancelAll(1);
+      if (!item) return;
       for (const entry of particleMap.values()) {
         const pe = entry.placedEntity;
-        const k = `${pe.x ?? 0},${pe.y ?? 0}`;
-        let alpha: number;
-        if (allBelt.has(k)) alpha = 0.5;
-        else if (inserters.has(k)) alpha = 0.9;
-        else if (machines.has(k)) alpha = 0.75;
-        else alpha = 0.15;
-        entry.entity.alpha = alpha;
-        if (entry.icon) entry.icon.alpha = alpha;
+        const chainKey = pe.carries ?? pe.recipe ?? null;
+        const target = chainKey === item ? 1 : 0.15;
+        entry.entity.alpha = target;
+        if (entry.icon) entry.icon.alpha = target;
       }
+    },
 
-      overlayGraphics = new Graphics();
-      drawBeltNetworkOverlay(overlayGraphics, downstream, upstream, anchor, beltGraph);
-      overlayContainer.addChild(overlayGraphics);
+    highlightBeltNetwork(entity: PlacedEntity | null): void {
+      if (!entity) {
+        // Animate back to full alpha.
+        for (const entry of particleMap.values()) {
+          const key = tileEntityKey(entry.placedEntity);
+          animator.animateTo(key, entry.entity, entry.icon, 1);
+        }
+        return;
+      }
+      applyDistanceFocus(entity);
     },
 
     clearHighlight(): void {
-      clearHighlightInternal();
+      for (const entry of particleMap.values()) {
+        const key = tileEntityKey(entry.placedEntity);
+        animator.animateTo(key, entry.entity, entry.icon, 1);
+      }
     },
 
     chainKey(entity: PlacedEntity): string | null {
       return entity.carries ?? entity.recipe ?? null;
+    },
+
+    destroy(): void {
+      animator.destroy();
     },
   };
 }

--- a/web/src/renderer/streamingRenderer.ts
+++ b/web/src/renderer/streamingRenderer.ts
@@ -662,7 +662,7 @@ export function createStreamingRenderer(
       applyReveals(scrubVirtualMs);
 
       // Build particle-aware HighlightController from the final layout.
-      return createParticleHighlightController(layout, container);
+      return createParticleHighlightController(layout, app);
     },
 
     seekTo(virtualMs: number): void {

--- a/web/src/ui/inspector.ts
+++ b/web/src/ui/inspector.ts
@@ -1,5 +1,5 @@
 import type { PlacedEntity } from "../engine";
-import { niceName, getRecipeFlows, isBeltEntity, type HighlightController } from "../renderer/entities";
+import { niceName, getRecipeFlows, type HighlightController } from "../renderer/entities";
 import type { TileContext, TileInfo } from "./tileContext";
 
 export interface InspectorControls {
@@ -607,11 +607,7 @@ export function createInspector(container: HTMLElement): InspectorControls {
     tooltip.style.display = "block";
 
     if (hoveredEntity && highlightCtrl) {
-      if (isBeltEntity(hoveredEntity.name)) {
-        highlightCtrl.highlightBeltNetwork(hoveredEntity);
-      } else {
-        highlightCtrl.highlightItem(highlightCtrl.chainKey(hoveredEntity));
-      }
+      highlightCtrl.highlightBeltNetwork(hoveredEntity);
     } else if (highlightCtrl) {
       highlightCtrl.clearHighlight();
     }


### PR DESCRIPTION
## Intent

Replace the dashed/solid Graphics overlay belt-network highlight with a smooth, distance-based focus dimming model. The user wants to see how a hovered entity fits into the whole production graph — not just the belt itself — so hovering anything now shows the full connectivity neighbourhood with graceful distance falloff.

## What changed

- **New file: `web/src/renderer/connectivityGraph.ts`** — Unified production-connectivity graph covering all entity types (belts, UG-belt pairs, splitters, inserters, machines, pipes, pipe-to-ground pairs). Built once per layout in O(N×4). `buildConnectivityGraph(layout)` + `bfsDistances(graph, start)` are the public API.

- **`web/src/renderer/particleLayout.ts`** — New `createHighlightAnimator` drives per-particle alpha transitions with `beginAnimating`/`endAnimating` lifecycle. New `createParticleHighlightController(layout, app)` (signature changed: `app: Application` instead of `overlayContainer: Container`) uses BFS + animated dimming. Old dashed/solid overlay removed entirely. `renderLayoutAsParticles` updated to accept optional `app` and fall back to a non-animated legacy path for call sites without an app ref. `highlightItem` also routes through the animator for smooth item-chain transitions.

- **`web/src/renderer/streamingRenderer.ts`** — `finish()` now passes `app` to `createParticleHighlightController` (was `container`).

- **`web/src/main.ts`** — `renderLayoutWithParticles` passes `app` to `renderLayoutAsParticles`.

- **`web/src/ui/inspector.ts`** — Hover path now calls `highlightBeltNetwork` for **all** entity types (not just belt entities). `isBeltEntity` import removed. `highlightItem` is kept for programmatic item-chain use.

## Behaviour

| Trigger | Effect |
|---|---|
| Hover belt | BFS from belt, all reachable entities alpha-graded by hop distance |
| Hover inserter / machine / pipe | Same BFS, shows the full production subgraph |
| Move cursor to adjacent entity | Alpha re-grades smoothly from current in-flight state |
| Move cursor off canvas | 200 ms linear fade back to 1.0 everywhere |
| `highlightItem(item)` (sidebar) | Instant set (ease-out for focal items) |

Alpha formula: `FLOOR + (1 - FLOOR) * (1 - d / effectiveMax)` where `FLOOR = 0.2` and `effectiveMax = max(actualMax, 5)`.

## Scope

- `drawBeltNetworkOverlay` in `beltGraph.ts` is **kept** — it is still used by the non-particle paths (`renderLayout` in `entities.ts` → `satEditor`, `phaseAnimation`). It is simply no longer called from the particle highlight path.
- `traceBeltNetwork`, `findAdjacentInserters`, `findAdjacentMachines` in `beltGraph.ts` are kept — no callers changed.
- No Rust changes.

## Verification run

- `cd web && npx tsc --noEmit` — clean.
- `cargo test --manifest-path crates/core/Cargo.toml` — 425 passed, 20 ignored.
- Browser eyeball delegated to user per project convention.

## Test cases for eyeball

- Hover a belt feeding into a chemical-plant: belt chain → inserter → machine → output inserter → output belt should all be bright; background bus dims with distance.
- Hover a pipe adjacent to a chemical-plant: plant, connected inserters, and the full pipe network should light up; distant belts fade toward 0.2.
- Hover a machine directly: BFS expands through all adjacent inserters and belts.
- Move cursor quickly across the bus: alphas re-grade smoothly without flickering.
- Move cursor off canvas: 200 ms linear fade-out to alpha 1.0 everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)