### PR TITLE
feat(web): hide trace overlay behind a sub-toggle (off by default)

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -116,7 +116,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   // --- Modules ---
   const overlayControls = createOverlayPanel(container);
-  const { debugCb, colorCb, regionsCb, soloRegionsCb, ghostTilesCb } = overlayControls;
+  const { debugCb, colorCb, regionsCb, soloRegionsCb, ghostTilesCb, traceOverlayCb } = overlayControls;
   // Sync the item-coloring flag with the persisted checkbox state so
   // a user who turned colours off stays off across reloads.
   setItemColoring(colorCb.checked);
@@ -140,6 +140,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       stepThrough: false,
       ghostTiles: ghostTilesCb.checked,
       satZones: regionsCb.checked,
+      traceOverlay: traceOverlayCb.checked,
     };
   }
 
@@ -468,7 +469,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       }
     }
 
-    if (!debugCb.checked || !lastLayout?.trace?.length) {
+    if (!debugCb.checked || !traceOverlayCb.checked || !lastLayout?.trace?.length) {
       stepThrough.update();
       requestRender();
       return;
@@ -1353,6 +1354,10 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     });
     ghostTilesCb.addEventListener("change", () => {
       updateGhostTilesOverlay();
+      updateLegend();
+    });
+    traceOverlayCb.addEventListener("change", () => {
+      updateTraceOverlay();
       updateLegend();
     });
     colorCb.addEventListener("change", () => {

--- a/web/src/state/debugState.ts
+++ b/web/src/state/debugState.ts
@@ -5,6 +5,7 @@ export interface DebugState {
   soloRegions: boolean;
   ghostTiles: boolean;
   itemColors: boolean;
+  traceOverlay: boolean;
 }
 
 type Subscriber = (state: DebugState) => void;
@@ -16,6 +17,7 @@ let state: DebugState = {
   soloRegions: false,
   ghostTiles: false,
   itemColors: true,
+  traceOverlay: false,
 };
 
 const subs: Subscriber[] = [];
@@ -26,12 +28,14 @@ export function create(): void {
   const satFromStorage = localStorage.getItem("fk-sat-zones") === "1";
   const ghostFromStorage = localStorage.getItem("fk-ghost-tiles") === "1";
   const itemColorsStored = localStorage.getItem("fk-item-colors");
+  const traceOverlayStored = localStorage.getItem("fk-trace-overlay") === "1";
   state = {
     ...state,
     master: fromParam || fromStorage,
     satZones: satFromStorage,
     ghostTiles: ghostFromStorage,
     itemColors: itemColorsStored === null ? true : itemColorsStored === "1",
+    traceOverlay: traceOverlayStored,
   };
 }
 
@@ -52,6 +56,9 @@ export function set(patch: Partial<DebugState>): void {
   }
   if ("itemColors" in patch) {
     localStorage.setItem("fk-item-colors", patch.itemColors ? "1" : "0");
+  }
+  if ("traceOverlay" in patch) {
+    localStorage.setItem("fk-trace-overlay", patch.traceOverlay ? "1" : "0");
   }
   for (const cb of subs) cb(state);
 }

--- a/web/src/ui/legendPanel.ts
+++ b/web/src/ui/legendPanel.ts
@@ -182,6 +182,7 @@ export interface LegendPanelState {
   stepThrough: boolean;
   ghostTiles: boolean;
   satZones: boolean;
+  traceOverlay: boolean;
 }
 
 export function createLegendPanel(container: HTMLElement): LegendPanelControls {
@@ -272,7 +273,7 @@ export function createLegendPanel(container: HTMLElement): LegendPanelControls {
       // Ghost paths — step-through mode draws them via renderTraceOverlay;
       // they also appear in the ghost routing overlay when debug is on.
       // Show when debug is on and there's trace data, regardless of step-through.
-      if (state.stepThrough) {
+      if (state.stepThrough || state.traceOverlay) {
         entries.push({ swatch: ghostPaletteSwatch(), label: "Ghost path (per-spec colour)" });
         entries.push({ swatch: diamondSwatch("#ffdd00", 0.85), label: "Crossing: two specs collide (SAT)" });
         entries.push({ swatch: crossSwatch("#ff3333"), label: "Route / ghost spec failed" });

--- a/web/src/ui/overlayPanel.ts
+++ b/web/src/ui/overlayPanel.ts
@@ -9,6 +9,7 @@ export interface OverlayPanelControls {
   regionsCb: HTMLInputElement;
   soloRegionsCb: HTMLInputElement;
   ghostTilesCb: HTMLInputElement;
+  traceOverlayCb: HTMLInputElement;
 }
 
 function makeToggle(parent: HTMLElement, label: string, checked = false): HTMLInputElement {
@@ -41,6 +42,7 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
 
   const regionsCb = makeToggle(subPanel, "SAT Zones", state.satZones);
   const ghostTilesCb = makeToggle(subPanel, "Ghost tiles", state.ghostTiles);
+  const traceOverlayCb = makeToggle(subPanel, "Trace overlay", state.traceOverlay);
   const soloRegionsCb = makeToggle(subPanel, "Solo regions", state.soloRegions);
   panel.appendChild(subPanel);
 
@@ -62,6 +64,9 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
   ghostTilesCb.addEventListener("change", () => {
     debugState.set({ ghostTiles: ghostTilesCb.checked });
   });
+  traceOverlayCb.addEventListener("change", () => {
+    debugState.set({ traceOverlay: traceOverlayCb.checked });
+  });
   colorCb.addEventListener("change", () => {
     debugState.set({ itemColors: colorCb.checked });
   });
@@ -77,5 +82,6 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
     regionsCb,
     soloRegionsCb,
     ghostTilesCb,
+    traceOverlayCb,
   };
 }


### PR DESCRIPTION
## Summary
- The lane/balancer/row/tap-off/merger overlays from \`renderTraceOverlay\` draw large translucent bands across the layout. Even at alpha 0.04–0.05 they read as a jarring \"flash\" because the staged phase animation fades entities in from alpha=0 over ~2.2s — the bands stand out against the empty canvas, then visually disappear once entities arrive on top.
- Adds a new \`Trace overlay\` sub-checkbox under the Debug master, **off by default**, persisted in \`localStorage\` as \`fk-trace-overlay\`. Mirrors the existing \`SAT Zones\` / \`Ghost tiles\` toggle pattern.
- Touches: \`web/src/state/debugState.ts\`, \`web/src/ui/overlayPanel.ts\`, \`web/src/ui/legendPanel.ts\`, \`web/src/main.ts\`.
- The bands are now opt-in even with Debug enabled. Other debug overlays (Validation, SAT Zones, Ghost tiles) keep their existing behavior.

## Test plan
- [ ] With Debug ON and \`Trace overlay\` OFF: load a layout (e.g. \`plastic-bar\`) and confirm no purple/green bands appear during the staged reveal or after.
- [ ] Tick \`Trace overlay\` ON: bands appear immediately. Untick: they vanish.
- [ ] Refresh the page with the toggle on/off — state persists.
- [ ] Existing toggles (Validation, SAT Zones, Ghost tiles) still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)