### PR TITLE
feat(web): always-on validation visuals (#209)

### DIFF
--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -363,9 +363,17 @@ pub fn validate_layout(
     layout_result: LayoutResult,
     solver_result: Option<SolverResult>,
     layout_style: Option<LayoutStyle>,
-) -> Result<Vec<ValidationIssue>, JsError> {
+) -> Vec<ValidationIssue> {
     let style = layout_style.unwrap_or_default();
     let solver_ref: Option<&SolverResult> = solver_result.as_ref();
-    validate::validate(&layout_result, solver_ref, style)
-        .map_err(|e| JsError::new(&e.to_string()))
+    // Always return the full issue list to the web UI. The native
+    // `validate::validate` returns `Err(ValidationError)` when any
+    // error-severity issues exist (Python parity), but the error path
+    // discards the structured issue list. The UI needs the issues
+    // themselves to render borders + the badge (#209), so we unwrap
+    // the error case back into the same `Vec<ValidationIssue>`.
+    match validate::validate(&layout_result, solver_ref, style) {
+        Ok(issues) => issues,
+        Err(err) => err.issues,
+    }
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -35,6 +35,7 @@ import { spawnRegionFlash } from "./renderer/improvementAnimation";
 import { createStreamingRenderer, type StreamingRendererHandle } from "./renderer/streamingRenderer";
 import { createTimelineScrubber, type TimelineScrubberHandle } from "./ui/timelineScrubber";
 import "./ui/timelineScrubber.css";
+import "./ui/validationBadge.css";
 import { attachBusyOverlay } from "./ui/busyOverlay";
 import { logLayoutStats } from "./ui/layoutTimingLog";
 
@@ -115,7 +116,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   // --- Modules ---
   const overlayControls = createOverlayPanel(container);
-  const { debugCb, colorCb, valCb, regionsCb, soloRegionsCb, ghostTilesCb } = overlayControls;
+  const { debugCb, colorCb, regionsCb, soloRegionsCb, ghostTilesCb } = overlayControls;
   // Sync the item-coloring flag with the persisted checkbox state so
   // a user who turned colours off stays off across reloads.
   setItemColoring(colorCb.checked);
@@ -137,7 +138,6 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       debugMode: debugCb.checked,
       hasTrace: !!(lastLayout?.trace?.length),
       stepThrough: false,
-      validation: valCb.checked,
       ghostTiles: ghostTilesCb.checked,
       satZones: regionsCb.checked,
     };
@@ -151,8 +151,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   const issuesDialog = createIssuesDialog(container, app, viewport);
   issuesDialog.setOnValClose(() => {
-    valCb.checked = false;
-    updateValidationOverlay();
+    issuesDialog.setVisible(false);
   });
 
   // Detailed PIXI overlay for the selected SAT zone. Added to the
@@ -305,7 +304,6 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   let soloRegionsActive = false;
   let soloSavedState: {
     colorChecked: boolean;
-    valChecked: boolean;
     regionsChecked: boolean;
     entityAlpha: number;
   } | null = null;
@@ -496,6 +494,34 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   let cachedValidationIssues: ValidationIssue[] | null = null;
   let validationInFlightFor: LayoutResult | null = null;
 
+  // Top-left static badge that surfaces the issue count whenever a layout
+  // has validation problems. No click handler yet (#209 deferred). Hidden
+  // when there are no issues.
+  const validationBadge = document.createElement("div");
+  validationBadge.className = "validation-badge";
+  validationBadge.style.display = "none";
+  container.appendChild(validationBadge);
+
+  function updateValidationBadge(issues: ValidationIssue[] | null): void {
+    if (!issues || issues.length === 0) {
+      validationBadge.style.display = "none";
+      return;
+    }
+    const errors = issues.filter((i) => i.severity === "Error").length;
+    const warnings = issues.length - errors;
+    let label: string;
+    if (errors > 0 && warnings > 0) {
+      label = `⚠ ${errors} error${errors > 1 ? "s" : ""}, ${warnings} warning${warnings > 1 ? "s" : ""}`;
+    } else if (errors > 0) {
+      label = `⚠ ${errors} error${errors > 1 ? "s" : ""}`;
+    } else {
+      label = `⚠ ${warnings} warning${warnings > 1 ? "s" : ""}`;
+    }
+    validationBadge.textContent = label;
+    validationBadge.classList.toggle("has-errors", errors > 0);
+    validationBadge.style.display = "block";
+  }
+
   let regionOverlayLayer: Container | null = null;
   let regionHitTest: ((wx: number, wy: number) => RegionOverlayItem | null) | null = null;
   let junctionOverlayLayer: Container | null = null;
@@ -516,9 +542,9 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     issuesDialog.clearPulse();
     issuesDialog.setCircleMap(valCircleMap);
 
-    // If we don't have cached issues yet for the current layout, kick off a
-    // validate in the worker and re-render when it lands. Guard against stale
-    // results by checking lastLayout identity when the promise resolves.
+    // Always run validation when a layout is finalised. The visuals are
+    // no longer gated on the Debug toggle (#209) — issues are surfaced as
+    // border outlines + a top-left badge whenever they exist.
     if (lastLayout && !cachedValidationIssues && validationInFlightFor !== lastLayout) {
       const target = lastLayout;
       validationInFlightFor = target;
@@ -539,14 +565,10 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     }
 
     sidebarCtrl?.updateValidation(cachedValidationIssues ?? [], panToTile);
+    updateValidationBadge(cachedValidationIssues);
 
-    if (!debugCb.checked || !valCb.checked || !lastLayout) {
-      issuesDialog.populate(cachedValidationIssues ?? [], debugCb.checked, valCb.checked);
-      requestRender();
-      return;
-    }
-    if (!cachedValidationIssues || cachedValidationIssues.length === 0) {
-      issuesDialog.populate([], debugCb.checked, valCb.checked);
+    if (!lastLayout || !cachedValidationIssues || cachedValidationIssues.length === 0) {
+      issuesDialog.populate(cachedValidationIssues ?? [], debugCb.checked);
       requestRender();
       return;
     }
@@ -560,7 +582,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     valOverlayLayer = result.layer;
     valCircleMap = result.circleMap;
     issuesDialog.setCircleMap(valCircleMap);
-    issuesDialog.populate(cachedValidationIssues, debugCb.checked, valCb.checked);
+    issuesDialog.populate(cachedValidationIssues, debugCb.checked);
     requestRender();
   }
 
@@ -679,7 +701,6 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     updateValidationOverlay,
     panToTile,
     onDebugEnable: () => overlayControls.setDebugEnabled(true),
-    onValEnable: () => { valCb.checked = true; },
     onClear: () => {
       snapshotMode.clear();
       entityLayer.removeChildren();
@@ -693,7 +714,8 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
       legendEl.style.display = "none";
       updateLegend();
       issuesDialog.setVisible(false);
-      issuesDialog.populate([], false, false);
+      issuesDialog.populate([], false);
+      updateValidationBadge(null);
       sidebarCtrl?.updateValidation([], panToTile);
       junctionDebugger.close();
     },
@@ -1342,10 +1364,6 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         renderLayoutOnCanvas(lastLayout);
       }
     });
-    valCb.addEventListener("change", () => {
-      updateValidationOverlay();
-      updateLegend();
-    });
     regionsCb.addEventListener("change", () => {
       updateRegionOverlay();
       updateLegend();
@@ -1357,7 +1375,6 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
         soloRegionsActive = true;
         soloSavedState = {
           colorChecked: colorCb.checked,
-          valChecked: valCb.checked,
           regionsChecked: regionsCb.checked,
           entityAlpha: entityLayer.alpha,
         };
@@ -1371,10 +1388,6 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
           setItemColoring(false);
           if (lastLayout) renderLayoutOnCanvas(lastLayout);
         }
-        if (valCb.checked) {
-          valCb.checked = false;
-          updateValidationOverlay();
-        }
 
         entityLayer.alpha = 0.12;
         updateRegionOverlay();
@@ -1387,10 +1400,6 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
           if (regionsCb.checked !== soloSavedState.regionsChecked) {
             regionsCb.checked = soloSavedState.regionsChecked;
             updateRegionOverlay();
-          }
-          if (valCb.checked !== soloSavedState.valChecked) {
-            valCb.checked = soloSavedState.valChecked;
-            updateValidationOverlay();
           }
           if (colorCb.checked !== soloSavedState.colorChecked) {
             colorCb.checked = soloSavedState.colorChecked;

--- a/web/src/renderer/validationOverlay.ts
+++ b/web/src/renderer/validationOverlay.ts
@@ -14,12 +14,14 @@ const COLORS: Record<string, number> = {
   Warning: 0xffaa00,
 };
 
-/** Alpha for the resting (non-pulsed) fill of validation circles. */
-export const VALIDATION_CIRCLE_ALPHA = 0.35;
+/** Resting alpha for the stroke around an issue tile. The pulse helper
+ *  in `issuesDialog.ts` blinks markers between this and 1.0 to draw the
+ *  eye after a row click in the issues dialog. */
+export const VALIDATION_BORDER_ALPHA = 0.85;
 
 export interface ValidationOverlayResult {
   layer: Container;
-  /** Map from "x,y" to all Graphics circles at that tile position. */
+  /** Map from "x,y" to all border Graphics at that tile position. */
   circleMap: Map<string, Graphics[]>;
 }
 
@@ -34,9 +36,10 @@ export function renderValidationOverlay(
     if (issue.x == null || issue.y == null) continue;
     const color = COLORS[issue.severity] ?? 0x44aaff;
     const g = new Graphics();
-    g.circle(issue.x * TILE_PX + TILE_PX / 2, issue.y * TILE_PX + TILE_PX / 2, TILE_PX * 0.4)
-      .fill({ color, alpha: VALIDATION_CIRCLE_ALPHA })
-      .stroke({ width: 1.5, color, alpha: 0.7 });
+    // Stroke-only rectangle around the tile. No fill — the entity
+    // underneath stays visible (issue #209 design constraint).
+    g.rect(issue.x * TILE_PX, issue.y * TILE_PX, TILE_PX, TILE_PX)
+      .stroke({ width: 2, color, alpha: VALIDATION_BORDER_ALPHA });
     g.eventMode = "static";
     g.on("pointerenter", () => onHover(`[${issue.severity}] ${issue.category}: ${issue.message}`));
     g.on("pointerleave", () => onHover(null));

--- a/web/src/state/debugState.ts
+++ b/web/src/state/debugState.ts
@@ -1,7 +1,6 @@
 export interface DebugState {
   master: boolean;
   stepThrough: boolean;
-  validation: boolean;
   satZones: boolean;
   soloRegions: boolean;
   ghostTiles: boolean;
@@ -13,7 +12,6 @@ type Subscriber = (state: DebugState) => void;
 let state: DebugState = {
   master: false,
   stepThrough: true,
-  validation: false,
   satZones: false,
   soloRegions: false,
   ghostTiles: false,

--- a/web/src/ui/issuesDialog.ts
+++ b/web/src/ui/issuesDialog.ts
@@ -1,7 +1,7 @@
 import type { Application } from "pixi.js";
 import type { Viewport } from "pixi-viewport";
 import type { Graphics } from "pixi.js";
-import { VALIDATION_CIRCLE_ALPHA } from "../renderer/validationOverlay";
+import { VALIDATION_BORDER_ALPHA } from "../renderer/validationOverlay";
 import { TILE_PX } from "../renderer/entities";
 import { beginAnimating, endAnimating, requestRender } from "../renderer/app";
 import "./issuesDialog.css";
@@ -15,12 +15,11 @@ export interface ValidationIssueItem {
 }
 
 export interface IssuesDialogControls {
-  populate(issues: ValidationIssueItem[], debugOn: boolean, valOn: boolean): void;
+  populate(issues: ValidationIssueItem[], debugOn: boolean): void;
   setVisible(visible: boolean): void;
   setCircleMap(map: Map<string, Graphics[]>): void;
   clearPulse(): void;
   panel: HTMLElement;
-  valCbRef: { checked: boolean };
   onValClose: (() => void) | null;
   setOnValClose(cb: () => void): void;
 }
@@ -88,7 +87,7 @@ export function createIssuesDialog(
 
   function clearPulse(): void {
     if (activePulse) {
-      for (const m of activePulse.markers) m.alpha = VALIDATION_CIRCLE_ALPHA;
+      for (const m of activePulse.markers) m.alpha = VALIDATION_BORDER_ALPHA;
       app.ticker.remove(activePulse.tickerFn);
       endAnimating();
       activePulse = null;
@@ -107,7 +106,7 @@ export function createIssuesDialog(
       if (elapsed >= 150) {
         elapsed -= 150;
         on = !on;
-        const alpha = on ? 1.0 : 0.35;
+        const alpha = on ? 1.0 : VALIDATION_BORDER_ALPHA;
         for (const m of markers) m.alpha = alpha;
       }
     };
@@ -135,11 +134,11 @@ export function createIssuesDialog(
     if (pinnedRow && !issuesPanel.contains(e.target as Node)) unpinRow();
   });
 
-  function populate(issues: ValidationIssueItem[], debugOn: boolean, valOn: boolean): void {
+  function populate(issues: ValidationIssueItem[], debugOn: boolean): void {
     body.innerHTML = "";
     pinnedRow = null;
     clearPulse();
-    if (!debugOn || !valOn || issues.length === 0) {
+    if (!debugOn || issues.length === 0) {
       issuesPanel.style.display = "none";
       return;
     }
@@ -202,9 +201,6 @@ export function createIssuesDialog(
     }
   }
 
-  // Expose a mutable ref so main.ts can point valCb at the dialog close handler
-  const valCbRef = { checked: false };
-
   return {
     populate,
     setVisible(visible: boolean): void {
@@ -215,7 +211,6 @@ export function createIssuesDialog(
     },
     clearPulse,
     panel: issuesPanel,
-    valCbRef,
     onValClose: null,
     setOnValClose(cb: () => void): void {
       onValCloseCb = cb;

--- a/web/src/ui/legendPanel.ts
+++ b/web/src/ui/legendPanel.ts
@@ -112,23 +112,6 @@ function rectOutlineSwatch(hex: string, fillAlpha = 0.12, strokeAlpha = 0.85): H
   return s;
 }
 
-/** Circle swatch — matches validation markers. */
-function circleSwatch(hex: string, alpha = 0.5): HTMLElement {
-  const s = document.createElement("span");
-  const [r, g, b] = hexToRgb(hex);
-  s.style.cssText = [
-    "display:inline-block",
-    "width:12px",
-    "height:12px",
-    "border-radius:50%",
-    "flex-shrink:0",
-    `background:rgba(${r},${g},${b},${alpha})`,
-    `border:1.5px solid rgba(${r},${g},${b},0.7)`,
-    "vertical-align:middle",
-  ].join(";");
-  return s;
-}
-
 // ---------------------------------------------------------------------------
 // Ghost-path palette swatch: a small coloured line strip showing 3 of the
 // cycling palette colours so the user knows paths are individually coloured.
@@ -197,7 +180,6 @@ export interface LegendPanelState {
   /** Trace events present (implies ghost paths / cluster zones may exist). */
   hasTrace: boolean;
   stepThrough: boolean;
-  validation: boolean;
   ghostTiles: boolean;
   satZones: boolean;
 }
@@ -311,11 +293,6 @@ export function createLegendPanel(container: HTMLElement): LegendPanelControls {
         entries.push({ swatch: colorSwatch("#40d0e0", 0.4), label: "Ghost router footprint" });
       }
 
-      // Validation circles
-      if (state.validation) {
-        entries.push({ swatch: circleSwatch("#ff4444", 0.5), label: "Validation error" });
-        entries.push({ swatch: circleSwatch("#ffaa00", 0.5), label: "Validation warning" });
-      }
 
       // SAT / Junction zones
       if (state.satZones) {

--- a/web/src/ui/overlayPanel.ts
+++ b/web/src/ui/overlayPanel.ts
@@ -6,7 +6,6 @@ export interface OverlayPanelControls {
   setDebugEnabled(on: boolean): void;
   debugCb: HTMLInputElement;
   colorCb: HTMLInputElement;
-  valCb: HTMLInputElement;
   regionsCb: HTMLInputElement;
   soloRegionsCb: HTMLInputElement;
   ghostTilesCb: HTMLInputElement;
@@ -40,7 +39,6 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
   subPanel.className = "overlay-sub-panel";
   subPanel.style.display = state.master ? "flex" : "none";
 
-  const valCb = makeToggle(subPanel, "Validation", state.validation);
   const regionsCb = makeToggle(subPanel, "SAT Zones", state.satZones);
   const ghostTilesCb = makeToggle(subPanel, "Ghost tiles", state.ghostTiles);
   const soloRegionsCb = makeToggle(subPanel, "Solo regions", state.soloRegions);
@@ -76,7 +74,6 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
     },
     debugCb,
     colorCb,
-    valCb,
     regionsCb,
     soloRegionsCb,
     ghostTilesCb,

--- a/web/src/ui/snapshotMode.ts
+++ b/web/src/ui/snapshotMode.ts
@@ -9,7 +9,6 @@ export interface SnapshotModeDeps {
   updateValidationOverlay(): void;
   panToTile(x: number, y: number): void;
   onDebugEnable(): void;
-  onValEnable(): void;
   onClear(): void;
 }
 
@@ -40,9 +39,6 @@ export function createSnapshotMode(deps: SnapshotModeDeps): SnapshotModeControls
 
     if (snapshot.trace.events.length > 0 || snapshot.validation.issues.length > 0) {
       deps.onDebugEnable();
-    }
-    if (snapshot.validation.issues.length > 0) {
-      deps.onValEnable();
     }
 
     deps.renderLayoutOnCanvas(layout);

--- a/web/src/ui/validationBadge.css
+++ b/web/src/ui/validationBadge.css
@@ -1,0 +1,21 @@
+/* Top-left badge that surfaces validation issue counts (#209). */
+.validation-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fa0;
+  font: 11px/1.3 monospace;
+  padding: 5px 9px;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 170, 0, 0.4);
+  z-index: 10;
+  user-select: none;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.validation-badge.has-errors {
+  color: #f66;
+  border-color: rgba(255, 68, 68, 0.5);
+}


### PR DESCRIPTION
## Intent

Validation visuals were gated on a "Debug → Validation" sub-toggle that most users never flipped, so layout bugs hid in plain sight. This makes them prominent: stroke-only red/orange tile borders whenever issues exist, plus a static top-left badge with the issue count. Closes #209.

## Scope

- **In:**
  - Drop the "Validation" sub-checkbox and its persisted state.
  - Replace filled circles with thin stroked rectangles around each issue tile so the entity underneath stays visible.
  - Add a static top-left `.validation-badge` showing `N errors` / `M warnings` (red when errors exist, orange when only warnings).
  - WASM `validate_layout`: return the full issue list on the Err path too. Previously errors were `to_string()`'d and the JS catch silently dropped them.
  - Hover tooltip continues to surface full issue details via the existing `setTooltipOverride` path.
- **Out:** click-to-open behaviour on the badge (deferred per design discussion). No icons. No per-issue list in the badge.

## Verification

- [x] `npx tsc --noEmit` (web) — clean
- [x] `cargo clippy --manifest-path crates/wasm-bindings/Cargo.toml -- -D warnings` — clean
- [x] WASM rebuild + browser eyeball at `http://localhost:5175/?item=processing-unit&rate=2&machine=assembling-machine-3&in=iron-plate,copper-plate,coal,water,crude-oil` — badge reads `⚠ 45 errors` (red), red borders visible on affected tiles, hover tooltip shows full message.
- [x] Clean fixture (`?item=iron-gear-wheel&rate=1&in=iron-plate`) — badge hidden, no borders.
- [x] Toggle Debug off — badge + borders remain visible (no longer gated on Debug).

## Deviations from intent

The original brief was "web/ only" but I needed one Rust change: the WASM `validate_layout` binding's `Err` path discarded the structured issue list, so the JS side was already silently dropping every error before any UI could render it. Fixed at the WASM boundary (`crates/wasm-bindings/src/lib.rs`) — both arms now return `Vec<ValidationIssue>`. Native `validate::validate` API unchanged; only the WASM wrapper differs. Confirmed during browser eyeball that the buggy fixture surfaces 45 errors instead of 0.

## Models / contracts touched

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)