### PR TITLE
fix(web): refresh pipe textures at streaming finish

### DIFF
--- a/web/src/renderer/particleLayout.ts
+++ b/web/src/renderer/particleLayout.ts
@@ -725,6 +725,25 @@ export function removeParticleAt(
 }
 
 /**
+ * Walk every committed pipe particle and refresh its atlas texture
+ * against the (now-complete) draw context. Streaming commits a pipe
+ * with whatever neighbours are visible at the moment its phase fires,
+ * so a pipe whose neighbour appears in a later phase ends up with a
+ * stale, under-connected texture. The non-streaming path doesn't hit
+ * this — it stages the whole tileMap before committing — but the
+ * streaming finish() does, so it calls this once at finalisation.
+ */
+export function refreshPipeTextures(ctx: DrawContext): void {
+  for (const entry of particleMap.values()) {
+    if (entry.placedEntity.name !== "pipe") continue;
+    const tex = getEntityAtlasTexture(entry.placedEntity, ctx);
+    if (entry.entity.texture !== tex) {
+      entry.entity.texture = tex;
+    }
+  }
+}
+
+/**
  * Walk all registered particles and update alpha based on
  * `(now - revealAt) / FADE_IN_MS`. Mirrors `applyReveals` in
  * `streamingRenderer.ts`. Called from the live-phase ticker.

--- a/web/src/renderer/streamingRenderer.ts
+++ b/web/src/renderer/streamingRenderer.ts
@@ -49,6 +49,7 @@ import {
   removeGhostParticle,
   clearAllGhostParticles,
   entityKey,
+  refreshPipeTextures,
   type ParticleScene,
 } from "./particleLayout";
 
@@ -661,6 +662,14 @@ export function createStreamingRenderer(
           }
         }
       }
+
+      // Pipes committed in earlier phases see only the neighbours that
+      // existed at commit time, so a pipe whose west/east/etc. neighbour
+      // arrived in a later phase is left with an under-connected texture
+      // (visible cut-offs in mid-bus pipe runs). drawCtx is now the
+      // complete tileMap — re-resolve every pipe particle's texture
+      // against it. Cheap: 16 cached variants, identity-equal hits skip.
+      refreshPipeTextures(drawCtx);
 
       reveals = list;
       scrubMode = true;


### PR DESCRIPTION
## Summary

Pipes committed during streaming bake their atlas texture from whatever neighbours are visible *at that phase*, and the sprite reference never refreshes when later phases drop additional neighbours into the tileMap. The result: a pipe whose west/east/etc. neighbour arrived in a later phase keeps its earlier under-connected texture, so contiguous runs render with visible cut-offs in the middle.

The non-streaming path (`renderLayoutAsParticles`) doesn't hit this — it stages the entire `tileMap` before committing any entity. Only the streaming `finish()` needs the fix.

- Add `refreshPipeTextures(ctx)` in `particleLayout.ts` — walks every committed pipe particle and re-resolves its texture against the (now-complete) `drawCtx`. Identity-equal hits skip; the atlas keeps 16 cached variants total, so cost is minimal.
- Call it from `streamingRenderer.ts finish()` after missing entities have been added.

## Trade-off

Pipe textures shown during scrub replay now reflect the **final** connectivity rather than per-phase historical state. Refreshing on every scrub tick would be expensive — the scrubber is a debug surface and the after-completion view is what users see in the common path, so this is the right call.

## Test plan

- [ ] Open `?item=processing-unit&rate=2&...&row_layout=horizontal-stack` (the URL where this regression was visible) — middle-of-bus pipe runs render contiguous.
- [ ] Open a simple fluid recipe (plastic-bar) — pipe-to-machine and PTG-to-pipe joins still look correct.
- [ ] Scrub back through phases — pipes show final connectivity (acceptable per trade-off above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)