### PR TITLE
fix(bus): order_specs preserves duplicate-recipe MachineSpecs

### DIFF
--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -175,8 +175,19 @@ pub(crate) fn order_specs<'a>(
     machines: &'a [MachineSpec],
     dependency_order: &[String],
 ) -> Vec<&'a MachineSpec> {
-    let recipe_to_spec: FxHashMap<&str, &MachineSpec> =
-        machines.iter().map(|m| (m.recipe.as_str(), m)).collect();
+    // The `recipe_to_specs` lookup must be a `Vec<&MachineSpec>` per
+    // recipe rather than a single `&MachineSpec` so duplicate-recipe
+    // entries survive. Today's pipeline produces one spec per recipe,
+    // but future strategies (notably the `PartitionedDecomposed` path
+    // in `bus::partitioner`, which Cartesian-splits consumer specs
+    // across input shards) generate N entries per recipe — and the
+    // previous `HashMap<recipe, &MachineSpec>` last-write-wins shape
+    // silently dropped all but the last sibling, halving placed
+    // machine counts. See `docs/rfp-modular-production.md` Phase 2.
+    let mut recipe_to_specs: FxHashMap<&str, Vec<&MachineSpec>> = FxHashMap::default();
+    for m in machines {
+        recipe_to_specs.entry(m.recipe.as_str()).or_default().push(m);
+    }
 
     // item -> recipe that produces it
     let mut producer: FxHashMap<&str, &str> = FxHashMap::default();
@@ -252,7 +263,7 @@ pub(crate) fn order_specs<'a>(
 
     emitted
         .into_iter()
-        .filter_map(|r| recipe_to_spec.get(r).copied())
+        .flat_map(|r| recipe_to_specs.get(r).cloned().unwrap_or_default())
         .collect()
 }
 
@@ -1784,5 +1795,57 @@ mod tests {
             outputs: vec![ItemFlow { item: "thing".to_string(), rate: 2.0, is_fluid: false, module_id: 0 }],
         };
         assert!(can_lane_split(&spec, 3));
+    }
+
+    /// Pre-fix bug: `recipe_to_spec: HashMap<recipe, &MachineSpec>`
+    /// silently dropped duplicate-recipe entries on insert (last-write-
+    /// wins), and the final `filter_map` lookup returned only the
+    /// surviving one. Result: if a strategy produced N siblings sharing
+    /// a recipe, only one made it through `order_specs`, and the
+    /// downstream layout placed only that one's machines.
+    ///
+    /// This test guards the post-fix property: every input spec is
+    /// preserved in the output, in topological order, with siblings
+    /// grouped together by recipe.
+    #[test]
+    fn order_specs_preserves_duplicate_recipes() {
+        // Two siblings of "ec_consumer" (e.g. Cartesian-split across
+        // input shards), each with a different `count`. Plus an
+        // upstream "cable_producer" they both consume from.
+        let cable = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "copper-cable".to_string(),
+            count: 4.0,
+            inputs: vec![ItemFlow { item: "copper-plate".to_string(), rate: 1.0, is_fluid: false, module_id: 0 }],
+            outputs: vec![ItemFlow { item: "copper-cable".to_string(), rate: 2.0, is_fluid: false, module_id: 0 }],
+        };
+        let ec_a = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "electronic-circuit".to_string(),
+            count: 5.0,
+            inputs: vec![ItemFlow { item: "copper-cable".to_string(), rate: 3.0, is_fluid: false, module_id: 0 }],
+            outputs: vec![ItemFlow { item: "electronic-circuit".to_string(), rate: 1.0, is_fluid: false, module_id: 0 }],
+        };
+        let ec_b = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "electronic-circuit".to_string(),
+            count: 7.0, // distinguishes this sibling from ec_a
+            inputs: vec![ItemFlow { item: "copper-cable".to_string(), rate: 3.0, is_fluid: false, module_id: 1 }],
+            outputs: vec![ItemFlow { item: "electronic-circuit".to_string(), rate: 1.0, is_fluid: false, module_id: 0 }],
+        };
+        let machines = vec![cable, ec_a, ec_b];
+        let dep_order: Vec<String> = vec!["copper-cable".into(), "electronic-circuit".into()];
+        let ordered = order_specs(&machines, &dep_order);
+
+        // All three specs survive.
+        assert_eq!(ordered.len(), 3, "all input specs must be preserved through topo sort");
+        // Topological order: cable producer first, then both EC siblings.
+        assert_eq!(ordered[0].recipe, "copper-cable");
+        assert_eq!(ordered[1].recipe, "electronic-circuit");
+        assert_eq!(ordered[2].recipe, "electronic-circuit");
+        // Both EC siblings are present (distinguishable by `count`).
+        let mut counts: Vec<usize> = ordered[1..3].iter().map(|s| s.count as usize).collect();
+        counts.sort();
+        assert_eq!(counts, vec![5, 7], "both EC siblings must appear with their original counts");
     }
 }


### PR DESCRIPTION
Companion to #238. Extracts the `order_specs` change from Phase 2 into its own focused PR so the fix can be scrutinised in isolation, regardless of what happens to Phase 2 itself.

## What this fixes

Today's `order_specs` builds a `HashMap<recipe, &MachineSpec>` and looks up by recipe at the end. If two `MachineSpec`s share a recipe, the HashMap insert is last-write-wins and the final `filter_map().copied()` returns only the surviving sibling. All other siblings silently disappear from the layout.

Today's pipeline never produces duplicate-recipe specs, so the bug is dormant — but `PartitionedDecomposed` (Phase 2 of `rfp-modular-production`) Cartesian-splits consumer specs across input shards, generating N siblings per recipe. Without this fix, half of those siblings vanish and the layout has half the expected machine count for each affected recipe.

## What changes

`order_specs` keeps a `Vec<&MachineSpec>` per recipe instead of a single `&MachineSpec`, and `flat_map`s over the bucket at the end. Siblings preserve their topological position grouped together by their shared recipe.

## What does *not* change

- No current strategy produces duplicate-recipe specs, so layout behaviour for `Pooled` and `PartitionedPerConsumer` is byte-identical.
- K0-1 golden hashes unchanged.
- All existing 19 e2e tests + 411 unit tests still pass.

## Why land this separately

Phase 2 (#238) is non-trivial in scope and currently in iteration. This `order_specs` change is locally good and useful regardless of Phase 2's fate — it removes a sharp edge so any future strategy that needs sibling specs sharing a recipe can rely on the topo sort handling them correctly.

## Verification

- 412 unit + 19 e2e tests pass; new `order_specs_preserves_duplicate_recipes` unit test asserts both siblings survive with their original `count`s.
- `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dyy5o9EH5tsavTZLPHjX9p)_