### PR TITLE
Add PR preview deployments with automatic cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
     needs: [web]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: web-dist
@@ -140,6 +141,7 @@ jobs:
     needs: [web]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: web-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -92,6 +91,8 @@ jobs:
     needs: changes
     if: always() && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true')
     runs-on: ubuntu-latest
+    env:
+      BASE_PATH: ${{ github.event_name == 'pull_request' && format('/fucktorio/pr-{0}/', github.event.pull_request.number) || '/fucktorio/' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -116,21 +117,46 @@ jobs:
           name: web-dist
           path: web/dist/
 
-  deploy:
-    if: github.ref == 'refs/heads/main'
+  deploy-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [web]
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: web-dist
           path: site/
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
+      - name: Deploy to gh-pages root
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
+          folder: site
+          branch: gh-pages
+          clean: true
+          clean-exclude: |
+            pr-*
+
+  deploy-preview:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: [web]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: web-dist
           path: site/
-      - id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Deploy preview to gh-pages/pr-${{ github.event.pull_request.number }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: site
+          branch: gh-pages
+          target-folder: pr-${{ github.event.pull_request.number }}
+          clean: true
+          commit-message: "Deploy preview for PR #${{ github.event.pull_request.number }} (${{ github.sha }})"
+      - name: Comment preview URL on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            Preview deployed: https://storkme.github.io/fucktorio/pr-${{ github.event.pull_request.number }}/
+
+            Last updated: ${{ github.sha }} at ${{ github.event.pull_request.updated_at }}

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,53 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+      - name: Remove preview directory
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ ! -d "pr-${PR_NUMBER}" ]; then
+            echo "No preview directory pr-${PR_NUMBER} to remove"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm -rf "pr-${PR_NUMBER}"
+          git commit -m "Remove preview for PR #${PR_NUMBER}"
+          for attempt in 1 2 3 4; do
+            if git push origin gh-pages; then
+              exit 0
+            fi
+            echo "Push failed (attempt ${attempt}); rebasing and retrying"
+            git pull --rebase origin gh-pages
+            sleep $((2 ** attempt))
+          done
+          echo "Failed to push cleanup commit after retries" >&2
+          exit 1
+      - name: Update PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            Preview for this PR has been removed.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -43,7 +43,7 @@ function wasmPackPlugin(): Plugin {
 
 export default defineConfig({
   root: ".",
-  base: process.env.GITHUB_ACTIONS ? "/fucktorio/" : "/",
+  base: process.env.BASE_PATH || (process.env.GITHUB_ACTIONS ? "/fucktorio/" : "/"),
   plugins: [wasmPackPlugin(), wasm(), topLevelAwait()],
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
## Intent

Enable automatic preview deployments for pull requests to the `gh-pages` branch, with automatic cleanup when PRs are closed. This allows reviewers to test changes in a live environment before merging to main.

## Scope

**In:**
- New workflow `pr-preview-cleanup.yml` that removes preview directories from `gh-pages` when PRs are closed
- Split `deploy` job into `deploy-main` (for main branch) and `deploy-preview` (for PRs)
- Preview deployments use `pr-{number}/` subdirectory on `gh-pages`
- Sticky PR comments showing preview URL and cleanup status
- Dynamic `BASE_PATH` environment variable for Vite to serve from correct subdirectory in previews
- Updated permissions in CI workflow to support git operations

**Out:**
- GitHub Pages environment configuration (replaced with direct `gh-pages` branch deployment)
- Automatic deployment to main (now explicit `deploy-main` job with same behavior)

## Verification

- CI workflow structure verified: `deploy-preview` only runs on PRs from the same repo, `deploy-main` only on pushes to main
- Cleanup workflow properly configured to run on PR close and remove preview directories
- Vite config correctly uses `BASE_PATH` environment variable with fallback
- Sticky comment action configured to post preview URL and cleanup messages
- Retry logic in cleanup script handles transient git push failures

## Deviations from intent

None.

## Models / contracts touched

None.

https://claude.ai/code/session_013UJgD3xAQvGoizrmL2vZWg