### PR TITLE
feat(web): persist proven-optimum SAT zones to localStorage

### DIFF
--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -860,8 +860,12 @@ impl JunctionStrategy for SatStrategy {
         // pre-baked cache embedded at compile time; native loads from
         // `~/.cache/fucktorio/sat-zones.bin`. Both honour
         // `FUCKTORIO_USE_ZONE_CACHE=0` to disable on native.
-        let cached_hit: Option<Vec<crate::models::PlacedEntity>> =
-            crate::zone_cache::lookup_zone(&zone, &channel_reaches, self.constraints.max_ug_ins);
+        let cached_hit: Option<Vec<crate::models::PlacedEntity>> = crate::zone_cache::lookup_zone(
+            &zone,
+            &channel_reaches,
+            self.constraints.max_ug_ins,
+            belt_name,
+        );
 
         if let Some(cached_entities) = cached_hit {
             let proposed_entities: Vec<SatProposedEntity> = cached_entities

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -590,7 +590,7 @@ fn place_poles(
         // the above-row is jammed with inserters/pipes. Both rows are
         // within POLE_RANGE of the machine center on the y axis.
         let mut candidate_ys: Vec<i32> = Vec::with_capacity(2);
-        if top_y - 1 >= 0 {
+        if top_y > 0 {
             candidate_ys.push(top_y - 1);
         }
         candidate_ys.push(top_y + sz);

--- a/crates/core/src/bus/templates.rs
+++ b/crates/core/src/bus/templates.rs
@@ -11,9 +11,9 @@
 
 use crate::models::{EntityDirection, PlacedEntity};
 
-/// Gap between machine groups when lane-splitting output belts.
-/// 3 tiles: 1 for sideload target filler, 1 for through-belt filler,
-/// 1 for the NORTH lift from group 2.
+// Gap between machine groups when lane-splitting output belts.
+// 3 tiles: 1 for sideload target filler, 1 for through-belt filler,
+// 1 for the NORTH lift from group 2.
 // (LANE_SPLIT_GAP = 3 deleted in the inline-bridge unification —
 // machines now pack tight with the bridge stamped inline.)
 

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -711,6 +711,24 @@ pub enum TraceEvent {
         entities: Vec<PlacedEntity>,
     },
 
+    /// Emitted by `region_reimprove::descend` (via the WASM binding) when
+    /// a descent terminates with `StopReason::Optimal` — the cap-1 probe
+    /// returned UNSAT, so the current layout is provably the cheapest
+    /// solution for this zone. Carries the canonical signature plus a
+    /// single-record binary blob in the same format used by
+    /// `crates/core/data/sat-zones.bin`, so the frontend can persist the
+    /// result to localStorage and seed it back into the cache on next
+    /// boot via [`crate::zone_cache::install_prebaked`].
+    SatOptimumProven {
+        /// `LayoutRegion.id` of the zone whose descent just proved optimal.
+        region_id: u32,
+        /// Cache key for this zone (canonical, orientation-invariant).
+        signature: String,
+        /// Single-record binary blob — concatenable with other records
+        /// to form a full cache file.
+        record_bytes: Vec<u8>,
+    },
+
     // SAT solution pruned of dangling (unreachable / dead-end) belt entities.
     SatPruned {
         zone_x: i32,

--- a/crates/core/src/zone_cache.rs
+++ b/crates/core/src/zone_cache.rs
@@ -93,6 +93,7 @@ use std::cell::RefCell;
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::Write as _;
 use std::sync::{Mutex, OnceLock};
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // Thread-local source tag so parallel tests each carry their own label
@@ -1142,6 +1143,13 @@ fn entity_carries_from_token(mut e: PlacedEntity, channel_items: &[String]) -> P
 /// `entities` should be the post-cost-descent SAT output, in absolute world
 /// coords (as returned by `solve_crossing_zone_per_channel`). We strip the
 /// world-coord origin and apply the canonical transform before storing.
+///
+/// Returns `(signature, record_bytes)` where `record_bytes` is the
+/// single-record binary blob (length prefix + body) — same wire format as
+/// the on-disk `sat-zones.bin`. Native callers don't need this return value
+/// (the disk-write side effect is internal); the WASM-bindings emit path
+/// uses it to forward the new entry to the frontend for localStorage
+/// persistence.
 pub fn record_zone_with_solution(
     zone: &CrossingZone,
     channel_reaches: &[u32],
@@ -1149,7 +1157,7 @@ pub fn record_zone_with_solution(
     stats: ZoneStats,
     entities: &[PlacedEntity],
     source: Option<&str>,
-) {
+) -> (String, Vec<u8>) {
     let form = canonicalise(zone, channel_reaches, max_ug_ins);
     let channel_items = canonical_channel_items(zone, &form);
 
@@ -1196,51 +1204,60 @@ pub fn record_zone_with_solution(
         );
     }
 
-    // WASM has nowhere to flush to, so skip the encode + buffer entirely
-    // (and avoid `SystemTime::now()`, which panics on the wasm32 target).
-    // The in-memory cache update above already gives us same-session reuse.
+    // Pack entities as [kind, x, y, dir, carries_idx] tuples. Anything that
+    // doesn't encode (unknown name, broken carries token) is dropped — these
+    // shouldn't happen for SAT-produced entities.
+    let entity_tuples: Vec<[i32; 5]> = canonical_entities
+        .iter()
+        .filter_map(entity_to_tuple)
+        .collect();
+
+    // Resolve the effective source label. Native: thread-local override →
+    // caller-provided → env var. WASM: caller-provided only (no env, no
+    // thread-local writer).
+    #[cfg(not(target_arch = "wasm32"))]
+    let effective_source: Option<String> = ZONE_SOURCE
+        .with(|s| s.borrow().clone())
+        .or_else(|| source.map(|s| s.to_string()))
+        .or_else(|| std::env::var("FUCKTORIO_ZONE_SOURCE").ok());
+    #[cfg(target_arch = "wasm32")]
+    let effective_source: Option<String> = source.map(|s| s.to_string());
+
+    // Avoid `SystemTime::now()` on WASM — it panics on the wasm32 target.
+    // The frontend's persistence path doesn't need a high-fidelity timestamp.
+    #[cfg(not(target_arch = "wasm32"))]
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    #[cfg(target_arch = "wasm32")]
+    let ts: u64 = 0;
+
+    let mut bytes: Vec<u8> = Vec::with_capacity(64 + entity_tuples.len() * 5);
+    encode_record(
+        &mut bytes,
+        ts,
+        &form.signature,
+        effective_source.as_deref(),
+        canon_w,
+        canon_h,
+        stats.variables,
+        stats.clauses,
+        stats.solve_time_us,
+        &channel_items,
+        &entity_tuples,
+    );
+
+    // Native: queue for disk flush. WASM: nothing to flush to — the
+    // returned bytes are the persistence vehicle.
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let thread_src = ZONE_SOURCE.with(|s| s.borrow().clone());
-        let effective_source: Option<String> = thread_src
-            .or_else(|| source.map(|s| s.to_string()))
-            .or_else(|| std::env::var("FUCKTORIO_ZONE_SOURCE").ok());
-
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-
-        // Pack entities as [kind, x, y, dir, carries_idx] tuples. Anything that
-        // doesn't encode (unknown name, broken carries token) is dropped — these
-        // shouldn't happen for SAT-produced entities.
-        let entity_tuples: Vec<[i32; 5]> = canonical_entities
-            .iter()
-            .filter_map(entity_to_tuple)
-            .collect();
-
-        let mut bytes: Vec<u8> = Vec::with_capacity(64 + entity_tuples.len() * 5);
-        encode_record(
-            &mut bytes,
-            ts,
-            &form.signature,
-            effective_source.as_deref(),
-            canon_w,
-            canon_h,
-            stats.variables,
-            stats.clauses,
-            stats.solve_time_us,
-            &channel_items,
-            &entity_tuples,
-        );
         if let Ok(mut buf) = buffer().lock() {
-            buf.push(PendingRecord { bytes });
+            buf.push(PendingRecord { bytes: bytes.clone() });
         }
     }
-    #[cfg(target_arch = "wasm32")]
-    {
-        let _ = (source, &stats);  // silence unused
-    }
+
+    (form.signature, bytes)
 }
 
 /// Look up a previously-cached SAT solution for `zone`. Returns `Some` of a
@@ -1250,10 +1267,20 @@ pub fn record_zone_with_solution(
 ///
 /// The returned entities have `segment_id` set to `"crossing:{x}:{y}"` to
 /// mirror the SAT path's tagging.
+///
+/// `fallback_belt_name` is the surface-belt entity name used to retype
+/// entities whose channel has no per-port `belt_tier` annotation (e.g.
+/// `"fast-transport-belt"`). The SAT formula is tier-agnostic, so a cache
+/// entry recorded under one tier is correct for any tier with the same
+/// per-channel reaches — but the stored entity names need to be re-typed
+/// to match each channel's tier in the current zone (mixed-tier zones in
+/// `ReachMode::Relaxed` collapse to the same signature across tiers, so a
+/// red-channel cached entry could be hit by a yellow-channel lookup).
 pub fn lookup_zone(
     zone: &CrossingZone,
     channel_reaches: &[u32],
     max_ug_ins: Option<u32>,
+    fallback_belt_name: &str,
 ) -> Option<Vec<PlacedEntity>> {
     if !cache_enabled() {
         return None;
@@ -1273,6 +1300,14 @@ pub fn lookup_zone(
         return None;
     }
 
+    // item → surface-belt tier from the current zone's boundaries. Used to
+    // retype each cached entity to its channel's actual tier.
+    let item_to_tier: std::collections::HashMap<&str, &str> = zone
+        .boundaries
+        .iter()
+        .filter_map(|b| b.belt_tier.as_deref().map(|t| (b.item.as_str(), t)))
+        .collect();
+
     // Inverse-transform entities: canonical-frame → zone-local → absolute.
     let segment_id = format!("crossing:{}:{}", zone.x, zone.y);
     let entities: Vec<PlacedEntity> = entry
@@ -1284,11 +1319,32 @@ pub fn lookup_zone(
             out.x += zone.x;
             out.y += zone.y;
             out.segment_id = Some(segment_id.clone());
+            let tier = out
+                .carries
+                .as_deref()
+                .and_then(|item| item_to_tier.get(item).copied())
+                .unwrap_or(fallback_belt_name);
+            retype_entity_to_tier(&mut out, tier);
             out
         })
         .collect();
 
     Some(entities)
+}
+
+/// Retype a belt or underground-belt entity's `name` to match `surface_belt_name`.
+/// Non-belt entities are left untouched. Uses [`crate::sat::ug_name_for_tier`]
+/// to map the surface tier to its corresponding UG tier.
+fn retype_entity_to_tier(e: &mut PlacedEntity, surface_belt_name: &str) {
+    match e.name.as_str() {
+        "transport-belt" | "fast-transport-belt" | "express-transport-belt" => {
+            e.name = surface_belt_name.to_string();
+        }
+        "underground-belt" | "fast-underground-belt" | "express-underground-belt" => {
+            e.name = crate::sat::ug_name_for_tier(surface_belt_name).to_string();
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -1592,5 +1648,158 @@ mod tests {
         buf.truncate(buf.len() - 5);
         let recs = parse_records(&buf);
         assert_eq!(recs.len(), 0, "truncated records should be skipped");
+    }
+
+    /// A solution recorded under yellow belts must be returned with the
+    /// caller's channel-tier names. `lookup_zone` reads the per-port
+    /// `belt_tier` from the current zone's boundaries (not the cache entry)
+    /// so the same cache entry serves any tier with matching channel reaches.
+    #[test]
+    fn lookup_zone_retypes_to_caller_tier() {
+        // Zone with one channel; carries item "iron-plate".
+        let mk_zone = |port_tier: &str| {
+            let item = "iron-plate".to_string();
+            CrossingZone {
+                x: 10, y: 20, width: 3, height: 3,
+                boundaries: vec![
+                    ZoneBoundary {
+                        x: 11, y: 20, direction: EntityDirection::South,
+                        item: item.clone(), is_input: true, interior: false,
+                        belt_tier: Some(port_tier.to_string()), channel_id: 0,
+                    },
+                    ZoneBoundary {
+                        x: 11, y: 22, direction: EntityDirection::South,
+                        item: item.clone(), is_input: false, interior: false,
+                        belt_tier: Some(port_tier.to_string()), channel_id: 0,
+                    },
+                ],
+                forced_empty: vec![],
+            }
+        };
+        let reaches = [5];
+        let yellow_zone = mk_zone("transport-belt");
+
+        // Record a yellow-belt solution.
+        let yellow_solution = vec![
+            PlacedEntity {
+                name: "transport-belt".into(), x: 11, y: 20,
+                direction: EntityDirection::South,
+                carries: Some("iron-plate".into()),
+                ..Default::default()
+            },
+            PlacedEntity {
+                name: "underground-belt".into(), x: 11, y: 21,
+                direction: EntityDirection::South,
+                io_type: Some("input".into()),
+                carries: Some("iron-plate".into()),
+                ..Default::default()
+            },
+            PlacedEntity {
+                name: "underground-belt".into(), x: 11, y: 22,
+                direction: EntityDirection::South,
+                io_type: Some("output".into()),
+                carries: Some("iron-plate".into()),
+                ..Default::default()
+            },
+        ];
+        record_zone_with_solution(
+            &yellow_zone,
+            &reaches,
+            None,
+            ZoneStats { variables: 0, clauses: 0, solve_time_us: 0 },
+            &yellow_solution,
+            Some("test"),
+        );
+
+        // Same topology + reaches but boundaries declare red tier.
+        let red_zone = mk_zone("fast-transport-belt");
+        let red = lookup_zone(&red_zone, &reaches, None, "fast-transport-belt")
+            .expect("cache hit");
+        assert_eq!(red.len(), 3);
+        for e in &red {
+            match e.name.as_str() {
+                "fast-transport-belt" | "fast-underground-belt" => {}
+                other => panic!("expected red-tier name, got {other:?}"),
+            }
+        }
+
+        // Blue:
+        let blue_zone = mk_zone("express-transport-belt");
+        let blue = lookup_zone(&blue_zone, &reaches, None, "express-transport-belt")
+            .expect("cache hit");
+        for e in &blue {
+            match e.name.as_str() {
+                "express-transport-belt" | "express-underground-belt" => {}
+                other => panic!("expected blue-tier name, got {other:?}"),
+            }
+        }
+
+        // Same-tier lookup is a no-op rename.
+        let yellow_again = lookup_zone(&yellow_zone, &reaches, None, "transport-belt")
+            .expect("cache hit");
+        for e in &yellow_again {
+            match e.name.as_str() {
+                "transport-belt" | "underground-belt" => {}
+                other => panic!("expected yellow-tier name, got {other:?}"),
+            }
+        }
+    }
+
+    /// Mixed-tier zone: per-channel rename must respect each channel's own
+    /// tier, not the dominant/fallback tier.
+    #[test]
+    fn lookup_zone_respects_per_channel_tier() {
+        // Two channels: copper-plate on yellow, iron-plate on red. Both
+        // have reach 5 (artificially uniform — like Relaxed mode).
+        let mk_boundary = |x, y, dir, item: &str, tier: &str, ch: u32, is_in| ZoneBoundary {
+            x, y, direction: dir,
+            item: item.to_string(),
+            is_input: is_in, interior: false,
+            belt_tier: Some(tier.to_string()),
+            channel_id: ch,
+        };
+        let zone = CrossingZone {
+            x: 0, y: 0, width: 3, height: 3,
+            boundaries: vec![
+                mk_boundary(1, 0, EntityDirection::South, "copper-plate", "transport-belt", 0, true),
+                mk_boundary(1, 2, EntityDirection::South, "copper-plate", "transport-belt", 0, false),
+                mk_boundary(0, 1, EntityDirection::East,  "iron-plate",   "fast-transport-belt", 1, true),
+                mk_boundary(2, 1, EntityDirection::East,  "iron-plate",   "fast-transport-belt", 1, false),
+            ],
+            forced_empty: vec![],
+        };
+        let reaches = [5, 5];
+
+        // Record stored entities under whatever tier names — we'll verify
+        // the rename does the right thing.
+        let solution = vec![
+            PlacedEntity {
+                name: "transport-belt".into(), x: 1, y: 0,
+                direction: EntityDirection::South,
+                carries: Some("copper-plate".into()),
+                ..Default::default()
+            },
+            PlacedEntity {
+                name: "express-transport-belt".into(), x: 0, y: 1,
+                direction: EntityDirection::East,
+                carries: Some("iron-plate".into()),
+                ..Default::default()
+            },
+        ];
+        record_zone_with_solution(
+            &zone,
+            &reaches,
+            None,
+            ZoneStats { variables: 0, clauses: 0, solve_time_us: 0 },
+            &solution,
+            Some("test"),
+        );
+
+        let out = lookup_zone(&zone, &reaches, None, "fast-transport-belt")
+            .expect("cache hit");
+        let copper = out.iter().find(|e| e.carries.as_deref() == Some("copper-plate")).unwrap();
+        let iron = out.iter().find(|e| e.carries.as_deref() == Some("iron-plate")).unwrap();
+        assert_eq!(copper.name, "transport-belt", "copper-plate channel should stay yellow");
+        assert_eq!(iron.name, "fast-transport-belt", "iron-plate channel should be red");
     }
 }

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -243,7 +243,7 @@ pub fn improve_region_streaming(
     let zh = zone.height;
     let mut iter: u32 = 0;
     let iter_cap = if max_iters == 0 { 1024 } else { max_iters };
-    let (final_raw, _stop) = descend(
+    let (final_raw, stop_reason) = descend(
         &zone,
         &belt_tier,
         max_ug_reach,
@@ -276,6 +276,45 @@ pub fn improve_region_streaming(
     // belt/UG inside the zone bbox, then push the new set. SAT stamps
     // per-channel tiers at solve time so no post-pass retype needed.
     let pruned_final = prune_dangling(final_raw, &boundaries, max_ug_reach, zx, zy);
+
+    // Descent terminated with UNSAT on cap-1: this is the proven optimum
+    // for the zone. Record it (updates the in-memory cache for same-session
+    // reuse) and emit a terminal trace event carrying the binary record so
+    // the frontend can persist to localStorage.
+    if matches!(stop_reason, fucktorio_core::bus::region_reimprove::StopReason::Optimal) {
+        // Per-channel reaches: descent uses uniform `max_ug_reach`, so the
+        // signature should match. Size the array to cover every channel_id
+        // referenced by any boundary. `max_ug_ins = None` matches the
+        // descent's call into `solve_crossing_zone_with_cost_cap`.
+        let n_channels = boundaries
+            .iter()
+            .map(|b| b.channel_id as usize + 1)
+            .max()
+            .unwrap_or(0);
+        let channel_reaches = vec![max_ug_reach; n_channels];
+        let stats = fucktorio_core::zone_cache::ZoneStats {
+            variables: 0,
+            clauses: 0,
+            solve_time_us: 0,
+        };
+        let (signature, record_bytes) = fucktorio_core::zone_cache::record_zone_with_solution(
+            &zone,
+            &channel_reaches,
+            None,
+            stats,
+            &pruned_final,
+            Some("wasm-optimize"),
+        );
+        let evt = fucktorio_core::trace::TraceEvent::SatOptimumProven {
+            region_id,
+            signature,
+            record_bytes,
+        };
+        if let Ok(js_evt) = serde_wasm_bindgen::to_value(&evt) {
+            let _ = emit.call1(&JsValue::NULL, &js_evt);
+        }
+    }
+
     layout_result
         .entities
         .retain(|e| !(in_bbox(e) && is_belt_or_ug(&e.name)));
@@ -304,6 +343,21 @@ pub fn export_blueprint(layout_result: LayoutResult, label: String) -> String {
 #[wasm_bindgen]
 pub fn parse_blueprint(bp_string: &str) -> Result<LayoutResult, JsError> {
     blueprint_parser::parse_blueprint_string(bp_string).map_err(|e| JsError::new(&e))
+}
+
+/// Seed the in-memory SAT crossing-zone cache with `bytes` — a sequence of
+/// length-prefixed binary records in the same format as
+/// `crates/core/data/sat-zones.bin`. The frontend calls this on boot with
+/// records previously persisted to localStorage by `SatOptimumProven`.
+///
+/// Returns the number of records successfully ingested. Malformed records
+/// are skipped silently, so a partially-corrupt blob still installs
+/// whatever decodes cleanly.
+#[wasm_bindgen]
+pub fn seed_zone_cache(bytes: &[u8]) -> u32 {
+    let count = fucktorio_core::zone_cache::parse_records(bytes).len() as u32;
+    fucktorio_core::zone_cache::install_prebaked(bytes);
+    count
 }
 
 /// Response shape for `solve_fixture`. Serialised via

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -56,6 +56,61 @@ let nextId = 0;
 const pending = new Map<number, PendingEntry>();
 let activeStreamingId: number | null = null;
 
+// SAT crossing-zone cache persisted to localStorage. Seeded into the WASM
+// in-memory cache on boot via `seedZoneCache`; appended to whenever a
+// descent terminates with `SatOptimumProven`. Same wire format as
+// `crates/core/data/sat-zones.bin` — concatenated length-prefixed records.
+const SAT_CACHE_KEY = "fucktorio:sat-cache:v1";
+let satCacheBytes: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+
+function readSatCacheFromStorage(): Uint8Array<ArrayBufferLike> {
+  try {
+    const raw = localStorage.getItem(SAT_CACHE_KEY);
+    if (!raw) return new Uint8Array(0);
+    const binary = atob(raw);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch (e) {
+    console.warn("[engine] could not read SAT cache from localStorage", e);
+    return new Uint8Array(0);
+  }
+}
+
+function writeSatCacheToStorage(bytes: Uint8Array): void {
+  // String.fromCharCode(...) blows the call-stack on large arrays, so chunk.
+  let binary = "";
+  const chunk = 8192;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunk)));
+  }
+  const b64 = btoa(binary);
+  try {
+    localStorage.setItem(SAT_CACHE_KEY, b64);
+  } catch (e) {
+    if (e instanceof DOMException && (e.name === "QuotaExceededError" || e.code === 22)) {
+      // Quota exceeded — drop everything and start over with the latest
+      // record. We've already lost the rest of the cache; logging and
+      // continuing keeps the session usable.
+      console.warn("[engine] SAT cache quota exceeded — clearing");
+      try {
+        localStorage.removeItem(SAT_CACHE_KEY);
+      } catch { /* ignore */ }
+      satCacheBytes = new Uint8Array(0);
+    } else {
+      console.warn("[engine] failed to persist SAT cache", e);
+    }
+  }
+}
+
+function appendSatCacheRecord(recordBytes: Uint8Array): void {
+  const next = new Uint8Array(satCacheBytes.length + recordBytes.length);
+  next.set(satCacheBytes, 0);
+  next.set(recordBytes, satCacheBytes.length);
+  satCacheBytes = next;
+  writeSatCacheToStorage(satCacheBytes);
+}
+
 let itemsCache: string[] = [];
 let machinesCache: string[] = [];
 let defaultMachineCache = new Map<string, string>();
@@ -136,6 +191,25 @@ export async function initEngine(): Promise<void> {
   };
 
   await call<null>({ method: "init" });
+
+  // Seed the SAT zone cache from localStorage before any solve goes out, so
+  // the very first layout pass can hit cached entries from prior sessions.
+  satCacheBytes = readSatCacheFromStorage();
+  if (satCacheBytes.length > 0) {
+    try {
+      const seeded = await call<number>({
+        method: "seedZoneCache",
+        bytes: satCacheBytes,
+      });
+      if ((globalThis as { __TRACE_LOGS?: boolean }).__TRACE_LOGS === true) {
+        // eslint-disable-next-line no-console
+        console.log(`[engine] seeded ${seeded} SAT zone records from localStorage`);
+      }
+    } catch (e) {
+      console.warn("[engine] seedZoneCache failed; persistence disabled this session", e);
+    }
+  }
+
   itemsCache = await call<string[]>({ method: "allProducibleItems" });
   machinesCache = await call<string[]>({ method: "allProducerMachines" });
   const defaults = await call<[string, string][]>({
@@ -348,9 +422,18 @@ async function improveRegion(
         reject(e);
       },
       onEvent: (evt) => {
-        const anyEvt = evt as unknown as { phase?: string; data?: SatImprovement };
+        const anyEvt = evt as unknown as { phase?: string; data?: unknown };
         if (anyEvt.phase === "SatImprovement" && anyEvt.data) {
-          onImprovement(anyEvt.data);
+          onImprovement(anyEvt.data as SatImprovement);
+        } else if (anyEvt.phase === "SatOptimumProven" && anyEvt.data) {
+          // Descent proved the current layout optimal. Persist the
+          // single-record binary blob to localStorage so next session
+          // hits the cache without re-running descent.
+          const data = anyEvt.data as { record_bytes: number[] | Uint8Array };
+          const bytes = data.record_bytes instanceof Uint8Array
+            ? data.record_bytes
+            : new Uint8Array(data.record_bytes);
+          appendSatCacheRecord(bytes);
         }
       },
     });

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -11,6 +11,7 @@ import wasmInit, {
   layout_traced,
   layout_streaming,
   parse_blueprint,
+  seed_zone_cache,
   validate_layout,
 } from "../wasm-pkg/fucktorio_wasm.js";
 import type {
@@ -50,7 +51,8 @@ type Request =
       regionId: number;
       budgetMs: number;
       maxIters: number;
-    };
+    }
+  | { id: number; method: "seedZoneCache"; bytes: Uint8Array };
 
 let ready: Promise<void> | null = null;
 
@@ -168,6 +170,9 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         break;
       case "solveFixture":
         result = solve_fixture(req.fixtureJson, req.pinsJson);
+        break;
+      case "seedZoneCache":
+        result = seed_zone_cache(req.bytes);
         break;
       case "improveRegionStreaming": {
         // Streams SatImprovement events through the same batched channel


### PR DESCRIPTION
## Summary

- Auto-optimize loop now persists **proven-optimum** SAT crossing-zone solves to `localStorage` in the same binary record format as `crates/core/data/sat-zones.bin`. On next boot the engine seeds the WASM in-memory cache from the persisted bytes, so previously-optimised zones skip descent entirely and the initial layout pass hits faster across sessions.
- Bundled correctness fix: `lookup_zone` now retypes belt/UG entity names **per channel** on cache hits, using each port's `belt_tier` from the current zone's boundaries. Same-tier sessions were already correct, but persistence broadens cross-tier hits (Relaxed-mode mixed-tier zones collapse to the same signature across tiers) — without this fix, a yellow-recorded entry hit by a red caller would render with yellow names.

### Storage shape
- `localStorage["fucktorio:sat-cache:v1"]` — base64 of concatenated length-prefixed binary records (same wire format as the on-disk file).
- Quota-exceeded fallback: clear the key and start over with the latest record.
- Records are recorded by signature (orientation-invariant + tier-agnostic), so the persisted cache works across tier switches and recipe changes that yield the same zone topology.

### How the optimum signal travels
1. `region_reimprove::descend` already returns `StopReason::Optimal` when the cap-1 probe returns UNSAT — previously discarded.
2. `improve_region_streaming` (WASM) now inspects this and, on `Optimal`, calls `record_zone_with_solution` (refactored to return `(signature, record_bytes)`) and emits a terminal `SatOptimumProven` trace event with the bytes.
3. JS catches the event, appends to an in-memory `Uint8Array`, and writes to `localStorage`.
4. `seed_zone_cache(bytes)` is a new WASM export wrapping `install_prebaked` for the boot-side seed call.

### Files

| File | Change |
|------|--------|
| `crates/core/src/zone_cache.rs` | `lookup_zone` adds `fallback_belt_name` param + per-channel retype; `record_zone_with_solution` returns `(signature, bytes)`; cfg-gate `SystemTime` import |
| `crates/core/src/bus/junction_sat_strategy.rs` | Pass `belt_name` into the new `lookup_zone` arg |
| `crates/core/src/trace.rs` | New `TraceEvent::SatOptimumProven` variant |
| `crates/wasm-bindings/src/lib.rs` | Emit terminal event on `StopReason::Optimal`; new `seed_zone_cache` export |
| `web/src/engine.ts` | Boot-seed from localStorage; persist on terminal event; quota fallback |
| `web/src/workers/engine.worker.ts` | New `seedZoneCache` worker method |

## Test plan

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 440 passed (incl. 2 new unit tests covering same-tier and mixed-tier rename behaviour)
- [x] `wasm-pack build crates/wasm-bindings --target web --out-dir web/src/wasm-pkg`
- [x] `npx tsc --noEmit` — clean
- [ ] Browser: load a tier-2 page (e.g. electronic-circuit), wait for auto-optimize to settle, confirm `localStorage["fucktorio:sat-cache:v1"]` populates
- [ ] Browser: reload, confirm initial solve is faster and zones don't churn through descent again
- [ ] Browser: switch belt tier (yellow → red) on the same recipe, confirm entities render with the correct tier (validates rename fix)
- [ ] Browser: `localStorage.clear()`, reload, confirm fresh solve still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)