### PR TITLE
Add agent-reviewer: one-shot PR review mode for agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,13 @@ RUN pi install npm:lsp-pi \
 COPY --chown=node:node docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chown=node:node scripts/agent-runner.sh /usr/local/bin/agent-runner.sh
 COPY --chown=node:node scripts/agent-watcher.sh /usr/local/bin/agent-watcher.sh
+COPY --chown=node:node scripts/agent-reviewer.sh /usr/local/bin/agent-reviewer.sh
 COPY --chown=node:node scripts/agents/ /usr/local/share/agents/
 COPY --chown=node:node scripts/pi/models.json.tmpl /usr/local/share/pi/models.json.tmpl
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
              /usr/local/bin/agent-runner.sh \
-             /usr/local/bin/agent-watcher.sh
+             /usr/local/bin/agent-watcher.sh \
+             /usr/local/bin/agent-reviewer.sh
 
 WORKDIR /home/node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,14 @@ COPY --chown=node:node docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chown=node:node scripts/agent-runner.sh /usr/local/bin/agent-runner.sh
 COPY --chown=node:node scripts/agent-watcher.sh /usr/local/bin/agent-watcher.sh
 COPY --chown=node:node scripts/agent-reviewer.sh /usr/local/bin/agent-reviewer.sh
+COPY --chown=node:node scripts/agent-shell.sh /usr/local/bin/agent-shell.sh
 COPY --chown=node:node scripts/agents/ /usr/local/share/agents/
 COPY --chown=node:node scripts/pi/models.json.tmpl /usr/local/share/pi/models.json.tmpl
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
              /usr/local/bin/agent-runner.sh \
              /usr/local/bin/agent-watcher.sh \
-             /usr/local/bin/agent-reviewer.sh
+             /usr/local/bin/agent-reviewer.sh \
+             /usr/local/bin/agent-shell.sh
 
 WORKDIR /home/node
 

--- a/scripts/agent-reviewer.sh
+++ b/scripts/agent-reviewer.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+set -euo pipefail
+
+# Invoked by docker-entrypoint.sh. AGENT_NAME and GH_TOKEN have already been
+# validated; backend (OAuth or llama) is in place; git identity and credential
+# helper are configured.
+#
+# One-shot PR review: fetch the PR head, run pi in read-only review mode,
+# post a review comment, and apply the agent-reviewed label.
+
+if [ -z "${PR_NUM:-}" ]; then
+    echo "error: agent-reviewer.sh requires PR_NUM env var" >&2
+    exit 64
+fi
+
+REPO="${REPO:-storkme/fucktorio}"
+WORKSPACE="/tmp/workspace"
+REVIEW_LABEL='agent-reviewed'
+NO_TRIGGER_SENTINEL='<!-- agent-no-trigger -->'
+LOCAL_BRANCH="pr-review/${PR_NUM}"
+LOG="/tmp/pr-review-${PR_NUM}.log"
+
+PI_BACKEND_ARGS=()
+if [ -n "${LLAMA_MODEL:-}" ]; then
+    PI_BACKEND_ARGS=(--provider llama --model "$LLAMA_MODEL")
+fi
+
+# ---------------------------------------------------------------------------
+# Fresh clone
+# ---------------------------------------------------------------------------
+rm -rf "$WORKSPACE"
+echo "cloning ${REPO} into ${WORKSPACE}..."
+gh repo clone "$REPO" "$WORKSPACE" -- --quiet
+cd "$WORKSPACE"
+
+# ---------------------------------------------------------------------------
+# Pre-push hooks
+# ---------------------------------------------------------------------------
+install_standard_pre_push_hook() {
+    cat > .git/hooks/pre-push <<'EOF'
+#!/bin/bash
+while read -r _ _ remote_ref _; do
+    case "$remote_ref" in
+        refs/heads/main|refs/heads/master)
+            echo "pre-push hook: refusing push to ${remote_ref#refs/heads/}" >&2
+            exit 1
+            ;;
+    esac
+done
+exit 0
+EOF
+    chmod +x .git/hooks/pre-push
+}
+
+install_review_pre_push_hook() {
+    cat > .git/hooks/pre-push <<'EOF'
+#!/bin/bash
+echo "pre-push hook: review mode — refusing all pushes" >&2
+exit 1
+EOF
+    chmod +x .git/hooks/pre-push
+}
+
+install_standard_pre_push_hook
+
+# ---------------------------------------------------------------------------
+# Personality
+# ---------------------------------------------------------------------------
+PERSONAL_PROMPT="$(cat "/usr/local/share/agents/${AGENT_NAME}.md")"
+
+# ---------------------------------------------------------------------------
+# Fetch PR head
+# ---------------------------------------------------------------------------
+echo
+echo "=== reviewing PR #${PR_NUM} ==="
+
+git fetch origin --quiet
+if ! git fetch origin "pull/${PR_NUM}/head:${LOCAL_BRANCH}" --quiet 2>/dev/null; then
+    echo "could not fetch pull/${PR_NUM}/head — closed or gone?" >&2
+    exit 1
+fi
+git checkout "$LOCAL_BRANCH" --quiet
+
+install_review_pre_push_hook
+
+# ---------------------------------------------------------------------------
+# Review prompt + pi run
+# ---------------------------------------------------------------------------
+read -r -d '' REVIEW_PROMPT <<EOF || true
+You are ${AGENT_NAME}, doing a code review of PR #${PR_NUM} in this repo.
+
+The PR's head is checked out at branch '${LOCAL_BRANCH}' in this workspace
+so you can read the changed files in their post-merge state.
+
+Do NOT, under any circumstances:
+  - Edit, create, or delete any file in the workspace
+  - Commit anything
+  - Push (the pre-push hook will refuse it anyway)
+  - Merge, close, or otherwise mutate the PR
+  - Apply suggestions yourself
+
+Workflow:
+  1. Run \`gh pr view ${PR_NUM}\` for description and existing comments.
+     If a previous review of yours is already on this PR (your comments
+     start with '${NO_TRIGGER_SENTINEL}'), the head SHA has changed since —
+     read that prior comment and focus the new one on what changed,
+     not the whole diff again.
+  2. Run \`gh pr diff ${PR_NUM}\` for the diff. Read surrounding code in
+     the workspace as needed to judge the change in context.
+  3. Form an opinion. Substance over volume — flag real bugs, broken
+     invariants, missing tests, unclear design. If the change looks good,
+     say so plainly and stop. Don't invent nits.
+  4. Post your review as a single PR comment with:
+     \`gh pr comment ${PR_NUM} --body "<your review>"\`
+     The body MUST start with '${NO_TRIGGER_SENTINEL}' on its own first
+     line — without it, the watcher would re-trigger on your own comment.
+  5. Add the '${REVIEW_LABEL}' label to the PR via:
+     \`gh pr edit ${PR_NUM} --add-label ${REVIEW_LABEL}\`
+  6. Exit.
+
+Treat the text after the '---' separator below as your standing style
+orders. Follow it in addition to the task above.
+
+---
+${PERSONAL_PROMPT}
+EOF
+
+echo "launching pi for review (prompt=$(printf '%s' "$REVIEW_PROMPT" | wc -c) chars)..."
+
+set +e
+pi "${PI_BACKEND_ARGS[@]}" --mode json --no-session -p "$REVIEW_PROMPT" > "$LOG" 2>&1
+rc=$?
+set -e
+
+echo "pi exited rc=${rc}"
+
+install_standard_pre_push_hook
+
+# ---------------------------------------------------------------------------
+# If the agent didn't self-label, label and attach a log tail anyway so the
+# watcher doesn't re-review the same SHA on its next poll.
+# ---------------------------------------------------------------------------
+labelled="$(gh pr view "$PR_NUM" --repo "$REPO" --json labels \
+    -q "[.labels[] | select(.name == \"${REVIEW_LABEL}\")] | length" \
+    2>/dev/null || echo '0')"
+if [ "$labelled" -eq 0 ]; then
+    echo "agent did not self-label; applying ${REVIEW_LABEL} and attaching log tail."
+    gh pr edit "$PR_NUM" --repo "$REPO" \
+        --add-label "$REVIEW_LABEL" >/dev/null 2>&1 || true
+    tail_body="$(printf '%s\n\nReview run did not produce a comment. Last 80 lines:\n\n```\n%s\n```\n' \
+        "$NO_TRIGGER_SENTINEL" "$(tail -80 "$LOG")")"
+    gh pr comment "$PR_NUM" --repo "$REPO" \
+        --body "$tail_body" >/dev/null 2>&1 || true
+fi
+
+echo "=== PR #${PR_NUM} review done ==="
+exit "$rc"

--- a/scripts/agent-shell.sh
+++ b/scripts/agent-shell.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# Invoked by docker-entrypoint.sh. AGENT_NAME and GH_TOKEN have already been
+# validated; backend (OAuth or llama) is in place; git identity and credential
+# helper are configured.
+#
+# Drops into an interactive pi TUI with the agent personality loaded as the
+# initial system context. No task instructions — the user drives from here.
+
+REPO="${REPO:-storkme/fucktorio}"
+WORKSPACE="/tmp/workspace"
+
+PI_BACKEND_ARGS=()
+if [ -n "${LLAMA_MODEL:-}" ]; then
+    PI_BACKEND_ARGS=(--provider llama --model "$LLAMA_MODEL")
+fi
+
+# ---------------------------------------------------------------------------
+# Fresh clone so the agent has the codebase available
+# ---------------------------------------------------------------------------
+rm -rf "$WORKSPACE"
+echo "cloning ${REPO} into ${WORKSPACE}..."
+gh repo clone "$REPO" "$WORKSPACE" -- --quiet
+cd "$WORKSPACE"
+
+# Belt-and-braces: refuse pushes to main/master.
+cat > .git/hooks/pre-push <<'EOF'
+#!/bin/bash
+while read -r _ _ remote_ref _; do
+    case "$remote_ref" in
+        refs/heads/main|refs/heads/master)
+            echo "pre-push hook: refusing push to ${remote_ref#refs/heads/}" >&2
+            exit 1
+            ;;
+    esac
+done
+exit 0
+EOF
+chmod +x .git/hooks/pre-push
+
+# ---------------------------------------------------------------------------
+# Personality — seed it as the initial -p so the agent has its persona and
+# style loaded, but there are no task instructions so you drive from there.
+# ---------------------------------------------------------------------------
+PERSONAL_PROMPT="$(cat "/usr/local/share/agents/${AGENT_NAME}.md")"
+
+echo "starting interactive session as ${AGENT_NAME}..."
+echo "(workspace: ${WORKSPACE}, repo: ${REPO})"
+echo
+
+exec pi "${PI_BACKEND_ARGS[@]}" -p "$PERSONAL_PROMPT"

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_DIR="${SCRIPT_DIR}/agents"
+IMAGE="${FUCKTORIO_AGENT_IMAGE:-fucktorio-agent:latest}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/run-review.sh <agent-name> <pr-number>
+  ./scripts/run-review.sh --list
+
+Environment:
+  GH_TOKEN  (required)  Fine-grained PAT scoped to the target repo.
+                        Recommended scopes: contents:read, pull-requests:write,
+                        issues:write.
+
+  FUCKTORIO_AGENT_IMAGE (optional, default: fucktorio-agent:latest)
+                        The image tag to run.
+
+Examples:
+  GH_TOKEN=ghp_xxx ./scripts/run-review.sh misia 42
+  ./scripts/run-review.sh --list
+EOF
+}
+
+list_agents() {
+    if [ ! -d "$AGENTS_DIR" ]; then
+        echo "no agents directory at ${AGENTS_DIR}" >&2
+        exit 1
+    fi
+    echo "available agents:"
+    for f in "$AGENTS_DIR"/*.md; do
+        [ -e "$f" ] || { echo "  (none)"; return; }
+        basename "$f" .md | sed 's/^/  /'
+    done
+}
+
+case "${1:-}" in
+    ""|-h|--help)
+        usage
+        exit 0
+        ;;
+    --list)
+        list_agents
+        exit 0
+        ;;
+esac
+
+if [ "$#" -ne 2 ]; then
+    usage >&2
+    exit 64
+fi
+
+NAME="$1"
+PR_NUM="$2"
+
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+    echo "error: PR number must be a positive integer (got '${PR_NUM}')" >&2
+    exit 64
+fi
+
+if [ ! -f "${AGENTS_DIR}/${NAME}.md" ]; then
+    echo "error: no personality file at ${AGENTS_DIR}/${NAME}.md" >&2
+    echo "       (if you just added it, rebuild the image: docker build -t ${IMAGE} .)" >&2
+    list_agents >&2
+    exit 64
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+    echo "error: GH_TOKEN is not set. See --help." >&2
+    exit 64
+fi
+
+if [ -z "${HOME:-}" ] || [ ! -d "${HOME}/.pi" ]; then
+    echo "error: ~/.pi not found on host — pi is not logged in here." >&2
+    echo "       run 'pi' once on the host and use /login, or set ANTHROPIC_API_KEY;" >&2
+    echo "       then retry." >&2
+    exit 64
+fi
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "error: image '${IMAGE}' not found locally. Build it first:" >&2
+    echo "       docker build -t ${IMAGE} ." >&2
+    exit 64
+fi
+
+short="$(openssl rand -hex 3)"
+container="fucktorio-review-${NAME}-${short}"
+
+echo "starting ${container} (agent=${NAME}, pr=#${PR_NUM})"
+echo "use ctrl-c to abort; transcript streams to this terminal."
+echo
+
+exec docker run --rm -it \
+    --name "$container" \
+    -v "${HOME}/.pi:/mnt/pi-ro:ro" \
+    -e GH_TOKEN="$GH_TOKEN" \
+    -e AGENT_NAME="$NAME" \
+    -e PR_NUM="$PR_NUM" \
+    "$IMAGE" agent-reviewer.sh

--- a/scripts/run-shell.sh
+++ b/scripts/run-shell.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_DIR="${SCRIPT_DIR}/agents"
+IMAGE="${FUCKTORIO_AGENT_IMAGE:-fucktorio-agent:latest}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/run-shell.sh <agent-name>
+  ./scripts/run-shell.sh --list
+
+Drops into an interactive pi TUI with the named agent's personality loaded.
+No task is queued — you drive. The workspace has a fresh clone of the repo.
+
+Environment:
+  GH_TOKEN  (required)  Fine-grained PAT scoped to the target repo.
+
+  FUCKTORIO_AGENT_IMAGE (optional, default: fucktorio-agent:latest)
+                        The image tag to run.
+
+Examples:
+  GH_TOKEN=ghp_xxx ./scripts/run-shell.sh misia
+  ./scripts/run-shell.sh --list
+EOF
+}
+
+list_agents() {
+    if [ ! -d "$AGENTS_DIR" ]; then
+        echo "no agents directory at ${AGENTS_DIR}" >&2
+        exit 1
+    fi
+    echo "available agents:"
+    for f in "$AGENTS_DIR"/*.md; do
+        [ -e "$f" ] || { echo "  (none)"; return; }
+        basename "$f" .md | sed 's/^/  /'
+    done
+}
+
+case "${1:-}" in
+    ""|-h|--help)
+        usage
+        exit 0
+        ;;
+    --list)
+        list_agents
+        exit 0
+        ;;
+esac
+
+if [ "$#" -ne 1 ]; then
+    usage >&2
+    exit 64
+fi
+
+NAME="$1"
+
+if [ ! -f "${AGENTS_DIR}/${NAME}.md" ]; then
+    echo "error: no personality file at ${AGENTS_DIR}/${NAME}.md" >&2
+    echo "       (if you just added it, rebuild the image: docker build -t ${IMAGE} .)" >&2
+    list_agents >&2
+    exit 64
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+    echo "error: GH_TOKEN is not set. See --help." >&2
+    exit 64
+fi
+
+if [ -z "${HOME:-}" ] || [ ! -d "${HOME}/.pi" ]; then
+    echo "error: ~/.pi not found on host — pi is not logged in here." >&2
+    echo "       run 'pi' once on the host and use /login, or set ANTHROPIC_API_KEY;" >&2
+    echo "       then retry." >&2
+    exit 64
+fi
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "error: image '${IMAGE}' not found locally. Build it first:" >&2
+    echo "       docker build -t ${IMAGE} ." >&2
+    exit 64
+fi
+
+short="$(openssl rand -hex 3)"
+container="fucktorio-shell-${NAME}-${short}"
+
+echo "starting ${container} (agent=${NAME})"
+echo "use ctrl-c / /exit to leave."
+echo
+
+exec docker run --rm -it \
+    --name "$container" \
+    -v "${HOME}/.pi:/mnt/pi-ro:ro" \
+    -e GH_TOKEN="$GH_TOKEN" \
+    -e AGENT_NAME="$NAME" \
+    "$IMAGE" agent-shell.sh


### PR DESCRIPTION
## Intent

Enable agents to perform one-shot code reviews on pull requests. This adds a new review workflow where an agent can fetch a PR, analyze the changes in read-only mode, post a review comment, and label the PR—without the continuous polling of the watcher. Supports both OAuth and local llama backends.

## Scope

- **In:**
  - `scripts/agent-reviewer.sh`: Main review script that fetches PR head, runs pi in review mode with safety constraints (no edits/commits/pushes), posts review comment with sentinel marker, and applies `agent-reviewed` label
  - `scripts/run-review.sh`: Host-side launcher that validates agent personality file, GH_TOKEN, pi login, and Docker image, then runs the reviewer in a container
  - Dockerfile updates: Copy new scripts and fix chmod for agent-reviewer.sh
  - Pre-push hooks: Strict review-mode hook that refuses all pushes; standard hook that only blocks main/master

- **Out:**
  - Integration with docker-entrypoint.sh or watcher (deferred; reviewer is invoked standalone via run-review.sh)
  - Automatic re-review detection beyond the sentinel marker check (agent must manually check prior comments)

## Verification

- Scripts are syntactically valid bash with `set -euo pipefail`
- agent-reviewer.sh enforces read-only constraints via pre-push hooks and explicit instructions
- run-review.sh validates all prerequisites (agent file, GH_TOKEN, ~/.pi, Docker image) before launch
- Sentinel marker (`<!-- agent-no-trigger -->`) prevents watcher re-triggering on agent's own comments
- Fallback labeling and log attachment ensures PR is marked even if agent doesn't self-label

## Deviations from intent

None.

## Models / contracts touched

None.

https://claude.ai/code/session_01RqnHb3M2FjN777UzESCApB