### PR TITLE
ci: pin Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

- Add `rust-toolchain.toml` at the repo root pinning Rust to `1.95.0` with `clippy` + `rustfmt` components and the `wasm32-unknown-unknown` target.
- Both `cargo` (local) and rustup-in-CI auto-respect this file, so everyone runs the same compiler.

## Why

CI workflow uses `dtolnay/rust-toolchain@stable`, which means every Rust point release silently changes what \`-D warnings\` accepts. PR #246 hit this when 1.95 promoted two pre-existing clippy lints to errors — main was fine with 1.94 and 1.96 broke without anyone touching code.

Pinning makes toolchain bumps a deliberate PR with a known blast radius.

## Test plan

- [x] Verified locally that rustup picks up the file and installs 1.95.0
- [x] \`cargo clippy -p fucktorio_core -- -D warnings\` (the exact CI invocation) passes
- [x] \`cargo test --manifest-path crates/core/Cargo.toml --lib\` — 411 passed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)