### PR TITLE
feat(scripts): one-shot PR review and interactive shell launchers

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,6 +35,7 @@ fi
 # ---------------------------------------------------------------------------
 have_oauth=0
 have_llama=0
+have_apikey=0
 
 if [ -d /mnt/pi-ro ]; then
     mkdir -p "$HOME/.pi"
@@ -59,10 +60,14 @@ if [ -n "${LLAMA_MODEL:-}" ]; then
     have_llama=1
 fi
 
-if [ $have_oauth -eq 0 ] && [ $have_llama -eq 0 ]; then
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    have_apikey=1
+fi
+
+if [ $have_oauth -eq 0 ] && [ $have_llama -eq 0 ] && [ $have_apikey -eq 0 ]; then
     echo "error: no backend configured." >&2
-    echo "       either bind-mount ~/.pi to /mnt/pi-ro (OAuth/API-key path)," >&2
-    echo "       or set LLAMA_MODEL (local llama.cpp path)." >&2
+    echo "       bind-mount ~/.pi to /mnt/pi-ro (OAuth/API-key path)," >&2
+    echo "       set ANTHROPIC_API_KEY, or set LLAMA_MODEL." >&2
     exit 64
 fi
 
@@ -112,6 +117,8 @@ else
 fi
 if [ $have_llama -eq 1 ]; then
     echo "backend: llama.cpp  (model=${LLAMA_MODEL}, host=llama-host:${LLAMA_PORT})"
+elif [ $have_apikey -eq 1 ]; then
+    echo "backend: ANTHROPIC_API_KEY"
 else
     echo "backend: pi OAuth/API key via ~/.pi"
 fi

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -74,10 +74,16 @@ if [ -z "${GH_TOKEN:-}" ]; then
     exit 64
 fi
 
-if [ -z "${HOME:-}" ] || [ ! -d "${HOME}/.pi" ]; then
-    echo "error: ~/.pi not found on host — pi is not logged in here." >&2
-    echo "       run 'pi' once on the host and use /login, or set ANTHROPIC_API_KEY;" >&2
-    echo "       then retry." >&2
+PI_MOUNT_ARGS=()
+PI_KEY_ARGS=()
+if [ -n "${HOME:-}" ] && [ -d "${HOME}/.pi" ]; then
+    PI_MOUNT_ARGS=(-v "${HOME}/.pi:/mnt/pi-ro:ro")
+elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    PI_KEY_ARGS=(-e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY")
+else
+    echo "error: no pi backend found." >&2
+    echo "       either have ~/.pi on the host (run 'pi' once and /login)," >&2
+    echo "       or set ANTHROPIC_API_KEY." >&2
     exit 64
 fi
 
@@ -96,7 +102,8 @@ echo
 
 exec docker run --rm -it \
     --name "$container" \
-    -v "${HOME}/.pi:/mnt/pi-ro:ro" \
+    "${PI_MOUNT_ARGS[@]}" \
+    "${PI_KEY_ARGS[@]}" \
     -e GH_TOKEN="$GH_TOKEN" \
     -e AGENT_NAME="$NAME" \
     -e ISSUE="$ISSUE" \

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -73,10 +73,16 @@ if [ -z "${GH_TOKEN:-}" ]; then
     exit 64
 fi
 
-if [ -z "${HOME:-}" ] || [ ! -d "${HOME}/.pi" ]; then
-    echo "error: ~/.pi not found on host — pi is not logged in here." >&2
-    echo "       run 'pi' once on the host and use /login, or set ANTHROPIC_API_KEY;" >&2
-    echo "       then retry." >&2
+PI_MOUNT_ARGS=()
+PI_KEY_ARGS=()
+if [ -n "${HOME:-}" ] && [ -d "${HOME}/.pi" ]; then
+    PI_MOUNT_ARGS=(-v "${HOME}/.pi:/mnt/pi-ro:ro")
+elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    PI_KEY_ARGS=(-e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY")
+else
+    echo "error: no pi backend found." >&2
+    echo "       either have ~/.pi on the host (run 'pi' once and /login)," >&2
+    echo "       or set ANTHROPIC_API_KEY." >&2
     exit 64
 fi
 
@@ -95,7 +101,8 @@ echo
 
 exec docker run --rm -it \
     --name "$container" \
-    -v "${HOME}/.pi:/mnt/pi-ro:ro" \
+    "${PI_MOUNT_ARGS[@]}" \
+    "${PI_KEY_ARGS[@]}" \
     -e GH_TOKEN="$GH_TOKEN" \
     -e AGENT_NAME="$NAME" \
     -e PR_NUM="$PR_NUM" \

--- a/scripts/run-shell.sh
+++ b/scripts/run-shell.sh
@@ -15,13 +15,19 @@ Drops into an interactive pi TUI with the named agent's personality loaded.
 No task is queued — you drive. The workspace has a fresh clone of the repo.
 
 Environment:
-  GH_TOKEN  (required)  Fine-grained PAT scoped to the target repo.
+  GH_TOKEN    (required)  Fine-grained PAT scoped to the target repo.
+  LLAMA_MODEL (required)  Model id from your llama-server's /v1/models endpoint.
+
+  LLAMA_PORT        (optional, default: 8080)
+  LLAMA_CONTEXT     (optional, default: 65536)
+  LLAMA_MAX_TOKENS  (optional, default: 8192)
+  LLAMA_HOST_IP     (optional)  Override the auto-detected Windows gateway IP.
 
   FUCKTORIO_AGENT_IMAGE (optional, default: fucktorio-agent:latest)
-                        The image tag to run.
 
 Examples:
-  GH_TOKEN=ghp_xxx ./scripts/run-shell.sh misia
+  export GH_TOKEN=ghp_xxx LLAMA_MODEL=qwen2.5-coder-32b-instruct
+  ./scripts/run-shell.sh misia
   ./scripts/run-shell.sh --list
 EOF
 }
@@ -68,16 +74,8 @@ if [ -z "${GH_TOKEN:-}" ]; then
     exit 64
 fi
 
-PI_MOUNT_ARGS=()
-PI_KEY_ARGS=()
-if [ -n "${HOME:-}" ] && [ -d "${HOME}/.pi" ]; then
-    PI_MOUNT_ARGS=(-v "${HOME}/.pi:/mnt/pi-ro:ro")
-elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-    PI_KEY_ARGS=(-e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY")
-else
-    echo "error: no pi backend found." >&2
-    echo "       either have ~/.pi on the host (run 'pi' once and /login)," >&2
-    echo "       or set ANTHROPIC_API_KEY." >&2
+if [ -z "${LLAMA_MODEL:-}" ]; then
+    echo "error: LLAMA_MODEL is not set. See --help." >&2
     exit 64
 fi
 
@@ -87,17 +85,28 @@ if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
     exit 64
 fi
 
+WIN_HOST="$(ip route | awk '/^default/ {print $3; exit}')"
+if [ -z "$WIN_HOST" ]; then
+    echo "error: could not auto-detect WSL default gateway. Override with:" >&2
+    echo "       LLAMA_HOST_IP=<your-windows-ip> $0 $NAME" >&2
+    exit 1
+fi
+WIN_HOST="${LLAMA_HOST_IP:-$WIN_HOST}"
+
 short="$(openssl rand -hex 3)"
 container="fucktorio-shell-${NAME}-${short}"
 
-echo "starting ${container} (agent=${NAME})"
+echo "starting ${container} (agent=${NAME}, model=${LLAMA_MODEL}, llama-host=${WIN_HOST})"
 echo "use ctrl-c / /exit to leave."
 echo
 
 exec docker run --rm -it \
     --name "$container" \
-    "${PI_MOUNT_ARGS[@]}" \
-    "${PI_KEY_ARGS[@]}" \
+    --add-host="llama-host:${WIN_HOST}" \
     -e GH_TOKEN="$GH_TOKEN" \
     -e AGENT_NAME="$NAME" \
+    -e LLAMA_MODEL="$LLAMA_MODEL" \
+    -e LLAMA_PORT="${LLAMA_PORT:-8080}" \
+    -e LLAMA_CONTEXT="${LLAMA_CONTEXT:-65536}" \
+    -e LLAMA_MAX_TOKENS="${LLAMA_MAX_TOKENS:-8192}" \
     "$IMAGE" agent-shell.sh

--- a/scripts/run-shell.sh
+++ b/scripts/run-shell.sh
@@ -68,10 +68,16 @@ if [ -z "${GH_TOKEN:-}" ]; then
     exit 64
 fi
 
-if [ -z "${HOME:-}" ] || [ ! -d "${HOME}/.pi" ]; then
-    echo "error: ~/.pi not found on host — pi is not logged in here." >&2
-    echo "       run 'pi' once on the host and use /login, or set ANTHROPIC_API_KEY;" >&2
-    echo "       then retry." >&2
+PI_MOUNT_ARGS=()
+PI_KEY_ARGS=()
+if [ -n "${HOME:-}" ] && [ -d "${HOME}/.pi" ]; then
+    PI_MOUNT_ARGS=(-v "${HOME}/.pi:/mnt/pi-ro:ro")
+elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    PI_KEY_ARGS=(-e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY")
+else
+    echo "error: no pi backend found." >&2
+    echo "       either have ~/.pi on the host (run 'pi' once and /login)," >&2
+    echo "       or set ANTHROPIC_API_KEY." >&2
     exit 64
 fi
 
@@ -90,7 +96,8 @@ echo
 
 exec docker run --rm -it \
     --name "$container" \
-    -v "${HOME}/.pi:/mnt/pi-ro:ro" \
+    "${PI_MOUNT_ARGS[@]}" \
+    "${PI_KEY_ARGS[@]}" \
     -e GH_TOKEN="$GH_TOKEN" \
     -e AGENT_NAME="$NAME" \
     "$IMAGE" agent-shell.sh


### PR DESCRIPTION
## Summary

- **`run-review.sh` + `agent-reviewer.sh`**: one-shot PR review launcher — `GH_TOKEN=... LLAMA_MODEL=... ./scripts/run-review.sh misia 42`. Extracts `review_pr()` from `agent-watcher.sh` into a standalone script; same prompt, same label-fallback behaviour, no loop.
- **`run-shell.sh` + `agent-shell.sh`**: interactive pi TUI launcher — clones the repo, seeds the agent personality, then hands control to the user. Uses the same llama + WSL gateway setup as `run-watcher.sh`.
- **`docker-entrypoint.sh`**: adds `ANTHROPIC_API_KEY` as a third valid backend path (alongside `~/.pi` mount and `LLAMA_MODEL`), for `run-agent.sh` / `run-review.sh` use outside WSL.
- **`Dockerfile`**: `COPY` + `chmod` for both new scripts.

## Test plan

- [ ] `docker build -t fucktorio-agent:latest .` succeeds
- [ ] `LLAMA_MODEL=... GH_TOKEN=... ./scripts/run-review.sh misia <pr>` runs and posts a review comment
- [ ] `LLAMA_MODEL=... GH_TOKEN=... ./scripts/run-shell.sh misia` drops into interactive pi with misia's personality loaded

## Deviations

None — implements the approach agreed in conversation (option 1 from the prior analysis).

https://claude.ai/code/session_01RqnHb3M2FjN777UzESCApB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqnHb3M2FjN777UzESCApB)_