### PR TITLE
ci: trigger rust job on rust-toolchain.toml changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
             web:
               - 'web/**'
 


### PR DESCRIPTION
## Summary

Add \`rust-toolchain.toml\` to the rust path-filter list so PRs that only modify the toolchain pin actually run the rust job.

## Why

#248 introduced the pin but its own CI run skipped \`rust\` and \`web\` jobs because the path-filter didn't include the new file. So we shipped the pin without ever exercising the new compiler in CI — the whole point was supposed to be making toolchain changes deliberate-and-verified.

This is a one-line fix that closes that loop for any future bumps.

## Test plan

- [ ] CI on this PR triggers the rust job (since this PR also touches \`.github/workflows/ci.yml\`, the workflow filter on its own would already trigger workflow-touching PRs — but the fix means future toolchain-only PRs will trigger too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)