### PR TITLE
test(#136): pin coprime balancer-template warning regression (fix blocked)

### DIFF
--- a/crates/core/src/bus/balancer_library.rs
+++ b/crates/core/src/bus/balancer_library.rs
@@ -4367,4 +4367,56 @@ mod tests {
             assert!(!t.source_blueprint.is_empty(), "source_blueprint empty for {key:?}");
         }
     }
+
+    /// Documents the dense-coverage gap at N=9 (and beyond).
+    ///
+    /// `scripts/generate_balancer_library.py` generates everything in
+    /// `1..=8 × 1..=8` minus `(1, 1)`. Anything with `N=9` or `M=9` is
+    /// missing because:
+    ///   1. there are no `external/factorio-sat/networks/Nx9` files
+    ///      (network construction for asymmetric balancers is non-trivial),
+    ///   2. and the `SHAPES` list in the generator caps at 8.
+    ///
+    /// [Issue #136][] tracks the user-visible failure mode: lane-planner
+    /// shapes such as `(5, 9)` and `(7, 9)` are coprime, so the
+    /// decomposition fallback in `stamp_family_balancer` (`gcd ≥ 2`)
+    /// can't paper over the gap, and the layout surfaces a
+    /// "No N→M balancer template" warning. Closing the gap requires
+    /// either generating proper SAT-validated 9-shapes (blocked on the
+    /// missing `Nx9` network files) or extending the stamper's
+    /// fallback to dominate-and-pad to a larger covered shape.
+    ///
+    /// Don't loosen the bound below as templates land — let this test
+    /// go green naturally.
+    ///
+    /// [Issue #136]: https://github.com/storkme/fucktorio/issues/136
+    #[test]
+    #[ignore = "Documents missing 9-shape templates (issue #136). \
+                Closing requires hand-built balancer networks for \
+                external/factorio-sat/networks/{N}x9 + an extension to \
+                generate_balancer_library.py's SHAPES range."]
+    fn balancer_library_should_cover_n_lt_10() {
+        let templates = balancer_templates();
+        let mut missing: Vec<(u32, u32)> = Vec::new();
+        for n in 1..=9u32 {
+            for m in 1..=9u32 {
+                if (n, m) == (1, 1) {
+                    continue;
+                }
+                if !templates.contains_key(&(n, m)) {
+                    missing.push((n, m));
+                }
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "balancer library is missing {} (N, M) shape(s) below 10x10:\n{}",
+            missing.len(),
+            missing
+                .iter()
+                .map(|(n, m)| format!("  ({n}, {m})"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
 }

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -1293,6 +1293,81 @@ fn tier4_advanced_circuit_from_ore_am1() {
     assert_round_trip(&result);
 }
 
+/// Regression test for [issue #136][] — coprime balancer-shape coverage.
+///
+/// Repro URL:
+/// `?item=advanced-circuit&rate=5&machine=assembling-machine-2&in=coal,water,crude-oil,iron-ore,copper-ore&belt=transport-belt`
+///
+/// The original bug report was triggered by a missing `5→9` balancer
+/// template in `bus::balancer_library`: the lane planner asked the
+/// stamper for `(5, 9)` for `copper-cable`, the stamper had no template
+/// and no decomposition for coprime shapes (`gcd(5, 9) = 1`), and the
+/// layout surfaced "No 5→9 balancer template for copper-cable; producer
+/// outputs are disconnected" as a layout warning.
+///
+/// On the current main this exact URL produces a `(5, 6)` family for
+/// copper-cable instead of `(5, 9)` — that shape *does* have a
+/// template, so the original symptom is masked. We keep the regression
+/// test pinned to the issue's URL parameters: any future change to
+/// lane-planning that drives the family back into a coprime shape that
+/// the library still doesn't cover will reintroduce the warning, and
+/// this test will catch it.
+///
+/// Specifically asserted:
+///   - layout pipeline returns Ok (does not panic on missing template).
+///   - `layout.warnings` contains no `"balancer template"` warning, i.e.
+///     the lane-planner family shape is one the library can stamp.
+///
+/// This test does *not* assert zero errors / warnings overall — the
+/// from-ore corpus has unrelated lane-throughput / pole issues tracked
+/// in #65 / #68 / `tier4_advanced_circuit_from_ore_am1`. The check is
+/// scoped to the balancer-template gap that #136 documents.
+///
+/// See `crates/core/src/bus/balancer.rs::stamp_family_balancer` for the
+/// fallback path and `crates/core/src/bus/balancer_library.rs` for the
+/// shape coverage. Templates currently cover `1..=8 × 1..=8`. Any
+/// `(N, 9)` or `(9, M)` shape will still trip the warning.
+///
+/// [issue #136]: https://github.com/storkme/fucktorio/issues/136
+#[test]
+#[ntest::timeout(60000)]
+fn issue_136_no_balancer_template_warning_ac5_ore_yellow() {
+    let inputs: FxHashSet<String> = [
+        "iron-ore", "copper-ore", "coal", "water", "crude-oil",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    let result = run_e2e(
+        "issue_136_no_balancer_template_warning_ac5_ore_yellow",
+        "advanced-circuit",
+        5.0,
+        "assembling-machine-2",
+        Some("transport-belt"),
+        &inputs,
+    )
+    .unwrap_or_else(|e| panic!("issue #136 repro pipeline: {e}"));
+
+    let template_warnings: Vec<_> = result
+        .layout
+        .warnings
+        .iter()
+        .filter(|w| w.contains("balancer template"))
+        .collect();
+    assert!(
+        template_warnings.is_empty(),
+        "expected zero \"No N→M balancer template for ...\" layout warnings \
+         (issue #136 — coprime balancer shapes), got {}:\n{}",
+        template_warnings.len(),
+        template_warnings
+            .iter()
+            .map(|w| format!("  {w}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    assert_produces(&result, "advanced-circuit", 5.0);
+}
+
 // ---------------------------------------------------------------------------
 // Strategy scoreboard — runs every tier case under both strategies and emits
 // a single line of (entities, density, validator) per (test, strategy). The


### PR DESCRIPTION
## Intent

Track [issue #136][] (missing coprime balancer templates) with two
regression tests instead of regenerating the library — generation is
blocked on missing input data, not on Factorio-SAT itself, and writing
proper splitter networks for asymmetric 9-shapes by hand is well outside
this PR's scope.

[issue #136]: https://github.com/storkme/fucktorio/issues/136

## Scope

- **In:**
  - new e2e test `issue_136_no_balancer_template_warning_ac5_ore_yellow`
    pins the AC@5/s ore yellow URL from the issue. On current main the
    lane planner produces `(5, 6)` for copper-cable (template exists),
    so the test passes today — its job is to fail loudly if a future
    change reroutes the family back into a still-uncovered shape.
  - new `#[ignore]`d unit test `balancer_library_should_cover_n_lt_10`
    in `bus::balancer_library` enumerates the 17 missing `(N, M)` pairs
    below 10×10 (every `(1..=8, 9)` and `(9, 1..=9)`). `--ignored` runs
    print the gap so the close-out PR's success criterion is "this test
    goes green."

- **Out:**
  - regenerating the library. The generator (`scripts/generate_balancer_library.py`)
    immediately fails with `FileNotFoundError` for `external/factorio-sat/networks/5x9`
    et al. — none of the `Nx9` / `9xN` network files exist. The
    Factorio-SAT helpers can't auto-create them: `network create N`
    only emits NxN Beneš networks, and `belt_balancer_net_free` warns
    that asymmetric outputs "[don't] always produce good/correct results".
    Hand-constructing valid splitter networks for `(5, 9)`, `(7, 9)`, etc.
    is research-grade work and a separate PR.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` (462 → 464 passed,
      26 → 27 ignored — added ones are the new e2e + the gap-doc unit test)
- [x] `cargo clippy --manifest-path crates/core/Cargo.toml -p fucktorio_core -- -D warnings` clean
- [x] `cargo test ... --lib bus::balancer_library::tests::balancer_library_should_cover_n_lt_10 -- --ignored`
      correctly fails with the 17-shape list
- [x] `cargo test ... --test e2e issue_136_no_balancer_template_warning_ac5_ore_yellow` passes
- [ ] WASM rebuild + browser — N/A; tests-only PR

## Deviations from intent

Original task asked for "fix: regenerate balancer library with missing
coprime shapes". After investigating, regeneration is blocked on missing
network files (not on Factorio-SAT itself), so I took the documented
fallback path: pin the failure with regression tests, document the gap,
and surface the work needed to actually close it. PR title updated to
match what landed.

## Models / contracts touched

None. Tests only.