### PR TITLE
Machine compatibility validation & per-category palette

### DIFF
--- a/crates/core/data/recipes.json
+++ b/crates/core/data/recipes.json
@@ -9032,7 +9032,8 @@
   },
   "machines": {
     "assembling-machine-1": {
-      "crafting_speed": 0.5
+      "crafting_speed": 0.5,
+      "ingredient_slots": 2
     },
     "assembling-machine-2": {
       "crafting_speed": 0.75,

--- a/crates/core/src/recipe_db.rs
+++ b/crates/core/src/recipe_db.rs
@@ -274,31 +274,42 @@ pub fn machine_can_run_recipe(
     Ok(())
 }
 
-/// Compatibility check between a machine and a recipe category. Mirrors the
-/// hardcoded mapping in [`machine_for_recipe`]. Specialised categories
-/// require their specialised machine; fall-through categories require an
-/// assembler tier (the only machines we model as general-purpose).
-fn machine_handles_category(machine: &str, category: &str) -> bool {
+/// Assembler tiers — the general-purpose machines that handle every
+/// non-specialised recipe category. Used both as the valid-machine set for
+/// fall-through categories in [`machine_handles_category`] and as the
+/// allowed-options gate in the web sidebar's crafting dropdown.
+pub const ASSEMBLER_TIERS: &[&str] =
+    &["assembling-machine-1", "assembling-machine-2", "assembling-machine-3"];
+
+/// Single source of truth for the recipe-category → valid-machines mapping.
+///
+/// The first entry in each slice is the canonical default that
+/// [`machine_for_recipe`] picks when the user hasn't overridden it via the
+/// palette. An empty slice means the category is "general-purpose": the
+/// caller's `default` machine is used (caller is expected to provide one
+/// of [`ASSEMBLER_TIERS`]).
+fn category_machines(category: &str) -> &'static [&'static str] {
     match category {
-        "chemistry" | "chemistry-or-cryogenics" | "organic-or-chemistry" => {
-            matches!(machine, "chemical-plant")
-        }
-        "oil-processing" => matches!(machine, "oil-refinery"),
-        "smelting" => matches!(
-            machine,
-            "stone-furnace" | "steel-furnace" | "electric-furnace"
-        ),
-        "electromagnetics" => matches!(machine, "electromagnetic-plant"),
-        "cryogenics" | "cryogenics-or-assembling" => matches!(machine, "cryogenic-plant"),
-        "metallurgy" | "metallurgy-or-assembling" | "pressing" => matches!(machine, "foundry"),
-        "organic" | "organic-or-assembling" => matches!(machine, "biochamber"),
-        // Fall-through categories. Only the assembler tiers handle these —
-        // dropping a furnace or foundry into a crafting palette slot is a
-        // user error worth catching.
-        _ => matches!(
-            machine,
-            "assembling-machine-1" | "assembling-machine-2" | "assembling-machine-3"
-        ),
+        "chemistry" | "chemistry-or-cryogenics" | "organic-or-chemistry" => &["chemical-plant"],
+        "oil-processing" => &["oil-refinery"],
+        "smelting" => &["electric-furnace", "stone-furnace", "steel-furnace"],
+        "electromagnetics" => &["electromagnetic-plant"],
+        "cryogenics" | "cryogenics-or-assembling" => &["cryogenic-plant"],
+        "metallurgy" | "metallurgy-or-assembling" | "pressing" => &["foundry"],
+        "organic" | "organic-or-assembling" => &["biochamber"],
+        _ => &[],
+    }
+}
+
+/// Compatibility check between a machine and a recipe category. Specialised
+/// categories require one of their listed machines; fall-through categories
+/// require an [assembler tier](ASSEMBLER_TIERS).
+fn machine_handles_category(machine: &str, category: &str) -> bool {
+    let valid = category_machines(category);
+    if valid.is_empty() {
+        ASSEMBLER_TIERS.contains(&machine)
+    } else {
+        valid.contains(&machine)
     }
 }
 
@@ -322,8 +333,9 @@ pub fn machine_for_recipe(recipe: &Recipe, default: &str) -> String {
 }
 
 /// Like [`machine_for_recipe`], but consults `palette` first. The palette is
-/// the caller's per-category override; on miss we fall through to the same
-/// hardcoded category → machine table, then finally to `default`.
+/// the caller's per-category override; on miss we consult the same
+/// category → machine table that [`machine_handles_category`] uses, and
+/// finally fall through to `default` for general-purpose categories.
 pub fn machine_for_recipe_with_palette(
     recipe: &Recipe,
     palette: &MachinePalette,
@@ -332,15 +344,9 @@ pub fn machine_for_recipe_with_palette(
     if let Some(override_machine) = palette.by_category.get(&recipe.category) {
         return override_machine.clone();
     }
-    match recipe.category.as_str() {
-        "chemistry" | "chemistry-or-cryogenics" | "organic-or-chemistry" => "chemical-plant".to_string(),
-        "oil-processing" => "oil-refinery".to_string(),
-        "smelting" => "electric-furnace".to_string(),
-        "electromagnetics" => "electromagnetic-plant".to_string(),
-        "cryogenics" | "cryogenics-or-assembling" => "cryogenic-plant".to_string(),
-        "metallurgy" | "metallurgy-or-assembling" | "pressing" => "foundry".to_string(),
-        "organic" | "organic-or-assembling" => "biochamber".to_string(),
-        _ => default.to_string(),
+    match category_machines(&recipe.category) {
+        [] => default.to_string(),
+        [first, ..] => (*first).to_string(),
     }
 }
 

--- a/crates/core/src/recipe_db.rs
+++ b/crates/core/src/recipe_db.rs
@@ -163,8 +163,36 @@ pub fn get_crafting_speed(entity: &str) -> f64 {
         .unwrap_or(1.0)
 }
 
+/// User-supplied per-category machine overrides.
+///
+/// Maps a recipe `category` string (the same key used in [`machine_for_recipe`])
+/// to the entity name the user picked for it (e.g. `crafting →
+/// assembling-machine-2`). Categories absent here fall through to the
+/// hardcoded mapping in [`machine_for_recipe`], which itself falls through to
+/// the caller's `default`.
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MachinePalette {
+    pub by_category: FxHashMap<String, String>,
+}
+
 /// Choose the right machine entity for a recipe based on its category.
 pub fn machine_for_recipe(recipe: &Recipe, default: &str) -> String {
+    machine_for_recipe_with_palette(recipe, &MachinePalette::default(), default)
+}
+
+/// Like [`machine_for_recipe`], but consults `palette` first. The palette is
+/// the caller's per-category override; on miss we fall through to the same
+/// hardcoded category → machine table, then finally to `default`.
+pub fn machine_for_recipe_with_palette(
+    recipe: &Recipe,
+    palette: &MachinePalette,
+    default: &str,
+) -> String {
+    if let Some(override_machine) = palette.by_category.get(&recipe.category) {
+        return override_machine.clone();
+    }
     match recipe.category.as_str() {
         "chemistry" | "chemistry-or-cryogenics" | "organic-or-chemistry" => "chemical-plant".to_string(),
         "oil-processing" => "oil-refinery".to_string(),
@@ -205,8 +233,18 @@ pub fn all_producer_machines() -> Vec<String> {
 /// Return the canonical machine for an item, falling back to `fallback` if
 /// the item has no recipe or the recipe uses the default crafting category.
 pub fn default_machine_for_item(item: &str, fallback: &str) -> String {
+    default_machine_for_item_with_palette(item, &MachinePalette::default(), fallback)
+}
+
+/// Like [`default_machine_for_item`], but consults the caller's palette before
+/// the hardcoded category mapping.
+pub fn default_machine_for_item_with_palette(
+    item: &str,
+    palette: &MachinePalette,
+    fallback: &str,
+) -> String {
     match find_recipe_for_item(item) {
-        Some(recipe) => machine_for_recipe(recipe, fallback).to_string(),
+        Some(recipe) => machine_for_recipe_with_palette(recipe, palette, fallback),
         None => fallback.to_string(),
     }
 }
@@ -293,5 +331,78 @@ mod tests {
         // chemistry-or-cryogenics still maps to chemical-plant
         let recipe = Recipe { category: "chemistry-or-cryogenics".into(), ..recipe.clone() };
         assert_eq!(machine_for_recipe(&recipe, "assembling-machine-3"), "chemical-plant");
+    }
+
+    fn palette_with(entries: &[(&str, &str)]) -> MachinePalette {
+        let mut p = MachinePalette::default();
+        for (k, v) in entries {
+            p.by_category.insert((*k).to_string(), (*v).to_string());
+        }
+        p
+    }
+
+    fn make_recipe(category: &str) -> Recipe {
+        Recipe {
+            name: "test-recipe".into(),
+            category: category.into(),
+            energy: 1.0,
+            ingredients: vec![],
+            products: vec![],
+        }
+    }
+
+    #[test]
+    fn palette_overrides_default_for_crafting() {
+        let palette = palette_with(&[("crafting", "assembling-machine-2")]);
+        let recipe = make_recipe("crafting");
+        assert_eq!(
+            machine_for_recipe_with_palette(&recipe, &palette, "assembling-machine-3"),
+            "assembling-machine-2"
+        );
+    }
+
+    #[test]
+    fn palette_miss_falls_through_to_hardcoded() {
+        // Empty palette: smelting still picks the hardcoded electric-furnace.
+        let palette = MachinePalette::default();
+        let recipe = make_recipe("smelting");
+        assert_eq!(
+            machine_for_recipe_with_palette(&recipe, &palette, "assembling-machine-3"),
+            "electric-furnace"
+        );
+    }
+
+    #[test]
+    fn palette_miss_falls_through_to_default() {
+        // Empty palette + crafting category falls through to caller's default.
+        let palette = MachinePalette::default();
+        let recipe = make_recipe("crafting");
+        assert_eq!(
+            machine_for_recipe_with_palette(&recipe, &palette, "assembling-machine-1"),
+            "assembling-machine-1"
+        );
+    }
+
+    #[test]
+    fn palette_does_not_override_hardcoded_when_absent() {
+        // Palette only sets crafting; smelting recipe still hits hardcoded path.
+        let palette = palette_with(&[("crafting", "assembling-machine-1")]);
+        let recipe = make_recipe("smelting");
+        assert_eq!(
+            machine_for_recipe_with_palette(&recipe, &palette, "assembling-machine-3"),
+            "electric-furnace"
+        );
+    }
+
+    #[test]
+    fn palette_can_override_hardcoded_smelting() {
+        // If a future palette wants stone-furnace for smelting, it wins over
+        // the hardcoded electric-furnace.
+        let palette = palette_with(&[("smelting", "stone-furnace")]);
+        let recipe = make_recipe("smelting");
+        assert_eq!(
+            machine_for_recipe_with_palette(&recipe, &palette, "assembling-machine-3"),
+            "stone-furnace"
+        );
     }
 }

--- a/crates/core/src/recipe_db.rs
+++ b/crates/core/src/recipe_db.rs
@@ -80,6 +80,17 @@ pub struct Recipe {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MachineData {
     pub crafting_speed: f64,
+    /// Maximum number of solid+fluid ingredient slots. `None` = unbounded
+    /// (Factorio represents this as `-1` on prototypes; we treat absence in
+    /// the data file as unbounded). Today only `assembling-machine-1` has a
+    /// finite limit (2) in the bundled `recipes.json`.
+    #[serde(default)]
+    pub ingredient_slots: Option<usize>,
+    /// Raw fluid-box descriptors copied from the prototype data. We don't
+    /// inspect their shape — only whether the array is non-empty (machine
+    /// supports fluids at all). Defaults to empty.
+    #[serde(default)]
+    pub fluid_boxes: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -161,6 +172,134 @@ pub fn get_crafting_speed(entity: &str) -> f64 {
         .get(entity)
         .map(|m| m.crafting_speed)
         .unwrap_or(1.0)
+}
+
+/// Reasons a chosen `(machine, recipe)` pair can't run as configured.
+///
+/// Surfaced via [`SolverError::IncompatibleMachine`](crate::solver::SolverError)
+/// and rendered in the web UI's config-error banner. Messages are
+/// user-facing so the wording in `Display` should suggest a fix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MachineIncompatibility {
+    /// Recipe lists more ingredients than the machine has slots
+    /// (e.g. `assembling-machine-1` caps at 2).
+    TooManyIngredients { limit: usize, got: usize },
+    /// Recipe has fluid ingredients or products and the machine has no
+    /// fluid boxes (AM1, stone/steel/electric furnaces, recycler, crusher).
+    FluidNotSupported { items: Vec<String> },
+    /// The chosen machine isn't a valid producer for the recipe's category.
+    /// Only triggers for hand-edited URLs that map a category to a machine
+    /// that never handles it (e.g. `?craft=stone-furnace`); the UI's
+    /// dropdown prevents this through normal use.
+    CategoryNotSupported { category: String },
+}
+
+impl std::fmt::Display for MachineIncompatibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MachineIncompatibility::TooManyIngredients { limit, got } => {
+                write!(
+                    f,
+                    "{got} ingredients exceed the {limit}-slot limit — switch to a machine with more slots"
+                )
+            }
+            MachineIncompatibility::FluidNotSupported { items } => {
+                write!(
+                    f,
+                    "needs fluid {} but the machine has no fluid connections — switch to a fluid-capable machine",
+                    items.join(", ")
+                )
+            }
+            MachineIncompatibility::CategoryNotSupported { category } => {
+                write!(f, "doesn't support recipe category `{category}`")
+            }
+        }
+    }
+}
+
+/// Verify that `machine` can actually run `recipe` as configured.
+///
+/// Returns `Ok(())` if the pair is buildable, otherwise the first
+/// incompatibility it hits (slot count → fluid → category). Unknown
+/// machines (not in the bundled data) are treated as unconstrained — the
+/// solver will hit `MissingCraftingSpeed` separately if the entity is
+/// completely unknown.
+pub fn machine_can_run_recipe(
+    machine: &str,
+    recipe: &Recipe,
+) -> Result<(), MachineIncompatibility> {
+    let Some(data) = db().machines.get(machine) else {
+        return Ok(());
+    };
+
+    if let Some(limit) = data.ingredient_slots {
+        let got = recipe.ingredients.len();
+        if got > limit {
+            return Err(MachineIncompatibility::TooManyIngredients { limit, got });
+        }
+    }
+
+    if data.fluid_boxes.is_empty() {
+        let mut fluids: Vec<String> = recipe
+            .ingredients
+            .iter()
+            .filter(|i| i.type_ == "fluid")
+            .map(|i| i.name.clone())
+            .chain(
+                recipe
+                    .products
+                    .iter()
+                    .filter(|p| p.type_ == "fluid")
+                    .map(|p| p.name.clone()),
+            )
+            .collect();
+        fluids.sort();
+        fluids.dedup();
+        if !fluids.is_empty() {
+            return Err(MachineIncompatibility::FluidNotSupported { items: fluids });
+        }
+    }
+
+    // Category whitelist: a machine is valid for a category if either
+    //   (a) `machine_for_recipe` would naturally pick it for that category, or
+    //   (b) the category falls through to `default` (the assembler tier),
+    //       in which case any non-specialised machine is fine.
+    // The check guards hand-edited URLs like `?craft=stone-furnace`.
+    if !machine_handles_category(machine, &recipe.category) {
+        return Err(MachineIncompatibility::CategoryNotSupported {
+            category: recipe.category.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Compatibility check between a machine and a recipe category. Mirrors the
+/// hardcoded mapping in [`machine_for_recipe`]. Specialised categories
+/// require their specialised machine; fall-through categories require an
+/// assembler tier (the only machines we model as general-purpose).
+fn machine_handles_category(machine: &str, category: &str) -> bool {
+    match category {
+        "chemistry" | "chemistry-or-cryogenics" | "organic-or-chemistry" => {
+            matches!(machine, "chemical-plant")
+        }
+        "oil-processing" => matches!(machine, "oil-refinery"),
+        "smelting" => matches!(
+            machine,
+            "stone-furnace" | "steel-furnace" | "electric-furnace"
+        ),
+        "electromagnetics" => matches!(machine, "electromagnetic-plant"),
+        "cryogenics" | "cryogenics-or-assembling" => matches!(machine, "cryogenic-plant"),
+        "metallurgy" | "metallurgy-or-assembling" | "pressing" => matches!(machine, "foundry"),
+        "organic" | "organic-or-assembling" => matches!(machine, "biochamber"),
+        // Fall-through categories. Only the assembler tiers handle these —
+        // dropping a furnace or foundry into a crafting palette slot is a
+        // user error worth catching.
+        _ => matches!(
+            machine,
+            "assembling-machine-1" | "assembling-machine-2" | "assembling-machine-3"
+        ),
+    }
 }
 
 /// User-supplied per-category machine overrides.
@@ -392,6 +531,88 @@ mod tests {
             machine_for_recipe_with_palette(&recipe, &palette, "assembling-machine-3"),
             "electric-furnace"
         );
+    }
+
+    #[test]
+    fn am1_rejects_recipe_with_too_many_ingredients() {
+        // advanced-circuit needs 3 ingredients; AM1 has 2 slots.
+        let recipe = find_recipe_for_item("advanced-circuit").expect("recipe exists");
+        let err = machine_can_run_recipe("assembling-machine-1", recipe).unwrap_err();
+        match err {
+            MachineIncompatibility::TooManyIngredients { limit, got } => {
+                assert_eq!(limit, 2);
+                assert!(got >= 3, "expected ≥3 ingredients, got {got}");
+            }
+            other => panic!("expected TooManyIngredients, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn am1_rejects_recipe_with_fluid_ingredient() {
+        // plastic-bar uses petroleum-gas (fluid). AM1 has no fluid boxes.
+        let recipe = find_recipe_for_item("plastic-bar").expect("recipe exists");
+        // plastic-bar's category is "chemistry" → category check would fire
+        // first. Test against a fluid-using crafting recipe that AM1 fails on
+        // the fluid check, not the category check.
+        // Use the 2-ingredient lubricant recipe: any AM2/3-only recipe with
+        // a fluid will do. Fall back to a hardcoded constructed recipe if
+        // none is in the DB to keep this test stable.
+        let _ = recipe; // keep the lookup as a sanity check on data.
+        let synthetic = Recipe {
+            name: "synthetic".into(),
+            category: "crafting-with-fluid".into(),
+            energy: 1.0,
+            ingredients: vec![
+                Ingredient {
+                    name: "iron-plate".into(),
+                    amount: 1.0,
+                    type_: "item".into(),
+                },
+                Ingredient {
+                    name: "water".into(),
+                    amount: 10.0,
+                    type_: "fluid".into(),
+                },
+            ],
+            products: vec![],
+        };
+        let err = machine_can_run_recipe("assembling-machine-1", &synthetic).unwrap_err();
+        assert!(matches!(err, MachineIncompatibility::FluidNotSupported { .. }));
+    }
+
+    #[test]
+    fn am3_accepts_arbitrary_recipes() {
+        let recipe = find_recipe_for_item("advanced-circuit").expect("recipe exists");
+        machine_can_run_recipe("assembling-machine-3", recipe)
+            .expect("AM3 handles 3+ ingredients");
+    }
+
+    #[test]
+    fn category_mismatch_rejected() {
+        // Hand-edited URL would put stone-furnace in the crafting palette.
+        let recipe = make_recipe("crafting");
+        let err = machine_can_run_recipe("stone-furnace", &recipe).unwrap_err();
+        assert!(matches!(
+            err,
+            MachineIncompatibility::CategoryNotSupported { .. }
+        ));
+    }
+
+    #[test]
+    fn smelting_accepts_stone_furnace() {
+        // Conversely, stone-furnace IS valid for the smelting category.
+        let recipe = make_recipe("smelting");
+        machine_can_run_recipe("stone-furnace", &recipe)
+            .expect("stone-furnace handles smelting");
+    }
+
+    #[test]
+    fn unknown_machine_passes_through() {
+        // Unknown entities are treated as unconstrained — the solver hits
+        // MissingCraftingSpeed separately for these.
+        let recipe = make_recipe("crafting");
+        machine_can_run_recipe("totally-made-up-machine", &recipe)
+            .expect("unknown machines bypass the capability check");
     }
 
     #[test]

--- a/crates/core/src/solver.rs
+++ b/crates/core/src/solver.rs
@@ -1,7 +1,10 @@
 //! Recursive recipe solver: target item/rate → machine counts & flows.
 
 use crate::models::{ItemFlow, MachineSpec, SolverResult};
-use crate::recipe_db::{find_recipe_for_item_excluding, get_crafting_speed, machine_for_recipe};
+use crate::recipe_db::{
+    find_recipe_for_item_excluding, get_crafting_speed, machine_for_recipe_with_palette,
+    MachinePalette,
+};
 use rustc_hash::FxHashSet;
 
 #[derive(Debug, thiserror::Error)]
@@ -45,11 +48,31 @@ pub fn solve(
     available_inputs: &FxHashSet<String>,
     machine_entity: &str,
 ) -> Result<SolverResult, SolverError> {
-    solve_with_exclusions(
+    solve_with_palette_and_exclusions(
         target_item,
         target_rate,
         available_inputs,
+        &MachinePalette::default(),
         machine_entity,
+        &FxHashSet::default(),
+    )
+}
+
+/// Like [`solve`] but consults a per-category [`MachinePalette`] before
+/// falling back to the hardcoded category mapping and `default_machine`.
+pub fn solve_with_palette(
+    target_item: &str,
+    target_rate: f64,
+    available_inputs: &FxHashSet<String>,
+    palette: &MachinePalette,
+    default_machine: &str,
+) -> Result<SolverResult, SolverError> {
+    solve_with_palette_and_exclusions(
+        target_item,
+        target_rate,
+        available_inputs,
+        palette,
+        default_machine,
         &FxHashSet::default(),
     )
 }
@@ -66,6 +89,25 @@ pub fn solve_with_exclusions(
     machine_entity: &str,
     excluded_recipes: &FxHashSet<String>,
 ) -> Result<SolverResult, SolverError> {
+    solve_with_palette_and_exclusions(
+        target_item,
+        target_rate,
+        available_inputs,
+        &MachinePalette::default(),
+        machine_entity,
+        excluded_recipes,
+    )
+}
+
+/// Combined variant: per-category palette + recipe exclusions.
+pub fn solve_with_palette_and_exclusions(
+    target_item: &str,
+    target_rate: f64,
+    available_inputs: &FxHashSet<String>,
+    palette: &MachinePalette,
+    default_machine: &str,
+    excluded_recipes: &FxHashSet<String>,
+) -> Result<SolverResult, SolverError> {
     let mut state = SolveState {
         machines: Vec::new(),
         external_inputs: Vec::new(),
@@ -78,7 +120,8 @@ pub fn solve_with_exclusions(
         target_rate,
         false,
         available_inputs,
-        machine_entity,
+        palette,
+        default_machine,
         excluded_recipes,
         &mut state,
     )?;
@@ -96,12 +139,14 @@ pub fn solve_with_exclusions(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve(
     item: &str,
     rate: f64,
     is_fluid: bool,
     available_inputs: &FxHashSet<String>,
-    machine_entity: &str,
+    palette: &MachinePalette,
+    default_machine: &str,
     excluded_recipes: &FxHashSet<String>,
     state: &mut SolveState,
 ) -> Result<(), SolverError> {
@@ -125,7 +170,7 @@ fn resolve(
 
     state.resolving.insert(item.to_string());
 
-    let entity = machine_for_recipe(recipe, machine_entity);
+    let entity = machine_for_recipe_with_palette(recipe, palette, default_machine);
     let crafting_speed = get_crafting_speed(&entity);
     if crafting_speed <= 0.0 {
         return Err(SolverError::MissingCraftingSpeed {
@@ -194,7 +239,8 @@ fn resolve(
             ingredient_rate,
             ing_is_fluid,
             available_inputs,
-            machine_entity,
+            palette,
+            default_machine,
             excluded_recipes,
             state,
         )?;
@@ -242,5 +288,34 @@ mod tests {
         assert_eq!(result.external_outputs.len(), 1);
         assert_eq!(result.external_outputs[0].item, "iron-gear-wheel");
         assert_eq!(result.external_outputs[0].rate, 10.0);
+    }
+
+    #[test]
+    fn palette_overrides_electronics_machine_end_to_end() {
+        // electronic-circuit and copper-cable are both `electronics` category
+        // (a fall-through, not hardcoded). With palette {electronics: AM1},
+        // both production steps should land on AM1 regardless of `default`.
+        let available = inputs_of(&["iron-plate", "copper-plate"]);
+        let mut palette = MachinePalette::default();
+        palette
+            .by_category
+            .insert("electronics".into(), "assembling-machine-1".into());
+        let result = solve_with_palette(
+            "electronic-circuit",
+            5.0,
+            &available,
+            &palette,
+            "assembling-machine-3",
+        )
+        .expect("solver runs");
+
+        assert!(!result.machines.is_empty());
+        for m in &result.machines {
+            assert_eq!(
+                m.entity, "assembling-machine-1",
+                "recipe {} ended up on {}, expected AM1",
+                m.recipe, m.entity
+            );
+        }
     }
 }

--- a/crates/core/src/solver.rs
+++ b/crates/core/src/solver.rs
@@ -2,10 +2,16 @@
 
 use crate::models::{ItemFlow, MachineSpec, SolverResult};
 use crate::recipe_db::{
-    find_recipe_for_item_excluding, get_crafting_speed, machine_for_recipe_with_palette,
-    MachinePalette,
+    find_recipe_for_item_excluding, get_crafting_speed, machine_can_run_recipe,
+    machine_for_recipe_with_palette, MachineIncompatibility, MachinePalette,
 };
 use rustc_hash::FxHashSet;
+
+/// Marker prefix carried in `IncompatibleMachine` error strings across the
+/// WASM boundary. The web sidebar splits on this to route the message to
+/// the dedicated config-error banner instead of the generic solver-error
+/// region. Keep in sync with `INCOMPATIBLE_MACHINE_PREFIX` in the web layer.
+pub const INCOMPATIBLE_MACHINE_PREFIX: &str = "[INCOMPATIBLE_MACHINE] ";
 
 #[derive(Debug, thiserror::Error)]
 pub enum SolverError {
@@ -13,6 +19,16 @@ pub enum SolverError {
     ZeroProduct { recipe: String, item: String },
     #[error("no crafting speed for entity {entity}")]
     MissingCraftingSpeed { entity: String },
+    /// Pre-flight rejection: the machine the palette resolved to can't run
+    /// this recipe. The Display impl prefixes the message with
+    /// [`INCOMPATIBLE_MACHINE_PREFIX`] so web callers can route it to the
+    /// dedicated config-error banner.
+    #[error("{}{machine} can't make {recipe}: {reason}", INCOMPATIBLE_MACHINE_PREFIX)]
+    IncompatibleMachine {
+        recipe: String,
+        machine: String,
+        reason: MachineIncompatibility,
+    },
 }
 
 struct SolveState {
@@ -171,6 +187,13 @@ fn resolve(
     state.resolving.insert(item.to_string());
 
     let entity = machine_for_recipe_with_palette(recipe, palette, default_machine);
+    if let Err(reason) = machine_can_run_recipe(&entity, recipe) {
+        return Err(SolverError::IncompatibleMachine {
+            recipe: recipe.name.clone(),
+            machine: entity.clone(),
+            reason,
+        });
+    }
     let crafting_speed = get_crafting_speed(&entity);
     if crafting_speed <= 0.0 {
         return Err(SolverError::MissingCraftingSpeed {
@@ -288,6 +311,57 @@ mod tests {
         assert_eq!(result.external_outputs.len(), 1);
         assert_eq!(result.external_outputs[0].item, "iron-gear-wheel");
         assert_eq!(result.external_outputs[0].rate, 10.0);
+    }
+
+    #[test]
+    fn am1_palette_for_advanced_circuit_returns_incompatible_error() {
+        // advanced-circuit has 3 ingredients in `electronics` category. Pin
+        // electronics → AM1 in the palette and expect a typed
+        // IncompatibleMachine error rather than a silent half-broken layout.
+        let available = inputs_of(&[
+            "iron-plate",
+            "copper-plate",
+            "plastic-bar",
+            "electronic-circuit",
+        ]);
+        let mut palette = MachinePalette::default();
+        palette
+            .by_category
+            .insert("electronics".into(), "assembling-machine-1".into());
+        let err = solve_with_palette(
+            "advanced-circuit",
+            1.0,
+            &available,
+            &palette,
+            "assembling-machine-3",
+        )
+        .expect_err("AM1 should be rejected for advanced-circuit");
+        match err {
+            SolverError::IncompatibleMachine { machine, reason, .. } => {
+                assert_eq!(machine, "assembling-machine-1");
+                assert!(matches!(
+                    reason,
+                    MachineIncompatibility::TooManyIngredients { limit: 2, .. }
+                ));
+            }
+            other => panic!("expected IncompatibleMachine, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn incompatible_machine_error_message_carries_marker_prefix() {
+        // The web layer relies on the marker prefix to route this error to
+        // the dedicated config-error banner. Lock the contract.
+        let err = SolverError::IncompatibleMachine {
+            recipe: "advanced-circuit".into(),
+            machine: "assembling-machine-1".into(),
+            reason: MachineIncompatibility::TooManyIngredients { limit: 2, got: 3 },
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.starts_with(INCOMPATIBLE_MACHINE_PREFIX),
+            "expected leading marker, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -631,6 +631,70 @@ fn tier1_iron_gear_wheel_20s() {
     assert_golden_hash(&result, "tier1_iron_gear_wheel_20s");
 }
 
+/// E2E coverage for the per-category machine palette: solve →
+/// layout → validate, but with a non-default palette that pins the
+/// crafting category to AM1 (the slowest tier) and verify (a) every
+/// machine in the result uses AM1 and (b) the layout is still valid.
+/// AM1, AM2, AM3 are all 3x3, so the layout engine sees identical
+/// geometry — only machine count changes (AM1 is slower → more
+/// machines). Catches regressions where the palette doesn't actually
+/// thread through to the solver, and any layout-engine assumptions
+/// that machines must be AM3.
+#[test]
+#[ntest::timeout(10000)]
+fn palette_pins_iron_gear_wheel_to_am1() {
+    use fucktorio_core::recipe_db::MachinePalette;
+
+    let inputs: FxHashSet<String> = ["iron-plate"].iter().map(|s| s.to_string()).collect();
+    let mut palette = MachinePalette::default();
+    palette
+        .by_category
+        .insert("crafting".into(), "assembling-machine-1".into());
+
+    let solver_result = solver::solve_with_palette(
+        "iron-gear-wheel",
+        10.0,
+        &inputs,
+        &palette,
+        "assembling-machine-3",
+    )
+    .expect("solver runs with AM1 palette");
+
+    // Every recipe step in this chain is `crafting` category, so the
+    // palette pin should win across the board.
+    assert!(
+        solver_result.machines.iter().all(|m| m.entity == "assembling-machine-1"),
+        "expected all AM1, got {:?}",
+        solver_result.machines.iter().map(|m| &m.entity).collect::<Vec<_>>()
+    );
+
+    // AM1 (speed 0.5) needs more machines than AM3 (speed 1.25) for the
+    // same throughput. Sanity-check we got the slower path, not silently
+    // re-resolved to the default.
+    let am1_count: f64 = solver_result.machines.iter().map(|m| m.count).sum();
+    assert!(am1_count > 4.0, "expected >4 AM1s for 10/s gears, got {am1_count}");
+
+    // Layout + validate. We don't pin a golden hash — the goal is to
+    // confirm the palette doesn't break the layout engine, not to lock
+    // a specific layout.
+    let layout = layout::build_bus_layout(
+        &solver_result,
+        layout::LayoutOptions::default(),
+    )
+    .expect("layout builds");
+
+    let issues = match validate::validate(&layout, Some(&solver_result), LayoutStyle::Bus) {
+        Ok(issues) => issues,
+        Err(e) => e.issues,
+    };
+    let errors: Vec<&ValidationIssue> =
+        issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    assert!(
+        errors.is_empty(),
+        "AM1 palette layout produced validation errors: {errors:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Tier 2: electronic-circuit (2 recipes, 2 solid inputs)
 // ---------------------------------------------------------------------------

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -9,6 +9,7 @@
 //! `get_all_items`, `get_recipes_for_item`, `parse_blueprint`.
 
 use fucktorio_core::models::{LayoutResult, PlacedEntity, SolverResult};
+use fucktorio_core::recipe_db::MachinePalette;
 use fucktorio_core::validate::{self, LayoutStyle, ValidationIssue};
 use fucktorio_core::{
     blueprint, blueprint_parser, bus::junction_cost::solution_cost,
@@ -59,6 +60,23 @@ pub fn solve(
 ) -> Result<SolverResult, JsError> {
     let inputs: FxHashSet<String> = available_inputs.into_iter().collect();
     solver::solve(target_item, target_rate, &inputs, machine_entity)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Solve with a per-category machine palette. Categories absent from the
+/// palette fall through to the hardcoded mapping (see
+/// `recipe_db::machine_for_recipe`); fully unmapped categories use
+/// `default_machine`.
+#[wasm_bindgen]
+pub fn solve_with_palette(
+    target_item: &str,
+    target_rate: f64,
+    available_inputs: Vec<String>,
+    palette: MachinePalette,
+    default_machine: &str,
+) -> Result<SolverResult, JsError> {
+    let inputs: FxHashSet<String> = available_inputs.into_iter().collect();
+    solver::solve_with_palette(target_item, target_rate, &inputs, &palette, default_machine)
         .map_err(|e| JsError::new(&e.to_string()))
 }
 

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -224,7 +224,8 @@ async function solve(
   targetItem: string,
   targetRate: number,
   availableInputs: string[],
-  machineEntity: string,
+  palette: Record<string, string>,
+  defaultMachine: string,
 ): Promise<SolverResult> {
   // If a streaming layout is in flight, the user has just typed a new target
   // and is waiting for feedback — kill the old WASM work so solve isn't
@@ -235,7 +236,8 @@ async function solve(
     targetItem,
     targetRate,
     availableInputs,
-    machineEntity,
+    palette,
+    defaultMachine,
   });
 }
 

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_CHECKED_INPUTS,
   DEFAULT_ITEM,
-  DEFAULT_MACHINE,
+  DEFAULT_MACHINES,
   DEFAULT_RATE,
   type FormState,
   readUrlState,
@@ -21,12 +21,11 @@ function setUrl(suffix: string): void {
   history.replaceState(null, "", suffix);
 }
 
-function makeState(overrides: Partial<FormState> & { machine: string }): FormState & {
-  machine: string;
-} {
+function makeState(overrides: Partial<FormState>): FormState {
   return {
     item: DEFAULT_ITEM,
     rate: DEFAULT_RATE,
+    machines: {},
     inputs: DEFAULT_CHECKED_INPUTS,
     belt: null,
     strategy: null,
@@ -41,7 +40,7 @@ describe("readUrlState — defaults", () => {
     expect(readUrlState()).toEqual({
       item: DEFAULT_ITEM,
       rate: DEFAULT_RATE,
-      machine: null,
+      machines: {},
       inputs: DEFAULT_CHECKED_INPUTS,
       belt: null,
       strategy: null,
@@ -57,7 +56,7 @@ describe("readUrlState — hash form", () => {
     const s = readUrlState();
     expect(s.item).toBe("iron-gear-wheel");
     expect(s.rate).toBe(10);
-    expect(s.machine).toBeNull();
+    expect(s.machines).toEqual({});
     expect(s.inputs).toEqual(DEFAULT_CHECKED_INPUTS);
     expect(s.belt).toBeNull();
   });
@@ -67,7 +66,7 @@ describe("readUrlState — hash form", () => {
     const s = readUrlState();
     expect(s.item).toBe("advanced-circuit");
     expect(s.rate).toBe(5);
-    expect(s.machine).toBe("assembling-machine-1");
+    expect(s.machines.crafting).toBe("assembling-machine-1");
     expect(s.inputs).toEqual([
       "iron-ore",
       "copper-ore",
@@ -107,7 +106,7 @@ describe("readUrlState — hash form", () => {
     expect(readUrlState()).toEqual({
       item: DEFAULT_ITEM,
       rate: DEFAULT_RATE,
-      machine: null,
+      machines: {},
       inputs: DEFAULT_CHECKED_INPUTS,
       belt: null,
       strategy: null,
@@ -123,7 +122,7 @@ describe("readUrlState — legacy query string", () => {
     const s = readUrlState();
     expect(s.item).toBe("iron-plate");
     expect(s.rate).toBe(5);
-    expect(s.machine).toBe("assembling-machine-3");
+    expect(s.machines.crafting).toBe("assembling-machine-3");
     expect(s.inputs).toEqual(["iron-ore", "copper-ore"]);
   });
 
@@ -134,13 +133,15 @@ describe("readUrlState — legacy query string", () => {
 });
 
 describe("writeUrlState → readUrlState round-trip", () => {
-  function roundTrip(state: FormState & { machine: string }): FormState {
+  function roundTrip(state: FormState): FormState {
     writeUrlState(state);
     return readUrlState();
   }
 
   it("default state collapses to a bare URL", () => {
-    const state = makeState({ machine: DEFAULT_MACHINE });
+    const state = makeState({
+      machines: { crafting: DEFAULT_MACHINES.crafting },
+    });
     writeUrlState(state);
     expect(window.location.hash).toBe("");
     expect(window.location.search).toBe("");
@@ -150,13 +151,14 @@ describe("writeUrlState → readUrlState round-trip", () => {
     const state = makeState({
       item: "iron-plate",
       rate: 5,
-      machine: DEFAULT_MACHINE,
+      machines: { crafting: DEFAULT_MACHINES.crafting },
     });
     const back = roundTrip(state);
     expect(back.item).toBe(state.item);
     expect(back.rate).toBe(state.rate);
-    // machine omitted in URL → reader returns null, sidebar derives from item.
-    expect(back.machine).toBeNull();
+    // machine matches default → omitted from URL, reader returns empty map,
+    // sidebar derives from item.
+    expect(back.machines).toEqual({});
     expect(back.inputs).toEqual(DEFAULT_CHECKED_INPUTS);
   });
 
@@ -164,14 +166,14 @@ describe("writeUrlState → readUrlState round-trip", () => {
     const state = makeState({
       item: "advanced-circuit",
       rate: 5,
-      machine: "assembling-machine-1",
+      machines: { crafting: "assembling-machine-1" },
       inputs: ["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
       belt: "fast-transport-belt",
     });
     const back = roundTrip(state);
     expect(back.item).toBe(state.item);
     expect(back.rate).toBe(state.rate);
-    expect(back.machine).toBe(state.machine);
+    expect(back.machines.crafting).toBe(state.machines.crafting);
     expect(back.inputs).toEqual(state.inputs);
     expect(back.belt).toBe(state.belt);
   });
@@ -180,7 +182,7 @@ describe("writeUrlState → readUrlState round-trip", () => {
     const state = makeState({
       item: "processing-unit",
       rate: 2,
-      machine: "assembling-machine-3",
+      machines: { crafting: "assembling-machine-3" },
       strategy: "partitioned-decomposed",
       rowLayout: "horizontal-stack",
       customInputs: ["iron-plate", "copper-plate"],
@@ -191,9 +193,25 @@ describe("writeUrlState → readUrlState round-trip", () => {
     expect(back.customInputs).toEqual(["iron-plate", "copper-plate"]);
   });
 
+  it("survives a non-default smelting machine via extras", () => {
+    const state = makeState({
+      item: "iron-plate",
+      rate: 5,
+      machines: { smelting: "stone-furnace" },
+    });
+    const back = roundTrip(state);
+    expect(back.machines.smelting).toBe("stone-furnace");
+    // Crafting unspecified → reader leaves it absent.
+    expect(back.machines.crafting).toBeUndefined();
+  });
+
   it("trims trailing skip slots in the emitted URL", () => {
     writeUrlState(
-      makeState({ item: "iron-gear-wheel", rate: 7, machine: DEFAULT_MACHINE }),
+      makeState({
+        item: "iron-gear-wheel",
+        rate: 7,
+        machines: { crafting: DEFAULT_MACHINES.crafting },
+      }),
     );
     // No machine/inputs/belt slots written when they're at default —
     // makes shared URLs read cleanly.

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -3,8 +3,12 @@ import { shortIdForSlug, slugForShortId } from "./shortIds.js";
 export interface FormState {
   item: string;
   rate: number;
-  /** null means "no machine in URL — caller should derive from item". */
-  machine: string | null;
+  /** Per-recipe-category machine override. Sparse — categories absent here
+   * fall through to the hardcoded mapping in the Rust solver, which itself
+   * falls through to `DEFAULT_MACHINES.crafting`. URL keys are listed in
+   * `URL_KEY_BY_CATEGORY`; the legacy `?machine=` param (single-string
+   * AM tier) is migrated into `machines.crafting` on read. */
+  machines: Record<string, string>;
   inputs: string[];
   /** Max belt tier override, e.g. "transport-belt". null = auto. */
   belt: string | null;
@@ -61,7 +65,24 @@ export const DEFAULT_CHECKED_INPUTS: string[] = [
 
 export const DEFAULT_ITEM = "iron-gear-wheel";
 export const DEFAULT_RATE = 10;
-export const DEFAULT_MACHINE = "assembling-machine-3";
+/** Per-category default machine. Read by the sidebar to populate selectors
+ * and by the engine to fill the `default_machine` argument. The crafting
+ * entry doubles as the "fall-through" machine for any category not present
+ * in the palette and not hardcoded in `recipe_db::machine_for_recipe`. */
+export const DEFAULT_MACHINES: Record<string, string> = {
+  crafting: "assembling-machine-3",
+  smelting: "electric-furnace",
+};
+
+/** Categories the user can edit in the URL, with their short URL keys. */
+export const URL_KEY_BY_CATEGORY: Record<string, string> = {
+  crafting: "craft",
+  smelting: "smelt",
+};
+
+/** Back-compat alias: the legacy single-machine URL parameter used to
+ * configure the assembler tier. Read into `machines.crafting`. */
+const LEGACY_MACHINE_KEY = "machine";
 
 // Hash-form (Bucket B) URL scheme:
 //
@@ -150,10 +171,13 @@ function readHashState(): FormState | null {
   const rate = !isNaN(rateParsed) && rateParsed > 0 ? rateParsed : DEFAULT_RATE;
 
   const machineCode = get(2);
-  let machine: string | null = null;
+  const machines: Record<string, string> = {};
   if (machineCode) {
-    machine = codeToSlug(machineCode);
-    if (machine === null) return null;
+    const decoded = codeToSlug(machineCode);
+    if (decoded === null) return null;
+    // Slot 2 is the crafting tier — the canonical "the user changed the
+    // assembler" knob. Other categories ride in extras (see below).
+    machines.crafting = decoded;
   }
 
   const inputsRaw = get(3);
@@ -194,7 +218,19 @@ function readHashState(): FormState | null {
     }
   }
 
-  return { item, rate, machine, inputs, belt, strategy, rowLayout, customInputs };
+  // Per-category machines other than crafting (which lives in slot 2)
+  // ride as `<urlKey>=<short-code>` extras — smelting today, plus any
+  // future category in `URL_KEY_BY_CATEGORY`.
+  for (const [category, urlKey] of Object.entries(URL_KEY_BY_CATEGORY)) {
+    if (category === "crafting") continue;
+    const code = extras.get(urlKey);
+    if (!code) continue;
+    const slug = codeToSlug(code);
+    if (slug === null) return null;
+    machines[category] = slug;
+  }
+
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, customInputs };
 }
 
 function readQueryState(): FormState {
@@ -203,7 +239,18 @@ function readQueryState(): FormState {
   const item = params.get("item") ?? DEFAULT_ITEM;
   const rawRate = parseFloat(params.get("rate") ?? "");
   const rate = isNaN(rawRate) || rawRate <= 0 ? DEFAULT_RATE : rawRate;
-  const machine = params.get("machine");
+
+  // Per-category machine palette. Read each editable category's URL key,
+  // then fold in the legacy `?machine=` value as `machines.crafting` if
+  // the new `?craft=` key is absent.
+  const machines: Record<string, string> = {};
+  for (const [category, urlKey] of Object.entries(URL_KEY_BY_CATEGORY)) {
+    const value = params.get(urlKey);
+    if (value) machines[category] = value;
+  }
+  const legacy = params.get(LEGACY_MACHINE_KEY);
+  if (legacy && !machines.crafting) machines.crafting = legacy;
+
   const inParam = params.get("in");
   const inputs = inParam ? inParam.split(",").filter((s) => s.length > 0) : DEFAULT_CHECKED_INPUTS;
   const belt = params.get("belt");
@@ -218,7 +265,7 @@ function readQueryState(): FormState {
   const ciParam = params.get("ci");
   const customInputs = ciParam ? ciParam.split(",").filter((s) => s.length > 0) : [];
 
-  return { item, rate, machine, inputs, belt, strategy, rowLayout, customInputs };
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, customInputs };
 }
 
 export function readUrlState(): FormState {
@@ -241,13 +288,32 @@ export function urlHasGeneratorState(): boolean {
   );
 }
 
-function formatHashState(
-  state: Omit<FormState, "machine"> & { machine: string },
-): string {
+function machinesAreDefault(machines: Record<string, string>): boolean {
+  // Defaults are equal when every editable category either matches its
+  // default exactly or is absent from the palette.
+  for (const [category, urlKey] of Object.entries(URL_KEY_BY_CATEGORY)) {
+    void urlKey;
+    const picked = machines[category];
+    if (picked && picked !== DEFAULT_MACHINES[category]) return false;
+  }
+  // Reject any palette entry not in URL_KEY_BY_CATEGORY (shouldn't happen
+  // through the UI, but a hand-edited URL could).
+  for (const category of Object.keys(machines)) {
+    if (!(category in URL_KEY_BY_CATEGORY)) return false;
+  }
+  return true;
+}
+
+function formatHashState(state: FormState): string {
   const itemCode = slugToCode(state.item);
   const rate = String(state.rate);
+  // Slot 2 carries the crafting tier — the canonical assembler-tier knob.
+  // Other categories (smelting today) ride as extras when non-default.
+  const crafting = state.machines.crafting;
   const machineCode =
-    state.machine === DEFAULT_MACHINE ? SKIP_TOKEN : slugToCode(state.machine);
+    !crafting || crafting === DEFAULT_MACHINES.crafting
+      ? SKIP_TOKEN
+      : slugToCode(crafting);
   const inputsAreDefault =
     state.inputs.length === DEFAULT_CHECKED_INPUTS.length &&
     state.inputs.every((v, i) => v === DEFAULT_CHECKED_INPUTS[i]);
@@ -270,6 +336,17 @@ function formatHashState(
       state.customInputs.map(slugToCode).join(INPUT_SEPARATOR),
     );
   }
+  // Per-category machines other than crafting — encode as
+  // `<urlKey>=<short-code>` extras using the same `URL_KEY_BY_CATEGORY`
+  // table the query-form writer uses, so a hand-edited hash URL reads
+  // the same as a hand-edited query URL for any non-default smelter.
+  for (const [category, urlKey] of Object.entries(URL_KEY_BY_CATEGORY)) {
+    if (category === "crafting") continue;
+    const picked = state.machines[category];
+    if (picked && picked !== DEFAULT_MACHINES[category]) {
+      extras.set(urlKey, slugToCode(picked));
+    }
+  }
 
   // Trim trailing skip-token slots when no extras follow — produces
   // `#/l/ipr/5` instead of `#/l/ipr/5/_/_/_` for the common case where
@@ -287,11 +364,11 @@ function formatHashState(
   return path;
 }
 
-export function writeUrlState(state: Omit<FormState, "machine"> & { machine: string }): void {
+export function writeUrlState(state: FormState): void {
   const isDefault =
     state.item === DEFAULT_ITEM &&
     state.rate === DEFAULT_RATE &&
-    state.machine === DEFAULT_MACHINE &&
+    machinesAreDefault(state.machines) &&
     state.inputs.length === DEFAULT_CHECKED_INPUTS.length &&
     state.inputs.every((v, i) => v === DEFAULT_CHECKED_INPUTS[i]) &&
     !state.belt &&

--- a/web/src/ui/landing.ts
+++ b/web/src/ui/landing.ts
@@ -609,7 +609,10 @@ function openPreview(
     let layout: LayoutResult;
     try {
       const machine = engine.defaultMachineForItem(entry.item, entry.machine);
-      solverResult = await engine.solve(entry.item, entry.rate, entry.inputs, machine);
+      // Landing thumbnails don't expose a per-category palette; pass an
+      // empty palette so the solver falls through to the hardcoded category
+      // mapping for everything except crafting (which uses `machine`).
+      solverResult = await engine.solve(entry.item, entry.rate, entry.inputs, {}, machine);
       layout = await engine.buildLayout(solverResult, entry.beltTier);
     } catch (err) {
       card.classList.remove("loading");

--- a/web/src/ui/sidebar.css
+++ b/web/src/ui/sidebar.css
@@ -82,6 +82,18 @@
 }
 .sb-select:focus { border-color: #555; }
 
+/* Read-only machine label, styled like a disabled .sb-select. Used in the
+ * Machines section for categories with only a single Space Age option. */
+.sb-machine-readonly {
+  background: #1a1a1a;
+  color: #888;
+  border: 1px solid #2a2a2a;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+}
+
 /* ---- Tag pills ---- */
 .sb-tags {
   display: flex;
@@ -314,6 +326,18 @@
 
 /* ---- Errors (inline) ---- */
 .sb-result-error {
+  color: #f44;
+  font-family: monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 4px 0;
+}
+
+/* Pre-flight config error — same red styling as `.sb-result-error` but
+ * sits above the result container so it stays visible while a stale
+ * solver result is being discarded. */
+.sb-config-error {
   color: #f44;
   font-family: monospace;
   font-size: 11px;

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -1,5 +1,5 @@
 import type { Engine, SolverResult, LayoutResult, ItemFlow, ValidationIssue, TraceEvent } from "../engine.js";
-import { readUrlState, writeUrlState, DEFAULT_INPUTS } from "../state.js";
+import { readUrlState, writeUrlState, DEFAULT_INPUTS, DEFAULT_MACHINES } from "../state.js";
 import { beltTierForRate, hexToCss } from "../renderer/colors.js";
 import { niceName, setRecipeFlows, preloadCarriesIcons } from "../renderer/entities.js";
 import "./sidebar.css";
@@ -342,13 +342,76 @@ export function renderSidebar(
   picker.el.style.cssText = "margin-bottom:6px";
   targetBody.appendChild(picker.el);
 
-  // Assembler tier (only assembling-machine-1/2/3 — specialized machines are auto-picked per recipe)
-  const machineSelect = document.createElement("select");
-  machineSelect.className = "sb-select";
-  ["assembling-machine-1", "assembling-machine-2", "assembling-machine-3"].forEach(
-    (m) => machineSelect.appendChild(makeOption(m, "assembling-machine-3")),
-  );
-  targetBody.appendChild(makeField("Assembler", machineSelect));
+  // Per-category machine palette. Each editable category gets a `<select>`
+  // tagged with `data-cat="<category>"` so the solve handler can build the
+  // palette in one pass. Categories with only one Space Age option today
+  // render as a read-only label so the user can see which machine each
+  // recipe class will use.
+  type EditableMachine = {
+    category: string;
+    label: string;
+    options: { value: string; disabled?: boolean; title?: string }[];
+  };
+  const EDITABLE_MACHINES: EditableMachine[] = [
+    {
+      category: "crafting",
+      label: "Assembler",
+      options: [
+        { value: "assembling-machine-1" },
+        { value: "assembling-machine-2" },
+        { value: "assembling-machine-3" },
+      ],
+    },
+    {
+      category: "smelting",
+      label: "Furnace",
+      options: [
+        { value: "electric-furnace" },
+        { value: "stone-furnace", disabled: true, title: "Requires fuel routing — coming later" },
+      ],
+    },
+  ];
+  const READONLY_MACHINES: { label: string; machine: string }[] = [
+    { label: "Foundry", machine: "foundry" },
+    { label: "EM Plant", machine: "electromagnetic-plant" },
+    { label: "Chemical Plant", machine: "chemical-plant" },
+    { label: "Oil Refinery", machine: "oil-refinery" },
+    { label: "Cryogenic Plant", machine: "cryogenic-plant" },
+    { label: "Biochamber", machine: "biochamber" },
+  ];
+
+  const machineSelects = new Map<string, HTMLSelectElement>();
+  for (const m of EDITABLE_MACHINES) {
+    const sel = document.createElement("select");
+    sel.className = "sb-select";
+    sel.dataset.cat = m.category;
+    const defaultValue = DEFAULT_MACHINES[m.category] ?? "";
+    for (const opt of m.options) {
+      const o = makeOption(opt.value, defaultValue);
+      if (opt.disabled) o.disabled = true;
+      if (opt.title) o.title = opt.title;
+      sel.appendChild(o);
+    }
+    targetBody.appendChild(makeField(m.label, sel));
+    machineSelects.set(m.category, sel);
+  }
+  // Kept around for the back-compat readers below (auto-pick on item change,
+  // setParams snapshot restore). These all act on the assembler tier.
+  const machineSelect = machineSelects.get("crafting")!;
+  for (const ro of READONLY_MACHINES) {
+    const span = document.createElement("span");
+    span.className = "sb-machine-readonly";
+    span.textContent = niceName(ro.machine);
+    targetBody.appendChild(makeField(ro.label, span));
+  }
+
+  function buildPalette(): Record<string, string> {
+    const palette: Record<string, string> = {};
+    for (const [cat, sel] of machineSelects) {
+      if (sel.value) palette[cat] = sel.value;
+    }
+    return palette;
+  }
 
   // Belt tier (Auto / Yellow / Red / Blue) — moved up from the former Layout section
   const beltSelect = document.createElement("select");
@@ -570,11 +633,20 @@ export function renderSidebar(
   const urlState = readUrlState();
   picker.setValue(urlState.item);
   rateInput.value = String(urlState.rate);
-  // Only accept assembling-machine-1/2/3 from URL; anything else (legacy specialized machines) → AM3
+  // Per-category palette. Each `<select>` only keeps a URL value if it's a
+  // valid (non-disabled) option for its category, so a hand-edited URL or a
+  // legacy `?machine=`-derived value that points at a removed machine falls
+  // back to the default rather than rendering an empty select.
   const ASSEMBLER_TIERS = new Set(["assembling-machine-1", "assembling-machine-2", "assembling-machine-3"]);
-  machineSelect.value = (urlState.machine && ASSEMBLER_TIERS.has(urlState.machine))
-    ? urlState.machine
-    : "assembling-machine-3";
+  for (const [cat, sel] of machineSelects) {
+    const urlValue = urlState.machines[cat];
+    const validOptions = new Set(
+      Array.from(sel.options).filter((o) => !o.disabled).map((o) => o.value),
+    );
+    sel.value = urlValue && validOptions.has(urlValue)
+      ? urlValue
+      : (DEFAULT_MACHINES[cat] ?? sel.options[0]?.value ?? "");
+  }
   checkboxes.forEach((cb, name) => {
     cb.checked = urlState.inputs.includes(name);
     const tag = cb.closest(".sb-tag") as HTMLLabelElement;
@@ -588,6 +660,23 @@ export function renderSidebar(
     if (itemSet.has(item) && !defaultInputSet.has(item) && !customInputs.includes(item)) {
       customInputs.push(item);
       renderCustomTag(item);
+    }
+  }
+
+  // Pre-flight error banner. Rendered above the solver result; populated
+  // by `setConfigError(msg)`. Today nothing writes to it — the next PR
+  // (incompatible-machine preflight + layout-error promotion) wires it up.
+  const configErrorDiv = document.createElement("div");
+  configErrorDiv.className = "sb-config-error";
+  configErrorDiv.style.display = "none";
+  resultContainer.before(configErrorDiv);
+  function setConfigError(message: string | null): void {
+    if (message) {
+      configErrorDiv.textContent = message;
+      configErrorDiv.style.display = "";
+    } else {
+      configErrorDiv.textContent = "";
+      configErrorDiv.style.display = "none";
     }
   }
 
@@ -606,7 +695,6 @@ export function renderSidebar(
   async function runSolve(): Promise<void> {
     const targetItem = picker.getValue();
     const targetRate = parseFloat(rateInput.value);
-    const machineEntity = machineSelect.value;
     const checkedDefaults = DEFAULT_INPUTS.filter((inp) => checkboxes.get(inp)?.checked);
     const availableInputs = [...checkedDefaults, ...customInputs];
 
@@ -619,15 +707,20 @@ export function renderSidebar(
     if (isNaN(targetRate) || targetRate <= 0) return;
 
     if (targetItem !== previousItem) {
-      const suggestedMachine = engine.defaultMachineForItem(targetItem, machineEntity);
+      // Auto-pick assembler tier from the recipe's category mapping. Only
+      // applies to the crafting `<select>` — the per-category palette
+      // doesn't (yet) feed `defaultMachineForItem`.
+      const suggestedMachine = engine.defaultMachineForItem(targetItem, machineSelect.value);
       if (ASSEMBLER_TIERS.has(suggestedMachine)) machineSelect.value = suggestedMachine;
       previousItem = targetItem;
     }
 
+    const palette = buildPalette();
+
     writeUrlState({
       item: targetItem,
       rate: targetRate,
-      machine: machineSelect.value,
+      machines: palette,
       inputs: checkedDefaults,
       belt: beltSelect.value || null,
       strategy: strategySelect.value || null,
@@ -637,12 +730,19 @@ export function renderSidebar(
 
     const gen = ++solveGeneration;
     resultContainer.innerHTML = "";
+    setConfigError(null);
     currentLayout = null;
     blueprintSection.style.display = "none";
 
     let result: SolverResult;
     try {
-      result = await engine.solve(targetItem, targetRate, availableInputs, machineSelect.value);
+      result = await engine.solve(
+        targetItem,
+        targetRate,
+        availableInputs,
+        palette,
+        palette.crafting ?? DEFAULT_MACHINES.crafting,
+      );
     } catch (err) {
       if (gen !== solveGeneration) return;
       callbacks.renderGraph(null);
@@ -711,7 +811,9 @@ export function renderSidebar(
   });
 
   rateInput.addEventListener("input", scheduleAutoSolve);
-  machineSelect.addEventListener("change", scheduleAutoSolve);
+  for (const sel of machineSelects.values()) {
+    sel.addEventListener("change", scheduleAutoSolve);
+  }
   beltSelect.addEventListener("change", scheduleAutoSolve);
   strategySelect.addEventListener("change", scheduleAutoSolve);
   rowLayoutSelect.addEventListener("change", scheduleAutoSolve);

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -4,6 +4,12 @@ import { beltTierForRate, hexToCss } from "../renderer/colors.js";
 import { niceName, setRecipeFlows, preloadCarriesIcons } from "../renderer/entities.js";
 import "./sidebar.css";
 
+/** Marker the Rust solver prepends to `SolverError::IncompatibleMachine`
+ * messages. Must stay in sync with `INCOMPATIBLE_MACHINE_PREFIX` in
+ * `crates/core/src/solver.rs`. The sidebar splits on it to route the
+ * message to the dedicated config-error banner. */
+const INCOMPATIBLE_MACHINE_MARKER = "[INCOMPATIBLE_MACHINE]";
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -747,10 +753,20 @@ export function renderSidebar(
       if (gen !== solveGeneration) return;
       callbacks.renderGraph(null);
       if (solverCount) solverCount.textContent = "error";
-      const errDiv = document.createElement("div");
-      errDiv.className = "sb-result-error";
-      errDiv.textContent = String(err);
-      resultContainer.appendChild(errDiv);
+      const msg = String(err instanceof Error ? err.message : err);
+      // Pre-flight machine/category errors carry a marker prefix from the
+      // Rust solver. Route them to the dedicated config-error banner so
+      // they sit above the result container; everything else stays inline.
+      if (msg.includes(INCOMPATIBLE_MACHINE_MARKER)) {
+        const idx = msg.indexOf(INCOMPATIBLE_MACHINE_MARKER);
+        const cleaned = msg.slice(idx + INCOMPATIBLE_MACHINE_MARKER.length).trim();
+        setConfigError(cleaned);
+      } else {
+        const errDiv = document.createElement("div");
+        errDiv.className = "sb-result-error";
+        errDiv.textContent = msg;
+        resultContainer.appendChild(errDiv);
+      }
       return;
     }
     if (gen !== solveGeneration) return;

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -1,6 +1,6 @@
 import wasmInit, {
   init,
-  solve,
+  solve_with_palette,
   solve_fixture,
   all_producible_items,
   all_producer_machines,
@@ -30,7 +30,8 @@ type Request =
       targetItem: string;
       targetRate: number;
       availableInputs: string[];
-      machineEntity: string;
+      palette: Record<string, string>;
+      defaultMachine: string;
     }
   | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null }
   | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null }
@@ -98,7 +99,13 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         break;
       }
       case "solve":
-        result = solve(req.targetItem, req.targetRate, req.availableInputs, req.machineEntity);
+        result = solve_with_palette(
+          req.targetItem,
+          req.targetRate,
+          req.availableInputs,
+          { by_category: req.palette },
+          req.defaultMachine,
+        );
         break;
       case "layout":
         result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined);


### PR DESCRIPTION
## Intent

Add pre-flight validation that a chosen machine can actually run a recipe (slot limits, fluid support, category compatibility), and introduce a per-category machine palette so users can override which machine handles each recipe type instead of a single global assembler tier.

This prevents silent failures where a palette pins `assembling-machine-1` to a category but the recipe has 3 ingredients (AM1 only has 2 slots), or where a furnace is hand-edited into a crafting slot. Incompatible pairs now surface a dedicated config-error banner in the web UI.

## Scope

**In:**
- `MachineData` struct gains `ingredient_slots` (max solid+fluid ingredients) and `fluid_boxes` (whether machine supports fluids)
- New `MachineIncompatibility` enum with three error types: `TooManyIngredients`, `FluidNotSupported`, `CategoryNotSupported`
- `machine_can_run_recipe()` validates a machine/recipe pair before solving
- `MachinePalette` struct: sparse per-category machine overrides (e.g. `{crafting: AM2, smelting: stone-furnace}`)
- `machine_for_recipe_with_palette()` and `default_machine_for_item_with_palette()` consult the palette before falling back to hardcoded mappings
- `SolverError::IncompatibleMachine` variant with marker prefix for web routing
- `solve_with_palette()` and `solve_with_palette_and_exclusions()` entry points
- Web sidebar refactored: editable `<select>` per category (crafting, smelting) + read-only labels for specialized machines
- URL state migrated from single `?machine=` to per-category `?craft=`, `?smelt=` with back-compat fallback
- `.sb-config-error` CSS class for dedicated error banner above results
- WASM binding `solve_with_palette()` and `MachinePalette` export
- `recipes.json` updated: `assembling-machine-1` now declares `ingredient_slots: 2`

**Out:**
- No changes to the hardcoded category→machine mapping in `machine_for_recipe()` (still the fallback)
- Palette is sparse; unmapped categories use hardcoded logic then `default_machine`
- Disabled UI options (e.g. stone-furnace) are stubbed but not wired to fuel routing yet
- No migration of existing saved layouts or bookmarks (URL format change is forward-compatible via legacy key fallback)

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 12 new unit tests added covering palette overrides, incompatibility detection (slot limits, fluids, categories), and end-to-end solver integration
- [x] `cargo clippy -- -D warnings` — passes
- [x] WASM rebuild + browser eyeball:
  - Sidebar now shows per-category selects (Assembler, Furnace) + read-only labels (Foundry, EM Plant, etc.)
  - Pinning `assembling-machine-1` to electronics category and solving for `advanced-circuit` (3 ingredients) surfaces config-error banner: "3 ingredients exceed the 2-slot limit — switch to a machine with more slots"
  - Legacy `?machine=assembling-machine-2` URLs still work (migrated to `?craft=assembling-machine-2`)
  - New `?craft=assembling-machine-1&smelt=stone-furnace` URLs parse correctly
  - Solver result renders normally when palette is compatible

## Deviations from intent

None. The palette is intentionally sparse (only editable categories in the UI) to keep the URL readable and avoid over-specifying; the hardcoded fallback handles specialized machines automatically.

## Models / contracts touched

- `recipe_db.rs`: `MachineData` struct contract expanded (new optional fields with sensible defaults)
- `solver.rs`: `SolverError` enum extended; error messages now carry a marker prefix for web routing
- Web state contract: `FormState.machine` → `FormState.machines` (Record

https://claude.ai/code/session_01PXP87xBCWp4iKFrwpUTGhR