### PR TITLE
feat(web): balancer template showcase route (#274)

### DIFF
--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -469,3 +469,95 @@ pub fn validate_layout(
         Err(err) => err.issues,
     }
 }
+
+// ---------------------------------------------------------------------------
+// Balancer showcase (issue #274) — feeds the `/balancers` web QA tool.
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ShowcaseTemplate {
+    /// Short label describing the source — `"Factorio-SAT"` for library
+    /// entries, or a `compose: ...` recipe for generator output.
+    source: String,
+    width: u32,
+    height: u32,
+    n_inputs: u32,
+    n_outputs: u32,
+    /// Stamped at origin (0, 0). Belt-tier strings are the yellow-tier
+    /// defaults (`transport-belt` / `splitter` / `underground-belt`); the
+    /// showcase doesn't care about higher tiers since it's a topology QA
+    /// tool, not a throughput tool.
+    entities: Vec<PlacedEntity>,
+}
+
+#[derive(Serialize)]
+struct ShowcaseCell {
+    n_inputs: u32,
+    n_outputs: u32,
+    library: Option<ShowcaseTemplate>,
+    generated: Option<ShowcaseTemplate>,
+}
+
+/// Mirror of `balancer_generate::generate`'s decision tree (enough of it
+/// to label the construction recipe). When the generator grows new shapes
+/// extend this in lockstep — the showcase caption reads from this.
+fn describe_generated(n_in: u32, n_out: u32) -> String {
+    if n_in == n_out {
+        return "compose: passthrough".to_string();
+    }
+    if n_in == 1 && n_out == 2 {
+        return "compose: 1→2 atom".to_string();
+    }
+    if n_in == 2 && n_out == 1 {
+        return "compose: 2→1 atom".to_string();
+    }
+    if n_in != 0 && n_out.is_multiple_of(n_in) {
+        let k = n_out / n_in;
+        return format!("compose: {n_in} × (1, {k})");
+    }
+    if n_out != 0 && n_in.is_multiple_of(n_out) {
+        let k = n_in / n_out;
+        return format!("compose: {k} × (2, 1)");
+    }
+    "compose: ?".to_string()
+}
+
+/// Enumerate balancer templates for `(1..=max_inputs) × (1..=max_outputs)`.
+/// Each cell carries the library entry (if present) and the generator's
+/// output (if it can build that shape) so the web showcase can render
+/// both side-by-side.
+///
+/// Single round-trip — calling per-shape would be 100+ wasm-bindgen calls
+/// for the default 10×10 grid; one call instead.
+#[wasm_bindgen]
+pub fn balancer_showcase(max_inputs: u32, max_outputs: u32) -> Result<JsValue, JsError> {
+    use fucktorio_core::bus::balancer_generate::generate;
+    use fucktorio_core::bus::balancer_library::balancer_templates;
+
+    let templates = balancer_templates();
+    let mut cells: Vec<ShowcaseCell> = Vec::with_capacity(
+        (max_inputs as usize).saturating_mul(max_outputs as usize),
+    );
+    for n_in in 1..=max_inputs {
+        for n_out in 1..=max_outputs {
+            let library = templates.get(&(n_in, n_out)).map(|t| ShowcaseTemplate {
+                source: "Factorio-SAT".to_string(),
+                width: t.width,
+                height: t.height,
+                n_inputs: n_in,
+                n_outputs: n_out,
+                entities: t.stamp(0, 0, "transport-belt", "splitter", "underground-belt", None),
+            });
+            let generated = generate(n_in, n_out).map(|t| ShowcaseTemplate {
+                source: describe_generated(n_in, n_out),
+                width: t.width,
+                height: t.height,
+                n_inputs: n_in,
+                n_outputs: n_out,
+                entities: t.stamp(0, 0, "transport-belt", "splitter", "underground-belt", None),
+            });
+            cells.push(ShowcaseCell { n_inputs: n_in, n_outputs: n_out, library, generated });
+        }
+    }
+    serde_wasm_bindgen::to_value(&cells).map_err(|e| JsError::new(&e.to_string()))
+}

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -517,6 +517,41 @@ export async function cancelInFlight(): Promise<void> {
   }
 }
 
+/**
+ * One balancer template — entities stamped at origin (0, 0), with the
+ * source label and footprint metadata. Mirrors the Rust
+ * `ShowcaseTemplate` in `crates/wasm-bindings/src/lib.rs`.
+ */
+export interface BalancerShowcaseTemplate {
+  source: string;
+  width: number;
+  height: number;
+  n_inputs: number;
+  n_outputs: number;
+  entities: PlacedEntity[];
+}
+
+/** Library + generated entries for a single (n_inputs, n_outputs) shape. */
+export interface BalancerShowcaseCell {
+  n_inputs: number;
+  n_outputs: number;
+  library: BalancerShowcaseTemplate | null;
+  generated: BalancerShowcaseTemplate | null;
+}
+
+/** Enumerate templates for `(1..=maxInputs) × (1..=maxOutputs)`. Single
+ *  WASM round-trip; consumed by the `/balancers` showcase route. */
+function balancerShowcase(
+  maxInputs: number,
+  maxOutputs: number,
+): Promise<BalancerShowcaseCell[]> {
+  return call<BalancerShowcaseCell[]>({
+    method: "balancerShowcase",
+    maxInputs,
+    maxOutputs,
+  });
+}
+
 export type Engine = {
   solve: typeof solve;
   allProducibleItems: typeof allProducibleItems;
@@ -530,6 +565,7 @@ export type Engine = {
   solveFixture: typeof solveFixture;
   improveRegion: typeof improveRegion;
   optimizeAllRegions: typeof optimizeAllRegions;
+  balancerShowcase: typeof balancerShowcase;
 };
 
 export function getEngine(): Engine {
@@ -546,5 +582,6 @@ export function getEngine(): Engine {
     solveFixture,
     improveRegion,
     optimizeAllRegions,
+    balancerShowcase,
   };
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -62,6 +62,17 @@ async function main(): Promise<void> {
   const appRoot = document.getElementById("app")!;
   const hash = window.location.hash;
   const params = new URLSearchParams(window.location.search);
+
+  // Balancer showcase QA tool — issue #274. Standalone route that
+  // renders the library + compose-bake balancer templates side-by-side
+  // for every (n_inputs, n_outputs) shape. Bypasses landing + generator
+  // entirely.
+  if (hash.startsWith("#/balancers")) {
+    const { renderBalancerShowcase } = await import("./ui/balancers");
+    renderBalancerShowcase(appRoot, engine);
+    return;
+  }
+
   // Skip the landing page when the URL carries any generator state. Both
   // legacy `?item=...` query strings and new `#/l/...` hash fragments
   // count — `urlHasGeneratorState` knows about both shapes.

--- a/web/src/ui/balancers.ts
+++ b/web/src/ui/balancers.ts
@@ -1,0 +1,496 @@
+/**
+ * Balancer showcase QA tool — issue #274.
+ *
+ * Standalone route at `#/balancers` rendering every (n_inputs, n_outputs)
+ * shape in a 10×10 grid. Each cell shows the Factorio-SAT library entry
+ * (left) side-by-side with the compose-bake generator output (right),
+ * captioned with source / dimensions / entity count so the topology and
+ * sizing differences read at a glance.
+ *
+ * The compose-bake side is the moving target — when generated layouts
+ * are visibly fatter than the library equivalent (e.g. (1, 9) at 9×20 /
+ * 93 entities vs library (1, 8) at 8×5 / 17 entities), this view is the
+ * fastest QA loop. classify_ref returning Balanced misses the sizing
+ * problem; the eyeball doesn't.
+ *
+ * URL state: `#/balancers?focus=n,m` highlights and scrolls to that
+ * shape. Used for permalinks in code review / decision log entries.
+ */
+
+import { Application, Container } from "pixi.js";
+import {
+  TILE_PX,
+  createDrawContext,
+  addEntityToDrawContext,
+  drawEntityGraphic,
+  drawUgTunnelStripe,
+  UG_BELT_ENTITIES,
+} from "../renderer/entities";
+import type { Engine, BalancerShowcaseCell, BalancerShowcaseTemplate } from "../engine";
+
+const MAX_INPUTS = 10;
+const MAX_OUTPUTS = 10;
+
+// Display target for each rendered template panel. Real templates fit
+// well under this — library (1, 8) is 8×5 = 256×160 px at TILE_PX=32 —
+// and CSS scales down inside the panel if a compose-bake template
+// over-runs (e.g. 9×20 = 288×640 px). Keeping the absolute pixel
+// dimensions in the canvas means small templates aren't blurred up
+// while big ones gracefully shrink to fit.
+const PANEL_WIDTH_TILES = 12;
+const PANEL_HEIGHT_TILES = 12;
+
+export function renderBalancerShowcase(
+  appRoot: HTMLElement,
+  engine: Engine,
+): void {
+  // Take over the existing #app skeleton — hide the sidebar+canvas
+  // panels, install our own scrollable host.
+  appRoot.innerHTML = "";
+  appRoot.style.display = "block";
+  appRoot.style.height = "100vh";
+  appRoot.style.width = "100vw";
+  appRoot.style.overflow = "auto";
+
+  const host = document.createElement("div");
+  host.id = "balancer-showcase";
+  host.style.padding = "24px 32px 64px";
+  host.style.maxWidth = "1600px";
+  host.style.margin = "0 auto";
+  host.style.fontFamily =
+    "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  appRoot.appendChild(host);
+
+  injectStyles();
+
+  const header = document.createElement("header");
+  header.className = "bs-header";
+  header.innerHTML = `
+    <div>
+      <h1>Balancer template showcase</h1>
+      <p>Library (Factorio-SAT) vs compose-bake generator, side-by-side. Issue #274.</p>
+    </div>
+    <a href="#/" class="bs-back">← back</a>
+  `;
+  host.appendChild(header);
+
+  const grid = document.createElement("div");
+  grid.className = "bs-grid";
+  grid.style.setProperty("--bs-cols", String(MAX_OUTPUTS));
+  host.appendChild(grid);
+
+  const focus = parseFocus();
+  const cellMap = new Map<string, HTMLElement>();
+
+  // Pre-create one cell per (n, m) so the grid pops into the correct
+  // shape immediately. Slots are filled as each template arrives.
+  for (let n = 1; n <= MAX_INPUTS; n++) {
+    for (let m = 1; m <= MAX_OUTPUTS; m++) {
+      const cell = createCellSkeleton(n, m, focus);
+      cellMap.set(cellKey(n, m), cell);
+      grid.appendChild(cell);
+    }
+  }
+
+  // If the URL focuses a specific shape, scroll it into view once the
+  // grid is laid out.
+  if (focus) {
+    const target = cellMap.get(cellKey(focus.n, focus.m));
+    if (target) {
+      // Defer to the next frame so layout has settled.
+      requestAnimationFrame(() => {
+        target.scrollIntoView({ behavior: "auto", block: "center" });
+      });
+    }
+  }
+
+  void hydrate(engine, cellMap);
+}
+
+interface FocusShape {
+  n: number;
+  m: number;
+}
+
+function parseFocus(): FocusShape | null {
+  // Hash format: `#/balancers?focus=n,m`
+  const hash = window.location.hash;
+  const idx = hash.indexOf("?");
+  if (idx < 0) return null;
+  const params = new URLSearchParams(hash.slice(idx + 1));
+  const focusVal = params.get("focus");
+  if (!focusVal) return null;
+  const [nStr, mStr] = focusVal.split(",");
+  const n = Number.parseInt(nStr, 10);
+  const m = Number.parseInt(mStr, 10);
+  if (
+    !Number.isFinite(n) || !Number.isFinite(m) ||
+    n < 1 || n > MAX_INPUTS || m < 1 || m > MAX_OUTPUTS
+  ) {
+    return null;
+  }
+  return { n, m };
+}
+
+function cellKey(n: number, m: number): string {
+  return `${n},${m}`;
+}
+
+function createCellSkeleton(
+  n: number,
+  m: number,
+  focus: FocusShape | null,
+): HTMLElement {
+  const cell = document.createElement("div");
+  cell.className = "bs-cell";
+  cell.dataset.n = String(n);
+  cell.dataset.m = String(m);
+  if (focus && focus.n === n && focus.m === m) {
+    cell.classList.add("bs-focus");
+  }
+
+  cell.innerHTML = `
+    <header class="bs-cell-header">
+      <span class="bs-shape">(${n}, ${m})</span>
+      <span class="bs-summary"></span>
+    </header>
+    <div class="bs-panels">
+      <div class="bs-panel" data-side="library">
+        <div class="bs-panel-caption">loading…</div>
+        <div class="bs-panel-canvas"></div>
+      </div>
+      <div class="bs-panel" data-side="generated">
+        <div class="bs-panel-caption">loading…</div>
+        <div class="bs-panel-canvas"></div>
+      </div>
+    </div>
+  `;
+
+  return cell;
+}
+
+async function hydrate(
+  engine: Engine,
+  cellMap: Map<string, HTMLElement>,
+): Promise<void> {
+  let cells: BalancerShowcaseCell[];
+  try {
+    cells = await engine.balancerShowcase(MAX_INPUTS, MAX_OUTPUTS);
+  } catch (err) {
+    // Surface the failure in every cell so the bug is impossible to miss.
+    for (const cell of cellMap.values()) {
+      const summary = cell.querySelector(".bs-summary");
+      if (summary) summary.textContent = "showcase fetch failed";
+    }
+    console.error("[balancers] showcase fetch failed", err);
+    return;
+  }
+
+  // One off-screen Pixi app shared across all extractions. Spinning up
+  // an Application per cell would burn through the WebGL context limit
+  // (~16 contexts in browsers) immediately.
+  const offApp = new Application();
+  await offApp.init({
+    width: PANEL_WIDTH_TILES * TILE_PX,
+    height: PANEL_HEIGHT_TILES * TILE_PX,
+    background: 0x1e1e1e,
+    antialias: true,
+    autoStart: false,
+    sharedTicker: false,
+    preference: "webgl",
+  });
+
+  for (const cellData of cells) {
+    const dom = cellMap.get(cellKey(cellData.n_inputs, cellData.n_outputs));
+    if (!dom) continue;
+
+    fillPanel(offApp, dom, "library", cellData.library);
+    fillPanel(offApp, dom, "generated", cellData.generated);
+
+    const summary = dom.querySelector(".bs-summary") as HTMLElement | null;
+    if (summary) {
+      summary.innerHTML = comparisonSummary(cellData);
+    }
+  }
+
+  // The off-screen app keeps a GL context alive until destroyed. We
+  // don't need it past hydration — re-renders happen on reload — so
+  // free the resources.
+  offApp.destroy(true, { children: true, texture: true });
+}
+
+function fillPanel(
+  offApp: Application,
+  cellDom: HTMLElement,
+  side: "library" | "generated",
+  template: BalancerShowcaseTemplate | null,
+): void {
+  const panel = cellDom.querySelector(
+    `.bs-panel[data-side="${side}"]`,
+  ) as HTMLElement | null;
+  if (!panel) return;
+  const caption = panel.querySelector(".bs-panel-caption") as HTMLElement | null;
+  const canvasHost = panel.querySelector(".bs-panel-canvas") as HTMLElement | null;
+  if (!caption || !canvasHost) return;
+
+  if (!template) {
+    panel.classList.add("bs-empty");
+    caption.textContent = side === "library"
+      ? "no library entry"
+      : "no compose entry";
+    canvasHost.innerHTML = "";
+    return;
+  }
+
+  const entityCount = template.entities.length;
+  caption.innerHTML = `
+    <div class="bs-source">${escapeHtml(template.source)}</div>
+    <div class="bs-stats">
+      ${template.n_inputs} → ${template.n_outputs} ·
+      ${template.width}×${template.height} ·
+      <strong>${entityCount} ${entityCount === 1 ? "entity" : "entities"}</strong>
+    </div>
+  `;
+
+  const rendered = renderTemplateCanvas(offApp, template);
+  canvasHost.innerHTML = "";
+  canvasHost.appendChild(rendered);
+}
+
+/**
+ * Render `template` to a fresh `<canvas>` sized to its tile bounds.
+ * Reuses the main app's per-entity drawing helpers so belts, splitters,
+ * and undergrounds look identical to the generator route.
+ *
+ * The off-screen Pixi app is reused across extractions — for each
+ * template we build a temporary container, render the scene with that
+ * container as root, then snapshot the framebuffer into a new canvas.
+ */
+function renderTemplateCanvas(
+  app: Application,
+  template: BalancerShowcaseTemplate,
+): HTMLCanvasElement {
+  const widthPx = Math.max(1, template.width) * TILE_PX;
+  const heightPx = Math.max(1, template.height) * TILE_PX;
+
+  // Resize the renderer to fit this template exactly. PixiJS doesn't
+  // mind being resized between renders — it just retargets the GL
+  // viewport. Skip if already correct to avoid the resize cost.
+  if (app.renderer.width !== widthPx || app.renderer.height !== heightPx) {
+    app.renderer.resize(widthPx, heightPx);
+  }
+
+  const root = new Container();
+  const ctx = createDrawContext();
+
+  // Underground tunnel stripes go beneath the surface entities. Build a
+  // small map of UG entities first so `drawUgTunnelStripe` can find
+  // the matching output.
+  const ugEntityMap = new Map<string, typeof template.entities[0]>();
+  for (const e of template.entities) {
+    if (UG_BELT_ENTITIES.has(e.name)) {
+      ugEntityMap.set(`${e.x ?? 0},${e.y ?? 0}`, e);
+    }
+  }
+  for (const e of template.entities) {
+    if (!UG_BELT_ENTITIES.has(e.name) || e.io_type !== "input") continue;
+    const stripe = drawUgTunnelStripe(e, ugEntityMap);
+    if (stripe) root.addChild(stripe);
+  }
+
+  // Populate draw context first — `detectBeltTurn` reads neighbours
+  // from it, so all entities must be registered before any are drawn.
+  for (const e of template.entities) addEntityToDrawContext(e, ctx);
+  for (const e of template.entities) {
+    const g = drawEntityGraphic(e, ctx);
+    root.addChild(g);
+  }
+
+  // `extract.canvas` returns the renderer's internal canvas — copy
+  // pixels into a fresh canvas so this DOM element survives subsequent
+  // extractions (otherwise every cell in the grid would point at the
+  // same shared canvas, which then keeps mutating as we render the
+  // next template).
+  const sourceCanvas = app.renderer.extract.canvas(root) as HTMLCanvasElement;
+  const out = document.createElement("canvas");
+  out.width = sourceCanvas.width;
+  out.height = sourceCanvas.height;
+  const ctx2d = out.getContext("2d");
+  if (ctx2d) ctx2d.drawImage(sourceCanvas, 0, 0);
+  out.style.maxWidth = "100%";
+  out.style.height = "auto";
+  out.style.imageRendering = "pixelated";
+
+  // Drop the children so Pixi can free their textures on the next
+  // implicit GC pass. We don't `destroy()` because that recurses into
+  // the shared atlas textures the entity helpers cache.
+  root.removeChildren();
+
+  return out;
+}
+
+function comparisonSummary(cell: BalancerShowcaseCell): string {
+  const lib = cell.library;
+  const gen = cell.generated;
+  if (lib && gen) {
+    const libE = lib.entities.length;
+    const genE = gen.entities.length;
+    if (libE === 0) return "library has 0 entities (?)";
+    const delta = genE - libE;
+    if (delta === 0) {
+      return `<span class="bs-eq">parity</span>`;
+    }
+    if (delta < 0) {
+      const pct = Math.round(100 * (-delta) / libE);
+      return `<span class="bs-win">compose −${-delta} (−${pct}%)</span>`;
+    }
+    const pct = Math.round(100 * delta / libE);
+    return `<span class="bs-lose">compose +${delta} (+${pct}%)</span>`;
+  }
+  if (lib && !gen) return `<span class="bs-only-lib">library only</span>`;
+  if (!lib && gen) return `<span class="bs-only-gen">compose only</span>`;
+  return `<span class="bs-none">no template</span>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function injectStyles(): void {
+  if (document.getElementById("bs-styles")) return;
+  const style = document.createElement("style");
+  style.id = "bs-styles";
+  style.textContent = `
+    #balancer-showcase {
+      color: #d8d8d8;
+    }
+    .bs-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin-bottom: 24px;
+      gap: 16px;
+    }
+    .bs-header h1 {
+      font-size: 22px;
+      margin: 0 0 4px;
+      font-weight: 500;
+      letter-spacing: 0.2px;
+    }
+    .bs-header p {
+      margin: 0;
+      color: #888;
+      font-size: 13px;
+    }
+    .bs-back {
+      color: #6a9ed8;
+      text-decoration: none;
+      font-size: 13px;
+    }
+    .bs-back:hover { text-decoration: underline; }
+
+    .bs-grid {
+      display: grid;
+      grid-template-columns: repeat(var(--bs-cols, 10), minmax(0, 1fr));
+      gap: 12px;
+    }
+    @media (max-width: 1400px) {
+      .bs-grid { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+    }
+    @media (max-width: 800px) {
+      .bs-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
+    .bs-cell {
+      background: #232323;
+      border: 1px solid #2e2e2e;
+      border-radius: 6px;
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-width: 0;
+    }
+    .bs-cell.bs-focus {
+      border-color: #d39a3a;
+      box-shadow: 0 0 0 2px rgba(211, 154, 58, 0.25);
+    }
+    .bs-cell-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 6px;
+      font-size: 12px;
+    }
+    .bs-shape {
+      font-weight: 600;
+      color: #f0f0f0;
+      font-variant-numeric: tabular-nums;
+    }
+    .bs-summary { color: #888; font-size: 11px; }
+    .bs-summary .bs-win { color: #4eb072; }
+    .bs-summary .bs-lose { color: #d35a5a; }
+    .bs-summary .bs-eq { color: #888; }
+    .bs-summary .bs-only-lib { color: #6a9ed8; }
+    .bs-summary .bs-only-gen { color: #d39a3a; }
+    .bs-summary .bs-none { color: #555; }
+
+    .bs-panels {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 6px;
+    }
+    .bs-panel {
+      background: #1a1a1a;
+      border-radius: 4px;
+      padding: 6px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-height: 80px;
+    }
+    .bs-panel.bs-empty {
+      opacity: 0.45;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+    }
+    .bs-panel-caption {
+      font-size: 10px;
+      line-height: 1.3;
+      color: #aaa;
+    }
+    .bs-panel-caption .bs-source {
+      font-weight: 500;
+      color: #d8d8d8;
+    }
+    .bs-panel-caption .bs-stats {
+      color: #888;
+      font-variant-numeric: tabular-nums;
+    }
+    .bs-panel-caption strong {
+      color: #d8d8d8;
+      font-weight: 600;
+    }
+    .bs-panel-canvas {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 0;
+      max-height: 320px;
+      overflow: hidden;
+    }
+    .bs-panel-canvas canvas {
+      display: block;
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+    }
+  `;
+  document.head.appendChild(style);
+}

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -4,6 +4,7 @@ import wasmInit, {
   solve_fixture,
   all_producible_items,
   all_producer_machines,
+  balancer_showcase,
   default_machine_for_item,
   export_blueprint,
   improve_region_streaming,
@@ -53,7 +54,8 @@ type Request =
       budgetMs: number;
       maxIters: number;
     }
-  | { id: number; method: "seedZoneCache"; bytes: Uint8Array };
+  | { id: number; method: "seedZoneCache"; bytes: Uint8Array }
+  | { id: number; method: "balancerShowcase"; maxInputs: number; maxOutputs: number };
 
 let ready: Promise<void> | null = null;
 
@@ -180,6 +182,9 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         break;
       case "seedZoneCache":
         result = seed_zone_cache(req.bytes);
+        break;
+      case "balancerShowcase":
+        result = balancer_showcase(req.maxInputs, req.maxOutputs);
         break;
       case "improveRegionStreaming": {
         // Streams SatImprovement events through the same batched channel


### PR DESCRIPTION
**Preview:** <https://storkme.github.io/fucktorio/pr-275/#/balancers>

## Intent

Closes #274. Visual QA tool for compose-bake balancer outputs. `classify_ref` returning `Balanced` doesn't catch the eyeball-obvious sizing problems — e.g. a generated `(1, 9)` at 9×20 / 93 entities next to library `(1, 8)` at 8×5 / 17 entities. The compose-bake work (phase 3.4) is in flight on a sibling branch, so this lands the QA loop now and starts paying off as the generator fills shapes.

## Scope

- **In:**
  - New WASM export `balancer_showcase(max_in, max_out)` enumerating Factorio-SAT library entries plus `balancer_generate::generate(...)` outputs in one round-trip (one call, not 100).
  - New web route `#/balancers` rendering a 10×10 grid of (n_inputs, n_outputs) shapes, each cell showing the library and compose entries side-by-side with source / dimensions / entity count and a colour-coded "compose ±N% vs library" summary.
  - Reuses the existing `drawEntityGraphic` + `drawUgTunnelStripe` helpers via a shared off-screen Pixi `Application` and `extract.canvas`, so cells visually match what the generator route would draw.
  - URL state `#/balancers?focus=n,m` highlights and `scrollIntoView`s the target cell.
- **Out:** throughput visualisation, per-shape solve-time benchmarks, stress shapes >10×10 — all called out as out-of-scope in the issue.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml --lib` — 520 passed, 3 ignored.
- [x] `cargo test --manifest-path crates/core/Cargo.toml --test e2e` — 32 passed, 20 ignored.
- [x] `cargo clippy --manifest-path crates/core/Cargo.toml --lib -- -D warnings` — clean (the existing `--all-targets` warnings live in test files and pre-date this branch).
- [x] `cargo clippy --manifest-path crates/wasm-bindings/Cargo.toml --target wasm32-unknown-unknown -- -D warnings` — clean.
- [x] `wasm-pack build crates/wasm-bindings --target web --out-dir <abs>/web/src/wasm-pkg` — clean.
- [x] `npx tsc --noEmit` in `web/` — clean.
- [x] Browser eyeball at `http://localhost:5180/#/balancers` — grid renders 10×10, captions correct, the (2, 2) compose `passthrough` shows the −60% win, (2, 4) shows the −11% `2 × (1, 2)` win, parity cells render parity, missing cells (e.g. (1, 9), (9, x)) read as "no template" without errors.

## Deviations from intent

- The issue says "Reuses the WASM `solve`/`layout` exports — no new pipeline plumbing." I added a thin accessor export (`balancer_showcase`) rather than going through `solve`/`layout`, since balancer templates aren't part of those pipelines. Reading the issue's intent, "no new pipeline plumbing" means we shouldn't extend the solver/layout pipeline; a plain accessor that surfaces existing data structures is in keeping with that goal.

## Models / contracts touched

None. Renderer helpers (`drawEntityGraphic`, `drawUgTunnelStripe`, `createDrawContext`) are reused as published. The WASM accessor reads `balancer_library::balancer_templates()` and `balancer_generate::generate()` — both stable APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
