### PR TITLE
fix(templates): fall back to non-staggered path for multi-machine 3-fluid-output rows

### DIFF
--- a/crates/core/src/bus/templates.rs
+++ b/crates/core/src/bus/templates.rs
@@ -2116,7 +2116,14 @@ pub fn fluid_only_row(
     // layout (advanced-oil-processing, coal-liquefaction). Each output gets
     // its own trunk row below the machine so flanks and drop-UGs don't
     // share tiles.
-    if output_distinct_items.len() >= 3 {
+    //
+    // The staggered path requires machine_count == 1 (east R-flank of
+    // machine N at (mx + msz, y_east) collides with west drop UG of
+    // machine N+1 at the same tile). When machine_count > 1 we fall
+    // through to the non-staggered path, which places per-port isolated
+    // pipes for the multi-fluid output side and loops over each machine
+    // safely. See issue #277.
+    if output_distinct_items.len() >= 3 && machine_count == 1 {
         return fluid_only_row_staggered_3output(
             recipe, machine_entity, machine_size, machine_count,
             y_offset, x_offset, fluid_inputs, fluid_outputs,
@@ -3639,21 +3646,34 @@ mod tests {
         }
     }
 
-    // Staggered 3-output with machine_count > 1 is not yet supported —
-    // east R-flank at (mx+5, y_east) overlaps next machine's west drop UG.
+    // Staggered 3-output with machine_count > 1 falls back to the
+    // non-staggered path (per-port isolated pipes) rather than panicking.
+    // Regression guard for issue #277.
     #[test]
-    #[should_panic(expected = "multi-machine")]
-    fn fluid_only_row_advanced_multi_machine_panics() {
-        let _ = fluid_only_row(
+    fn fluid_only_row_advanced_multi_machine_non_staggered_fallback() {
+        let (entities, row_height, in_ports, out_ports) = fluid_only_row(
             "advanced-oil-processing",
             "oil-refinery",
             5,
-            2, // multi-machine
+            2, // multi-machine — previously hit assert_eq!(machine_count, 1)
             0,
             0,
             &[(1, "water"), (3, "crude-oil")],
             &[(0, "heavy-oil"), (2, "light-oil"), (4, "petroleum-gas")],
         );
+        // Non-staggered path: row_height = msz + 2 = 7
+        assert_eq!(row_height, 7, "non-staggered fallback row height should be msz+2=7");
+        // Two machines × msz=5 pitch = entities must include machines at x=0 and x=5
+        let machine_xs: Vec<i32> = entities.iter()
+            .filter(|e| e.name == "oil-refinery")
+            .map(|e| e.x)
+            .collect();
+        assert!(machine_xs.contains(&0), "first machine at x=0; got {machine_xs:?}");
+        assert!(machine_xs.contains(&5), "second machine at x=5; got {machine_xs:?}");
+        // 3 distinct output fluids → per-port isolated pipes, one per port per machine
+        assert_eq!(out_ports.len(), 6, "2 machines × 3 output ports = 6 out-port entries");
+        // 2 distinct input fluids → per-port pipes, one per port per machine
+        assert_eq!(in_ports.len(), 4, "2 machines × 2 input ports = 4 in-port entries");
     }
 
     // (machine_xs helper deleted in the inline-bridge unification —

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -1051,6 +1051,39 @@ fn tier3_heavy_oil_cracking() {
     assert_golden_hash(&result, "tier3_heavy_oil_cracking");
 }
 
+/// Regression for issue #277: `fluid_only_row_staggered_3output` panicked with
+/// `machine_count == 1` assertion when advanced-oil-processing needed ≥2
+/// refineries.  At 12/s petroleum-gas the solver yields 2 oil-refineries
+/// (one refinery produces 11/s petroleum-gas), forcing the multi-machine
+/// 3-fluid-output path that previously hit the assertion.
+#[test]
+#[ntest::timeout(15000)]
+fn tier3_advanced_oil_processing_multi_machine() {
+    let inputs: FxHashSet<String> = ["water", "crude-oil"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let result = run_e2e(
+        "tier3_advanced_oil_processing_multi_machine",
+        "petroleum-gas",
+        12.0,
+        "oil-refinery",
+        None,
+        &inputs,
+    )
+    .unwrap_or_else(|e| panic!("tier3_advanced_oil_processing_multi_machine: {e}"));
+
+    assert_no_errors(&result);
+    // Two refineries should be present.
+    let refinery_count = result.layout.entities.iter()
+        .filter(|e| e.name == "oil-refinery")
+        .count();
+    assert!(
+        refinery_count >= 2,
+        "expected ≥2 oil-refineries for 12/s petroleum-gas, got {refinery_count}",
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Tier 4: advanced-circuit (5+ recipes, mixed solid/fluid)
 // Known issues: lane-throughput warnings from single-lane sideload bottleneck (#64)


### PR DESCRIPTION
## Summary

- At the `fluid_only_row` dispatch site, gates the staggered 3-output path on `machine_count == 1`; multi-machine rows (advanced-oil-processing / coal-liquefaction with ≥2 refineries) now fall through to the non-staggered path instead of panicking.
- The non-staggered path already handles 3 distinct output fluids via per-port isolated pipes and loops over machines correctly — no changes needed there.
- Updated the existing `#[should_panic]` unit test to a positive geometry assertion (two machines, correct port counts).
- Added `tier3_advanced_oil_processing_multi_machine` e2e test: 12/s petroleum-gas forces 2 oil-refineries, previously panicked, now passes with zero validation errors.

## Option taken

**Option A** — dispatch-site guard only. The non-staggered path handles 3 distinct output fluids cleanly without modification (the `else` branch at line 2247 places per-port isolated pipes for any `output_distinct_items.len() > 1`).

The staggered path's `assert_eq!(machine_count, 1)` guard is preserved as a safety net; it is now unreachable via `fluid_only_row` but would still fire if anyone calls `fluid_only_row_staggered_3output` directly in future.

## Regression test

`crates/core/tests/e2e.rs` — `tier3_advanced_oil_processing_multi_machine`

Targets `petroleum-gas @ 12/s` with `oil-refinery` machine, water + crude-oil as inputs. One refinery produces 11/s petroleum-gas, so the solver yields 2 refineries — the exact shape that previously hit the assertion.

## Gauntlet impact

No change. The science gauntlet remains at 3 pass / 3 fail (logistic, production, utility packs). The utility-science-pack `float drift` case was already sidestepped by the upstream d83dbc3 fix; the multi-machine fallback is a separate code path that doesn't affect the gauntlet test cases at their current rates.

## Test plan

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 575 passed, 29 ignored
- [x] `cargo test --manifest-path crates/core/Cargo.toml --test science_gauntlet -- --ignored` — 3 pass, 3 fail (unchanged baseline)
- [x] `cargo clippy -p fucktorio_core -- -D warnings` — clean

Closes #277 (multi-machine panic; the float-drift subcase was already fixed in d83dbc3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)