### PR TITLE
fix(ghost_router): equalize UG pair tiers after family-trunk upgrade (#280 Bug 1)

### DIFF
--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -2829,6 +2829,69 @@ pub fn route_bus_ghost(
                 ent.name = splitter_for_belt(tier).to_string();
             }
         }
+
+        // UG pair equalization: the rename above is keyed by (item, x-column).
+        // A horizontal UG INPUT upgraded on the trunk column leaves its OUTPUT
+        // (at a different x, outside the trunk columns) at the original tier,
+        // creating a mismatched pair that fails the underground-belt validator.
+        // Fix: for every crossing:/junction: UG input that was upgraded, find
+        // its matching output (same segment_id, item, direction) and set it to
+        // the same UG tier.
+        //
+        // Collect upgraded crossing/junction UG inputs: (seg, item, dir_u8) → new_ug_name
+        // EntityDirection is repr(u8) but doesn't impl Hash, so cast to u8 for the key.
+        let mut upgraded_ug_inputs: FxHashMap<(String, String, u8), String> =
+            FxHashMap::default();
+        for ent in entities.iter() {
+            if !crate::common::is_ug_belt(&ent.name) {
+                continue;
+            }
+            if ent.io_type.as_deref() != Some("input") {
+                continue;
+            }
+            let Some(seg) = ent.segment_id.as_deref() else {
+                continue;
+            };
+            if !seg.starts_with("crossing:") && !seg.starts_with("junction:") {
+                continue;
+            }
+            let Some(item) = ent.carries.as_deref() else {
+                continue;
+            };
+            // Only record if this input was actually upgraded (i.e. it hit a
+            // family_tier_for entry at its column).
+            if !family_tier_for.contains_key(&(item.to_string(), ent.x)) {
+                continue;
+            }
+            upgraded_ug_inputs.insert(
+                (seg.to_string(), item.to_string(), ent.direction as u8),
+                ent.name.clone(),
+            );
+        }
+        // Apply the same UG name to the matching outputs.
+        if !upgraded_ug_inputs.is_empty() {
+            for ent in &mut entities {
+                if !crate::common::is_ug_belt(&ent.name) {
+                    continue;
+                }
+                if ent.io_type.as_deref() != Some("output") {
+                    continue;
+                }
+                let Some(seg) = ent.segment_id.as_deref() else {
+                    continue;
+                };
+                if !seg.starts_with("crossing:") && !seg.starts_with("junction:") {
+                    continue;
+                }
+                let Some(item) = ent.carries.as_deref() else {
+                    continue;
+                };
+                let key = (seg.to_string(), item.to_string(), ent.direction as u8);
+                if let Some(ug_name) = upgraded_ug_inputs.get(&key) {
+                    ent.name = ug_name.clone();
+                }
+            }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -921,6 +921,28 @@ impl JunctionStrategy for SatStrategy {
             }
         }
 
+        // Tier normalisation: ensure every boundary for a participating
+        // spec's item uses the spec's declared belt tier. Without this,
+        // `assign_channels` buckets IN and OUT for the same item into
+        // separate channels when the topology walk uses the physical
+        // entity's tier (e.g. "transport-belt" for a yellow tap segment)
+        // while the spec-chain-head augmentation uses `sc.belt_tier`
+        // (e.g. "express-transport-belt" for a blue-tier spec). The split
+        // channels cause SAT to route IN and OUT independently, producing
+        // mismatched UG belt pairs (blue input / yellow output) and
+        // belt-loop / dead-end validation errors.
+        for sc in ctx.junction.specs.iter() {
+            if sc.kind == SpecKind::Pipe {
+                continue;
+            }
+            let tier = sc.belt_tier.belt_name().to_string();
+            for b in boundaries.iter_mut() {
+                if b.item == sc.item {
+                    b.belt_tier = Some(tier.clone());
+                }
+            }
+        }
+
         // Assign channel ids now that the boundary set is final. Buckets
         // by (item, belt_tier); ids are deterministic. `channel_table[i]`
         // gives `(item, belt_tier)` for channel id `i` — used below to


### PR DESCRIPTION
## Summary

- **Root cause**: The family-trunk post-routing pass (`ghost_router.rs`) lifts belt entities on trunk columns to the family tier when `lane.rate * 2.0 < family.total_rate`. For `crossing:` / `junction:` segments this renamed UG INPUT entities (which sit on the trunk column x) but left UG OUTPUT entities (at x + reach distance, outside the trunk columns) at the original SAT-assigned tier. Result: `express-underground-belt` input / `underground-belt` output pairs that fail the underground-belt validator.
- **Fix 1 (ghost_router.rs)**: After the column-keyed rename loop, collect every `crossing:`/`junction:` UG input that was upgraded and propagate the same UG name to its matching output, matched by `(segment_id, item, direction)`.
- **Fix 2 (junction_sat_strategy.rs)**: Add a boundary tier-normalisation pass before `assign_channels` so all IN/OUT boundaries for a participating spec's item use `sc.belt_tier`, preventing `assign_channels` from bucketing them into separate channels (which would cause SAT to route them independently and produce belt-loop / dead-end errors).

## Impact

Science gauntlet: `utility-science-pack` FAIL×41 → FAIL×17. Remaining 17 are pre-existing fluid/pipe layout issues unrelated to this fix. All other packs unchanged.

## Test plan

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 574 passed, 0 failed
- [x] `cargo clippy --manifest-path crates/core/Cargo.toml --lib -- -D warnings` — clean (pre-existing example clippy errors unchanged)
- [x] Science gauntlet (`--ignored --nocapture`): utility drops 41→17 errors; no other pack regresses
- [ ] Visual browser check (utility-science-pack layout) — belt routing and UG pairs look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)