### PR TITLE
validator follow-ups: gate audit, dedup lane-transfer logic

### DIFF
--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -2461,19 +2461,73 @@ fn compute_lane_rates_impl(
     lane_rates
 }
 
-/// Pull-direction analogue of [`do_propagate`]'s lane logic: given a feeder
-/// at `fp` with rates `fr` flowing into receiver `pos`, return the per-lane
-/// contribution that lands on `pos`.  Used by the iterative convergence pass
-/// in [`compute_lane_rates_impl`] which needs to recompute each tile's rate
-/// from current upstream rates without the side effects of the push-direction
-/// `do_propagate`.
+/// Compute the per-lane contribution from a tile flowing into a downstream
+/// tile, applying Factorio's belt-mixing rules. Single source of truth for
+/// the four lane-transfer cases used by both [`do_propagate`] (push) and
+/// [`feeder_contribution`] (pull).
 ///
-/// Mirrors the four cases in `do_propagate`:
-/// - same direction → straight pass-through, lanes preserved
-/// - feeder is directly behind `pos` → also straight (e.g. UG-output → belt)
-/// - else, if `pos` has any straight feeder → sideload (everything onto one
-///   lane based on which side `fp` sits)
-/// - else → 90-degree turn (lanes swap on CW, preserve on CCW)
+/// Cases (in order):
+/// - **Same direction** → straight pass-through, lanes preserved.
+/// - **`from` directly behind `to`** → also straight (e.g. UG-output feeding
+///   a belt that turns).
+/// - **`to` has a straight feeder** (`to_has_straight_feeder=true`) →
+///   sideload: all flow goes onto the lane closest to `from`.
+/// - **Otherwise** → 90-degree turn: lanes swap on CW, preserve on CCW.
+fn lane_transfer(
+    from_pos: (i32, i32),
+    from_dir: EntityDirection,
+    from_rates: [f64; 2],
+    to_pos: (i32, i32),
+    to_dir: EntityDirection,
+    to_has_straight_feeder: bool,
+) -> [f64; 2] {
+    if from_dir == to_dir {
+        return from_rates;
+    }
+    let (fdx, fdy) = dir_to_vec(from_dir);
+    let (tdx, tdy) = dir_to_vec(to_dir);
+    let behind_to = (to_pos.0 - tdx, to_pos.1 - tdy);
+    if from_pos == behind_to {
+        return from_rates;
+    }
+
+    if to_has_straight_feeder {
+        let (left_dx, left_dy) = (-tdy, tdx);
+        let rel_x = from_pos.0 - to_pos.0;
+        let rel_y = from_pos.1 - to_pos.1;
+        let dot = rel_x * left_dx + rel_y * left_dy;
+        let total = from_rates[0] + from_rates[1];
+        if dot > 0 {
+            [total, 0.0]
+        } else {
+            [0.0, total]
+        }
+    } else {
+        let cross = fdx * tdy - fdy * tdx;
+        if cross > 0 {
+            [from_rates[1], from_rates[0]]
+        } else {
+            [from_rates[0], from_rates[1]]
+        }
+    }
+}
+
+/// Whether `pos`'s feeder list contains a straight feeder (ft == 0). Used
+/// by [`lane_transfer`] callers to disambiguate sideload from turn.
+fn has_straight_feeder(
+    pos: (i32, i32),
+    feeders: &FxHashMap<(i32, i32), Vec<((i32, i32), u8)>>,
+) -> bool {
+    feeders
+        .get(&pos)
+        .is_some_and(|fs| fs.iter().any(|(_, ft)| *ft == 0))
+}
+
+/// Pull-direction lane transfer: given a feeder at `fp` with rates `fr`
+/// flowing into receiver `pos`, return the per-lane contribution that lands
+/// on `pos`. Used by the iterative convergence pass in
+/// [`compute_lane_rates_impl`] which needs to recompute each tile's rate
+/// from current upstream rates without the side effects of [`do_propagate`].
 fn feeder_contribution(
     fp: (i32, i32),
     pos: (i32, i32),
@@ -2489,39 +2543,7 @@ fn feeder_contribution(
         Some(&d) => d,
         None => return [0.0, 0.0],
     };
-    let (fdx, fdy) = dir_to_vec(fd);
-    let (pdx, pdy) = dir_to_vec(pd);
-
-    if fd == pd {
-        return fr;
-    }
-    let behind_pos = (pos.0 - pdx, pos.1 - pdy);
-    if fp == behind_pos {
-        return fr;
-    }
-
-    let (left_dx, left_dy) = (-pdy, pdx);
-    let pos_feeders = feeders.get(&pos);
-    let has_straight = pos_feeders.is_some_and(|fs| fs.iter().any(|(_, ft)| *ft == 0));
-
-    if has_straight {
-        let rel_x = fp.0 - pos.0;
-        let rel_y = fp.1 - pos.1;
-        let dot = rel_x * left_dx + rel_y * left_dy;
-        let total = fr[0] + fr[1];
-        if dot > 0 {
-            [total, 0.0]
-        } else {
-            [0.0, total]
-        }
-    } else {
-        let cross = fdx * pdy - fdy * pdx;
-        if cross > 0 {
-            [fr[1], fr[0]]
-        } else {
-            [fr[0], fr[1]]
-        }
-    }
+    lane_transfer(fp, fd, fr, pos, pd, has_straight_feeder(pos, feeders))
 }
 
 /// Sum every feeder's contribution into `pos`.  Wrapper over
@@ -2566,52 +2588,17 @@ fn do_propagate(
 
     let my_rates = *lane_rates.get(&tile).unwrap_or(&[0.0, 0.0]);
     let ds_d = belt_dir_map[&downstream];
-    let (downstream_dx, downstream_dy) = dir_to_vec(ds_d);
-    let (left_dx, left_dy) = (-downstream_dy, downstream_dx);
-
+    let contrib = lane_transfer(
+        tile,
+        d,
+        my_rates,
+        downstream,
+        ds_d,
+        has_straight_feeder(downstream, feeders),
+    );
     let ds_rates = lane_rates.entry(downstream).or_insert([0.0, 0.0]);
-
-    if d == ds_d {
-        // Straight continuation
-        ds_rates[0] += my_rates[0];
-        ds_rates[1] += my_rates[1];
-    } else {
-        let behind_downstream = (downstream.0 - downstream_dx, downstream.1 - downstream_dy);
-        if tile == behind_downstream {
-            ds_rates[0] += my_rates[0];
-            ds_rates[1] += my_rates[1];
-        } else {
-            // Check if sideload (downstream has a straight feeder) or turn
-            let ds_feeders = feeders.get(&downstream);
-            let has_straight =
-                ds_feeders.is_some_and(|fs| fs.iter().any(|(_, ft)| *ft == 0));
-
-            if has_straight {
-                // Sideload: all items go onto the near lane
-                let rel_x = tile.0 - downstream.0;
-                let rel_y = tile.1 - downstream.1;
-                let dot = rel_x * left_dx + rel_y * left_dy;
-                let total = my_rates[0] + my_rates[1];
-                if dot > 0 {
-                    ds_rates[0] += total;
-                } else {
-                    ds_rates[1] += total;
-                }
-            } else {
-                // 90-degree turn: CW or CCW
-                let cross = ddx * downstream_dy - ddy * downstream_dx;
-                if cross > 0 {
-                    // Clockwise
-                    ds_rates[1] += my_rates[0];
-                    ds_rates[0] += my_rates[1];
-                } else {
-                    // Counter-clockwise
-                    ds_rates[0] += my_rates[0];
-                    ds_rates[1] += my_rates[1];
-                }
-            }
-        }
-    }
+    ds_rates[0] += contrib[0];
+    ds_rates[1] += contrib[1];
 
     let deg = in_degree.entry(downstream).or_insert(0);
     *deg -= 1;

--- a/crates/core/tests/balancer_lane_audit.rs
+++ b/crates/core/tests/balancer_lane_audit.rs
@@ -1,4 +1,4 @@
-//! Phase-1 audit of lane-correctness across the entire baked balancer
+//! Audit of lane-correctness across the entire baked balancer
 //! library (`docs/rfp-balancer-bake-lane-validation.md`).
 //!
 //! For every `(m, n)` template in
@@ -7,10 +7,13 @@
 //! validators (UG pair / UG sideload / UG entry-sideload /
 //! lane-throughput). Print a markdown taxonomy table to stderr.
 //!
-//! This test does not assert on the issue counts: the first run is
-//! discovery; the report itself is the deliverable. Run with
-//! `--nocapture` (or pass `BALANCER_AUDIT_FAIL=1` once we know what the
-//! baseline is) to inspect findings.
+//! **Gates by default**: as of the (7, 2) re-bake (#285) the library
+//! is fully lane-clean (0 errors / 0 templates affected across all
+//! 75 entries). The test now asserts that baseline holds — any future
+//! change that adds a lane-throughput error to the audit will break
+//! this test. Set `BALANCER_AUDIT_NO_FAIL=1` to suppress the assert
+//! during exploratory work (e.g. baking new shapes, regenerating the
+//! library).
 //!
 //! Pattern mirrors `balancer_classify::tests::audit_report` (line 811
 //! of that module).
@@ -175,12 +178,17 @@ fn audit_lane_correctness() {
     eprintln!("- Total warning issues: **{total_warnings}**");
     eprintln!();
 
-    // Optional fail-on-error gate: useful once we know the baseline. For
-    // discovery we leave the test green so the report always prints.
-    if std::env::var("BALANCER_AUDIT_FAIL").is_ok() {
+    // Gate-on-by-default. The (7, 2) re-bake (#285) brought the library
+    // to 0 errors / 0 templates — the audit's job now is to keep it
+    // there. Set `BALANCER_AUDIT_NO_FAIL=1` to suppress the assert
+    // during exploratory work (baking new shapes, regenerating the
+    // library) where transient errors are expected.
+    if std::env::var("BALANCER_AUDIT_NO_FAIL").is_err() {
         assert_eq!(
-            templates_with_errors, 0,
-            "BALANCER_AUDIT_FAIL set: {templates_with_errors} templates have lane errors"
+            total_errors, 0,
+            "balancer library audit: {total_errors} lane errors across {templates_with_errors} \
+             template(s). Set BALANCER_AUDIT_NO_FAIL=1 to suppress this assert. Full report \
+             above (run with --nocapture)."
         );
     }
 }


### PR DESCRIPTION
## Intent

Two non-blocker follow-ups from #283's review (items 5 and 6), now actionable since #285 brought the library audit to **0 errors / 0 templates**.

## Scope

### `7194daa` — gate audit-on-by-default

Library audit reached 0 errors with the (7, 2) re-bake. The audit test was opt-in (`BALANCER_AUDIT_FAIL=1`) so any future regression that adds a lane-throughput error wouldn't be caught by CI. Flip to gate-on-by-default; add `BALANCER_AUDIT_NO_FAIL=1` escape hatch for exploratory work (baking new shapes, regenerating the library) where transient errors are expected.

### `3945f82` — dedup lane-transfer logic

The four-case Factorio belt-mixing rule (same-dir / behind-pos straight / sideload / 90-deg turn) was duplicated between `do_propagate` (push) and `feeder_contribution` (pull). Reviewer flagged as drift risk: someone fixes a sideload edge case in one and forgets the other, the validator silently disagrees with itself.

Extract `lane_transfer(from_pos, from_dir, from_rates, to_pos, to_dir, to_has_straight_feeder) -> [f64; 2]` as the single source of truth. Both call sites now thin-wrap it. Plus `has_straight_feeder(pos, feeders)` helper for the sideload-vs-turn disambiguation, also previously inlined twice.

Net: -5 LOC, no behaviour change.

## Verification

- [x] `cargo test` — **586 tests pass**, 0 failures.
- [x] `cargo clippy --lib` clean.
- [x] Library audit holds at 0 errors with the new gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)