### PR TITLE
Mode D UG-correctness constraints + showcase provenance metadata

### DIFF
--- a/crates/balancer-gen/scripts/place.py
+++ b/crates/balancer-gen/scripts/place.py
@@ -540,6 +540,13 @@ def solve_synth_place(req: dict) -> dict:
     n_splitters = req["n_splitters"]
     edges = req["edges"]
     width, height = req["bounds"]
+    # Per-call UG transit-tile reach. Mirrors the parameter in
+    # `solve_pure_routing`; commit 5781676 added it to the pure-routing
+    # solvers but missed `solve_synth_place`'s UG path, leaving the
+    # name unbound at every UG-related loop. Default 4 = yellow-belt
+    # tier (matches `UG_MAX_REACH = 5` minus 1, since these loops use
+    # `range(1, ug_max_reach_param + 1)`).
+    ug_max_reach_param: int = req.get("ug_max_reach", 4)
 
     if height < 3 or width < max(n_inputs, n_outputs, 2):
         return {
@@ -835,6 +842,75 @@ def solve_synth_place(req: dict) -> dict:
                 for e2 in range(len(edges)):
                     if (ucx, ucy, d1, L2, e2) in ug_arcs and (ucx, ucy, d1, L2, e2) != (c1x, c1y, d1, L1, e1):
                         model.AddBoolOr([arc1.Not(), ug_arcs[(ucx, ucy, d1, L2, e2)].Not()])
+
+    # =========================================================================
+    # UG-correctness constraints (Phase 2C of rfp-ug-sideload-prevention.md).
+    # Mirror the four constraints from `solve_pure_routing` adapted for Mode D.
+    # All UGs in Mode D face south (d=facing=2); the d_ug iteration loops from
+    # solve_pure_routing collapse to a single iteration here. Constraint 3
+    # (chained UG) is vacuously satisfied because all chained UGs face south.
+    # =========================================================================
+
+    # Constraint 1 (Mode D): same-edge belt into UG-input sideload.
+    # When a UG-input is active, only a south-facing belt from the cell
+    # directly above (the straight-behind cell) may feed it. Belts entering
+    # from any other direction would only load one lane of the UG.
+    for (cx, cy, d_ug, L_ug, e_idx), ug_var in ug_arcs.items():
+        for d_in in range(4):
+            if d_in == d_ug:
+                continue  # straight feed is allowed
+            n_dx, n_dy = DIR_STEPS[d_in]
+            ncx, ncy = cx - n_dx, cy - n_dy
+            if not (0 <= ncx < width and 0 <= ncy < height):
+                continue
+            arc_var = arcs.get((ncx, ncy, d_in, e_idx))
+            if arc_var is not None:
+                model.Add(arc_var + ug_var <= 1)
+
+    # Constraint 2 (Mode D): InputPort src-cell direction.
+    # InputPort sources are at y=0; their column is a CP-SAT variable
+    # tracked via input_at[(i, cx)]. Items arrive from the north flowing
+    # south — only south-direction entities (belts or UGs) are valid at
+    # the chosen column. A non-south entity there would sideload the
+    # incoming flow.
+    for e_idx, edge in enumerate(edges):
+        if edge["src_kind"] != "InputPort":
+            continue
+        i = edge["src_idx"]
+        for cx in range(width):
+            in_v = input_at.get((i, cx))
+            if in_v is None:
+                continue
+            for d in range(4):
+                if d == facing:
+                    continue
+                arc_var = arcs.get((cx, 0, d, e_idx))
+                if arc_var is not None:
+                    model.Add(arc_var + in_v <= 1)
+            # UG-inputs at (cx, 0) all face south (d=facing) by construction
+            # of ug_arcs in this solver, so no UG forbid loop is needed.
+
+    # Constraint 3 (Mode D): vacuously satisfied. All UG arcs face south
+    # by construction, so chained UG-inputs of the same edge are necessarily
+    # both south-facing and the same-direction requirement holds.
+
+    # Constraint 4 (Mode D): UG-output head-on collision prevention.
+    # The UG-output is at (cx + L*dx, cy + L*dy); the cell ahead of the
+    # output flows in d_ug. A belt at the cell ahead facing the opposite
+    # direction would collide head-on with the UG-output.
+    OPPOSITE = {0: 2, 1: 3, 2: 0, 3: 1}
+    for (cx, cy, d_ug, L_ug, e_idx), ug_var in ug_arcs.items():
+        dx, dy = DIR_STEPS[d_ug]
+        # `out_x, out_y` to avoid shadowing the outer `ox` list (output
+        # port column vars used later when extracting solver values).
+        out_x, out_y = cx + L_ug * dx, cy + L_ug * dy
+        nx, ny = out_x + dx, out_y + dy
+        if not (0 <= nx < width and 0 <= ny < height):
+            continue
+        d_opposite = OPPOSITE[d_ug]
+        opp_arc = arcs.get((nx, ny, d_opposite, e_idx))
+        if opp_arc is not None:
+            model.Add(opp_arc + ug_var <= 1)
 
     # Flow conservation per (cell, edge), reified is_src/is_dst.
     for cx in range(width):

--- a/crates/balancer-gen/src/main.rs
+++ b/crates/balancer-gen/src/main.rs
@@ -161,6 +161,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("=== phase 3.4: bake missing shapes ===");
         return bake_missing_shapes();
     }
+    if std::env::var("FUCKTORIO_MODE_D_ONLY").is_ok() {
+        // Fast path: skip phases 3.1, 3.2 (round-trips), 3.2A/B/C
+        // (flow-conservation routing) and run only phase 3.2D (Mode D
+        // synth-place). Used to validate Mode D constraints in
+        // isolation without paying for the upstream spike phases.
+        println!("=== Mode D-only: skipping earlier spike phases ===");
+        let mode_d_shapes: &[(&str, (u32, u32))] = &[
+            ("(1, 2)", (1, 2)),
+            ("(2, 2)", (2, 2)),
+            ("(2, 4)", (2, 4)),
+            ("(1, 4)", (1, 4)),
+            ("(4, 4)", (4, 4)),
+            ("(1, 8)", (1, 8)),
+            // Round-trip Raynquist's (5, 1) topology through Mode D.
+            // Mode D re-places an existing topology; if our UG-correctness
+            // constraints prevent a feasible layout for a topology that
+            // *should* be feasible (Raynquist proved feasibility by hand),
+            // that's a sign the constraints over-restrict.
+            ("(5, 1)", (5, 1)),
+        ];
+        for &(label, shape) in mode_d_shapes {
+            match spike_synth_place(label, shape, None) {
+                Ok(()) => {}
+                Err(e) => println!("  ✗ {label}: {e}"),
+            }
+        }
+        return Ok(());
+    }
     let templates = balancer_templates();
 
     // Mode A — phase 3.1 splitter no-overlap.

--- a/crates/core/src/bus/balancer_library.rs
+++ b/crates/core/src/bus/balancer_library.rs
@@ -5290,6 +5290,81 @@ pub fn balancer_templates() -> &'static FxHashMap<(u32, u32), BalancerTemplate> 
     MAP.get_or_init(build_templates)
 }
 
+/// Provenance metadata for a library entry: where it came from and (when
+/// applicable) the strategy used to construct it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TemplateProvenance {
+    /// High-level source category — e.g. `"Raynquist"`, `"compose"`,
+    /// `"Factorio-SAT"`. Stable label suitable for display.
+    pub source: &'static str,
+    /// Optional strategy descriptor — for compose-baked entries this is
+    /// the recipe (e.g. `"Lib(7, 1) → Lib(1, 2)"`). Empty for atomic
+    /// generator outputs that have no decomposition.
+    pub strategy: &'static str,
+    /// Optional reference link — e.g. the Factoriobin URL for a
+    /// Raynquist import. Empty if no link is available.
+    pub reference: &'static str,
+}
+
+impl TemplateProvenance {
+    const fn factorio_sat() -> Self {
+        Self {
+            source: "Factorio-SAT",
+            strategy: "",
+            reference: "",
+        }
+    }
+}
+
+/// Provenance for every shape we know specifically. Defaults to
+/// `Factorio-SAT` for shapes not listed (the original python generator
+/// at `scripts/generate_balancer_library.py` was the source for most of
+/// the original library).
+///
+/// Update this when importing or re-baking a shape so the showcase
+/// surfaces accurate provenance instead of the misleading default.
+pub fn template_provenance(shape: (u32, u32)) -> TemplateProvenance {
+    use TemplateProvenance as P;
+
+    // Raynquist's TU collection (Factoriobin KafN8H7L). Imported via
+    // `import_balancer` — see PR #290 (1, 9) and PR #291 (5, x).
+    const RAYNQUIST: &str = "Raynquist (TU)";
+    const RAYNQUIST_URL: &str = "https://factoriobin.com/post/KafN8H7L/245";
+
+    match shape {
+        // Raynquist's TU (throughput-unlimited) imports.
+        (1, 9) | (5, 1) | (5, 2) | (5, 3) | (5, 4) => P {
+            source: RAYNQUIST,
+            strategy: "hand-tuned with priority annotations",
+            reference: RAYNQUIST_URL,
+        },
+
+        // Compose-baked re-bakes. Strategy = the recipe used in
+        // `bake_missing_shapes` to construct via `compose_series`.
+        (1, 10) => P { source: "compose", strategy: "Lib(1, 5) → Parallel(1, 2, 5)", reference: "" },
+        (2, 9) => P { source: "compose", strategy: "Parallel(1, 3, 2) → Parallel(2, 3, 3) via Clos(2, 3)", reference: "" },
+        (3, 2) => P { source: "compose", strategy: "Lib(3, 1) → Lib(1, 2)", reference: "" },
+        (3, 9) => P { source: "compose", strategy: "Parallel(1, 3, 3) → Parallel(3, 3, 3) via Clos(3, 3)", reference: "" },
+        (6, 1) => P { source: "compose", strategy: "Parallel(3, 1, 2) → Lib(2, 1)", reference: "" },
+        (6, 2) => P { source: "compose", strategy: "Parallel(3, 1, 2) → Lib(2, 2)", reference: "" },
+        (7, 2) => P { source: "compose", strategy: "Lib(7, 1) → Lib(1, 2)", reference: "" },
+        (7, 3) => P { source: "compose", strategy: "Lib(7, 1) → Lib(1, 3)", reference: "" },
+        (8, 1) => P { source: "compose", strategy: "Parallel(4, 1, 2) → Lib(2, 1)", reference: "" },
+        (8, 2) => P { source: "compose", strategy: "Parallel(4, 1, 2) → Lib(2, 2)", reference: "" },
+        (8, 6) => P { source: "compose", strategy: "Parallel(4, 1, 2) → Lib(2, 6)", reference: "" },
+        (9, 1) => P { source: "compose", strategy: "Parallel(3, 1, 3) → Lib(3, 1)", reference: "" },
+        (9, 2) => P { source: "compose", strategy: "Parallel(3, 1, 3) → Lib(3, 2)", reference: "" },
+        (9, 3) => P { source: "compose", strategy: "Parallel(3, 1, 3) → Lib(3, 3)", reference: "" },
+        (9, 4) => P { source: "compose", strategy: "Parallel(3, 1, 3) → Lib(3, 4)", reference: "" },
+        (9, 5) => P { source: "compose", strategy: "Parallel(3, 1, 3) → Lib(3, 5)", reference: "" },
+        (9, 6) => P { source: "compose", strategy: "Parallel(3, 1, 3) → Lib(3, 6)", reference: "" },
+        (10, 1) => P { source: "compose", strategy: "Parallel(5, 1, 2) → Lib(2, 1)", reference: "" },
+
+        // Default: original python Factorio-SAT generator.
+        _ => P::factorio_sat(),
+    }
+}
+
 fn build_templates() -> FxHashMap<(u32, u32), BalancerTemplate> {
     let mut m = FxHashMap::with_capacity_and_hasher(58, Default::default());
 

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -476,9 +476,15 @@ pub fn validate_layout(
 
 #[derive(Serialize)]
 struct ShowcaseTemplate {
-    /// Short label describing the source — `"Factorio-SAT"` for library
-    /// entries, or a `compose: ...` recipe for generator output.
+    /// High-level source — e.g. `"Raynquist (TU)"`, `"compose"`,
+    /// `"Factorio-SAT"`. Set from `template_provenance(shape)`.
     source: String,
+    /// Strategy descriptor for compose-baked entries, e.g.
+    /// `"Lib(7, 1) → Lib(1, 2)"`. Empty for atomic entries.
+    strategy: String,
+    /// Optional reference URL — Factoriobin link for Raynquist's
+    /// imports, etc. Empty if no link is available.
+    reference: String,
     width: u32,
     height: u32,
     n_inputs: u32,
@@ -495,44 +501,17 @@ struct ShowcaseCell {
     n_inputs: u32,
     n_outputs: u32,
     library: Option<ShowcaseTemplate>,
-    generated: Option<ShowcaseTemplate>,
 }
 
-/// Mirror of `balancer_generate::generate`'s decision tree (enough of it
-/// to label the construction recipe). When the generator grows new shapes
-/// extend this in lockstep — the showcase caption reads from this.
-fn describe_generated(n_in: u32, n_out: u32) -> String {
-    if n_in == n_out {
-        return "compose: passthrough".to_string();
-    }
-    if n_in == 1 && n_out == 2 {
-        return "compose: 1→2 atom".to_string();
-    }
-    if n_in == 2 && n_out == 1 {
-        return "compose: 2→1 atom".to_string();
-    }
-    if n_in != 0 && n_out.is_multiple_of(n_in) {
-        let k = n_out / n_in;
-        return format!("compose: {n_in} × (1, {k})");
-    }
-    if n_out != 0 && n_in.is_multiple_of(n_out) {
-        let k = n_in / n_out;
-        return format!("compose: {k} × (2, 1)");
-    }
-    "compose: ?".to_string()
-}
-
-/// Enumerate balancer templates for `(1..=max_inputs) × (1..=max_outputs)`.
-/// Each cell carries the library entry (if present) and the generator's
-/// output (if it can build that shape) so the web showcase can render
-/// both side-by-side.
+/// Enumerate balancer templates for `(1..=max_inputs) × (1..=max_outputs)`
+/// with provenance metadata. The showcase displays one cell per shape
+/// with source / strategy / reference labels.
 ///
 /// Single round-trip — calling per-shape would be 100+ wasm-bindgen calls
 /// for the default 10×10 grid; one call instead.
 #[wasm_bindgen]
 pub fn balancer_showcase(max_inputs: u32, max_outputs: u32) -> Result<JsValue, JsError> {
-    use fucktorio_core::bus::balancer_generate::generate;
-    use fucktorio_core::bus::balancer_library::balancer_templates;
+    use fucktorio_core::bus::balancer_library::{balancer_templates, template_provenance};
 
     let templates = balancer_templates();
     let mut cells: Vec<ShowcaseCell> = Vec::with_capacity(
@@ -540,23 +519,20 @@ pub fn balancer_showcase(max_inputs: u32, max_outputs: u32) -> Result<JsValue, J
     );
     for n_in in 1..=max_inputs {
         for n_out in 1..=max_outputs {
-            let library = templates.get(&(n_in, n_out)).map(|t| ShowcaseTemplate {
-                source: "Factorio-SAT".to_string(),
-                width: t.width,
-                height: t.height,
-                n_inputs: n_in,
-                n_outputs: n_out,
-                entities: t.stamp(0, 0, "transport-belt", "splitter", "underground-belt", None),
+            let library = templates.get(&(n_in, n_out)).map(|t| {
+                let p = template_provenance((n_in, n_out));
+                ShowcaseTemplate {
+                    source: p.source.to_string(),
+                    strategy: p.strategy.to_string(),
+                    reference: p.reference.to_string(),
+                    width: t.width,
+                    height: t.height,
+                    n_inputs: n_in,
+                    n_outputs: n_out,
+                    entities: t.stamp(0, 0, "transport-belt", "splitter", "underground-belt", None),
+                }
             });
-            let generated = generate(n_in, n_out).map(|t| ShowcaseTemplate {
-                source: describe_generated(n_in, n_out),
-                width: t.width,
-                height: t.height,
-                n_inputs: n_in,
-                n_outputs: n_out,
-                entities: t.stamp(0, 0, "transport-belt", "splitter", "underground-belt", None),
-            });
-            cells.push(ShowcaseCell { n_inputs: n_in, n_outputs: n_out, library, generated });
+            cells.push(ShowcaseCell { n_inputs: n_in, n_outputs: n_out, library });
         }
     }
     serde_wasm_bindgen::to_value(&cells).map_err(|e| JsError::new(&e.to_string()))

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -523,7 +523,12 @@ export async function cancelInFlight(): Promise<void> {
  * `ShowcaseTemplate` in `crates/wasm-bindings/src/lib.rs`.
  */
 export interface BalancerShowcaseTemplate {
+  /** High-level source — `"Raynquist (TU)"`, `"compose"`, `"Factorio-SAT"`. */
   source: string;
+  /** Strategy descriptor for compose-baked entries (e.g. `"Lib(7, 1) → Lib(1, 2)"`). Empty for atoms. */
+  strategy: string;
+  /** Optional reference URL — Factoriobin link for Raynquist's imports, etc. */
+  reference: string;
   width: number;
   height: number;
   n_inputs: number;
@@ -531,12 +536,11 @@ export interface BalancerShowcaseTemplate {
   entities: PlacedEntity[];
 }
 
-/** Library + generated entries for a single (n_inputs, n_outputs) shape. */
+/** Library entry for a single (n_inputs, n_outputs) shape. */
 export interface BalancerShowcaseCell {
   n_inputs: number;
   n_outputs: number;
   library: BalancerShowcaseTemplate | null;
-  generated: BalancerShowcaseTemplate | null;
 }
 
 /** Enumerate templates for `(1..=maxInputs) × (1..=maxOutputs)`. Single

--- a/web/src/ui/balancers.ts
+++ b/web/src/ui/balancers.ts
@@ -2,16 +2,16 @@
  * Balancer showcase QA tool — issue #274.
  *
  * Standalone route at `#/balancers` rendering every (n_inputs, n_outputs)
- * shape in a 10×10 grid. Each cell shows the Factorio-SAT library entry
- * (left) side-by-side with the compose-bake generator output (right),
- * captioned with source / dimensions / entity count so the topology and
- * sizing differences read at a glance.
+ * library entry in a 10×10 grid. Each cell shows the template captioned
+ * with source provenance (Raynquist / compose / Factorio-SAT) plus the
+ * construction strategy (e.g. `Lib(7, 1) → Lib(1, 2)`) so it's immediately
+ * clear where each balancer came from.
  *
- * The compose-bake side is the moving target — when generated layouts
- * are visibly fatter than the library equivalent (e.g. (1, 9) at 9×20 /
- * 93 entities vs library (1, 8) at 8×5 / 17 entities), this view is the
- * fastest QA loop. classify_ref returning Balanced misses the sizing
- * problem; the eyeball doesn't.
+ * The "generated" side-panel was removed — `balancer_generate::generate`
+ * is a stub that only handles trivial cases, and the compose pipeline
+ * (the real generator) doesn't run in WASM. Browser users who want to see
+ * a constructed layout look at the library entry, which IS the output of
+ * compose for the shapes we've baked through it.
  *
  * URL state: `#/balancers?focus=n,m` highlights and scrolls to that
  * shape. Used for permalinks in code review / decision log entries.
@@ -159,10 +159,6 @@ function createCellSkeleton(
         <div class="bs-panel-caption">loading…</div>
         <div class="bs-panel-canvas"></div>
       </div>
-      <div class="bs-panel" data-side="generated">
-        <div class="bs-panel-caption">loading…</div>
-        <div class="bs-panel-canvas"></div>
-      </div>
     </div>
   `;
 
@@ -204,12 +200,11 @@ async function hydrate(
     const dom = cellMap.get(cellKey(cellData.n_inputs, cellData.n_outputs));
     if (!dom) continue;
 
-    fillPanel(offApp, dom, "library", cellData.library);
-    fillPanel(offApp, dom, "generated", cellData.generated);
+    fillPanel(offApp, dom, cellData.library);
 
     const summary = dom.querySelector(".bs-summary") as HTMLElement | null;
     if (summary) {
-      summary.innerHTML = comparisonSummary(cellData);
+      summary.innerHTML = sourceSummary(cellData);
     }
   }
 
@@ -222,11 +217,10 @@ async function hydrate(
 function fillPanel(
   offApp: Application,
   cellDom: HTMLElement,
-  side: "library" | "generated",
   template: BalancerShowcaseTemplate | null,
 ): void {
   const panel = cellDom.querySelector(
-    `.bs-panel[data-side="${side}"]`,
+    `.bs-panel[data-side="library"]`,
   ) as HTMLElement | null;
   if (!panel) return;
   const caption = panel.querySelector(".bs-panel-caption") as HTMLElement | null;
@@ -235,16 +229,21 @@ function fillPanel(
 
   if (!template) {
     panel.classList.add("bs-empty");
-    caption.textContent = side === "library"
-      ? "no library entry"
-      : "no compose entry";
+    caption.textContent = "no library entry";
     canvasHost.innerHTML = "";
     return;
   }
 
   const entityCount = template.entities.length;
+  const strategyLine = template.strategy
+    ? `<div class="bs-strategy">${escapeHtml(template.strategy)}</div>`
+    : "";
+  const referenceLine = template.reference
+    ? `<div class="bs-reference"><a href="${escapeHtml(template.reference)}" target="_blank" rel="noopener">ref</a></div>`
+    : "";
   caption.innerHTML = `
-    <div class="bs-source">${escapeHtml(template.source)}</div>
+    <div class="bs-source">${escapeHtml(template.source)}${referenceLine}</div>
+    ${strategyLine}
     <div class="bs-stats">
       ${template.n_inputs} → ${template.n_outputs} ·
       ${template.width}×${template.height} ·
@@ -329,27 +328,17 @@ function renderTemplateCanvas(
   return out;
 }
 
-function comparisonSummary(cell: BalancerShowcaseCell): string {
+function sourceSummary(cell: BalancerShowcaseCell): string {
   const lib = cell.library;
-  const gen = cell.generated;
-  if (lib && gen) {
-    const libE = lib.entities.length;
-    const genE = gen.entities.length;
-    if (libE === 0) return "library has 0 entities (?)";
-    const delta = genE - libE;
-    if (delta === 0) {
-      return `<span class="bs-eq">parity</span>`;
-    }
-    if (delta < 0) {
-      const pct = Math.round(100 * (-delta) / libE);
-      return `<span class="bs-win">compose −${-delta} (−${pct}%)</span>`;
-    }
-    const pct = Math.round(100 * delta / libE);
-    return `<span class="bs-lose">compose +${delta} (+${pct}%)</span>`;
-  }
-  if (lib && !gen) return `<span class="bs-only-lib">library only</span>`;
-  if (!lib && gen) return `<span class="bs-only-gen">compose only</span>`;
-  return `<span class="bs-none">no template</span>`;
+  if (!lib) return `<span class="bs-none">no template</span>`;
+  // Color-code by source so the grid scans visually.
+  const cls = (() => {
+    if (lib.source.startsWith("Raynquist")) return "bs-source-raynquist";
+    if (lib.source === "compose") return "bs-source-compose";
+    if (lib.source === "Factorio-SAT") return "bs-source-fsat";
+    return "bs-source-other";
+  })();
+  return `<span class="${cls}">${escapeHtml(lib.source)}</span>`;
 }
 
 function escapeHtml(s: string): string {
@@ -431,17 +420,16 @@ function injectStyles(): void {
       color: #f0f0f0;
       font-variant-numeric: tabular-nums;
     }
-    .bs-summary { color: #888; font-size: 11px; }
-    .bs-summary .bs-win { color: #4eb072; }
-    .bs-summary .bs-lose { color: #d35a5a; }
-    .bs-summary .bs-eq { color: #888; }
-    .bs-summary .bs-only-lib { color: #6a9ed8; }
-    .bs-summary .bs-only-gen { color: #d39a3a; }
-    .bs-summary .bs-none { color: #555; }
+    .bs-summary { color: #888; font-size: 11px; font-weight: 500; }
+    .bs-summary .bs-source-raynquist { color: #d39a3a; }
+    .bs-summary .bs-source-compose   { color: #4eb072; }
+    .bs-summary .bs-source-fsat      { color: #6a9ed8; }
+    .bs-summary .bs-source-other     { color: #aaa; }
+    .bs-summary .bs-none             { color: #555; }
 
     .bs-panels {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 1fr;
       gap: 6px;
     }
     .bs-panel {
@@ -467,10 +455,29 @@ function injectStyles(): void {
     .bs-panel-caption .bs-source {
       font-weight: 500;
       color: #d8d8d8;
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+    }
+    .bs-panel-caption .bs-strategy {
+      color: #888;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 9px;
+      margin-top: 2px;
+      word-break: break-word;
+    }
+    .bs-panel-caption .bs-reference a {
+      color: #6a9ed8;
+      text-decoration: none;
+      font-size: 9px;
+    }
+    .bs-panel-caption .bs-reference a:hover {
+      text-decoration: underline;
     }
     .bs-panel-caption .bs-stats {
       color: #888;
       font-variant-numeric: tabular-nums;
+      margin-top: 2px;
     }
     .bs-panel-caption strong {
       color: #d8d8d8;


### PR DESCRIPTION
Two threads bundled:

## 1. Phase 2C — UG-correctness constraints in Mode D (commit `6bdf72e`)

Ports the four UG-correctness constraints from `solve_pure_routing` to `solve_synth_place` (Mode D), per the scope laid out in `docs/rfp-ug-sideload-prevention.md`. Mode D is now sideload-free for any topology — including prime-merger atoms (e.g. (5, 1)) that the compose pipeline can't decompose.

Constraints:
1. Same-edge belt → UG-input sideload (~12 LOC)
2. InputPort src-cell direction (~15 LOC, reified via `input_at[(i, cx)]`)
3. Chained UG sideload — vacuous in Mode D (all UGs face south)
4. UG-output head-on collision (~14 LOC)

Plus two latent bugs fixed: `ug_max_reach_param` was undefined in `solve_synth_place` (commit `5781676` missed it), and an `ox`/`oy` shadowing in constraint 4. Both surfaced when running Phase 2C verification.

`FUCKTORIO_MODE_D_ONLY` env var added to skip the spike's earlier failing phases for direct Mode D testing.

Verification: 7 shapes pass OPTIMAL with new constraints, including (4, 4) (10 UGs, exercises the constraints) and (5, 1) (first prime-atom Mode D round-trip).

## 2. Showcase provenance metadata (commit `5385460`)

Track where each library entry came from. `balancer_library::template_provenance(shape) -> TemplateProvenance` returns:
- `source` — `"Raynquist (TU)"` / `"compose"` / `"Factorio-SAT"`
- `strategy` — recipe descriptor for compose-baked entries (e.g. `"Lib(7, 1) → Lib(1, 2)"`)
- `reference` — Factoriobin URL for Raynquist's imports

Wired through to the `#/balancers` showcase: source label color-coded (orange for Raynquist, green for compose, blue for Factorio-SAT), strategy in monospace below, reference link as a compact "ref" pill.

Also removed the unused right-hand "generated" panel from the showcase. It called `balancer_generate::generate` which is a stub that returned `None` for ~90% of shapes; the compose pipeline can't run in WASM so the panel was empty for everything interesting. Single-panel layout is now standard.

Currently labelled:
- 5 Raynquist imports: (1, 9), (5, 1), (5, 2), (5, 3), (5, 4) — each with the Factoriobin reference.
- 18 compose-baked re-bakes (1,10), (2,9), (3,2), (3,9), (6,1), (6,2), (7,2), (7,3), (8,1), (8,2), (8,6), (9,1)..(9,6), (10,1) — each with its specific compose recipe shown.
- All other shapes default to "Factorio-SAT".

## Verification (combined)

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — **594 pass**, 30 ignored.
- [x] `cargo clippy --lib` clean.
- [x] `npx tsc --noEmit` (web) clean.
- [x] `wasm-pack build` succeeds.
- [x] `FUCKTORIO_MODE_D_ONLY=1 ./target/release/balancer-gen` — 7 Mode D shapes solve OPTIMAL including (5, 1).

## Notes

- Use **merge commit, not squash** — keeps the two commits separate so the Mode D constraints and showcase work stay distinguishable in history.
- Followups: `solve_synth_place_dirs` direction-freedom port (Phase 2C.2) — tracked in the RFP. Constructive primitives (`tree_merger`, `tree_fanout`) for atom-level graph generation — discussed in conversation, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)