### PR TITLE
balancer-gen: loosen Mode D class gate to ≥ TBR + overnight bench

### DIFF
--- a/crates/balancer-gen/src/main.rs
+++ b/crates/balancer-gen/src/main.rs
@@ -161,28 +161,66 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("=== phase 3.4: bake missing shapes ===");
         return bake_missing_shapes();
     }
-    if std::env::var("FUCKTORIO_MODE_D_ONLY").is_ok() {
+    if let Ok(mode_d_value) = std::env::var("FUCKTORIO_MODE_D_ONLY") {
         // Fast path: skip phases 3.1, 3.2 (round-trips), 3.2A/B/C
         // (flow-conservation routing) and run only phase 3.2D (Mode D
         // synth-place). Used to validate Mode D constraints in
         // isolation without paying for the upstream spike phases.
+        //
+        // Value formats:
+        //   - "1" / unset-but-present: run a curated set of small shapes.
+        //   - "all": run every shape currently in `balancer_templates()`.
+        //   - "(n,m);(n2,m2);...": run only the listed shapes.
         println!("=== Mode D-only: skipping earlier spike phases ===");
-        let mode_d_shapes: &[(&str, (u32, u32))] = &[
-            ("(1, 2)", (1, 2)),
-            ("(2, 2)", (2, 2)),
-            ("(2, 4)", (2, 4)),
-            ("(1, 4)", (1, 4)),
-            ("(4, 4)", (4, 4)),
-            ("(1, 8)", (1, 8)),
-            // Round-trip Raynquist's (5, 1) topology through Mode D.
-            // Mode D re-places an existing topology; if our UG-correctness
-            // constraints prevent a feasible layout for a topology that
-            // *should* be feasible (Raynquist proved feasibility by hand),
-            // that's a sign the constraints over-restrict.
-            ("(5, 1)", (5, 1)),
+
+        let curated: Vec<(String, (u32, u32))> = vec![
+            ("(1, 2)".into(), (1, 2)),
+            ("(2, 2)".into(), (2, 2)),
+            ("(2, 4)".into(), (2, 4)),
+            ("(1, 4)".into(), (1, 4)),
+            ("(4, 4)".into(), (4, 4)),
+            ("(1, 8)".into(), (1, 8)),
+            ("(5, 1)".into(), (5, 1)),
         ];
-        for &(label, shape) in mode_d_shapes {
-            match spike_synth_place(label, shape, None) {
+
+        let shapes: Vec<(String, (u32, u32))> = match mode_d_value.as_str() {
+            "" | "1" => curated,
+            "all" => {
+                let mut shapes: Vec<(u32, u32)> =
+                    balancer_templates().keys().copied().collect();
+                shapes.sort();
+                shapes
+                    .into_iter()
+                    .map(|s| (format!("({}, {})", s.0, s.1), s))
+                    .collect()
+            }
+            spec => spec
+                .split(';')
+                .filter_map(|tok| {
+                    let nums: Vec<u32> = tok
+                        .trim_matches(|c: char| !c.is_ascii_digit())
+                        .split(|c: char| !c.is_ascii_digit())
+                        .filter(|p| !p.is_empty())
+                        .filter_map(|p| p.parse().ok())
+                        .collect();
+                    if nums.len() == 2 {
+                        Some((format!("({}, {})", nums[0], nums[1]), (nums[0], nums[1])))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        };
+
+        if shapes.is_empty() {
+            return Err(format!(
+                "FUCKTORIO_MODE_D_ONLY={mode_d_value:?} parsed to zero shapes"
+            )
+            .into());
+        }
+
+        for (label, shape) in &shapes {
+            match spike_synth_place(label, *shape, None) {
                 Ok(()) => {}
                 Err(e) => println!("  ✗ {label}: {e}"),
             }
@@ -825,8 +863,18 @@ fn spike_synth_place(
         Some(_) => " [4-dir]",
         None => "",
     };
+    // Optional bbox slack: expand width and height by N (each) so Mode D
+    // has more room. Used by `scripts/overnight_mode_d_bench.sh` to retry
+    // after an INFEASIBLE at library bbox. Library entries (especially
+    // Factorio-SAT-generated ones) are often very tight; Mode D's
+    // current encoding may need 1-2 cells of slack to find a placement.
+    let slack: u32 = std::env::var("FUCKTORIO_MODE_D_BBOX_SLACK")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let bounds = (lib.width + slack, lib.height + slack);
     let req = PlaceRequest::SynthPlace {
-        bounds: (lib.width, lib.height),
+        bounds,
         n_inputs: shape.0,
         n_outputs: shape.1,
         n_splitters: topology.n_splitters,
@@ -835,10 +883,15 @@ fn spike_synth_place(
         max_time_s: None,
     };
 
+    let slack_suffix = if slack > 0 {
+        format!(" [+{slack} slack]")
+    } else {
+        String::new()
+    };
     println!(
-        "\n--- {label}{label_suffix} ---  bbox: {}×{}  splitters: {}  edges: {}",
-        lib.width,
-        lib.height,
+        "\n--- {label}{label_suffix}{slack_suffix} ---  bbox: {}×{}  splitters: {}  edges: {}",
+        bounds.0,
+        bounds.1,
         topology.n_splitters,
         topology.edges.len()
     );
@@ -899,20 +952,39 @@ fn spike_synth_place(
         .map_err(|e| format!("{label}: classify_ref on synth-placed template: {e:?}"))?;
     let original = classify_ref(BalancerTemplateRef::from(lib))
         .map_err(|e| format!("{label}: classify original library template: {e:?}"))?;
-    if class_report.class != original.class {
+    // Bus minimum is MX2a (ThroughputBalancedRate). Library entries are typically MX3
+    // because the seed corpus was Raynquist-derived, but Mode D's CP-SAT model only
+    // enforces saturated rate balance — accepting any class at or above the bus
+    // requirement avoids rejecting correct-for-bus solutions purely on composition.
+    if !class_acceptable_for_bus(class_report.class) {
         return Err(format!(
-            "{label}: synth-placed class {:?} differs from library class {:?}",
+            "{label}: synth-placed class {:?} is below bus minimum (TBR or stronger required); library was {:?}",
             class_report.class, original.class
         )
         .into());
     }
+    let comparison = if class_report.class == original.class {
+        "matches library".to_string()
+    } else {
+        format!("library was {:?}, accepted as ≥ TBR", original.class)
+    };
     println!(
-        "  ✓ {label}: classified {:?} (matches library); IO {:?}→{:?}",
-        class_report.class,
-        resp.input_port_tiles,
-        resp.output_port_tiles,
+        "  ✓ {label}: classified {:?} ({comparison}); IO {:?}→{:?}",
+        class_report.class, resp.input_port_tiles, resp.output_port_tiles,
     );
     Ok(())
+}
+
+/// MX2a (saturated + balanced rate) is the minimum class needed for fucktorio's
+/// homogeneous-row bus. MX2b and MX3 are stronger and also acceptable. MX1 is
+/// not — outputs may starve.
+fn class_acceptable_for_bus(class: BalancerClass) -> bool {
+    matches!(
+        class,
+        BalancerClass::ThroughputBalancedRate
+            | BalancerClass::ThroughputUnlimited
+            | BalancerClass::Balanced
+    )
 }
 
 fn assemble_template_from_routing(

--- a/scripts/overnight_mode_d_bench.sh
+++ b/scripts/overnight_mode_d_bench.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Conservative overnight Mode D bench.
+#
+# For each (n, m) library shape, attempts to re-place its topology
+# through Mode D and records the result. Designed to run unattended
+# overnight on a memory-constrained box (~20 GB RAM in WSL) without
+# risking OOM that would take WSL down.
+#
+# Three layers of protection:
+#
+#   1. **Per-process address-space cap** via `prlimit --as=<bytes>`. If a
+#      single solve exceeds the cap, the kernel kills *only that process*
+#      with a clean error — host stays up.
+#   2. **Pre-flight memory check** before each shape. If `MemAvailable`
+#      drops below the floor, abort the whole run cleanly. Better to
+#      stop early than crash mid-shape.
+#   3. **Sequential** — never run two CP-SAT processes in parallel.
+#      Even at low memory each can blow up; no concurrency = predictable
+#      footprint.
+#
+# Plus `nice -n 19` and `ionice -c idle` so the host stays interactive
+# (keyboard/mouse responsiveness, browser tabs, etc.) even if a solve
+# is going hard. These don't help with memory but they help with the
+# system feeling alive.
+#
+# Resumable: if killed mid-run, re-running skips shapes already in the
+# log file. Worst case the in-flight shape gets retried.
+#
+# Usage:
+#   scripts/overnight_mode_d_bench.sh                        # all library shapes
+#   scripts/overnight_mode_d_bench.sh '(5,1);(7,1);(11,1)'   # specific shapes
+#
+# Output: TSV log at /tmp/mode_d_overnight_<timestamp>.tsv with columns
+#   shape  status  splitters  belts  ugs  solve_s  wall_s  notes
+#
+# Tunables (override via env):
+#   PER_PROCESS_MEM_GB   per-process address-space cap (default 4)
+#   MIN_FREE_GB          abort floor — if MemAvailable drops below, stop (default 4)
+#   PER_SHAPE_TIMEOUT_S  per-shape wall-time limit (default 300)
+#   LOG                  output TSV path (default /tmp/mode_d_overnight_<ts>.tsv)
+
+set -uo pipefail
+
+# Tunables (overridable via env)
+MIN_FREE_GB=${MIN_FREE_GB:-6}              # abort floor — 6GB host headroom by default
+PER_PROC_CAP_GB=${PER_PROC_CAP_GB:-14}     # prlimit --as for the one running process
+PER_SHAPE_TIMEOUT_S=${PER_SHAPE_TIMEOUT_S:-300}
+RETRY_SLACK=${RETRY_SLACK:-2}              # bbox slack to retry with on INFEASIBLE (0 disables)
+LOG=${LOG:-/tmp/mode_d_overnight_$(date +%Y%m%d_%H%M%S).tsv}
+
+MIN_FREE_KB=$((MIN_FREE_GB * 1024 * 1024))
+
+# We run sequentially, one process at a time. With ~20GB available on the
+# host, a flat ~14GB cap on virtual address space gives Python+ortools+CP-SAT
+# room to start (the prior 2GB tier killed Python at startup) while still
+# leaving enough host headroom that a runaway process can't take WSL down.
+# Cap is on virtual size (--as), not RSS — actual memory used is typically
+# a fraction of this.
+
+BIN="./target/release/balancer-gen"
+if [[ ! -x "$BIN" ]]; then
+    echo "ERROR: $BIN not found. Build first:" >&2
+    echo "  cargo build --release -p balancer-gen" >&2
+    exit 1
+fi
+
+# Determine shape list. Either from arg ((n,m);(n,m);...) or "all" via
+# the binary's curated query.
+shapes_arg=${1:-"all"}
+
+if [[ "$shapes_arg" == "all" ]]; then
+    # Pull library shapes via a one-shot Mode D query that returns
+    # immediately; we just need the side-effect listing. Easier: do
+    # the loop in shell over the whole grid and let the binary skip
+    # missing entries.
+    shape_list=()
+    for n in {1..10}; do
+        for m in {1..10}; do
+            shape_list+=("($n,$m)")
+        done
+    done
+else
+    IFS=';' read -ra shape_list <<< "$shapes_arg"
+fi
+
+# Resumability: if LOG exists, parse it for shapes already done.
+declare -A done_shapes=()
+if [[ -f "$LOG" ]]; then
+    while IFS=$'\t' read -r shape _; do
+        [[ "$shape" == "shape" ]] && continue
+        done_shapes["$shape"]=1
+    done < "$LOG"
+    echo "Resuming: ${#done_shapes[@]} shape(s) already in $LOG"
+else
+    printf 'shape\tstatus\tsplitters\tbelts\tugs\tsolve_s\twall_s\tnotes\n' > "$LOG"
+fi
+
+# Run Mode D for one shape at one slack level, with cap and timeout.
+# Echoes the raw spike output to stdout. Caller parses.
+run_mode_d_attempt() {
+    local shape=$1 slack=$2 cap_gb=$3 timeout_s=$4
+    local cap_bytes=$((cap_gb * 1024 * 1024 * 1024))
+    FUCKTORIO_MODE_D_ONLY="$shape" \
+    FUCKTORIO_MODE_D_BBOX_SLACK="$slack" \
+    nice -n 19 ionice -c idle \
+    prlimit --as="$cap_bytes" \
+    timeout "$timeout_s" \
+    "$BIN" 2>&1
+}
+
+echo "Mode D overnight bench"
+echo "  log:                $LOG"
+echo "  shape count:        ${#shape_list[@]}"
+echo "  per-process cap:    ${PER_PROC_CAP_GB}GB virtual (sequential, one at a time)"
+echo "  min-free floor:     ${MIN_FREE_GB}GB"
+echo "  per-shape timeout:  ${PER_SHAPE_TIMEOUT_S}s (×$((1 + RETRY_SLACK > 0 ? 1 : 0)) attempts on INFEASIBLE)"
+echo "  retry slack:        ${RETRY_SLACK} cells (0 disables retry)"
+echo
+
+start_time=$(date +%s)
+
+for shape in "${shape_list[@]}"; do
+    # Skip already-done.
+    if [[ -n "${done_shapes[$shape]:-}" ]]; then
+        continue
+    fi
+
+    # Pre-flight: abort if we're below the memory floor.
+    avail_kb=$(awk '/MemAvailable/ { print $2 }' /proc/meminfo)
+    if [[ $avail_kb -lt $MIN_FREE_KB ]]; then
+        avail_gb=$((avail_kb / 1024 / 1024))
+        echo "ABORT: only ${avail_gb}GB available, need ${MIN_FREE_GB}GB. Stopping cleanly." >&2
+        printf '%s\tABORT\t\t\t\t\t\tlow_memory(%dGB)\n' \
+            "$shape" "$avail_gb" >> "$LOG"
+        break
+    fi
+
+    cap_gb=$PER_PROC_CAP_GB
+    echo "=== $shape (cap=${cap_gb}GB, avail: $((avail_kb/1024/1024))GB) ==="
+    t0=$(date +%s)
+
+    # First attempt at slack=0 (library bbox).
+    out=$(run_mode_d_attempt "$shape" 0 "$cap_gb" "$PER_SHAPE_TIMEOUT_S") || true
+    used_slack=0
+
+    # Retry with bbox slack if first attempt was INFEASIBLE.
+    if (( RETRY_SLACK > 0 )) && echo "$out" | grep -q 'INFEASIBLE'; then
+        echo "  → INFEASIBLE at library bbox, retrying with +${RETRY_SLACK} slack..."
+        # Re-check memory before retry (slack solves use more).
+        avail_kb_retry=$(awk '/MemAvailable/ { print $2 }' /proc/meminfo)
+        if [[ $avail_kb_retry -lt $MIN_FREE_KB ]]; then
+            echo "  skip retry: low memory ($((avail_kb_retry/1024/1024))GB)" >&2
+        else
+            out=$(run_mode_d_attempt "$shape" "$RETRY_SLACK" "$cap_gb" "$PER_SHAPE_TIMEOUT_S") || true
+            used_slack=$RETRY_SLACK
+        fi
+    fi
+
+    wall=$(($(date +%s) - t0))
+
+    # Parse result. The spike prints lines like:
+    #   --- (2, 2) ---  bbox: 2×3  splitters: 1  edges: 4
+    #     synth-place: status=OPTIMAL elapsed=0.007s splitters=1 belts=4 ugs=0
+    #     ✓ (2, 2): classified Balanced ...
+    # On failure (timeout, OOM, infeasible), various error patterns.
+    status=$(echo "$out" | grep -oP 'status=\K\w+' | head -1)
+    splitters=$(echo "$out" | grep -oP 'synth-place: status=\w+ elapsed=[0-9.]+s splitters=\K\d+' | head -1)
+    belts=$(echo "$out" | grep -oP 'belts=\K\d+' | head -1)
+    ugs=$(echo "$out" | grep -oP 'ugs=\K\d+' | head -1)
+    solve_s=$(echo "$out" | grep -oP 'elapsed=\K[0-9.]+(?=s)' | head -1)
+
+    notes=""
+    if [[ -z "$status" ]]; then
+        # No "status=..." line — fall back to error-pattern matching.
+        if echo "$out" | grep -q 'INFEASIBLE'; then
+            status="INFEASIBLE"
+            # Capture extra context — usually the bbox where the solver
+            # gave up. Keep short for TSV cleanliness.
+            ctx=$(echo "$out" | grep -oP 'bbox: \K[0-9]+×[0-9]+' | head -1)
+            notes="bbox=${ctx:-?}_at_library_dims"
+        elif echo "$out" | grep -qE 'process killed by signal|Cannot allocate|MemoryError|OOM'; then
+            status="KILLED"
+            notes="oom_or_signal"
+        elif [[ $wall -ge $PER_SHAPE_TIMEOUT_S ]]; then
+            status="TIMEOUT"
+            notes="${PER_SHAPE_TIMEOUT_S}s_wall"
+        else
+            status="ERROR"
+            # Capture last error line for diagnosis. Strip newlines, keep
+            # short. The leading `✗` marks spike-side failure summaries.
+            err=$(echo "$out" | grep -oP '✗ \([^)]+\): \K[^\n]{1,120}' | head -1 \
+                | tr '\t\n' '  ' | sed 's/[[:space:]]\+/ /g')
+            notes="${err:-unknown}"
+        fi
+    fi
+
+    # Tag notes with slack level when retry was used.
+    if (( used_slack > 0 )); then
+        if [[ -n "$notes" ]]; then
+            notes="$notes; slack=+${used_slack}"
+        else
+            notes="slack=+${used_slack}"
+        fi
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$shape" "$status" "${splitters:-}" "${belts:-}" "${ugs:-}" \
+        "${solve_s:-}" "$wall" "$notes" >> "$LOG"
+
+    slack_msg=""
+    if (( used_slack > 0 )); then
+        slack_msg=" (slack=+$used_slack)"
+    fi
+    echo "  → $status  splitters=${splitters:-?}  belts=${belts:-?}  ugs=${ugs:-?}  ${wall}s${slack_msg}"
+done
+
+elapsed=$(($(date +%s) - start_time))
+echo
+echo "=== done in ${elapsed}s ==="
+echo "Summary by status:"
+tail -n +2 "$LOG" | awk -F'\t' '{ print $2 }' | sort | uniq -c | sort -rn
+echo
+echo "Full log: $LOG"


### PR DESCRIPTION
## Summary

- **Loosen Mode D class gate**: accept any class ≥ `ThroughputBalancedRate` (MX2a) instead of requiring strict equality with the library entry. MX2a is documented as the project's actual bus requirement (`balancer_classify.rs:60-61`); the strict-equality gate was rejecting Mode D solutions that were correct for the bus but happened to produce MX2a topologies where Raynquist-seeded library entries are MX3.
- **Add `scripts/overnight_mode_d_bench.sh`**: sequential, low-priority harness for characterising Mode D's coverage across the whole library. Uses a flat 14GB virtual-memory cap (the prior tiered scheme killed Python at startup at 2GB) with a 6GB host-headroom floor and `nice -n 19 ionice -c idle` to keep WSL responsive.

## Mode D capability picture (post-gate)

Of the 11 shapes that previously failed exit-127 (class mismatch), **6 now produce OPTIMAL TBR templates**: `(1,7), (2,5), (2,6), (2,7), (5,2), (8,1)`. The remaining 5 hit unrelated limits — bbox-INFEASIBLE on the library bbox, or the 30s solver-kill criterion in `main.rs:2059`. Those are real Mode D capability gaps, separate from this gate change.

The library audit (`crates/core/tests/balancer_tu_audit.rs`) already iterates the whole library and emits per-entry classification — sufficient visibility for keeping mixed-class entries auditable as Mode D contributes new ones with `source: "Mode D"` provenance (machinery added in #292).

## Test plan

- [x] `cargo test --manifest-path crates/core/Cargo.toml --release --test mode_d_baseline`
- [x] `cargo test --manifest-path crates/core/Cargo.toml --release --test balancer_tu_audit`
- [x] `cargo test --manifest-path crates/core/Cargo.toml --release --test balancer_cross_validation`
- [x] Re-ran the 11 previously-127 shapes through the harness; 6 flip to OPTIMAL, the other 5 fail for unrelated reasons (documented above).
- [ ] Full overnight bench across all 80 library shapes (will run after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)