### PR TITLE
fix(validate): keep warnings on the Err path (#298)

### DIFF
--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -104,9 +104,13 @@ impl ValidationIssue {
 
 /// Raised when critical validation issues block blueprint generation.
 ///
-/// Mirrors Python's `ValidationError` exception.
+/// `issues` contains the full list — both errors and warnings — so callers
+/// that want a complete picture (e.g. scoreboards) don't lose warning
+/// counts when an error is also present. The `Display` impl only renders
+/// the error subset to keep the "Validation failed" message focused on
+/// what actually blocked generation.
 #[derive(Debug, Error)]
-#[error("Validation failed:\n{}", format_issues(.issues))]
+#[error("Validation failed:\n{}", format_errors(.issues))]
 pub struct ValidationError {
     pub issues: Vec<ValidationIssue>,
 }
@@ -117,9 +121,10 @@ impl ValidationError {
     }
 }
 
-fn format_issues(issues: &[ValidationIssue]) -> String {
+fn format_errors(issues: &[ValidationIssue]) -> String {
     issues
         .iter()
+        .filter(|i| i.severity == Severity::Error)
         .map(|i| format!("  [{}] {}", i.severity.as_str(), i.message))
         .collect::<Vec<_>>()
         .join("\n")
@@ -341,13 +346,13 @@ pub fn validate(
         }).collect(),
     });
 
-    let errors: Vec<ValidationIssue> = issues
-        .iter()
-        .filter(|i| i.severity == Severity::Error)
-        .cloned()
-        .collect();
-    if !errors.is_empty() {
-        return Err(ValidationError::new(errors));
+    let any_errors = issues.iter().any(|i| i.severity == Severity::Error);
+    if any_errors {
+        // Pass the full issues list (errors + warnings) so callers that
+        // do `Err(e) => e.issues` keep an accurate picture. Without this,
+        // a single masking error silently dropped every warning produced
+        // in the same run (issue #298).
+        return Err(ValidationError::new(issues));
     }
 
     Ok(issues)
@@ -447,6 +452,32 @@ mod tests {
         let lr = layout_with_machine();
         let result = validate(&lr, None, LayoutStyle::Bus);
         assert!(result.is_err(), "expected errors for a machine with no belts");
+    }
+
+    #[test]
+    fn validation_error_carries_warnings_alongside_errors() {
+        // Regression test for #298: when both errors and warnings exist,
+        // the Err path used to drop the warnings, hiding pre-existing
+        // issues from any caller that checked `e.issues.len()`.
+        let issues = vec![
+            ValidationIssue::new(Severity::Error, "pipe-isolation", "fluids merged"),
+            ValidationIssue::new(Severity::Warning, "input-rate-delivery", "slow input"),
+            ValidationIssue::new(Severity::Warning, "belt-flow-reachability", "stranded furnace"),
+        ];
+        let err = ValidationError::new(issues);
+        assert_eq!(err.issues.len(), 3, "all issues must survive on Err path");
+        assert_eq!(
+            err.issues.iter().filter(|i| i.severity == Severity::Error).count(),
+            1
+        );
+        assert_eq!(
+            err.issues.iter().filter(|i| i.severity == Severity::Warning).count(),
+            2
+        );
+        // Display should still focus on errors only.
+        let msg = err.to_string();
+        assert!(msg.contains("fluids merged"), "error message must surface");
+        assert!(!msg.contains("slow input"), "warnings shouldn't pollute error message");
     }
 
     #[test]

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -3064,8 +3064,14 @@ fn stress_electronic_circuit_35s_from_ore() {
             // pre-fix). Same regime as 30/s but with more lanes; the
             // residual errors are orphaned output-merger belts that
             // the SAT zone fixes haven't reached.
+            //
+            // Warnings: 123 (88 belt-flow-reachability + 35 input-rate-
+            // delivery). These were hidden by the masking-error path in
+            // `validate()` until #298; the underlying issues have been
+            // present at this scoreboard for a long time. Tighten when
+            // the upstream layout-pipeline bugs (e.g. #297) get fixed.
             max_errors: 4,
-            max_warnings: 0,
+            max_warnings: 123,
             max_errors_by_category: [
                 ("belt-dead-end".to_string(), 4),
             ].into_iter().collect(),
@@ -3096,8 +3102,15 @@ fn stress_electronic_circuit_40s_from_ore() {
             // overlap pre-fix). The belt-junction + entity-overlap
             // categories are gone entirely; remaining errors are
             // orphaned output-merger belts.
+            //
+            // Warnings: 195 (25 belt-flow-path + 116 belt-flow-
+            // reachability + 54 input-rate-delivery). These were hidden
+            // by the masking-error path in `validate()` until #298. The
+            // underlying issues have been present at this scoreboard
+            // for a long time. Tighten when the upstream layout-pipeline
+            // bugs (e.g. #297) get fixed.
             max_errors: 13,
-            max_warnings: 0,
+            max_warnings: 195,
             max_errors_by_category: [
                 ("belt-dead-end".to_string(), 13),
             ].into_iter().collect(),


### PR DESCRIPTION
## Summary
`validate()` was filtering issues to errors-only when constructing `ValidationError`, dropping any warnings produced in the same run. Callers that did `Err(e) => e.issues` saw an incomplete picture — scoreboards undercounted warnings whenever a louder error was also present.

Closes #298.

## Why this matters
Caught while investigating #297. Production-science-pack started showing `WARN×42 belt-flow-reachability` after #296 fixed its belt-dead-end — but the warnings had been there all along, hidden by the masking error. Confirmed by instrumenting `bfs_belt_upstream` and reproducing the same `reaches_source: false` outcome on both sides of #296.

## Change
- `ValidationError` now holds the full issues list (errors + warnings) on the `Err` path.
- `Display` impl filters to errors only so the "Validation failed:" message stays focused on what actually blocked generation.
- New unit test `validation_error_carries_warnings_alongside_errors` pins both behaviours.

## Baseline updates

`stress_electronic_circuit_35s_from_ore` and `stress_electronic_circuit_40s_from_ore` had `max_warnings: 0` baselines. The reality, now visible:

| Test | Was | Now | Categories |
|---|---|---|---|
| 35s_from_ore | 0 | 123 | 88 belt-flow-reachability + 35 input-rate-delivery |
| 40s_from_ore | 0 | 195 | 25 belt-flow-path + 116 belt-flow-reachability + 54 input-rate-delivery |

These warnings reflect existing pipeline issues (#297 and adjacent — orphaned trunk lanes etc.), not new regressions. Documented in the baseline comments so future work can tighten the ceiling once the upstream layout bugs are fixed.

## Test plan
- [x] `cargo test --manifest-path crates/core/Cargo.toml` — all 595 tests pass.
- [x] Gauntlet re-run on clean cache — production-science correctly surfaces `WARN×42 belt-flow-reachability` (whereas pre-fix it would have been swallowed by any present error).
- [x] Spot-check via `git checkout d2ec8ad^` (pre-#296): with this fix applied, that state would now correctly report 1 error + 42 warnings instead of just 1 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)