### PR TITLE
docs+landing: sync README + showcase with current tier-4/5 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ How far up the recipe tree we can currently produce an error-free blueprint. Tes
 |    1 | `iron-gear-wheel`           | Solved                                               |
 |    2 | `electronic-circuit`        | Solved (including from ores)                         |
 |    3 | `plastic-bar`               | Solved                                               |
-|    4 | `advanced-circuit`          | Partial — lane-throughput + missing balancer shapes  |
-|    5 | `processing-unit`           | Not attempted                                        |
+|    4 | `advanced-circuit`          | Solved (AM2 + yellow from ores); from plates still has lane-throughput warnings |
+|    5 | `processing-unit`           | In progress — scoped regression tests passing        |
 |    6 | `rocket-control-unit`       | Not attempted                                        |
 
 CLAUDE.md has the detailed breakdown and links to open tracking issues.

--- a/web/src/ui/landing.ts
+++ b/web/src/ui/landing.ts
@@ -68,33 +68,49 @@ const SHOWCASE: ShowcaseEntry[] = [
     desc: "1 recipe, fluid + solid input",
   },
   {
-    label: "Advanced Circuit",
-    item: "advanced-circuit",
-    rate: 10,
-    inputs: ["iron-plate", "copper-plate", "plastic-bar"],
-    machine: "assembling-machine-2",
-    tier: 4,
-    status: "partial",
-    desc: "5+ recipes, mixed solid/fluid",
-  },
-  {
-    label: "Advanced Circuit (ores, T1)",
+    label: "Advanced Circuit (ores, AM2)",
     item: "advanced-circuit",
     rate: 5,
     inputs: [
-      "iron-plate",
-      "copper-plate",
       "coal",
       "water",
       "crude-oil",
       "iron-ore",
       "copper-ore",
     ],
-    machine: "assembling-machine-1",
+    machine: "assembling-machine-2",
     beltTier: "transport-belt",
     tier: 4,
+    status: "solved",
+    desc: "Full stack from raw ores, AM2 + yellow belts (0 errors / 0 warnings)",
+  },
+  {
+    label: "Advanced Circuit (from plates)",
+    item: "advanced-circuit",
+    rate: 10,
+    inputs: ["iron-plate", "copper-plate", "plastic-bar"],
+    machine: "assembling-machine-2",
+    tier: 4,
     status: "partial",
-    desc: "Full stack from raw ores, tier-1 machines + yellow belts",
+    desc: "5+ recipes, mixed solid/fluid — still has lane-throughput warnings",
+  },
+  {
+    label: "Processing Unit",
+    item: "processing-unit",
+    rate: 2,
+    inputs: [
+      "iron-ore",
+      "copper-ore",
+      "stone",
+      "coal",
+      "water",
+      "crude-oil",
+    ],
+    machine: "assembling-machine-3",
+    beltTier: "fast-transport-belt",
+    tier: 5,
+    status: "wip",
+    desc: "Deep chain, multiple fluids — scoped regression tests passing",
   },
 ];
 
@@ -503,7 +519,7 @@ export function renderLanding(
 
   const title = document.createElement("h1");
   title.className = "spaghettio-landing-title";
-  title.innerHTML = "Fuck<span>torio</span>";
+  title.innerHTML = "Spagh<span>ettio</span>";
   header.appendChild(title);
 
   const subtitle = document.createElement("p");


### PR DESCRIPTION
## Summary

Audit pass on the README and landing-page showcase — both had drifted from the e2e test reality.

**README** (`docs/file-reference.md`-backed claims):
- Tier 4 was "Partial — lane-throughput + missing balancer shapes", but `tier4_advanced_circuit_from_ore_am2` (AC@5/s, ores, AM2, yellow belts) is fully green with `assert_no_errors` + `assert_no_warnings`. Row now reflects "Solved (AM2 + yellow from ores); from plates still has lane-throughput warnings".
- Tier 5 was "Not attempted", but `crates/core/tests/e2e.rs` has `tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass`, `tier5_processing_unit_25s_horizontal_stack_pole_coverage`, `pipe_belt_processing_unit_1s_routes`, and stress harnesses. Row now says "In progress — scoped regression tests passing".

**Landing page** (`web/src/ui/landing.ts`):
- H1 still rendered "Fucktorio" — the `3c0dcfc` rebrand sed missed the literal `Fuck<span>torio</span>` because the word was split by an HTML tag. Fixed to "Spaghettio".
- Showcase had two tier-4 "partial" cards and was missing the flagship green tier-4 case. Now adds an "Advanced Circuit (ores, AM2)" `solved` card matching `tier4_advanced_circuit_from_ore_am2`, keeps the plate-based variant as an honest `partial`, drops the AM1 ores variant (demoed a worse config than what works), and adds a tier-5 processing-unit WIP placeholder so the ladder doesn't visually stop at tier 4.

## Out of scope (discussed, not done here)

Considered reframing the showcase around the 6 Nauvis science packs to match `crates/core/tests/science_gauntlet.rs`, but no doc/RFP/code reframe exists yet and `docs/file-reference.md:98` still describes the landing as "recipe-ladder cards". Left as a follow-up — would require running the gauntlet for current PASS/WARN/FAIL/PANIC status per pack before wiring it in.

## Test plan

- [ ] `cargo test --manifest-path crates/core/Cargo.toml` still green (no code changes, but the README claims are pinned to specific tests in the suite)
- [ ] Load `https://storkme.github.io/spaghettio/` after deploy and confirm the H1 reads "Spaghettio"
- [ ] Click the new "Advanced Circuit (ores, AM2)" card and confirm the modal renders the layout without errors
- [ ] Confirm the tier-5 card shows as WIP / non-clickable

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTdZ3P7vNoqrmdHPz9v6sW)_