### PR TITLE
Quality-aware pole-band thinning (#310 Phase 1)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,7 +11,7 @@ wasm = ["dep:tsify-next", "dep:wasm-bindgen"]
 base64 = "0.22"
 flate2 = "1"
 indexmap = { version = "2.13.1", features = ["serde"] }
-# LP backend for the net-flow solver (docs/rfp-solver-net-flow.md).
+# LP backend for the net-flow solver (docs/rfc-solver-net-flow.md).
 # Pure Rust, WASM-clean, deterministic pivoting. NOTE: LinearExpr panics on
 # duplicate variables in one constraint — coefficients must be netted per
 # (item, recipe) before insertion (see netflow.rs).

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -1189,6 +1189,150 @@ fn compute_extra_gaps(families: &[LaneFamily]) -> FxHashMap<usize, i32> {
     extra
 }
 
+/// rfp-pole-band-thinning (#310): depth slack a single band has after
+/// spanning from its candidate row to the OPPOSITE inserter row
+/// (`mh + 1` tiles away). Negative at Normal for every machine height
+/// (pole_range 3 < mh+1 ≥ 4) — the single-band gate (`budget >= 1`)
+/// is structurally unreachable at default quality (kill criterion 1).
+/// The floor-based `pole_range` is EXACT against the validator's
+/// continuous `3.5 + level` bound: center distances are integral and
+/// the bound's fraction is a fixed .5, so no rounding slop exists.
+fn single_band_depth_budget(mh: i32, pole_range: i32) -> i32 {
+    pole_range - (mh + 1)
+}
+
+/// The two per-row pole band candidate y-lists (north then south),
+/// each seeded from the shared `pole_candidate_ys` and searched
+/// outward AWAY from the machine so a saturated inserter/belt band is
+/// still covered from the first free row beyond it (Phase 0f).
+fn band_y_lists(top_y: i32, mh: i32, pole_range: i32) -> Vec<Vec<i32>> {
+    crate::common::pole_candidate_ys(top_y, mh)
+        .into_iter()
+        .map(|cy| {
+            let dir = if cy < top_y { -1 } else { 1 };
+            (0..=pole_range).map(|d| cy + dir * d).filter(|&y| y >= 0).collect()
+        })
+        .collect()
+}
+
+/// Place one band's pole line along `cxs` (machine-center columns,
+/// sorted). A 3×3 machine's inserters span cx−1..cx+1, so a pole in
+/// cx−2..cx+2 (rightmost-first, for forward reach) covers the machine's
+/// whole inserter footprint; if that window is full at every candidate
+/// y, a center-only fallback tile at cx±pole_range is tried. A placed
+/// pole credits (skip-ahead) every subsequent machine center within
+/// `pole_range` in x. A target with no free tile is skipped — the
+/// power validator flags the resulting gap (mop-up may still cover it).
+fn place_band_line(
+    band_ys: &[i32],
+    cxs: &[i32],
+    pole_range: i32,
+    occ: &FxHashSet<(i32, i32)>,
+    placed: &mut FxHashSet<(i32, i32)>,
+    entities: &mut Vec<PlacedEntity>,
+) {
+    let mut i = 0;
+    while i < cxs.len() {
+        let target_cx = cxs[i];
+        let mut placed_at: Option<(i32, i32)> = None;
+        'find: for &py in band_ys {
+            for px in (target_cx - 2..=target_cx + 2).rev() {
+                if !occ.contains(&(px, py)) && !placed.contains(&(px, py)) {
+                    placed_at = Some((px, py));
+                    break 'find;
+                }
+            }
+        }
+        if placed_at.is_none() {
+            'fallback: for &py in band_ys {
+                for px in [target_cx + pole_range, target_cx - pole_range] {
+                    if !occ.contains(&(px, py)) && !placed.contains(&(px, py)) {
+                        placed_at = Some((px, py));
+                        break 'fallback;
+                    }
+                }
+            }
+        }
+        match placed_at {
+            Some((px, py)) => {
+                entities.push(make_pole(px, py));
+                placed.insert((px, py));
+                i += 1;
+                while i < cxs.len() && (cxs[i] - px).abs() <= pole_range {
+                    i += 1;
+                }
+            }
+            None => {
+                i += 1;
+            }
+        }
+    }
+}
+
+/// Single-band mode's unified pass (rfp-pole-band-thinning v2): tries
+/// the truncated north window first, then the truncated south window —
+/// within the depth budget the two are coverage-INTERCHANGEABLE (a
+/// south pole at depth d covers the north inserter row by the same
+/// `mh+1+d ≤ pole_range` bound), so the skip-ahead credit is
+/// band-agnostic and cannot leak un-credited poles (review finding 3).
+/// Returns the DEGENERATE targets (no free tile in either truncated
+/// window); the caller retries those with today's full two-band
+/// placement — strictly no worse than unthinned, per target.
+fn place_unified_band_line(
+    north_ys: &[i32],
+    south_ys: &[i32],
+    cxs: &[i32],
+    pole_range: i32,
+    occ: &FxHashSet<(i32, i32)>,
+    placed: &mut FxHashSet<(i32, i32)>,
+    entities: &mut Vec<PlacedEntity>,
+) -> Vec<i32> {
+    let mut degenerate = Vec::new();
+    let mut i = 0;
+    while i < cxs.len() {
+        let target_cx = cxs[i];
+        let mut placed_at: Option<(i32, i32)> = None;
+        'find: for ys in [north_ys, south_ys] {
+            for &py in ys {
+                for px in (target_cx - 2..=target_cx + 2).rev() {
+                    if !occ.contains(&(px, py)) && !placed.contains(&(px, py)) {
+                        placed_at = Some((px, py));
+                        break 'find;
+                    }
+                }
+            }
+        }
+        if placed_at.is_none() {
+            'fallback: for ys in [north_ys, south_ys] {
+                for &py in ys {
+                    for px in [target_cx + pole_range, target_cx - pole_range] {
+                        if !occ.contains(&(px, py)) && !placed.contains(&(px, py)) {
+                            placed_at = Some((px, py));
+                            break 'fallback;
+                        }
+                    }
+                }
+            }
+        }
+        match placed_at {
+            Some((px, py)) => {
+                entities.push(make_pole(px, py));
+                placed.insert((px, py));
+                i += 1;
+                while i < cxs.len() && (cxs[i] - px).abs() <= pole_range {
+                    i += 1;
+                }
+            }
+            None => {
+                degenerate.push(target_cx);
+                i += 1;
+            }
+        }
+    }
+    degenerate
+}
+
+
 /// Place power poles for grid coverage. Runs LAST in `build_bus_layout`, after
 /// `route_bus_ghost` — poles live on leftover tiles and are never router
 /// obstacles (invariant restored in Phase 0f, `docs/rfc-power-supply.md`).
@@ -1337,92 +1481,49 @@ fn place_poles(
         let (top_y, mh) = key;
         let cxs = &by_row[&key];
 
-        // Phase 0f (RFC `docs/rfc-power-supply.md`): place a pole line in
-        // BOTH candidate bands, not just the preferred one. The north band
-        // (top_y-1) sits on the row's input-inserter row and covers the
-        // machine's north face; the south band (top_y+mh) sits on the
-        // output-inserter row and covers the machine's south face. A single
-        // band leaves the opposite inserter row at Chebyshev distance mh+1
-        // (=4 for a 3×3 machine — one tile past the ±3 supply area), which
-        // was the systemic uncovered-inserter signature Phase 0c measured
-        // (40-52% of electric inserters). Both inserter rows are now
-        // coverage subjects (validate/power.rs), so both bands must carry a
-        // line. Redundant machine-center coverage from the two lines is
-        // fine; `repair_pole_connectivity` still bridges the row cluster.
-        // Each band targets one inserter row and may place the pole up to
-        // pole_range tiles FURTHER from the machine than that row, so a
-        // saturated inserter/belt band (high-throughput rows fill every
-        // column of the input-inserter row and the belt rows above it) can
-        // still be covered from the first free row beyond it. Ordered from
-        // the inserter row outward: the near tile also covers the machine,
-        // and one of the two bands always lands close enough to keep the
-        // machine center in range.
-        // Seed each band from the shared `pole_candidate_ys` (the row Phase 1
-        // reserves gap tiles in) and search outward from it, AWAY from the
-        // machine — north band (candidate above the machine) upward past the
-        // belts, south band (below) downward — so a saturated inserter/belt
-        // band is still covered from the first free row beyond it.
-        let band_y_lists: Vec<Vec<i32>> = crate::common::pole_candidate_ys(top_y, mh)
-            .into_iter()
-            .map(|cy| {
-                let dir = if cy < top_y { -1 } else { 1 };
-                (0..=pole_range)
-                    .map(|d| cy + dir * d)
-                    .filter(|&y| y >= 0)
-                    .collect()
-            })
-            .collect();
-
-        for band_ys in &band_y_lists {
-            let mut i = 0;
-            while i < cxs.len() {
-                // A 3×3 machine's inserters span cx-1..cx+1, so a pole in
-                // cx-2..cx+2 (rightmost-first, for forward reach) covers the
-                // machine's whole inserter footprint. Try each candidate y
-                // (inserter row first), then the same y's with a center-only
-                // fallback tile (cx±pole_range) if the inserter-covering
-                // window is full. The old `cx + pole_range` alone left the
-                // machine's own left inserter at distance 4.
-                let target_cx = cxs[i];
-                let mut placed_at: Option<(i32, i32)> = None;
-                'find: for &py in band_ys {
-                    for px in (target_cx - 2..=target_cx + 2).rev() {
-                        if !occ.contains(&(px, py)) && !placed.contains(&(px, py)) {
-                            placed_at = Some((px, py));
-                            break 'find;
-                        }
-                    }
-                }
-                if placed_at.is_none() {
-                    'fallback: for &py in band_ys {
-                        for px in [target_cx + pole_range, target_cx - pole_range] {
-                            if !occ.contains(&(px, py)) && !placed.contains(&(px, py)) {
-                                placed_at = Some((px, py));
-                                break 'fallback;
-                            }
-                        }
-                    }
-                }
-
-                match placed_at {
-                    Some((px, py)) => {
-                        entities.push(make_pole(px, py));
-                        placed.insert((px, py));
-                        // Advance past every machine whose center this pole
-                        // still covers (Chebyshev, x only).
-                        i += 1;
-                        while i < cxs.len() && (cxs[i] - px).abs() <= pole_range {
-                            i += 1;
-                        }
-                    }
-                    None => {
-                        // No free tile covers cxs[i] in this band — skip to
-                        // avoid an infinite loop; the power validator flags
-                        // the resulting inserter/machine coverage gap.
-                        i += 1;
-                    }
+        // Phase 0f (RFC `docs/rfc-power-supply.md`): by default place a pole
+        // line in BOTH candidate bands. The north band (top_y-1) sits on the
+        // row's input-inserter row; the south band (top_y+mh) on the
+        // output-inserter row. At Normal radius a single band leaves the
+        // opposite inserter row at Chebyshev distance mh+1 (= 4 for a 3×3
+        // machine — one past ±3), the systemic uncovered-inserter signature
+        // Phase 0c measured. Both inserter rows are coverage subjects
+        // (validate/power.rs), so both bands carry a line — EXCEPT when the
+        // quality radius makes one band sufficient:
+        //
+        // rfc-043-pole-band-thinning (#310) v2: when
+        // `single_band_depth_budget(mh, pole_range) >= 1`, one unified band
+        // covers both inserter rows AND the machine center
+        // (mh/2 + 0.5 < mh + 1). The gate is ≥1, not ≥0: fluid msz=3
+        // templates fully pack the north candidate row at d=0, and the
+        // ≥1 tiers' wire reach clears every row pitch with margin
+        // (adversarial-review findings 3/4/5). Qualification: mh=3 at
+        // Rare+, mh=4 at Epic+, mh=5 at Legendary; never at Normal or
+        // Uncommon (kill criterion 1 is structural).
+        let budget = single_band_depth_budget(mh, pole_range);
+        if budget >= 1 {
+            let north_ys: Vec<i32> =
+                (0..=budget).map(|d| (top_y - 1) - d).filter(|&y| y >= 0).collect();
+            let south_ys: Vec<i32> = (0..=budget).map(|d| (top_y + mh) + d).collect();
+            let degenerate = place_unified_band_line(
+                &north_ys,
+                &south_ys,
+                cxs,
+                pole_range,
+                &occ,
+                &mut placed,
+                &mut entities,
+            );
+            if !degenerate.is_empty() {
+                for band_ys in band_y_lists(top_y, mh, pole_range) {
+                    place_band_line(&band_ys, &degenerate, pole_range, &occ, &mut placed, &mut entities);
                 }
             }
+            continue;
+        }
+
+        for band_ys in band_y_lists(top_y, mh, pole_range) {
+            place_band_line(&band_ys, cxs, pole_range, &occ, &mut placed, &mut entities);
         }
     }
 
@@ -2008,6 +2109,83 @@ mod tests {
             0,
             "after repair the emitted wire graph must be one connected component"
         );
+    }
+
+    /// rfc-043-pole-band-thinning kill criterion 1: the single-band gate is
+    /// STRUCTURALLY unreachable at Normal and Uncommon, and activates
+    /// exactly per the v2 table — mh=3 at Rare+, mh=4 at Epic+, mh=5 at
+    /// Legendary only. Budget is computed from the same floor'd
+    /// pole_range `place_poles` uses; the floor is exact against the
+    /// validator's continuous `.5`-fraction bound (review finding 1).
+    #[test]
+    fn single_band_gate_table_per_mh_and_tier() {
+        use crate::common::QualityTier;
+        for tier in QualityTier::ALL {
+            let pole_range =
+                crate::common::supply_area_distance("medium-electric-pole", tier).floor() as i32;
+            for mh in [3, 4, 5] {
+                let budget = single_band_depth_budget(mh, pole_range);
+                let thins = budget >= 1;
+                let expected = match (mh, tier) {
+                    (_, QualityTier::Normal) | (_, QualityTier::Uncommon) => false,
+                    (3, t) => t >= QualityTier::Rare,
+                    (4, t) => t >= QualityTier::Epic,
+                    (5, t) => t == QualityTier::Legendary,
+                    _ => unreachable!(),
+                };
+                assert_eq!(thins, expected, "mh={mh} {tier:?} budget={budget}");
+                if tier == QualityTier::Normal {
+                    assert!(budget < 0, "Normal budget must be negative (mh={mh})");
+                }
+            }
+        }
+    }
+
+    /// rfc-043-pole-band-thinning: a qualifying tier emits ONE band per row
+    /// where Normal emits two, and the thinned field still covers both
+    /// inserter rows under the validator's own per-entity quality walk.
+    #[test]
+    fn single_band_mode_halves_row_bands_and_stays_covered() {
+        use crate::common::QualityTier;
+        let machines = [(5, 10, 3), (12, 10, 3)];
+        let occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+
+        let (normal_poles, _) =
+            place_poles(&machines, &[], &occupied, &[], QualityTier::Normal);
+        let (rare_poles, _) = place_poles(&machines, &[], &occupied, &[], QualityTier::Rare);
+
+        // Normal: two bands (y=9 and y=13). Rare (budget 1): one unified
+        // band, north-first → all poles on y ∈ {9, 8}.
+        let normal_ys: FxHashSet<i32> = normal_poles.iter().map(|e| e.y).collect();
+        assert!(normal_ys.contains(&9) && normal_ys.contains(&13), "{normal_ys:?}");
+        let rare_ys: FxHashSet<i32> = rare_poles.iter().map(|e| e.y).collect();
+        assert!(
+            rare_ys.iter().all(|&y| y == 9 || y == 8),
+            "rare must be single-band north: {rare_ys:?}"
+        );
+        assert!(rare_poles.len() < normal_poles.len());
+
+        // The thinned field must cover BOTH inserter rows (y=9 north,
+        // y=13 south) for both machines under the validator's exact
+        // continuous check, at the tier the poles will be stamped with.
+        let mut lr = crate::models::LayoutResult::default();
+        lr.entities = rare_poles;
+        for e in &mut lr.entities {
+            e.quality = Some(QualityTier::Rare);
+        }
+        for &(cx, iy) in &[(5, 9), (5, 13), (12, 9), (12, 13)] {
+            let mut ins = crate::models::PlacedEntity {
+                name: "inserter".to_string(),
+                x: cx,
+                y: iy,
+                quality: Some(QualityTier::Rare),
+                ..Default::default()
+            };
+            ins.direction = crate::models::EntityDirection::North;
+            lr.entities.push(ins);
+        }
+        let issues = crate::validate::power::check_power_coverage(&lr);
+        assert!(issues.is_empty(), "thinned Rare field must cover both inserter rows: {issues:?}");
     }
 
     /// Phase 2 adversarial-review regression (rfc-build-quality decision

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -1189,7 +1189,7 @@ fn compute_extra_gaps(families: &[LaneFamily]) -> FxHashMap<usize, i32> {
     extra
 }
 
-/// rfp-pole-band-thinning (#310): depth slack a single band has after
+/// rfc-043-pole-band-thinning (#310): depth slack a single band has after
 /// spanning from its candidate row to the OPPOSITE inserter row
 /// (`mh + 1` tiles away). Negative at Normal for every machine height
 /// (pole_range 3 < mh+1 ≥ 4) — the single-band gate (`budget >= 1`)
@@ -1269,7 +1269,7 @@ fn place_band_line(
     }
 }
 
-/// Single-band mode's unified pass (rfp-pole-band-thinning v2): tries
+/// Single-band mode's unified pass (rfc-043-pole-band-thinning v2): tries
 /// the truncated north window first, then the truncated south window —
 /// within the depth budget the two are coverage-INTERCHANGEABLE (a
 /// south pole at depth d covers the north inserter row by the same
@@ -1947,7 +1947,7 @@ mod tests {
         );
     }
 
-    /// Band-adequacy invariant (issue #315, `docs/rfp-build-quality.md`):
+    /// Band-adequacy invariant (issue #315, `docs/rfc-build-quality.md`):
     /// `compute_substation_bands`'s `SUBSTATION_BAND_TILES` geometry is tuned
     /// at Normal-tier reach — a fixed row-count constant that never changes
     /// with quality. What DOES change is the covering pole's own supply

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -7157,7 +7157,7 @@ fn quality_ec_45s_express_legendary_from_ore() {
         "expected at most the single known input-rate-delivery residual, got {issues:?}"
     );
 
-    // rfp-pole-band-thinning kill criterion 2 pin: single-band mode at
+    // rfc-043-pole-band-thinning kill criterion 2 pin: single-band mode at
     // Legendary (budget 4) — 30 medium poles vs 60 unthinned (50%
     // reduction; census 2026-07-20). Exact pin so any placement change
     // renegotiates the number consciously.
@@ -7183,7 +7183,7 @@ fn quality_ec_45s_express_legendary_from_ore() {
 /// assembling-machine-3, input uranium-238, excluding uranium-processing so
 /// the solver has no choice but the self-loop recipe, belt tier unset) run
 /// at Normal vs Legendary. This is the one corpus case where the Phase 3b
-/// top-edge substation fallback fires (`docs/rfp-power-reservation.md`): at
+/// top-edge substation fallback fires (`docs/rfc-power-reservation.md`): at
 /// Normal a substation covers the 5-row-deep recirc inserter bank because no
 /// medium pole's ±3 reaches that far. Both tiers assert 0 errors; the
 /// hand-derived machine-count ratio (Normal 6 centrifuges ÷ 2.5 = Legendary

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -7157,6 +7157,17 @@ fn quality_ec_45s_express_legendary_from_ore() {
         "expected at most the single known input-rate-delivery residual, got {issues:?}"
     );
 
+    // rfp-pole-band-thinning kill criterion 2 pin: single-band mode at
+    // Legendary (budget 4) — 30 medium poles vs 60 unthinned (50%
+    // reduction; census 2026-07-20). Exact pin so any placement change
+    // renegotiates the number consciously.
+    let poles = layout_result
+        .entities
+        .iter()
+        .filter(|e| e.name == "medium-electric-pole")
+        .count();
+    assert_eq!(poles, 30, "kill-2 pole census pin (was 60 unthinned)");
+
     // Functional entities stamped; logistics not (spot-check via export).
     let bp = blueprint::export(&layout_result, "ec-45s-legendary");
     let parsed = blueprint_parser::parse_blueprint_string(&bp).unwrap();

--- a/docs/rfc-043-pole-band-thinning.md
+++ b/docs/rfc-043-pole-band-thinning.md
@@ -1,4 +1,4 @@
-# RFP: Quality-aware pole-band thinning (#310)
+# RFC-043: Quality-aware pole-band thinning (#310)
 
 Status: ACCEPTED-PENDING-IMPLEMENTATION v2 (2026-07-20) — Phase 0
 census done; adversarial review round 1 complete (one blocker + two
@@ -10,7 +10,7 @@ At build quality ≥ Uncommon, a single medium-pole band can cover BOTH
 of a machine row's inserter rows — the reason `place_poles` emits two
 bands per row is purely the Normal-tier radius (floor 3, which cannot
 span the `mh+1` distance from one band to the opposite inserter row).
-This RFP gates the south band off per row when the quality radius
+This RFC gates the south band off per row when the quality radius
 affords it **with at least one tile of depth slack** (`budget ≥ 1` —
 see the gate), one unified placement pass per qualifying row with
 per-target fallback, and the existing mop-up + reactive-substation
@@ -18,10 +18,10 @@ machinery unchanged as backstops. Normal-quality layouts are
 structurally untouched (the gate can never fire at radius 3), and the
 corpus's only live substation user is already dormant at every
 qualifying tier (kovarex 3b fallback fires at Normal only — pinned by
-`quality_differential_kovarex_self_loop_normal_vs_legendary`, #315). Follow-up to `docs/rfp-build-quality.md`; tracked as
+`quality_differential_kovarex_self_loop_normal_vs_legendary`, #315). Follow-up to `docs/rfc-build-quality.md`; tracked as
 [#310](https://github.com/storkme/spaghettio/issues/310); sibling
 thread [#315](https://github.com/storkme/spaghettio/issues/315)
-(power-arc quality verification) proceeds in parallel and this RFP must
+(power-arc quality verification) proceeds in parallel and this RFC must
 not touch its surface (see kill criterion 4).
 
 ## Motivation (Phase 0 census, 2026-07-20)
@@ -44,7 +44,7 @@ express (the build-quality reference config), measured via
 (The PU config carries non-power junction/belt errors at Rare+ — the
 documented machine-count-collapse gap, #135/#136/#312 — but its
 power-category results are clean at every tier, so its pole census is
-valid for this RFP's purposes.)
+valid for this RFC's purposes.)
 
 Every remaining pole row is one of a north/south pair whose partner is
 redundant at quality: a legendary pole's ±8 vertical reach covers a
@@ -53,7 +53,7 @@ depth to spare. Expected effect of thinning: roughly half the
 remaining poles at qualifying tiers (legendary ~60 → ~35 on the census
 config), zero effect at Normal. The user-visible symptom today is the
 browser eyeball: legendary layouts show doubled bands of nearly-idle
-poles (the exact trigger condition the build-quality RFP recorded for
+poles (the exact trigger condition the build-quality RFC recorded for
 pulling this work forward).
 
 ## Design
@@ -199,7 +199,7 @@ per-tier NET pole assertion catches any bridge-bloat wash.
 
 #315 (verification sweep) runs first/parallel on the UNthinned
 geometry, establishing the per-tier baseline the kill-3 differentials
-compare against. This RFP's changes land after the sweep's baseline is
+compare against. This RFC's changes land after the sweep's baseline is
 recorded, so any regression is attributable. Both threads read the
 same shared helpers; only this one writes `place_poles`.
 
@@ -245,7 +245,7 @@ same shared helpers; only this one writes `place_poles`.
 - *2026-07-20 — implementation adversarial review: **clean, zero
   BUG/RISK findings**. Refactor fidelity verified statement-for-
   statement against the pre-commit loop; unified-pass ordering matches
-  the RFP; the fallback-tile far-side x-gap and the top_y=0
+  the RFC; the fallback-tile far-side x-gap and the top_y=0
   empty-north edge both confirmed pre-existing/identical behavior, not
   Phase-1 regressions; degenerate-path ordering sound (sorted
   subsequence); gate-table boundaries hand-verified with no

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -54,5 +54,6 @@ backfill the status next time the doc is touched.
 | RFC-040 | 2026-07-19 | [`rfc-power-supply.md`](rfc-power-supply.md) | Complete |
 | RFC-041 | 2026-07-20 | [`rfc-build-quality.md`](rfc-build-quality.md) | Complete (in-game anchor open) |
 | RFC-042 | 2026-07-20 | [`rfc-power-reservation.md`](rfc-power-reservation.md) | Complete |
+| RFC-043 | 2026-07-20 | [`rfc-043-pole-band-thinning.md`](rfc-043-pole-band-thinning.md) | Complete (Phase 1; Phase 2 cross-row sharing deferred) |
 
-Next number: **RFC-043**.
+Next number: **RFC-044**.

--- a/docs/rfp-pole-band-thinning.md
+++ b/docs/rfp-pole-band-thinning.md
@@ -206,6 +206,25 @@ same shared helpers; only this one writes `place_poles`.
 ## Decision log
 
 - *2026-07-20 — Phase 0 census run (numbers above); v1 draft written.*
+- *2026-07-20 — **Phase 1 landed** (gate + unified pass in
+  `place_poles`, extracted `place_band_line` /
+  `place_unified_band_line` / `band_y_lists` /
+  `single_band_depth_budget` helpers). Kill-2/3 census, thinned vs
+  unthinned NET medium poles:
+  EC@45/s — Normal 239→239 and Uncommon 129→129 (bit-identical,
+  gate off), **Legendary 60→30 (50%, beats the ≤48 gate and the ~35
+  prediction)**, validation issues identical per tier;
+  PU@2/s (tier5 fixture config) — Normal 343→343 identical with 0
+  issues, Rare 156→89, Epic 149→76, Legendary 98→53, failure
+  categories at qualifying tiers unchanged (the pre-existing
+  non-power Finding-B classes from #315 — belt-dead-end at Rare,
+  unresolved-junction at Legendary — zero power issues introduced
+  anywhere). Kovarex differential clean at both tiers, substation
+  behavior unchanged. Unit gates: `single_band_gate_table_per_mh_and_tier`
+  (structural kill-1: Normal/Uncommon can never thin),
+  `single_band_mode_halves_row_bands_and_stays_covered` (validator's
+  own continuous check on the thinned field), kill-2 pole pin (== 30)
+  in `quality_ec_45s_express_legendary_from_ore`.*
 - *2026-07-20 — adversarial review round 1: depth-budget math verified
   EXACT (floor vs continuous `.5`-fraction bound — no rounding slop);
   Chebyshev coverage confirmed from `check_power_coverage`; scope

--- a/docs/rfp-pole-band-thinning.md
+++ b/docs/rfp-pole-band-thinning.md
@@ -1,0 +1,225 @@
+# RFP: Quality-aware pole-band thinning (#310)
+
+Status: ACCEPTED-PENDING-IMPLEMENTATION v2 (2026-07-20) — Phase 0
+census done; adversarial review round 1 complete (one blocker + two
+must-fixes, all resolved in v2 — decision log).
+
+## Summary
+
+At build quality ≥ Uncommon, a single medium-pole band can cover BOTH
+of a machine row's inserter rows — the reason `place_poles` emits two
+bands per row is purely the Normal-tier radius (floor 3, which cannot
+span the `mh+1` distance from one band to the opposite inserter row).
+This RFP gates the south band off per row when the quality radius
+affords it **with at least one tile of depth slack** (`budget ≥ 1` —
+see the gate), one unified placement pass per qualifying row with
+per-target fallback, and the existing mop-up + reactive-substation
+machinery unchanged as backstops. Normal-quality layouts are
+structurally untouched (the gate can never fire at radius 3), and the
+corpus's only live substation user is already dormant at every
+qualifying tier (kovarex 3b fallback fires at Normal only — pinned by
+`quality_differential_kovarex_self_loop_normal_vs_legendary`, #315). Follow-up to `docs/rfp-build-quality.md`; tracked as
+[#310](https://github.com/storkme/spaghettio/issues/310); sibling
+thread [#315](https://github.com/storkme/spaghettio/issues/315)
+(power-arc quality verification) proceeds in parallel and this RFP must
+not touch its surface (see kill criterion 4).
+
+## Motivation (Phase 0 census, 2026-07-20)
+
+`place_poles`' along-band cadence already scales with quality (it
+derives from `supply_area_distance`), so pole counts drop steeply with
+tier — but the band COUNT per row does not. EC@45/s from ore on
+express (the build-quality reference config), measured via
+`debug_quality_layout`:
+
+| Config | Tier | Medium poles |
+|---|---|---|
+| EC@45/s from ore, express (solid rows only) | Normal | 239 |
+| | Uncommon | 129 |
+| | Legendary | 60 |
+| PU@2/s from ore, red (fluid rows; `tier5` fixture config, #315 sweep numbers) | Normal | 343 |
+| | Rare | 156 |
+| | Legendary | 98 |
+
+(The PU config carries non-power junction/belt errors at Rare+ — the
+documented machine-count-collapse gap, #135/#136/#312 — but its
+power-category results are clean at every tier, so its pole census is
+valid for this RFP's purposes.)
+
+Every remaining pole row is one of a north/south pair whose partner is
+redundant at quality: a legendary pole's ±8 vertical reach covers a
+3-tall machine row's opposite inserter row (distance 4) with 4 tiles of
+depth to spare. Expected effect of thinning: roughly half the
+remaining poles at qualifying tiers (legendary ~60 → ~35 on the census
+config), zero effect at Normal. The user-visible symptom today is the
+browser eyeball: legendary layouts show doubled bands of nearly-idle
+poles (the exact trigger condition the build-quality RFP recorded for
+pulling this work forward).
+
+## Design
+
+### The gate (per machine row, per tier)
+
+`pole_range = floor(supply_area_distance("medium-electric-pole", q))`
+(3/4/5/6/8 across the tiers). The north band's candidate at
+`cy = top_y - 1` sits `mh + 1` tiles from the south inserter row
+(`top_y + mh`). A pole placed at depth `d` above the candidate
+(`place_poles` searches outward, away from the machine) covers the
+south inserter row iff `mh + 1 + d ≤ pole_range`. Define
+
+```
+single_band_depth_budget(mh, q) = pole_range(q) − (mh + 1)   // may be negative
+```
+
+The gate requires **budget ≥ 1**, not ≥ 0 (v2, from adversarial
+review findings 4+5):
+
+- Budget ≥ 1 → **single-band mode** for this row: one unified pass
+  (below), searches truncated to depths `0..=budget` (deeper
+  placements would break opposite-row coverage — the truncation is
+  what makes the mode sound, not hoped-for).
+- Budget ≤ 0 → today's two-band behavior, unchanged.
+
+Why ≥ 1: at budget 0 the search is d=0 only, and `fluid_only_row` /
+`fluid_dual_input_row` (msz=3) **fully pack the north candidate row**
+— single-band mode would deterministically fail into fallback for
+every machine of every fluid-touching 3×3 row at its first ≥0 tier,
+yielding zero thinning exactly where the v1 table claimed it started.
+Requiring one tile of depth slack gives packed rows their d=1 escape
+and (see wire section) lands activation on tiers whose wire reach
+clears every row pitch with margin.
+
+Per-tier qualification (v2): 3-tall machines thin at **Rare+**
+(budget 1/2/4 at Rare/Epic/Legendary); 4-tall (EM plant) at **Epic+**
+(1/3); 5-tall (refinery/foundry/cryo) at **Legendary** (2). Uncommon
+never thins. At Normal the budget is negative for every machine
+height — the gate structurally cannot fire (kill criterion 1). The
+floor-based comparison is EXACT, not conservative: the validator's
+continuous bound is `3.5 + level` (fixed `.5` fraction) against an
+always-integer center distance, so `n ≤ 3.5+level ⟺ n ≤ floor(...)`
+(review finding 1).
+
+North band is the keeper (not south): fluid-row templates reserve
+their pole-gap tiles on the north band (`templates.rs` asserts
+`pole_candidate_ys`' north row), and the machine center at distance
+`mh/2 + 0.5 + d` is always covered whenever the opposite inserter row
+is (`mh/2 + 0.5 < mh + 1` for every mh).
+
+### Unified single pass + per-target fallback (v2, review finding 3)
+
+In single-band mode the row runs ONE left-to-right pass over machine
+targets (replacing the two-band loop for that row only). Key soundness
+fact: within the truncated depth window, north and south poles are
+coverage-INTERCHANGEABLE — a south pole at depth d covers the north
+inserter row by the same `mh + 1 + d ≤ pole_range` bound — so
+skip-ahead crediting is band-agnostic and pole-count bookkeeping stays
+coherent (v1's inline retry would have leaked un-credited fallback
+poles past the north loop's cursor, review finding 3). Per target:
+
+1. Try north band, depths `0..=budget` (candidate window + fallback
+   tiles as today).
+2. Else try south band, depths `0..=budget` — interchangeable, so the
+   unified skip-ahead applies to whichever placed.
+3. Else mark the target DEGENERATE. After the pass, degenerate targets
+   (if any) run today's two-band placement restricted to their
+   x-windows — strictly-no-worse-than-today per target, with each
+   band's own crediting.
+
+Below all of that, the uncovered-inserter mop-up and the reactive
+substation chain (3a-ii/3b) are untouched backstops — thinning changes
+where bands try first, never what happens when coverage fails.
+
+### Wire connectivity (v2 — per-tier, per-shape arithmetic)
+
+One band per row raises inter-band vertical distance to the row pitch:
+north-to-north spacing ≈ row_height + 2 (inter-recipe gap). Row
+heights (msz=3): single_input_row 7→spacing 9, dual 8→10, triple
+9→11, quad/fluid_dual 10→12. Against wire reach at the v2 qualifying
+tiers: **Rare 13 ≥ 12** (every msz=3 shape clears, margin ≥1), Epic
+15, Legendary 19. v1's Uncommon activation would have sat exactly at
+(triple, 11=11) and over (quad, 12>11) the wire boundary — the second
+reason the gate is budget ≥ 1 (review finding 5). Balancer/retry gaps
+still stretch pitch beyond reach occasionally; the quality-aware
+`repair_pole_connectivity` bridges those, same as today, and kill 2's
+per-tier NET pole assertion catches any bridge-bloat wash.
+
+### What this does NOT touch
+
+- `compute_substation_bands` / top-edge bands / convergence signal —
+  the 3a-ii/3b reactive contract stays byte-identical (kill 4), and
+  the #315 sweep owns that surface in parallel.
+- Normal-quality placement — structurally unreachable gate.
+- Cross-row band sharing (one band powering two adjacent rows' facing
+  inserter rows) — Phase 2, only if Phase 1's eyeball still shows
+  redundancy; needs pitch analysis across row layouts and interacts
+  with variable gaps.
+
+## Kill criteria
+
+1. **Normal identity (structural + empirical).** The gate cannot fire
+   at Normal (negative budget for all machine heights — unit-tested per
+   (mh, tier) pair), and the full suite + `SPAGHETTIO_STRESS_GOLDEN=check`
+   stay clean. Any Normal-quality diff ⇒ the gate leaked — halt.
+2. **The reduction must pay — at every qualifying tier, both configs
+   (v2).** NET medium-pole count (bands + repair bridges) must strictly
+   decrease vs unthinned at EVERY qualifying tier on BOTH census
+   configs (EC solid, PU fluid), with no new warning categories; and on
+   the EC config at Legendary the reduction must be ≥ 20% (predicted
+   60 → ~35, gate ≤ 48). A wash-or-worse at any qualifying tier (e.g.
+   repair-bridge bloat eating the band savings) fails this criterion —
+   abandon or re-scope to the tiers that pay, and record which.
+3. **No coverage regressions at any tier.** Per-tier differential runs
+   of the census config plus the #315 sweep fixtures: any power
+   coverage/connectivity warning present with thinning but absent
+   without it means the depth-budget math or fallback is wrong — halt
+   and fix root-cause, never widen the fallback to paper over it.
+4. **Scope fence.** If a correct implementation requires modifying the
+   reactive substation trigger/band code (not merely reading shared
+   helpers), stop — that contract belongs to 3a-ii/3b and the #315
+   sweep; redesign the gate instead.
+
+## Verification plan
+
+- Unit: `single_band_depth_budget` table per (mh ∈ {3,4,5}, tier) —
+  including every Normal entry negative; a place_poles-level test in
+  the style of `repair_pole_connectivity_uses_quality_wire_reach`
+  asserting a two-row legendary field powers both inserter rows from
+  one band and that the same field at Normal still emits two bands.
+- Differential: census-config pole counts per tier asserted (kill 2
+  numbers) with validator cleanliness; reuse the
+  `quality_differential_ec_normal_vs_legendary` fixture, extending its
+  assertions with pole-count expectations.
+- Corpus: full suite; STRESSGOLD check; the #315 fixtures at Legendary
+  after both threads land (sequencing note below).
+- Browser eyeball (user validates): the legendary census URL —
+  `#/l/ecl/45/am3/ior,coo/etb?q=l` — should visibly show single pole
+  rows between machine rows.
+
+## Sequencing with #315
+
+#315 (verification sweep) runs first/parallel on the UNthinned
+geometry, establishing the per-tier baseline the kill-3 differentials
+compare against. This RFP's changes land after the sweep's baseline is
+recorded, so any regression is attributable. Both threads read the
+same shared helpers; only this one writes `place_poles`.
+
+## Decision log
+
+- *2026-07-20 — Phase 0 census run (numbers above); v1 draft written.*
+- *2026-07-20 — adversarial review round 1: depth-budget math verified
+  EXACT (floor vs continuous `.5`-fraction bound — no rounding slop);
+  Chebyshev coverage confirmed from `check_power_coverage`; scope
+  fence verified real (substation pass independent of the band loop).
+  One blocker: fluid msz=3 templates fully pack the north candidate
+  row, so budget-0 tiers get zero thinning there (census was
+  solid-only and blind to it). Two must-fixes: Uncommon wire margins
+  (triple 11=11, quad 12>11) and v1's underspecified fallback/skip-
+  ahead interaction. **v2 resolves all three with one design change —
+  gate raised to budget ≥ 1** (activation Rare+/Epic+/Legendary by
+  machine height; Uncommon never thins) — plus the unified
+  interchangeable-coverage pass and a per-tier/per-config NET-pole
+  kill criterion. Fluid census added from the #315 sweep's valid PU
+  numbers (my own PU probe had mis-set inputs — Gleba chain — and was
+  discarded). Kovarex substation dormancy at Rare+ (pinned in #315's
+  differential) removes the last thinning×substation interaction at
+  qualifying tiers.*

--- a/docs/rfp-pole-band-thinning.md
+++ b/docs/rfp-pole-band-thinning.md
@@ -242,3 +242,14 @@ same shared helpers; only this one writes `place_poles`.
   discarded). Kovarex substation dormancy at Rare+ (pinned in #315's
   differential) removes the last thinning×substation interaction at
   qualifying tiers.*
+- *2026-07-20 — implementation adversarial review: **clean, zero
+  BUG/RISK findings**. Refactor fidelity verified statement-for-
+  statement against the pre-commit loop; unified-pass ordering matches
+  the RFP; the fallback-tile far-side x-gap and the top_y=0
+  empty-north edge both confirmed pre-existing/identical behavior, not
+  Phase-1 regressions; degenerate-path ordering sound (sorted
+  subsequence); gate-table boundaries hand-verified with no
+  off-by-ones; scope fence (kill 4) holds byte-for-byte on the
+  substation block. One accepted NIT: the ==30 pole pin is tighter
+  than kill-2's ≤48 bar — deliberate, consistent with house exact-pin
+  style. Safe to PR.*


### PR DESCRIPTION
## Intent

Implements Phase 1 of [`docs/rfc-043-pole-band-thinning.md`](docs/rfc-043-pole-band-thinning.md) (RFC-043; closes #310): at build quality tiers where the medium-pole supply radius spans both of a machine row's inserter rows with depth slack, `place_poles` emits ONE band per row instead of two. Follow-up to the build-quality RFC; the eyeball trigger it recorded ("double bands of nearly-idle poles at legendary") is what this removes.

## Scope

- **In:**
  - `single_band_depth_budget` gate (`pole_range − (mh+1)`, fires at `≥ 1`): 3-tall machines thin at Rare+, 4-tall at Epic+, 5-tall at Legendary; **structurally unreachable at Normal/Uncommon**.
  - Unified single pass with band-agnostic skip-ahead (north/south poles are coverage-interchangeable within the budget) and per-target degenerate fallback to today's full two-band placement — strictly no worse than unthinned, per target.
  - Band-line placement extracted into shared helpers (`place_band_line`, `place_unified_band_line`, `band_y_lists`); mop-up and reactive-substation chains **behavior-identical, golden-proven** (their text sits inside the refactored region; behavior identity is what the goldens + pins establish).
  - RFC v2 (post-adversarial-review: gate raised from ≥0 to ≥1 to handle fluid-packed north rows and Uncommon wire margins) + decision log through implementation review.
  - RFC-043 taxonomy per the new docs registry (rename, registry row, next-number bump) + conversion of the two `rfp` references that slipped the #316 rename sed.
- **Out:** cross-row band sharing (RFC Phase 2, deferred); any change to substation band/trigger code.

## Verification

- [x] Rebased onto post-#317 main: `cargo test --manifest-path crates/core/Cargo.toml` — **803/803** (the union count the #317 review predicted); `SPAGHETTIO_STRESS_GOLDEN=check` 9/9 (the golden check doubles as the Normal-identity proof for the refactor).
- [x] `cargo clippy -p spaghettio_core -- -D warnings` — clean.
- [x] Census, thinned vs unthinned NET medium poles: EC@45/s — Normal 239/Uncommon 129 **bit-identical**, Legendary **60 → 30** (50%; kill-2 gate ≤48); PU tier5-config — Normal 343 identical at 0 issues, Rare 156→89, Epic 149→76, Legendary 98→53. Zero power issues introduced at any cell (kill 3); PU tiers' failures are the pre-existing non-power #315 Finding-B classes, unchanged.
- [x] Unit gates: `single_band_gate_table_per_mh_and_tier` (kill-1 structural), `single_band_mode_halves_row_bands_and_stays_covered` (validator's own continuous check), kill-2 pole pin `== 30` in `quality_ec_45s_express_legendary_from_ore` — independently tile-verified in review (14 bands for 14 rows, 0 uncovered inserters, one connected wire component).
- [x] Adversarial implementation review: clean, zero BUG/RISK (decision log); deep review APPROVE with the conditions addressed by this revision.
- [ ] Browser eyeball (user): `#/l/ecl/45/am3/ior,coo/etb?q=l` — single pole bands, 30 poles.

## Deviations from intent

Gate is `≥ 1` not `≥ 0` (RFC v2, from the design review's fluid-template blocker + Uncommon wire-margin finding); Uncommon deliberately never thins.

## Models / contracts touched

`docs/rfc-043-pole-band-thinning.md` (new, RFC-043 in the registry, full decision log). No shared-helper or validator contracts changed — placement-only, reading the existing quality-aware tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55