### PR TITLE
Pole wire modes: dense mesh vs deterministic minimal tree (RFC-045)

### DIFF
--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -135,13 +135,15 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
         })
         .collect();
 
-    // Pole copper wires: `compute_pole_wires` returns 0-based entity index
-    // pairs; the blueprint numbers entities from 1, so entity_number = index+1.
-    // Connector id 5 on both ends = pole-to-pole copper. Recomputed from the
-    // same `layout.entities` the entity list above enumerates, so the indices
-    // line up exactly.
-    let wires: Vec<[u32; 4]> = crate::power_wires::compute_pole_wires(&layout.entities)
-        .into_iter()
+    // Pole copper wires: 0-based entity index pairs; the blueprint numbers
+    // entities from 1, so entity_number = index+1. Connector id 5 on both
+    // ends = pole-to-pole copper. RFC-044 stored-graph contract: the STORED
+    // `layout.power_wires` is authoritative (it indexes the same
+    // `layout.entities` this export enumerates); `wires_for` falls back to
+    // a dense derivation only for layouts that never computed wires.
+    let wires: Vec<[u32; 4]> = crate::power_wires::wires_for(layout)
+        .iter()
+        .copied()
         .map(|(a, b)| {
             [
                 a + 1,
@@ -287,7 +289,7 @@ mod tests {
         }
         // The four poles are entity_numbers {1,3,4,5}; the wire graph must
         // connect all of them (compute_pole_wires drives both export + check).
-        let pw = crate::power_wires::compute_pole_wires(&layout.entities);
+        let pw = crate::power_wires::compute_pole_wires(&layout.entities, crate::power_wires::WireMode::Dense);
         assert_eq!(
             crate::power_wires::count_disconnected_poles(&layout.entities, &pw),
             0,

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -422,7 +422,7 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
         entities,
         width: max_x + 1,
         height: max_y + 1,
-        power_wires,
+        power_wires: Some(power_wires),
         ..Default::default()
     }
 }
@@ -510,6 +510,38 @@ mod tests {
             "0{}",
             base64::engine::general_purpose::STANDARD.encode(&compressed)
         )
+    }
+
+    /// RFC-044 round-trip: a Tree-mode wire graph survives export → parse
+    /// verbatim (the parser reads the artifact's wires array; it never
+    /// recomputes), and re-export is byte-identical.
+    #[test]
+    fn tree_wires_round_trip_through_export_and_parse() {
+        use crate::power_wires::{compute_pole_wires, WireMode};
+        let ents: Vec<PlacedEntity> = (0..4)
+            .map(|i| PlacedEntity {
+                name: "medium-electric-pole".to_string(),
+                x: i * 7,
+                y: 0,
+                ..Default::default()
+            })
+            .collect();
+        let mut layout = LayoutResult::default();
+        layout.width = 25;
+        layout.height = 1;
+        layout.entities = ents;
+        layout.wire_mode = WireMode::Tree;
+        layout.power_wires = Some(compute_pole_wires(&layout.entities, WireMode::Tree));
+        let tree = layout.power_wires.clone().unwrap();
+        assert_eq!(tree.len(), 3);
+
+        let bp = blueprint::export(&layout, "tree-mode");
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.power_wires.as_deref(), Some(tree.as_slice()));
+        // Re-export from the parsed layout: same wires bytes (parser stored
+        // Some, so export consumes it verbatim — no re-densify).
+        let bp2 = blueprint::export(&parsed, "tree-mode");
+        assert_eq!(bp, bp2, "tree export must be a fixed point of export→parse→export");
     }
 
     #[test]
@@ -633,15 +665,15 @@ mod tests {
             height: 1,
             ..Default::default()
         };
-        let emitted = crate::power_wires::compute_pole_wires(&layout.entities);
+        let emitted = crate::power_wires::compute_pole_wires(&layout.entities, crate::power_wires::WireMode::Dense);
         assert_eq!(emitted, vec![(0, 1), (1, 2)]);
 
         let bp_string = blueprint::export(&layout, "pole-wires");
         let parsed = parse_blueprint_string(&bp_string).expect("should parse");
         // Wires must survive export → parse (before the fix: empty).
-        assert_eq!(parsed.power_wires, emitted, "power_wires must round-trip");
+        assert_eq!(parsed.power_wires.as_deref(), Some(emitted.as_slice()), "power_wires must round-trip");
         assert_eq!(
-            crate::power_wires::count_disconnected_poles(&parsed.entities, &parsed.power_wires),
+            crate::power_wires::count_disconnected_poles(&parsed.entities, parsed.power_wires.as_deref().unwrap_or(&[])),
             0,
             "all three poles are one network after round-trip"
         );
@@ -667,7 +699,7 @@ mod tests {
         }
         let layout = LayoutResult { entities, width: 25, height: 25, ..Default::default() };
 
-        let emitted = crate::power_wires::compute_pole_wires(&layout.entities);
+        let emitted = crate::power_wires::compute_pole_wires(&layout.entities, crate::power_wires::WireMode::Dense);
         assert!(!emitted.is_empty(), "dense grid must wire");
         assert_eq!(
             crate::power_wires::count_disconnected_poles(&layout.entities, &emitted),
@@ -677,9 +709,9 @@ mod tests {
 
         let bp_string = blueprint::export(&layout, "dense-grid");
         let parsed = parse_blueprint_string(&bp_string).expect("should parse");
-        assert_eq!(parsed.power_wires, emitted, "dense wire set must round-trip");
+        assert_eq!(parsed.power_wires.as_deref(), Some(emitted.as_slice()), "dense wire set must round-trip");
         assert_eq!(
-            crate::power_wires::count_disconnected_poles(&parsed.entities, &parsed.power_wires),
+            crate::power_wires::count_disconnected_poles(&parsed.entities, parsed.power_wires.as_deref().unwrap_or(&[])),
             0,
             "the 25-pole network stays connected after round-trip"
         );

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -234,6 +234,7 @@ impl DecompositionCandidate for ModuleSizeSplit {
             surplus_policy: opts.surplus_policy,
             max_inserter_tier: opts.max_inserter_tier,
             quality: opts.quality,
+            wire_mode: opts.wire_mode,
             merge_tap: opts.merge_tap,
         };
         run_layout_with_retry(&transformed, &inner_opts)
@@ -930,7 +931,8 @@ mod tests {
             surplus_exits: vec![],
             voided_streams: vec![],
             effective_rows: vec![],
-            power_wires: vec![],
+            power_wires: None,
+            wire_mode: Default::default(),
         }
     }
 

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -90,6 +90,11 @@ pub struct LayoutOptions {
     /// functional entities (machines/inserters/poles) for export.
     /// Default `Normal` — a bit-exact no-op (kill criterion 2).
     pub quality: crate::common::QualityTier,
+    /// Pole wiring mode (RFC-044): `Dense` (default — every in-reach
+    /// pair, maximally robust) or `Tree` (deterministic minimum spanning
+    /// forest — fewest wires, visually clean). Purely an artifact-layer
+    /// choice; placement is untouched.
+    pub wire_mode: crate::power_wires::WireMode,
     /// Enable the merge-and-tap trunk fallback for unstampable
     /// multi-producer/multi-consumer families (`docs/rfc-merge-tap-trunks.md`).
     /// Default `false` (byte-identical to pre-fallback layouts). Set only by
@@ -110,6 +115,7 @@ impl LayoutOptions {
             surplus_policy: SurplusPolicy::default(),
             max_inserter_tier: InserterTier::default(),
             quality: crate::common::QualityTier::default(),
+            wire_mode: crate::power_wires::WireMode::default(),
             merge_tap: false,
         }
     }
@@ -1057,12 +1063,14 @@ fn layout_pass(
     }
 
     // Pole copper wire graph for the web overlay — the SAME graph
-    // `blueprint::export` re-derives and encodes in the blueprint `wires`
-    // array. Computed from the final entity order so the `(a, b)` index pairs
-    // stay valid — and AFTER the quality stamp pass above, because wire
-    // reach is per-entity quality-aware (rfc-build-quality merge with the
-    // power-3c arc). See `crate::power_wires`.
-    let power_wires = crate::power_wires::compute_pole_wires(&all_entities);
+    // `blueprint::export` and the connectivity validator consume this
+    // STORED graph verbatim (RFC-044 `wires_for` — one computation, all
+    // readers). Computed from the final entity order so the `(a, b)` index
+    // pairs stay valid — and AFTER the quality stamp pass above, because
+    // wire reach is per-entity quality-aware. `opts.wire_mode` selects
+    // dense mesh vs deterministic spanning tree; the mode is recorded on
+    // the result so post-layout recomputes honor it.
+    let power_wires = crate::power_wires::compute_pole_wires(&all_entities, opts.wire_mode);
 
     Ok((
         LayoutResult {
@@ -1075,7 +1083,8 @@ fn layout_pass(
             surplus_exits,
             voided_streams,
             effective_rows,
-            power_wires,
+            power_wires: Some(power_wires),
+            wire_mode: opts.wire_mode,
         },
         row_spans,
         cap_coords,
@@ -2079,7 +2088,7 @@ mod tests {
 
         // Pre-repair: the artifact-level wire graph leaves the boundary pair as
         // two separate islands — exactly what the old top-left metric missed.
-        let wires = compute_pole_wires(&entities);
+        let wires = compute_pole_wires(&entities, crate::power_wires::WireMode::Dense);
         assert!(wires.is_empty(), "boundary pair must not directly wire; got {wires:?}");
         assert_eq!(count_disconnected_poles(&entities, &wires), 1);
 
@@ -2103,7 +2112,7 @@ mod tests {
         // Post-repair: a bridge pole was added and the EMITTED wire graph is now
         // a single connected component — repair and artifact agree.
         assert!(entities.len() > 2, "repair must add at least one bridge pole");
-        let wires2 = compute_pole_wires(&entities);
+        let wires2 = compute_pole_wires(&entities, crate::power_wires::WireMode::Dense);
         assert_eq!(
             count_disconnected_poles(&entities, &wires2),
             0,

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -348,14 +348,28 @@ pub struct LayoutResult {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub effective_rows: Vec<EffectiveRow>,
     /// Pole-to-pole copper wire graph as `(a, b)` index pairs into `entities`
-    /// (`a < b`), from [`crate::power_wires::compute_pole_wires`]. Tsify emits
-    /// `power_wires?: [number, number][]` for the web power-connectivity
-    /// overlay. This is the SAME graph `blueprint::export` encodes in the
-    /// blueprint-level `wires` array, so the overlay shows exactly what pastes.
-    /// Recomputed after any post-layout entity-reordering splice (see
-    /// `wasm-bindings::improve_region_streaming`). Empty when <2 poles.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub power_wires: Vec<(u32, u32)>,
+    /// (`a < b`), from [`crate::power_wires::compute_pole_wires`]. RFC-044
+    /// stored-graph contract: `Some` is AUTHORITATIVE — `blueprint::export`
+    /// and the connectivity validator consume it verbatim via
+    /// [`crate::power_wires::wires_for`] (so the overlay, the artifact, and
+    /// the validated graph are the same object); `None` means "never
+    /// computed" (hand-built results, pre-power-3c snapshots) and consumers
+    /// fall back to a dense derivation. Recomputed after any post-layout
+    /// entity-reordering splice (see `wasm-bindings::improve_region_streaming`)
+    /// in [`LayoutResult::wire_mode`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub power_wires: Option<Vec<(u32, u32)>>,
+    /// How this layout's `power_wires` were generated (RFC-044): the layout
+    /// records its own wiring policy so post-layout recomputes honor it —
+    /// without this, an improve-region pass on a `Tree` layout would
+    /// silently re-densify it. `Dense`-default, skipped in serde when
+    /// default (old snapshots deserialize to `Dense`).
+    #[serde(default, skip_serializing_if = "wire_mode_is_default")]
+    pub wire_mode: crate::power_wires::WireMode,
+}
+
+fn wire_mode_is_default(m: &crate::power_wires::WireMode) -> bool {
+    *m == crate::power_wires::WireMode::default()
 }
 
 /// One solid surplus stream consumed by a layout-synthesized voider

--- a/crates/core/src/power_wires.rs
+++ b/crates/core/src/power_wires.rs
@@ -10,12 +10,18 @@
 //! disconnected islands and the whole factory is power-dead — the bug this
 //! module exists to prevent.
 //!
-//! [`compute_pole_wires`] is consumed by three call sites that MUST agree:
-//! - `blueprint::export` — emits the `wires` array (entity_number = index+1).
-//! - `validate::power::check_pole_network_connectivity` — asserts the emitted
-//!   graph is one connected component (checks the artifact, not mere geometry).
-//! - `bus::layout` / `blueprint_parser` — populate `LayoutResult::power_wires`
-//!   for the web power-connectivity overlay.
+//! RFC-044 stored-graph contract: the graph is computed ONCE
+//! (`bus::layout::layout_pass`, in `LayoutOptions::wire_mode` — dense
+//! mesh or deterministic spanning tree — recorded on
+//! `LayoutResult::wire_mode`) and stored in `LayoutResult::power_wires`;
+//! `blueprint::export` and
+//! `validate::power::check_pole_network_connectivity` both consume the
+//! STORED graph through [`wires_for`] (with a dense-derive fallback for
+//! layouts that never computed wires), and `blueprint_parser` preserves
+//! an imported blueprint's wires verbatim. The artifact, the validated
+//! graph, and the web overlay are therefore the same object by
+//! construction — the pre-RFC "N sites re-derive and must agree"
+//! convention is retired.
 //!
 //! ## Density: connect all in-reach pairs (no cap)
 //!

--- a/crates/core/src/power_wires.rs
+++ b/crates/core/src/power_wires.rs
@@ -40,7 +40,38 @@
 //! `+1.0`, a 1×1 medium pole at `+0.5`).
 
 use crate::common::entity_size;
-use crate::models::PlacedEntity;
+use crate::models::{LayoutResult, PlacedEntity};
+use std::borrow::Cow;
+
+/// User-facing pole wiring mode (RFC-044). `Dense` connects every
+/// in-reach pair (Factorio 2.0 has no copper connection cap) — the
+/// maximally robust artifact, and the default. `Tree` emits a
+/// deterministic minimum spanning forest over the SAME candidate set:
+/// the fewest wires that keep each connected component connected —
+/// visually clean, but deconstructing any one pole in-game splits the
+/// network. Recorded on `LayoutResult.wire_mode` so post-layout
+/// recomputes (the improve-region splice) honor the layout's policy.
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WireMode {
+    #[default]
+    Dense,
+    Tree,
+}
+
+impl WireMode {
+    /// Parse the URL/wasm string form; unknown → `None` (callers
+    /// default to `Dense`, the `max_inserter_tier` pattern).
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "dense" => Some(WireMode::Dense),
+            "tree" => Some(WireMode::Tree),
+            _ => None,
+        }
+    }
+}
 
 /// Blueprint `wires` connector id for pole-to-pole copper (draftsman
 /// `WireConnectorID.POLE_COPPER`).
@@ -81,7 +112,7 @@ pub fn pole_center(name: &str, x: i32, y: i32) -> (f64, f64) {
 /// poles within min-of-both wire reach. Connects every in-reach pair (no count
 /// cap — see the module docs). Iteration is in entity order, so the result is
 /// stable across runs given a stable entity list.
-pub fn compute_pole_wires(entities: &[PlacedEntity]) -> Vec<(u32, u32)> {
+pub fn compute_pole_wires(entities: &[PlacedEntity], mode: WireMode) -> Vec<(u32, u32)> {
     // (entity_index, center_x, center_y, wire_reach) for every pole, in order.
     let poles: Vec<(u32, f64, f64, f64)> = entities
         .iter()
@@ -110,7 +141,88 @@ pub fn compute_pole_wires(entities: &[PlacedEntity]) -> Vec<(u32, u32)> {
             }
         }
     }
-    wires
+    match mode {
+        WireMode::Dense => wires,
+        WireMode::Tree => minimum_spanning_forest(entities, &poles, wires),
+    }
+}
+
+/// Deterministic minimum spanning forest over the dense candidate set
+/// (RFC-044 §2). Kruskal with edges totally ordered by the PHYSICAL key
+/// `(squared_center_distance, min_endpoint_anchor, max_endpoint_anchor)`
+/// — anchors are the poles' integer `(x, y)` tile positions, so the
+/// selected wire SET is a unique function of the physical layout,
+/// invariant under entity-Vec reordering (the project's own
+/// `golden_hash` treats entity order as non-canonical, so an
+/// index-keyed tiebreak would let a legitimate pipeline reorder
+/// silently reshape trees; grid layouts tie on distance constantly).
+/// Distinct poles cannot share an anchor tile, so the key is a total
+/// order and the Kruskal result is unique, ties or not. Disconnected
+/// candidate graphs yield one tree per component — `Tree` never papers
+/// over a genuine disconnection.
+fn minimum_spanning_forest(
+    entities: &[PlacedEntity],
+    poles: &[(u32, f64, f64, f64)],
+    candidates: Vec<(u32, u32)>,
+) -> Vec<(u32, u32)> {
+    use rustc_hash::FxHashMap;
+    let centers: FxHashMap<u32, (f64, f64)> =
+        poles.iter().map(|&(i, cx, cy, _)| (i, (cx, cy))).collect();
+    let anchor = |i: u32| {
+        let e = &entities[i as usize];
+        (e.x, e.y)
+    };
+
+    let mut keyed: Vec<((f64, (i32, i32), (i32, i32)), (u32, u32))> = candidates
+        .into_iter()
+        .map(|(a, b)| {
+            let (ax, ay) = centers[&a];
+            let (bx, by) = centers[&b];
+            let d2 = (ax - bx) * (ax - bx) + (ay - by) * (ay - by);
+            let (pa, pb) = (anchor(a), anchor(b));
+            let (lo, hi) = if pa <= pb { (pa, pb) } else { (pb, pa) };
+            ((d2, lo, hi), (a, b))
+        })
+        .collect();
+    // All d2 are finite squared grid distances — partial_cmp cannot fail.
+    keyed.sort_by(|x, y| x.0.partial_cmp(&y.0).unwrap());
+
+    let n = entities.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(p: &mut [usize], mut x: usize) -> usize {
+        while p[x] != x {
+            p[x] = p[p[x]];
+            x = p[x];
+        }
+        x
+    }
+
+    let mut out: Vec<(u32, u32)> = Vec::new();
+    for (_, (a, b)) in keyed {
+        let (ra, rb) = (find(&mut parent, a as usize), find(&mut parent, b as usize));
+        if ra != rb {
+            parent[ra] = rb;
+            out.push((a, b));
+        }
+    }
+    // Same normalization/ordering convention as Dense output.
+    out.sort_unstable();
+    out
+}
+
+/// The stored-graph accessor (RFC-044 §1): `Some` is authoritative and
+/// consumed verbatim (even `Some(vec![])`); `None` means the layout
+/// never computed wires (hand-built `LayoutResult`s, pre-power-3c
+/// snapshots) and falls back to a dense derivation — exactly the
+/// pre-RFC behavior, so nothing that worked before can silently export
+/// power-dead poles. Export and the connectivity validator BOTH read
+/// through this single accessor, which is what makes the emitted
+/// artifact and the validated graph the same object by construction.
+pub fn wires_for(layout: &LayoutResult) -> Cow<'_, [(u32, u32)]> {
+    match &layout.power_wires {
+        Some(w) => Cow::Borrowed(w.as_slice()),
+        None => Cow::Owned(compute_pole_wires(&layout.entities, WireMode::Dense)),
+    }
 }
 
 /// Count how many pole entities are NOT reachable from the first pole via the
@@ -166,6 +278,122 @@ mod tests {
         PlacedEntity { name: name.to_string(), x, y, ..Default::default() }
     }
 
+    /// Kill 3 (RFC-044): tie-heavy determinism. An equidistant pole line
+    /// ties every adjacent pair; the physical-key Kruskal must pick the
+    /// SAME edge set every run, pinned exactly.
+    #[test]
+    fn tree_mode_is_deterministic_under_ties() {
+        let ents: Vec<PlacedEntity> =
+            (0..5).map(|i| pole("medium-electric-pole", i * 7, 0)).collect();
+        let t1 = compute_pole_wires(&ents, WireMode::Tree);
+        let t2 = compute_pole_wires(&ents, WireMode::Tree);
+        assert_eq!(t1, t2);
+        // 5 poles, one component → exactly 4 edges; the adjacent-pair MST.
+        assert_eq!(t1, vec![(0, 1), (1, 2), (2, 3), (3, 4)]);
+    }
+
+    /// Kill 3 (RFC-044, review finding 6): the selected wire SET is a
+    /// function of the PHYSICAL layout, not entity-Vec order — the same
+    /// poles constructed in reversed order must yield the same physical
+    /// edges (entity order is non-canonical per the project's own
+    /// golden-hash convention).
+    #[test]
+    fn tree_mode_is_invariant_under_entity_reordering() {
+        let fwd: Vec<PlacedEntity> = (0..6)
+            .map(|i| pole("medium-electric-pole", (i % 3) * 7, (i / 3) * 8))
+            .collect();
+        let rev: Vec<PlacedEntity> = fwd.iter().rev().cloned().collect();
+
+        let physical = |ents: &[PlacedEntity], wires: &[(u32, u32)]| {
+            let mut set: Vec<((i32, i32), (i32, i32))> = wires
+                .iter()
+                .map(|&(a, b)| {
+                    let pa = (ents[a as usize].x, ents[a as usize].y);
+                    let pb = (ents[b as usize].x, ents[b as usize].y);
+                    if pa <= pb { (pa, pb) } else { (pb, pa) }
+                })
+                .collect();
+            set.sort_unstable();
+            set
+        };
+        let t_fwd = compute_pole_wires(&fwd, WireMode::Tree);
+        let t_rev = compute_pole_wires(&rev, WireMode::Tree);
+        assert_eq!(physical(&fwd, &t_fwd), physical(&rev, &t_rev));
+    }
+
+    /// Kill 4 (RFC-044): tree property per component — `edges ==
+    /// poles − components`, every tree edge is a dense-candidate edge,
+    /// and the validator's actual scalar (`count_disconnected_poles`)
+    /// is identical between modes. Two clusters deliberately out of
+    /// reach of each other → a spanning FOREST that never papers over
+    /// the genuine disconnection.
+    #[test]
+    fn tree_mode_spans_each_component_and_matches_validator_scalar() {
+        let mut ents: Vec<PlacedEntity> =
+            (0..3).map(|i| pole("medium-electric-pole", i * 7, 0)).collect();
+        // Second cluster 100 tiles away — unreachable from the first.
+        ents.extend((0..4).map(|i| pole("medium-electric-pole", 100 + i * 7, 0)));
+
+        let dense = compute_pole_wires(&ents, WireMode::Dense);
+        let tree = compute_pole_wires(&ents, WireMode::Tree);
+
+        // 7 poles, 2 components → 5 edges.
+        assert_eq!(tree.len(), 5);
+        for e in &tree {
+            assert!(dense.contains(e), "tree edge {e:?} not in dense candidate set");
+        }
+        assert_eq!(
+            count_disconnected_poles(&ents, &tree),
+            count_disconnected_poles(&ents, &dense),
+            "validator scalar must be mode-invariant"
+        );
+    }
+
+    /// RFC-044 kill 6 contract (core half): a recompute in the layout's
+    /// OWN recorded `wire_mode` — the exact call
+    /// `improve_region_streaming` makes after its entity-reordering
+    /// splice — must preserve tree-ness. Simulates the splice as a
+    /// reorder + recompute; the wasm site is three lines reading
+    /// `layout.wire_mode`, review-verifiable against this pin.
+    #[test]
+    fn recompute_in_recorded_mode_preserves_tree() {
+        let ents: Vec<PlacedEntity> =
+            (0..4).map(|i| pole("medium-electric-pole", i * 7, 0)).collect();
+        let mut layout = LayoutResult::default();
+        layout.wire_mode = WireMode::Tree;
+        layout.entities = ents;
+        layout.power_wires = Some(compute_pole_wires(&layout.entities, layout.wire_mode));
+        assert_eq!(layout.power_wires.as_deref().map(|w| w.len()), Some(3));
+
+        // Splice-shaped mutation: rotate entity order, then recompute the
+        // way the wasm site does — in layout.wire_mode, not hardcoded Dense.
+        layout.entities.rotate_left(1);
+        layout.power_wires =
+            Some(compute_pole_wires(&layout.entities, layout.wire_mode));
+        let w = layout.power_wires.as_deref().unwrap();
+        assert_eq!(w.len(), 3, "tree-ness must survive the recompute: {w:?}");
+    }
+
+    /// RFC-044 kill 1: consuming the STORED dense graph must be
+    /// byte-indistinguishable from the `None`-fallback derivation at
+    /// export time.
+    #[test]
+    fn export_stored_dense_equals_fallback_derivation() {
+        let ents: Vec<PlacedEntity> =
+            (0..3).map(|i| pole("medium-electric-pole", i * 7, 0)).collect();
+        let mut stored = LayoutResult::default();
+        stored.entities = ents.clone();
+        stored.power_wires = Some(compute_pole_wires(&ents, WireMode::Dense));
+        let mut fallback = LayoutResult::default();
+        fallback.entities = ents;
+        fallback.power_wires = None;
+        assert_eq!(
+            crate::blueprint::export(&stored, "t"),
+            crate::blueprint::export(&fallback, "t"),
+            "stored-vs-derived export strings must be byte-identical at Dense"
+        );
+    }
+
     #[test]
     fn line_of_three_medium_poles_wires_in_reach_pairs() {
         // Centers 0.5, 7.5, 14.5 (spacing 7 ≤ 9). Adjacent pairs within reach:
@@ -175,7 +403,7 @@ mod tests {
             pole("medium-electric-pole", 7, 0),
             pole("medium-electric-pole", 14, 0),
         ];
-        let wires = compute_pole_wires(&ents);
+        let wires = compute_pole_wires(&ents, WireMode::Dense);
         assert_eq!(wires, vec![(0, 1), (1, 2)]);
         // Transitively connected → nothing disconnected.
         assert_eq!(count_disconnected_poles(&ents, &wires), 0);
@@ -190,7 +418,7 @@ mod tests {
             pole("medium-electric-pole", 5, 0),
             pole("medium-electric-pole", 5, 5),
         ];
-        let wires = compute_pole_wires(&ents);
+        let wires = compute_pole_wires(&ents, WireMode::Dense);
         assert_eq!(wires, vec![(0, 1), (0, 2), (1, 2)]);
     }
 
@@ -201,7 +429,7 @@ mod tests {
             pole("medium-electric-pole", 0, 0),
             pole("medium-electric-pole", 10, 0),
         ];
-        let wires = compute_pole_wires(&ents);
+        let wires = compute_pole_wires(&ents, WireMode::Dense);
         assert!(wires.is_empty());
         assert_eq!(count_disconnected_poles(&ents, &wires), 1);
     }
@@ -213,7 +441,7 @@ mod tests {
             pole("medium-electric-pole", 0, 0),
             pole("small-electric-pole", 8, 0),
         ];
-        assert!(compute_pole_wires(&ents).is_empty());
+        assert!(compute_pole_wires(&ents, WireMode::Dense).is_empty());
     }
 
     #[test]
@@ -226,12 +454,12 @@ mod tests {
             pole("substation", 0, 0),
             pole("medium-electric-pole", 16, 0),
         ];
-        assert!(compute_pole_wires(&far).is_empty());
+        assert!(compute_pole_wires(&far, WireMode::Dense).is_empty());
         let near = vec![
             pole("substation", 0, 0),
             pole("medium-electric-pole", 9, 0),
         ];
-        assert_eq!(compute_pole_wires(&near), vec![(0, 1)]);
+        assert_eq!(compute_pole_wires(&near, WireMode::Dense), vec![(0, 1)]);
     }
 
     #[test]
@@ -242,7 +470,7 @@ mod tests {
             PlacedEntity { name: "transport-belt".into(), x: 3, y: 0, ..Default::default() },
             pole("medium-electric-pole", 6, 0),
         ];
-        assert_eq!(compute_pole_wires(&ents), vec![(0, 2)]);
+        assert_eq!(compute_pole_wires(&ents, WireMode::Dense), vec![(0, 2)]);
     }
 
     #[test]

--- a/crates/core/src/validate/power.rs
+++ b/crates/core/src/validate/power.rs
@@ -24,8 +24,10 @@ use crate::validate::{Severity, ValidationIssue};
 
 /// Check that the EMITTED pole copper-wire graph is a single connected network.
 ///
-/// This validates the ARTIFACT, not mere geometry: it recomputes the exact
-/// `wires` array [`crate::blueprint::export`] encodes (via
+/// This validates the ARTIFACT, not mere geometry: it reads the exact
+/// `wires` graph [`crate::blueprint::export`] encodes — the STORED
+/// `LayoutResult::power_wires` via [`crate::power_wires::wires_for`]
+/// (RFC-044; dense-derive fallback only for never-computed layouts, via
 /// [`crate::power_wires::compute_pole_wires`] — the single source of wire reach
 /// and footprint centers) and asserts every pole is reachable from the first
 /// pole through it. A geometry-only check could pass while the export omitted

--- a/crates/core/src/validate/power.rs
+++ b/crates/core/src/validate/power.rs
@@ -37,7 +37,7 @@ use crate::validate::{Severity, ValidationIssue};
 /// poles' wire reaches, with no per-pole connection cap (Factorio 2.0 removed
 /// it). Returns a single `Warning` when any pole is unreachable.
 pub fn check_pole_network_connectivity(layout: &LayoutResult) -> Vec<ValidationIssue> {
-    let wires = crate::power_wires::compute_pole_wires(&layout.entities);
+    let wires = crate::power_wires::wires_for(layout);
     let disconnected = crate::power_wires::count_disconnected_poles(&layout.entities, &wires);
     if disconnected == 0 {
         return vec![];

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -7331,3 +7331,66 @@ fn quality_differential_kovarex_self_loop_normal_vs_legendary() {
         "every stamped entity must round-trip through export+parse"
     );
 }
+
+/// RFC-044 verification-plan differential (flagged as silently dropped by
+/// the implementation contract review — delivered here): the legendary
+/// census fixture wired in `Tree` mode vs `Dense`. 30 medium poles, one
+/// connected component → the tree is exactly 29 edges, strictly fewer
+/// than dense, every tree edge drawn from the dense candidate set, and
+/// the validator's scalar (0 disconnected) is identical in both modes.
+#[test]
+#[ntest::timeout(120000)]
+fn quality_ec_45s_legendary_tree_wire_differential() {
+    use spaghettio_core::common::QualityTier;
+    use spaghettio_core::power_wires::{compute_pole_wires, count_disconnected_poles, WireMode};
+    use spaghettio_core::recipe_db::MachinePalette;
+
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "electronic-circuit",
+        45.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Legendary,
+    )
+    .unwrap_or_else(|e| panic!("solve: {e}"));
+    let layout_result = layout::build_bus_layout(
+        &sr,
+        layout::LayoutOptions {
+            strategy: Default::default(),
+            surplus_policy: Default::default(),
+            max_belt_tier: Some("express-transport-belt".to_string()),
+            row_layout: Default::default(),
+            max_inserter_tier: Default::default(),
+            quality: QualityTier::Legendary,
+            wire_mode: WireMode::Tree,
+            merge_tap: false,
+        },
+    )
+    .unwrap_or_else(|e| panic!("layout: {e}"));
+
+    let poles = layout_result
+        .entities
+        .iter()
+        .filter(|e| e.name == "medium-electric-pole")
+        .count();
+    assert_eq!(poles, 30, "census pin (rfc-043)");
+
+    let tree = layout_result.power_wires.as_deref().expect("stored wires").to_vec();
+    let dense = compute_pole_wires(&layout_result.entities, WireMode::Dense);
+    assert_eq!(tree.len(), 29, "spanning tree of one 30-pole component");
+    assert!(dense.len() > tree.len(), "dense {} must exceed tree {}", dense.len(), tree.len());
+    for e in &tree {
+        assert!(dense.contains(e), "tree edge {e:?} not in dense candidate set");
+    }
+    assert_eq!(count_disconnected_poles(&layout_result.entities, &tree), 0);
+    assert_eq!(count_disconnected_poles(&layout_result.entities, &dense), 0);
+
+    let issues = validate::validate(&layout_result, Some(&sr), LayoutStyle::Bus)
+        .unwrap_or_else(|e| panic!("validate: {e}"));
+    let power: Vec<_> = issues.iter().filter(|i| i.category == "power").collect();
+    assert!(power.is_empty(), "tree mode must introduce no power issues: {power:?}");
+}

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -312,6 +312,7 @@ fn run_e2e_inner(
             row_layout,
             max_inserter_tier: Default::default(),
             quality: Default::default(),
+            wire_mode: Default::default(),
             merge_tap: false,
         },
     )
@@ -661,8 +662,8 @@ fn assert_round_trip(result: &E2EResult) {
         result.layout.power_wires, result.parsed.power_wires,
         "pole copper wires must round-trip through blueprint export/parse: \
          layout emitted {} wire(s), parsed recovered {}",
-        result.layout.power_wires.len(),
-        result.parsed.power_wires.len(),
+        result.layout.power_wires.as_deref().map_or(0, |w| w.len()),
+        result.parsed.power_wires.as_deref().map_or(0, |w| w.len()),
     );
 }
 
@@ -1747,6 +1748,7 @@ fn tier4_advanced_circuit_7s_horizontal_stack_belt_pipe_crossing() {
             surplus_policy: SurplusPolicy::default(),
             max_inserter_tier: Default::default(),
             quality: Default::default(),
+            wire_mode: Default::default(),
             merge_tap: false,
         },
     )
@@ -1893,6 +1895,7 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
             surplus_policy: SurplusPolicy::default(),
             max_inserter_tier: Default::default(),
             quality: Default::default(),
+            wire_mode: Default::default(),
             merge_tap: false,
         },
     )
@@ -2000,6 +2003,7 @@ fn tier5_processing_unit_25s_horizontal_stack_pole_coverage() {
             surplus_policy: SurplusPolicy::default(),
             max_inserter_tier: Default::default(),
             quality: Default::default(),
+            wire_mode: Default::default(),
             merge_tap: false,
         },
     )
@@ -7016,6 +7020,7 @@ fn quality_differential_ec_normal_vs_legendary() {
                 row_layout: Default::default(),
                 max_inserter_tier: Default::default(),
                 quality,
+                wire_mode: Default::default(),
                 merge_tap: false,
             },
         )
@@ -7136,6 +7141,7 @@ fn quality_ec_45s_express_legendary_from_ore() {
             row_layout: Default::default(),
             max_inserter_tier: Default::default(),
             quality: QualityTier::Legendary,
+            wire_mode: Default::default(),
             merge_tap: false,
         },
     )
@@ -7223,6 +7229,7 @@ fn quality_differential_kovarex_self_loop_normal_vs_legendary() {
                 row_layout: Default::default(),
                 max_inserter_tier: Default::default(),
                 quality,
+                wire_mode: Default::default(),
                 merge_tap: false,
             },
         )

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -31,6 +31,7 @@ fn layout_options(
     row_layout: Option<String>,
     max_inserter_tier: Option<String>,
     quality: Option<String>,
+    wire_mode: Option<String>,
 ) -> LayoutOptions {
     let strategy = match strategy.as_deref() {
         // `partitioned-per-consumer` is the deprecated P1 string; the
@@ -63,6 +64,12 @@ fn layout_options(
         // rfc-build-quality Phase 2: unknown/absent → Normal, same
         // hard-cap fallback semantics as the two tiers above.
         quality: quality_tier(quality),
+        // RFC-044: unknown/absent → Dense, same fallback semantics as the
+        // tiers above.
+        wire_mode: wire_mode
+            .as_deref()
+            .and_then(spaghettio_core::power_wires::WireMode::from_name)
+            .unwrap_or_default(),
         // The merge-tap fallback is chosen internally by the
         // decomposition search (`MergeTapCandidate`), never requested by the
         // web UI — always default-off at the public boundary.
@@ -156,10 +163,11 @@ pub fn layout(
     row_layout: Option<String>,
     max_inserter_tier: Option<String>,
     quality: Option<String>,
+    wire_mode: Option<String>,
 ) -> Result<LayoutResult, JsError> {
     build_bus_layout(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode),
     )
     .map_err(|e| JsError::new(&e))
 }
@@ -176,10 +184,11 @@ pub fn layout_traced(
     row_layout: Option<String>,
     max_inserter_tier: Option<String>,
     quality: Option<String>,
+    wire_mode: Option<String>,
 ) -> Result<LayoutResult, JsError> {
     spaghettio_core::bus::layout::build_bus_layout_traced(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode),
     )
     .map_err(|e| JsError::new(&e))
 }
@@ -240,6 +249,7 @@ pub fn layout_streaming(
     row_layout: Option<String>,
     max_inserter_tier: Option<String>,
     quality: Option<String>,
+    wire_mode: Option<String>,
     emit: &js_sys::Function,
 ) -> Result<LayoutResult, JsError> {
     let emit = emit.clone();
@@ -253,7 +263,7 @@ pub fn layout_streaming(
     });
     spaghettio_core::bus::layout::build_bus_layout_streaming(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode),
         on_event,
     )
     .map_err(|e| JsError::new(&e))
@@ -410,9 +420,13 @@ pub fn improve_region_streaming(
 
     // The retain+extend above reorders `entities`, invalidating the index pairs
     // in `power_wires`. Recompute so the field (and any downstream export /
-    // overlay) stays consistent with the new entity order.
-    layout_result.power_wires =
-        spaghettio_core::power_wires::compute_pole_wires(&layout_result.entities);
+    // overlay) stays consistent with the new entity order — in the layout's
+    // OWN recorded wire mode (RFC-044 kill 6: a Tree layout must not come
+    // back silently re-densified).
+    layout_result.power_wires = Some(spaghettio_core::power_wires::compute_pole_wires(
+        &layout_result.entities,
+        layout_result.wire_mode,
+    ));
 
     Ok(layout_result)
 }

--- a/docs/rfc-044-pole-wire-modes.md
+++ b/docs/rfc-044-pole-wire-modes.md
@@ -1,0 +1,207 @@
+# RFC-044: Pole wire modes — dense mesh vs deterministic minimal tree
+
+Status: DRAFT (2026-07-21) — spec'd from the 2026-07-20 power-arc
+close-out; adversarial review pending.
+
+## Summary
+
+Add a user-facing **pole wiring mode**: `dense` (today's behavior —
+every in-reach pole pair gets a copper wire, maximally robust) or
+`tree` (a deterministic minimum spanning tree per connected component —
+fewest wires that keep the network connected, visually clean,
+`|poles|−1` edges instead of a mesh). Alongside the toggle, restructure
+the wire-graph contract from "N call sites re-derive and must agree"
+to **"computed once, stored on the layout, all consumers read the
+stored graph"** — which retires the divergence-bug class the
+`power_wires` module's docs currently police by convention. Default is
+`dense`; Normal-and-default output stays byte-identical.
+
+## Motivation
+
+Aesthetic/user-choice, not correctness: dense wiring on a legendary
+layout (sparse poles, 17-tile spans, per `rfc-043-pole-band-thinning`)
+renders as a cross-hatched mesh; players routinely prefer minimal
+wiring. The trade-off is real and belongs to the user: in a tree,
+deconstructing any single pole splits the network, where the mesh is
+redundant. Secondary wins: smaller `wires` arrays in exported strings,
+and the structural fix below.
+
+Honest note on in-game semantics: tree-ness is not preserved by
+in-game *repair* — a pole rebuilt by bots auto-connects to everything
+in reach, locally re-meshing. The mode governs what the blueprint
+pastes, nothing more.
+
+## Current state (the four consumers)
+
+`power_wires::compute_pole_wires(&entities)` — per-entity quality
+reach (`common::pole_wire_reach`), min-of-both pairing, every in-reach
+pair, normalized `(a, b)` index pairs with `a < b` — is today invoked
+independently by:
+
+1. `bus::layout::layout_pass` (`layout.rs:1065`) — populates
+   `LayoutResult.power_wires` (after the quality stamp pass; ordering
+   is load-bearing) for the web overlay.
+2. `blueprint::export` (`blueprint.rs:138-150`) — **re-derives** and
+   encodes the blueprint-level `wires` array
+   (`[a+1, POLE_COPPER, b+1, POLE_COPPER]`).
+3. `validate::power::check_pole_network_connectivity`
+   (`power.rs:40-41`) — **re-derives** and checks the emitted-artifact
+   graph via `count_disconnected_poles`.
+4. `wasm-bindings::improve_region_streaming` — **recomputes** after
+   its entity-reordering splice (index pairs invalidate on reorder;
+   documented on the `power_wires` field, `models.rs:351-358`).
+
+`blueprint_parser` already does the fidelity-correct thing: it
+resolves an imported blueprint's actual `wires` array (copper
+connector-5 edges) into `power_wires` (`blueprint_parser.rs:312,
+393+`) — imported graphs are preserved verbatim, never recomputed.
+
+A mode toggle under the current shape would need the mode threaded to
+sites 2–4 and kept in agreement forever. Instead:
+
+## Design
+
+### 1. The stored-graph contract
+
+- `LayoutResult.power_wires` becomes `Option<Vec<(u32, u32)>>`:
+  - `Some(graph)` — authoritative; consumers use it verbatim (even
+    `Some(vec![])`, e.g. a single-pole layout).
+  - `None` — "never computed" (hand-built `LayoutResult`s in tests,
+    corpus tools, legacy snapshots predating power-3c). Consumers that
+    need a graph fall back to `compute_pole_wires(entities,
+    WireMode::Dense)` — exactly today's behavior, so nothing that
+    works today can silently lose its wires. The `Option` is what
+    makes "unpopulated" distinguishable from "legitimately empty";
+    a plain `Vec` cannot express that, and exporting an unpopulated
+    layout with zero wires would paste power-dead islands.
+  - Serde: `#[serde(default, skip_serializing_if = "Option::is_none")]`
+    — old snapshots (field absent) → `None` → fallback ✓; power-3c-era
+    snapshots (field present) → `Some` ✓.
+- `LayoutResult.wire_mode: WireMode` (new field, `#[serde(default)]`,
+  skipped when `Dense`): the layout records its own wiring policy, so
+  consumer 4's post-splice **recompute runs in the recorded mode** —
+  without this, an improve-region pass on a tree layout would silently
+  re-densify it.
+- Consumers 2 and 3 switch from re-deriving to
+  `layout.power_wires_or_derive()` (a small accessor holding the
+  fallback in ONE place). Consumer 1 computes-and-stores; consumer 4
+  recomputes-and-restores in `layout.wire_mode`.
+- The parser sets `Some(imported_graph)` (it already builds exactly
+  this) and leaves `wire_mode` at `Dense`-default — the mode field
+  describes how WE generate, not a claim about imports; imported
+  graphs are `Some` and therefore never regenerated regardless.
+
+Round-trip consequence, now guaranteed by construction: export a tree
+layout → parse it → `power_wires` is the tree again (the parser reads
+the artifact), and the validator validates that same tree. The
+"artifact cannot be lied about" property strengthens from convention
+to construction.
+
+### 2. `WireMode` and the deterministic MST
+
+```rust
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WireMode {
+    #[default]
+    Dense,
+    Tree,
+}
+
+pub fn compute_pole_wires(entities, mode: WireMode) -> Vec<(u32, u32)>
+```
+
+`Tree` runs Kruskal over the SAME candidate edge set `Dense` produces
+(in-reach pairs under per-entity quality reach, min-of-both — the
+physics is mode-independent), with edges sorted by
+
+```
+(squared_center_distance, a, b)      // full lexicographic order
+```
+
+- **Squared** Euclidean center distance: centers are `k + 0.5` /
+  `k + 1.0` grid values, so squared distances are exact in f64 at any
+  realistic layout size — no sqrt, no rounding wobble.
+- The `(a, b)` index tiebreak makes the sort a total order, so the
+  Kruskal result is a **unique function of the input**, tie or no tie
+  — grid layouts tie constantly (equidistant band neighbors), and MST
+  uniqueness is NOT otherwise guaranteed. Determinism is a
+  project-level contract (byte-identical output: URL state, `.fls`
+  snapshots, goldens).
+- Union-find: small local implementation (or extract the one inline
+  in `repair_pole_connectivity` — optional refactor, not required;
+  if extracted it must be behavior-identical there, golden-proven).
+- Output re-sorted by `(a, b)` — same normalization and ordering
+  convention as `Dense`, so downstream consumers see one format.
+- Disconnected pole fields (possible on degraded layouts) yield a
+  spanning **forest** — the validator still counts and warns about
+  disconnected components exactly as it does today; `Tree` never
+  papers over a genuine disconnection.
+
+### 3. Plumbing (the established ladder)
+
+`LayoutOptions.wire_mode: WireMode` (default `Dense`) → wasm `layout`
+/ `layout_traced` / `layout_streaming` gain a trailing
+`wire_mode: Option<String>` (unknown/absent → `Dense`, the
+`max_inserter_tier` pattern; trailing-optional keeps existing JS calls
+valid) → `engine.ts` → `FormState.wireMode` + URL short code `w=`
+(`t` = tree; absent = dense) → sidebar select ("Pole wiring: Dense
+(default) / Minimal tree"). `export_blueprint` and `validate` need NO
+new params — they read the stored graph. Renderer: the existing
+overlay draws whatever `power_wires` holds; only the TS type changes
+(`Option` → already-optional `power_wires?`).
+
+## Kill criteria
+
+1. **Default identity.** With `wire_mode` absent/`Dense`: full suite,
+   `SPAGHETTIO_STRESS_GOLDEN=check`, and byte-equal exported
+   blueprint strings on the quality differential fixtures
+   (stored-graph consumption must be indistinguishable from
+   re-derivation for pipeline-produced layouts — same function, same
+   entities, same bytes). Any default-mode diff ⇒ the restructure
+   leaked — halt.
+2. **Fallback honesty (the pre-agreed escape hatch).** If switching
+   export/validator to stored-wires breaks ANY existing round-trip,
+   corpus, or snapshot fixture in a way the `None`-fallback does not
+   cleanly absorb, abandon the stored-graph contract and fall back to
+   threading the mode parameter to all four sites (the design we
+   explicitly rejected as second-best — record why it won).
+3. **Determinism.** `Tree` on identical input must be bit-identical
+   across runs AND stable under a tie-heavy synthetic fixture
+   (equidistant pole line where every adjacent pair ties). A unit test
+   constructs ≥3-way ties and pins the exact edge list.
+4. **Tree property.** On every fixture where `Tree` runs:
+   `edges == poles − components`, the validator's own walk reports the
+   same `components` count as `Dense` would (never fewer warnings),
+   and every edge is a member of the dense candidate set.
+5. **Scope fence.** No placement, thinning, or substation changes; if
+   the accessor/fallback design requires touching those, stop.
+
+## Verification plan
+
+- Unit: tie-heavy determinism fixture (kill 3); tree property per
+  component incl. a deliberately disconnected two-cluster fixture
+  (kill 4); `None`-fallback exports wires for a hand-built layout
+  (the existing `export_emits_pole_copper_wires` test covers exactly
+  this path — it must keep passing unmodified).
+- Round-trip: export `Tree` → parse → `power_wires` equals the tree
+  edge set; re-export → byte-identical `wires` array.
+- Differential: 45/s legendary fixture — dense edge count vs tree
+  `== 29` (30 poles, one component; pin exact), both 0 power issues.
+- Byte-equality harness for kill 1 on the two quality differential
+  fixtures (export strings pre/post restructure at Dense).
+- Browser eyeball (user): legendary census URL with `w=t` — single
+  clean wire runs in the overlay.
+
+## Sequencing
+
+One phase; UI ships with it (no guard-rail split needed — the engine
+default is inert). Registry: RFC-044, row added in this commit's
+`docs/rfcs.md`, next number bumped to RFC-045.
+
+## Decision log
+
+- *2026-07-21 — spec'd; the stored-graph contract chosen over
+  param-threading (user decision, 2026-07-21: "the cleaner structural
+  fix"), with param-threading kept as kill-2's explicit fallback.
+  Adversarial review pending.*

--- a/docs/rfc-044-pole-wire-modes.md
+++ b/docs/rfc-044-pole-wire-modes.md
@@ -1,7 +1,8 @@
 # RFC-044: Pole wire modes — dense mesh vs deterministic minimal tree
 
-Status: DRAFT (2026-07-21) — spec'd from the 2026-07-20 power-arc
-close-out; adversarial review pending.
+Status: ACCEPTED v2 (2026-07-21) — adversarial review round 1
+complete; two must-fixes and two wording fixes folded in (decision
+log). Ready to implement.
 
 ## Summary
 
@@ -89,7 +90,12 @@ sites 2–4 and kept in agreement forever. Instead:
 - The parser sets `Some(imported_graph)` (it already builds exactly
   this) and leaves `wire_mode` at `Dense`-default — the mode field
   describes how WE generate, not a claim about imports; imported
-  graphs are `Some` and therefore never regenerated regardless.
+  graphs are `Some` and therefore never regenerated in any reachable
+  path. (Precisely: the only regeneration site is the improve-region
+  recompute, and parsed layouts carry `regions: vec![]`, so
+  `optimizeAllRegions` finds no crossing zones and never invokes it —
+  review finding 5's reachability argument, stated here so a future
+  change to parser region derivation knows to revisit this.)
 
 Round-trip consequence, now guaranteed by construction: export a tree
 layout → parse it → `power_wires` is the tree again (the parser reads
@@ -113,24 +119,32 @@ pub fn compute_pole_wires(entities, mode: WireMode) -> Vec<(u32, u32)>
 
 `Tree` runs Kruskal over the SAME candidate edge set `Dense` produces
 (in-reach pairs under per-entity quality reach, min-of-both — the
-physics is mode-independent), with edges sorted by
+physics is mode-independent), with edges sorted by the **physical**
+key (v2, review finding 6):
 
 ```
-(squared_center_distance, a, b)      // full lexicographic order
+(squared_center_distance, min_endpoint_pos, max_endpoint_pos)
+// endpoint_pos = the pole's (x, y) anchor; endpoints canonically
+// ordered per edge; full lexicographic total order
 ```
 
 - **Squared** Euclidean center distance: centers are `k + 0.5` /
   `k + 1.0` grid values, so squared distances are exact in f64 at any
   realistic layout size — no sqrt, no rounding wobble.
-- The `(a, b)` index tiebreak makes the sort a total order, so the
-  Kruskal result is a **unique function of the input**, tie or no tie
-  — grid layouts tie constantly (equidistant band neighbors), and MST
-  uniqueness is NOT otherwise guaranteed. Determinism is a
+- The tiebreak is **position-derived, not entity-index-derived**: the
+  codebase deliberately treats entity Vec order as a non-canonical
+  implementation detail (`golden_hash` sorts before hashing), so a
+  tree keyed on indices would silently change shape under a
+  legitimate pipeline reordering. With the physical key, the selected
+  wire SET is a unique function of the physical layout; tie or no
+  tie, MST uniqueness follows from the total order. Determinism is a
   project-level contract (byte-identical output: URL state, `.fls`
-  snapshots, goldens).
-- Union-find: small local implementation (or extract the one inline
-  in `repair_pole_connectivity` — optional refactor, not required;
-  if extracted it must be behavior-identical there, golden-proven).
+  snapshots, goldens), and an order-permutation fixture (kill 3)
+  proves the invariance rather than assuming it.
+- Union-find: small local implementation. (v1 floated extracting the
+  one inline in `repair_pole_connectivity`; dropped — that function is
+  placement-time code and kill 5 fences placement off. A shared
+  union-find is a possible follow-up chore, not part of this RFC.)
 - Output re-sorted by `(a, b)` — same normalization and ordering
   convention as `Dense`, so downstream consumers see one format.
 - Disconnected pole fields (possible on degraded layouts) yield a
@@ -171,19 +185,38 @@ overlay draws whatever `power_wires` holds; only the TS type changes
    (equidistant pole line where every adjacent pair ties). A unit test
    constructs ≥3-way ties and pins the exact edge list.
 4. **Tree property.** On every fixture where `Tree` runs:
-   `edges == poles − components`, the validator's own walk reports the
-   same `components` count as `Dense` would (never fewer warnings),
-   and every edge is a member of the dense candidate set.
-5. **Scope fence.** No placement, thinning, or substation changes; if
-   the accessor/fallback design requires touching those, stop.
+   `edges == poles − components` (components counted by the test's
+   own union-find over the dense candidate set), every edge is a
+   member of the dense candidate set, and
+   `count_disconnected_poles(entities, tree)` equals
+   `count_disconnected_poles(entities, dense)` — the validator's
+   actual scalar, identical between modes by construction (v2
+   wording, review finding 7).
+5. **Scope fence.** No placement, thinning, or substation changes
+   (`repair_pole_connectivity` explicitly included — the v1 "optional
+   union-find extraction" is dropped); if the accessor/fallback
+   design requires touching those, stop.
+6. **No silent re-densify (v2, review finding 10).** A Tree-mode
+   layout passed through `improve_region_streaming` must come back
+   with `power_wires` still satisfying the tree property of kill 4 —
+   the recompute at `wasm-bindings/src/lib.rs:414` must honor
+   `layout.wire_mode`, and a test proves it (build a Tree layout with
+   ≥1 crossing-zone region, run the improve pass, assert tree-shaped
+   wires after). If the mode field cannot survive the wasm boundary
+   (contradicting the `trace`/`RegionKind` precedents), that is a
+   kill-2-style abandon signal for the stored-mode design.
 
 ## Verification plan
 
-- Unit: tie-heavy determinism fixture (kill 3); tree property per
-  component incl. a deliberately disconnected two-cluster fixture
-  (kill 4); `None`-fallback exports wires for a hand-built layout
-  (the existing `export_emits_pole_copper_wires` test covers exactly
-  this path — it must keep passing unmodified).
+- Unit: tie-heavy determinism fixture (kill 3) PLUS the
+  order-permutation fixture — the same physical poles constructed in
+  two different entity orders must select the same physical wire SET
+  (v2, review finding 6); tree property per component incl. a
+  deliberately disconnected two-cluster fixture (kill 4);
+  `None`-fallback exports wires for a hand-built layout (the existing
+  `export_emits_pole_copper_wires` test covers exactly this path — it
+  must keep passing unmodified); the kill-6 improve-region
+  re-densify test.
 - Round-trip: export `Tree` → parse → `power_wires` equals the tree
   edge set; re-export → byte-identical `wires` array.
 - Differential: 45/s legendary fixture — dense edge count vs tree
@@ -203,5 +236,21 @@ default is inert). Registry: RFC-044, row added in this commit's
 
 - *2026-07-21 — spec'd; the stored-graph contract chosen over
   param-threading (user decision, 2026-07-21: "the cleaner structural
-  fix"), with param-threading kept as kill-2's explicit fallback.
-  Adversarial review pending.*
+  fix"), with param-threading kept as kill-2's explicit fallback.*
+- *2026-07-21 — adversarial review round 1. Verified sound against
+  code: the Option migration (golden hashes provably never touch
+  `power_wires`; web already treats the field as optional; consumer
+  enumeration complete — `region_reimprove` reachable only via
+  `improve_region_streaming`), the wasm round-trip (working
+  precedents: `trace: Option<Vec<..>>`, `RegionKind` enums), and the
+  parser/optimize non-reachability of the imported-wire clobber. Two
+  must-fixes folded into v2: **tiebreak retargeted from entity index
+  to physical coordinates** (entity Vec order is non-canonical by the
+  project's own golden-hash convention; index-keyed ties would let a
+  legitimate reorder silently reshape trees) with an
+  order-permutation fixture added to kill 3; and **kill 6 added** for
+  the improve-region re-densify hazard the Design section named but
+  never tested. Wording fixes: kill 4 now asserts on
+  `count_disconnected_poles`'s actual return; the union-find
+  extraction dropped to resolve the kill-5 self-tension. Ready to
+  implement.*

--- a/docs/rfc-044-pole-wire-modes.md
+++ b/docs/rfc-044-pole-wire-modes.md
@@ -254,3 +254,21 @@ default is inert). Registry: RFC-044, row added in this commit's
   `count_disconnected_poles`'s actual return; the union-find
   extraction dropped to resolve the kill-5 self-tension. Ready to
   implement.*
+- *2026-07-21 — **implemented and landed.** `WireMode` + physical-key
+  Kruskal in `power_wires`; `LayoutResult.power_wires` →
+  `Option<Vec<..>>` with `wires_for` as the single stored-or-derive
+  accessor consumed by export AND the connectivity validator;
+  `wire_mode` recorded on the layout and honored by the improve-region
+  recompute (kill 6, wasm site + core contract pin). Only ONE
+  exhaustive-literal site outside tests needed the Option migration.
+  Kill evidence: 818/818 full suite + STRESSGOLD clean (kill 1 — zero
+  golden bytes moved at Dense; `export_stored_dense_equals_fallback_derivation`
+  pins byte-equality directly); tie-heavy + order-permutation fixtures
+  (kill 3); spanning-forest property + validator-scalar invariance on
+  a two-cluster fixture (kill 4); tree round-trip is a FIXED POINT of
+  export→parse→export (byte-identical re-export);
+  `export_emits_pole_copper_wires` passes unmodified (the None-fallback
+  path). Web: `w=` codec + "Pole wiring" select; browser smoke — the
+  `q=l&w=t` URL solves (92 machines, known single warning), select
+  reads `tree`, hash round-trips. Kill 5 held: zero
+  placement/thinning/substation lines touched.*

--- a/docs/rfc-044-pole-wire-modes.md
+++ b/docs/rfc-044-pole-wire-modes.md
@@ -261,14 +261,45 @@ default is inert). Registry: RFC-044, row added in this commit's
   `wire_mode` recorded on the layout and honored by the improve-region
   recompute (kill 6, wasm site + core contract pin). Only ONE
   exhaustive-literal site outside tests needed the Option migration.
-  Kill evidence: 818/818 full suite + STRESSGOLD clean (kill 1 — zero
+  Kill evidence: full suite green + STRESSGOLD clean (kill 1 — zero
   golden bytes moved at Dense; `export_stored_dense_equals_fallback_derivation`
   pins byte-equality directly); tie-heavy + order-permutation fixtures
   (kill 3); spanning-forest property + validator-scalar invariance on
   a two-cluster fixture (kill 4); tree round-trip is a FIXED POINT of
   export→parse→export (byte-identical re-export);
   `export_emits_pole_copper_wires` passes unmodified (the None-fallback
-  path). Web: `w=` codec + "Pole wiring" select; browser smoke — the
+  path). **Kill 6 was verified by a lighter substitute than the RFC's
+  letter**: a simulated splice (`recompute_in_recorded_mode_preserves_tree`
+  — reorder + recompute-in-recorded-mode) plus inspection of the 3-line
+  wasm site, NOT the literal crossing-zone improve-pass integration run
+  the criterion described; functionally covered because kill 3's
+  order-invariance makes any real SAT-produced reordering equivalent to
+  the simulated one, but recorded here as the deviation it is. Web: `w=` codec + "Pole wiring" select; browser smoke — the
   `q=l&w=t` URL solves (92 machines, known single warning), select
   reads `tree`, hash round-trips. Kill 5 held: zero
   placement/thinning/substation lines touched.*
+- *2026-07-21 — implementation adversarial review (code + contract
+  lenses). Code: SAFE TO MERGE, zero BUG/RISK — anchor-uniqueness of
+  the MST tiebreak proven via the unconditional entity-overlap check;
+  the order-permutation fixture hand-derived to be genuinely
+  discriminating (it fails under the v1 index tiebreak: forward and
+  reversed orders would bridge different columns); the
+  None-vs-Some(vec![]) round-trip symmetry traced as
+  correct-by-construction; committed wasm-pkg `.d.ts` diffed against a
+  fresh build — byte-identical. Contract: three honesty must-fixes,
+  all landed here — (a) the earlier "818/818" figure was an
+  aggregation bug (the gates log appended the STRESSGOLD re-run and
+  the tally double-counted its 9 stress tests); the true single-run
+  count at this commit is **810 passed / 0 failed / 36 ignored**
+  (also correcting the same double-count pattern in earlier
+  same-log-append reports); (b) kill 6's simulated-splice substitute
+  now disclosed above instead of reading as satisfied-as-specified;
+  (c) the verification plan's dropped legendary tree differential is
+  now DELIVERED, not disclosed away —
+  `quality_ec_45s_legendary_tree_wire_differential` pins tree == 29
+  edges on the 30-pole census fixture, dense strictly greater, edges
+  ⊆ dense candidates, validator scalar 0 in both modes, zero power
+  issues. Doc-staleness nits fixed: the `power_wires` module header
+  and the connectivity check's doc comment described the retired
+  re-derivation architecture. Registry status bumped Design →
+  Complete (browser eyeball open).*

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -55,5 +55,6 @@ backfill the status next time the doc is touched.
 | RFC-041 | 2026-07-20 | [`rfc-build-quality.md`](rfc-build-quality.md) | Complete (in-game anchor open) |
 | RFC-042 | 2026-07-20 | [`rfc-power-reservation.md`](rfc-power-reservation.md) | Complete |
 | RFC-043 | 2026-07-20 | [`rfc-043-pole-band-thinning.md`](rfc-043-pole-band-thinning.md) | Complete (Phase 1; Phase 2 cross-row sharing deferred) |
+| RFC-044 | 2026-07-21 | [`rfc-044-pole-wire-modes.md`](rfc-044-pole-wire-modes.md) | Design |
 
-Next number: **RFC-044**.
+Next number: **RFC-045**.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -55,6 +55,6 @@ backfill the status next time the doc is touched.
 | RFC-041 | 2026-07-20 | [`rfc-build-quality.md`](rfc-build-quality.md) | Complete (in-game anchor open) |
 | RFC-042 | 2026-07-20 | [`rfc-power-reservation.md`](rfc-power-reservation.md) | Complete |
 | RFC-043 | 2026-07-20 | [`rfc-043-pole-band-thinning.md`](rfc-043-pole-band-thinning.md) | Complete (Phase 1; Phase 2 cross-row sharing deferred) |
-| RFC-044 | 2026-07-21 | [`rfc-044-pole-wire-modes.md`](rfc-044-pole-wire-modes.md) | Design |
+| RFC-044 | 2026-07-21 | [`rfc-044-pole-wire-modes.md`](rfc-044-pole-wire-modes.md) | Complete (browser eyeball open) |
 
 Next number: **RFC-045**.

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -251,7 +251,7 @@ function allProducerMachines(): string[] {
   return machinesCache;
 }
 
-function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string): Promise<LayoutResult> {
+function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string): Promise<LayoutResult> {
   return call<LayoutResult>({
     method: "layout",
     result,
@@ -260,10 +260,11 @@ function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: stri
     rowLayout: rowLayout ?? null,
     maxInserterTier: maxInserterTier ?? null,
     quality: quality ?? null,
+    wireMode: wireMode ?? null,
   });
 }
 
-function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string): Promise<LayoutResult> {
+function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string): Promise<LayoutResult> {
   return call<LayoutResult>({
     method: "layoutTraced",
     result,
@@ -272,6 +273,7 @@ function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?
     rowLayout: rowLayout ?? null,
     maxInserterTier: maxInserterTier ?? null,
     quality: quality ?? null,
+    wireMode: wireMode ?? null,
   });
 }
 
@@ -298,6 +300,7 @@ async function buildLayoutStreaming(
   rowLayout: string | undefined,
   maxInserterTier: string | undefined,
   quality: string | undefined,
+  wireMode: string | undefined,
   onEvent: (evt: TraceEvent) => void,
 ): Promise<LayoutResult> {
   if (activeStreamingId !== null) {
@@ -331,6 +334,7 @@ async function buildLayoutStreaming(
       rowLayout: rowLayout ?? null,
       maxInserterTier: maxInserterTier ?? null,
       quality: quality ?? null,
+      wireMode: wireMode ?? null,
       traceLogs,
     });
   });

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -32,6 +32,7 @@ function makeState(overrides: Partial<FormState>): FormState {
     rowLayout: null,
     inserterTier: null,
     quality: null,
+    wireMode: null,
     customInputs: [],
     ...overrides,
   };
@@ -49,6 +50,7 @@ describe("readUrlState — defaults", () => {
       rowLayout: null,
       inserterTier: null,
       quality: null,
+      wireMode: null,
       customInputs: [],
     });
   });
@@ -118,6 +120,7 @@ describe("readUrlState — hash form", () => {
       rowLayout: null,
       inserterTier: null,
       quality: null,
+      wireMode: null,
       customInputs: [],
     });
   });
@@ -204,6 +207,7 @@ describe("writeUrlState → readUrlState round-trip", () => {
       rowLayout: "horizontal-stack",
       inserterTier: "regular",
       quality: null,
+      wireMode: null,
       customInputs: ["iron-plate", "copper-plate"],
     });
     const back = roundTrip(state);
@@ -219,6 +223,7 @@ describe("writeUrlState → readUrlState round-trip", () => {
       rate: 4,
       machines: { crafting: DEFAULT_MACHINES.crafting },
       quality: "legendary",
+      wireMode: null,
     });
     writeUrlState(state);
     expect(window.location.hash).toContain("q=l");
@@ -230,10 +235,33 @@ describe("writeUrlState → readUrlState round-trip", () => {
       rate: 4,
       machines: { crafting: DEFAULT_MACHINES.crafting },
       quality: null,
+      wireMode: null,
     });
     writeUrlState(normal);
     expect(window.location.hash).not.toContain("q=");
     expect(readUrlState().quality).toBeNull();
+  });
+
+  it("wire mode round-trips via the w= short code; dense is omitted", () => {
+    const state = makeState({
+      item: "electronic-circuit",
+      rate: 4,
+      machines: { crafting: DEFAULT_MACHINES.crafting },
+      wireMode: "tree",
+    });
+    writeUrlState(state);
+    expect(window.location.hash).toContain("w=t");
+    expect(readUrlState().wireMode).toBe("tree");
+
+    const dense = makeState({
+      item: "electronic-circuit",
+      rate: 4,
+      machines: { crafting: DEFAULT_MACHINES.crafting },
+      wireMode: null,
+    });
+    writeUrlState(dense);
+    expect(window.location.hash).not.toContain("w=");
+    expect(readUrlState().wireMode).toBeNull();
   });
 
   it("stack (default) inserter tier is omitted from the URL", () => {
@@ -243,6 +271,7 @@ describe("writeUrlState → readUrlState round-trip", () => {
       machines: { crafting: DEFAULT_MACHINES.crafting },
       inserterTier: null,
       quality: null,
+      wireMode: null,
     });
     writeUrlState(state);
     expect(window.location.hash).toBe("#/l/igw/7");

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -32,6 +32,9 @@ export interface FormState {
    * "legendary"). null = normal (today's default) — same null-is-default
    * convention as `inserterTier`. See `docs/rfc-build-quality.md`. */
   quality: string | null;
+  /** Pole wiring mode ("tree"). null = dense (today's default) — same
+   * null-is-default convention as `quality`. See RFC-044. */
+  wireMode: string | null;
   /** User-added inputs beyond the DEFAULT_INPUTS list. */
   customInputs: string[];
 }
@@ -58,6 +61,11 @@ export const KNOWN_INSERTER_TIERS = ["regular", "fast"] as const;
  * `"normal"` (the default) is intentionally absent — represented by
  * `null`, same convention as `KNOWN_INSERTER_TIERS`. */
 export const KNOWN_QUALITIES = ["uncommon", "rare", "epic", "legendary"] as const;
+
+/** Wire-mode values accepted on the URL and in `FormState.wireMode`.
+ * `"dense"` (the default) is intentionally absent — represented by
+ * `null`, same convention as `KNOWN_QUALITIES`. */
+export const KNOWN_WIRE_MODES = ["tree"] as const;
 
 /** Full list of input pills rendered in the sidebar. */
 export const DEFAULT_INPUTS: string[] = [
@@ -159,6 +167,9 @@ const QUALITY_FULL_TO_SHORT: Record<string, string> = {
   legendary: "l",
 };
 
+const WIRE_MODE_SHORT_TO_FULL: Record<string, string> = { t: "tree" };
+const WIRE_MODE_FULL_TO_SHORT: Record<string, string> = { tree: "t" };
+
 function slugToCode(slug: string): string {
   // Fall back to the slug itself if it's not in the table — keeps
   // serialization total (e.g. an unknown / modded item still produces a
@@ -253,6 +264,8 @@ function readHashState(): FormState | null {
   const inserterTier = itShort ? INSERTER_TIER_SHORT_TO_FULL[itShort] ?? null : null;
   const qShort = extras.get("q");
   const quality = qShort ? QUALITY_SHORT_TO_FULL[qShort] ?? null : null;
+  const wShort = extras.get("w");
+  const wireMode = wShort ? WIRE_MODE_SHORT_TO_FULL[wShort] ?? null : null;
   const ciRaw = extras.get("ci");
   let customInputs: string[] = [];
   if (ciRaw) {
@@ -276,7 +289,7 @@ function readHashState(): FormState | null {
     machines[category] = slug;
   }
 
-  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, customInputs };
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, customInputs };
 }
 
 function readQueryState(): FormState {
@@ -313,6 +326,11 @@ function readQueryState(): FormState {
     rawInserterTier && (KNOWN_INSERTER_TIERS as readonly string[]).includes(rawInserterTier)
       ? rawInserterTier
       : null;
+  const rawWireMode = params.get("wire_mode");
+  const wireMode =
+    rawWireMode && (KNOWN_WIRE_MODES as readonly string[]).includes(rawWireMode)
+      ? rawWireMode
+      : null;
   const rawQuality = params.get("quality");
   const quality =
     rawQuality && (KNOWN_QUALITIES as readonly string[]).includes(rawQuality)
@@ -321,7 +339,7 @@ function readQueryState(): FormState {
   const ciParam = params.get("ci");
   const customInputs = ciParam ? ciParam.split(",").filter((s) => s.length > 0) : [];
 
-  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, customInputs };
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, customInputs };
 }
 
 export function readUrlState(): FormState {
@@ -391,6 +409,9 @@ function formatHashState(state: FormState): string {
   }
   if (state.quality && QUALITY_FULL_TO_SHORT[state.quality]) {
     extras.set("q", QUALITY_FULL_TO_SHORT[state.quality]);
+  }
+  if (state.wireMode && WIRE_MODE_FULL_TO_SHORT[state.wireMode]) {
+    extras.set("w", WIRE_MODE_FULL_TO_SHORT[state.wireMode]);
   }
   if (state.customInputs.length > 0) {
     extras.set(

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -475,6 +475,22 @@ export function renderSidebar(
   });
   targetBody.appendChild(makeField("Build quality", qualitySelect));
 
+  // Pole wiring mode (RFC-044): dense mesh (robust, default) vs a
+  // deterministic minimal spanning tree (fewest wires, visually clean;
+  // note deconstructing one pole in-game splits a tree network).
+  const wireModeSelect = document.createElement("select");
+  wireModeSelect.className = "sb-select";
+  [
+    ["Dense (default)", ""],
+    ["Minimal tree", "tree"],
+  ].forEach(([label, value]) => {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = label;
+    wireModeSelect.appendChild(opt);
+  });
+  targetBody.appendChild(makeField("Pole wiring", wireModeSelect));
+
   // Layout strategy. Phase 0b of `rfc-modular-production` shipped the
   // dropdown; the surviving `partitioned-decomposed` variant produces
   // strictly ≤ Pooled errors on every case in the corpus. The deprecated
@@ -703,6 +719,7 @@ export function renderSidebar(
   if (urlState.rowLayout) rowLayoutSelect.value = urlState.rowLayout;
   if (urlState.inserterTier) inserterTierSelect.value = urlState.inserterTier;
   if (urlState.quality) qualitySelect.value = urlState.quality;
+  if (urlState.wireMode) wireModeSelect.value = urlState.wireMode;
   // Restore custom inputs from URL
   for (const item of urlState.customInputs) {
     if (itemSet.has(item) && !defaultInputSet.has(item) && !customInputs.includes(item)) {
@@ -775,6 +792,7 @@ export function renderSidebar(
       rowLayout: rowLayoutSelect.value || null,
       inserterTier: inserterTierSelect.value || null,
       quality: qualitySelect.value || null,
+      wireMode: wireModeSelect.value || null,
       customInputs,
     });
 
@@ -844,8 +862,9 @@ export function renderSidebar(
       const rowLayout = rowLayoutSelect.value || undefined;
       const maxInserterTier = inserterTierSelect.value || undefined;
       const quality = qualitySelect.value || undefined;
+      const wireMode = wireModeSelect.value || undefined;
       const onEvent = callbacks.startStreaming();
-      layout = await engine.buildLayoutStreaming(result, maxTier, strategy, rowLayout, maxInserterTier, quality, onEvent);
+      layout = await engine.buildLayoutStreaming(result, maxTier, strategy, rowLayout, maxInserterTier, quality, wireMode, onEvent);
     } catch (err) {
       if (gen !== solveGeneration) return;
       const errDiv = document.createElement("div");
@@ -882,6 +901,7 @@ export function renderSidebar(
   rowLayoutSelect.addEventListener("change", scheduleAutoSolve);
   inserterTierSelect.addEventListener("change", scheduleAutoSolve);
   qualitySelect.addEventListener("change", scheduleAutoSolve);
+  wireModeSelect.addEventListener("change", scheduleAutoSolve);
   checkboxes.forEach((cb) => cb.addEventListener("change", scheduleAutoSolve));
 
   runSolve().catch((err) => console.error("runSolve failed:", err));

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -35,9 +35,9 @@ type Request =
       defaultMachine: string;
       quality: string | null;
     }
-  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null }
-  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null }
-  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null }
+  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null }
+  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null }
+  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null }
   | { id: number; method: "exportBlueprint"; layout: LayoutResult; label: string }
   | {
       id: number;
@@ -112,10 +112,10 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         );
         break;
       case "layout":
-        result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined);
+        result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined);
         break;
       case "layoutTraced":
-        result = layout_traced(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined);
+        result = layout_traced(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined);
         break;
       case "layoutStreaming": {
         const id = req.id;
@@ -158,7 +158,7 @@ self.onmessage = async (e: MessageEvent<Request>) => {
           if (batch.length >= BATCH_SIZE) flushBatch();
         };
         try {
-          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, emit);
+          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, emit);
         } finally {
           flushBatch();
           if (TRACE_LOGS) {


### PR DESCRIPTION
## Intent

Implements [`docs/rfc-045-pole-wire-modes.md`](docs/rfc-045-pole-wire-modes.md) (RFC-045, registered): a user-facing pole wiring toggle — `dense` (today's every-in-reach-pair mesh, maximally robust, default) or `tree` (deterministic minimum spanning forest — fewest wires, visually clean, especially on quality layouts' long spans). Ships the RFC's structural fix alongside: the wire graph is **computed once and stored on the layout**, and every consumer reads the stored graph.

## Scope

- **In:**
  - `WireMode` + Kruskal in `power_wires`, ordered by the **physical** key `(squared-center-distance, canonical endpoint anchors)` — the tree is a unique function of the physical layout, invariant under entity-Vec reordering (the review-driven design change; an order-permutation fixture pins it).
  - Stored-graph contract: `LayoutResult.power_wires: Option<Vec<..>>`, authoritative when `Some`; `blueprint::export` and `check_pole_network_connectivity` both consume it through the single `wires_for` accessor (`None` → dense-derive fallback, so hand-built layouts and old snapshots can't export power-dead poles). The artifact, the validated graph, and the overlay are now the same object **by construction**.
  - `LayoutResult.wire_mode` records the layout's own policy; the `improve_region_streaming` post-splice recompute honors it (RFC kill 6 — no silent re-densify).
  - Plumbing ladder: `LayoutOptions.wire_mode` → wasm `layout`/`layout_traced`/`layout_streaming` trailing optional param → `engine.ts` → `w=` URL short code → sidebar "Pole wiring" select.
- **Out:** any placement/thinning/substation change (kill 5, held — zero lines); the parser's imported-wire preservation was already correct and is unchanged (tree exports round-trip verbatim as a consequence).

## Verification

- [x] `cargo test` full suite — **810 passed / 0 failed / 36 ignored** (single clean run; an earlier 818/818 figure double-counted an appended STRESSGOLD re-run and is corrected in the decision log) + `SPAGHETTIO_STRESS_GOLDEN=check` 9/9, zero golden bytes moved at default mode (kill 1); `cargo clippy -p spaghettio_core -- -D warnings` clean.
- [x] Kill-criteria tests: tie-heavy determinism + order-permutation invariance (kill 3); spanning-forest property + `count_disconnected_poles` mode-invariance on a deliberately disconnected fixture (kill 4); `export_stored_dense_equals_fallback_derivation` byte-equality (kill 1); recompute-in-recorded-mode contract pin (kill 6); `export_emits_pole_copper_wires` passes unmodified (the `None`-fallback path).
- [x] Round-trip: a Tree export is a **fixed point** of export→parse→export (byte-identical re-export).
- [x] Legendary tree differential (delivered after the implementation contract review flagged it dropped): `quality_ec_45s_legendary_tree_wire_differential` — tree == 29 edges on the 30-pole census fixture, dense strictly greater, edges ⊆ dense candidates, validator scalar mode-invariant, zero power issues.
- [x] Implementation adversarial review (code + contract lenses): SAFE TO MERGE, zero BUG/RISK; three honesty must-fixes landed (`9efceaa`, decision log).
- [x] Web: tsc clean, 25/25 vitest (incl. the `w=` codec round-trip); browser smoke — `#/l/ecl/45/am3/ior,coo/etb?q=l&w=t` solves (92 machines, the known single warning), select reads `tree`, hash round-trips.
- [ ] Browser eyeball (user): same URL — single clean wire runs in the power overlay vs the dense mesh.

## Deviations from intent

- **Kill 6 verified by a lighter substitute than the RFC's letter**: a simulated splice (reorder + recompute-in-recorded-mode) plus inspection of the 3-line wasm site, not the literal crossing-zone improve-pass integration run — functionally covered via kill 3's order-invariance; disclosed in the decision log.
- (v1 → v2 spec evolution: tiebreak retargeted from entity index to physical coordinates and the re-densify kill added, per the spec adversarial review — decision log.)

## Models / contracts touched

`LayoutResult.power_wires` semantics (Option-al, stored-authoritative — documented on the field and in RFC-045 §1), `docs/rfcs.md` registry (RFC-045, next → 045). The `power_wires` module's "N sites must agree" convention is retired in favor of the accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55