### PR TITLE
feat: RFC-044 Phase 0 — module export format, quality in model, eligibility data

### DIFF
--- a/crates/core/data/recipes.json
+++ b/crates/core/data/recipes.json
@@ -1783,7 +1783,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "concrete": {
       "name": "concrete",
@@ -1932,7 +1933,8 @@
           "amount": 10,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "overgrowth-yumako-soil": {
       "name": "overgrowth-yumako-soil",
@@ -1971,7 +1973,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "artificial-jellynut-soil": {
       "name": "artificial-jellynut-soil",
@@ -2000,7 +2003,8 @@
           "amount": 10,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "overgrowth-jellynut-soil": {
       "name": "overgrowth-jellynut-soil",
@@ -2039,7 +2043,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "ice-platform": {
       "name": "ice-platform",
@@ -3670,7 +3675,8 @@
           "amount": 45,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "advanced-oil-processing": {
       "name": "advanced-oil-processing",
@@ -3704,7 +3710,8 @@
           "amount": 55,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "simple-coal-liquefaction": {
       "name": "simple-coal-liquefaction",
@@ -3733,7 +3740,8 @@
           "amount": 50,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "coal-liquefaction": {
       "name": "coal-liquefaction",
@@ -3760,7 +3768,8 @@
         {
           "name": "heavy-oil",
           "amount": 90,
-          "type": "fluid"
+          "type": "fluid",
+          "ignored_by_productivity": 25
         },
         {
           "name": "light-oil",
@@ -3772,7 +3781,8 @@
           "amount": 10,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "heavy-oil-cracking": {
       "name": "heavy-oil-cracking",
@@ -3796,7 +3806,8 @@
           "amount": 30,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "light-oil-cracking": {
       "name": "light-oil-cracking",
@@ -3820,7 +3831,8 @@
           "amount": 20,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "solid-fuel-from-petroleum-gas": {
       "name": "solid-fuel-from-petroleum-gas",
@@ -3839,7 +3851,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "solid-fuel-from-light-oil": {
       "name": "solid-fuel-from-light-oil",
@@ -3858,7 +3871,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "solid-fuel-from-heavy-oil": {
       "name": "solid-fuel-from-heavy-oil",
@@ -3877,7 +3891,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "lubricant": {
       "name": "lubricant",
@@ -3896,7 +3911,8 @@
           "amount": 10,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "sulfuric-acid": {
       "name": "sulfuric-acid",
@@ -3925,7 +3941,8 @@
           "amount": 50,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "acid-neutralisation": {
       "name": "acid-neutralisation",
@@ -3987,7 +4004,8 @@
           "amount": 20,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "iron-plate": {
       "name": "iron-plate",
@@ -4006,7 +4024,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "copper-plate": {
       "name": "copper-plate",
@@ -4025,7 +4044,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "steel-plate": {
       "name": "steel-plate",
@@ -4044,7 +4064,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "plastic-bar": {
       "name": "plastic-bar",
@@ -4068,7 +4089,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "sulfur": {
       "name": "sulfur",
@@ -4092,7 +4114,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "battery": {
       "name": "battery",
@@ -4121,7 +4144,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "explosives": {
       "name": "explosives",
@@ -4150,7 +4174,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "carbon": {
       "name": "carbon",
@@ -4174,7 +4199,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "coal-synthesis": {
       "name": "coal-synthesis",
@@ -4203,7 +4229,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "water-barrel": {
       "name": "water-barrel",
@@ -4654,7 +4681,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "iron-stick": {
       "name": "iron-stick",
@@ -4673,7 +4701,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "copper-cable": {
       "name": "copper-cable",
@@ -4692,7 +4721,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "barrel": {
       "name": "barrel",
@@ -4711,7 +4741,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "electronic-circuit": {
       "name": "electronic-circuit",
@@ -4735,7 +4766,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "advanced-circuit": {
       "name": "advanced-circuit",
@@ -4764,7 +4796,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "processing-unit": {
       "name": "processing-unit",
@@ -4793,7 +4826,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "engine-unit": {
       "name": "engine-unit",
@@ -4822,7 +4856,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "electric-engine-unit": {
       "name": "electric-engine-unit",
@@ -4851,7 +4886,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "flying-robot-frame": {
       "name": "flying-robot-frame",
@@ -4885,7 +4921,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "low-density-structure": {
       "name": "low-density-structure",
@@ -4914,7 +4951,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "rocket-fuel": {
       "name": "rocket-fuel",
@@ -4938,7 +4976,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "uranium-processing": {
       "name": "uranium-processing",
@@ -4964,7 +5003,8 @@
           "type": "item",
           "probability": 0.993
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "uranium-fuel-cell": {
       "name": "uranium-fuel-cell",
@@ -4993,7 +5033,8 @@
           "amount": 10,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "nuclear-fuel-reprocessing": {
       "name": "nuclear-fuel-reprocessing",
@@ -5012,7 +5053,8 @@
           "amount": 3,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "kovarex-enrichment-process": {
       "name": "kovarex-enrichment-process",
@@ -5034,14 +5076,17 @@
         {
           "name": "uranium-235",
           "amount": 41,
-          "type": "item"
+          "type": "item",
+          "ignored_by_productivity": 40
         },
         {
           "name": "uranium-238",
           "amount": 2,
-          "type": "item"
+          "type": "item",
+          "ignored_by_productivity": 2
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "nuclear-fuel": {
       "name": "nuclear-fuel",
@@ -5065,7 +5110,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "molten-iron-from-lava": {
       "name": "molten-iron-from-lava",
@@ -5094,7 +5140,8 @@
           "amount": 10,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "molten-copper-from-lava": {
       "name": "molten-copper-from-lava",
@@ -5123,7 +5170,8 @@
           "amount": 15,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "molten-iron": {
       "name": "molten-iron",
@@ -5147,7 +5195,8 @@
           "amount": 500,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "molten-copper": {
       "name": "molten-copper",
@@ -5171,7 +5220,8 @@
           "amount": 500,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "casting-iron": {
       "name": "casting-iron",
@@ -5190,7 +5240,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "casting-copper": {
       "name": "casting-copper",
@@ -5209,7 +5260,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "casting-steel": {
       "name": "casting-steel",
@@ -5228,7 +5280,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "casting-iron-gear-wheel": {
       "name": "casting-iron-gear-wheel",
@@ -5247,7 +5300,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "casting-iron-stick": {
       "name": "casting-iron-stick",
@@ -5266,7 +5320,8 @@
           "amount": 4,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "casting-low-density-structure": {
       "name": "casting-low-density-structure",
@@ -5295,7 +5350,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "concrete-from-molten-iron": {
       "name": "concrete-from-molten-iron",
@@ -5324,7 +5380,8 @@
           "amount": 10,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "casting-copper-cable": {
       "name": "casting-copper-cable",
@@ -5343,7 +5400,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "tungsten-carbide": {
       "name": "tungsten-carbide",
@@ -5372,7 +5430,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "tungsten-plate": {
       "name": "tungsten-plate",
@@ -5396,7 +5455,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "holmium-solution": {
       "name": "holmium-solution",
@@ -5425,7 +5485,8 @@
           "amount": 100,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "holmium-plate": {
       "name": "holmium-plate",
@@ -5444,7 +5505,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "superconductor": {
       "name": "superconductor",
@@ -5478,7 +5540,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "electrolyte": {
       "name": "electrolyte",
@@ -5507,7 +5570,8 @@
           "amount": 10,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "supercapacitor": {
       "name": "supercapacitor",
@@ -5546,7 +5610,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "yumako-processing": {
       "name": "yumako-processing",
@@ -5571,7 +5636,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "jellynut-processing": {
       "name": "jellynut-processing",
@@ -5596,7 +5662,8 @@
           "amount": 4,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "iron-bacteria": {
       "name": "iron-bacteria",
@@ -5621,7 +5688,8 @@
           "amount": 4,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "iron-bacteria-cultivation": {
       "name": "iron-bacteria-cultivation",
@@ -5645,7 +5713,8 @@
           "amount": 4,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "copper-bacteria": {
       "name": "copper-bacteria",
@@ -5670,7 +5739,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "copper-bacteria-cultivation": {
       "name": "copper-bacteria-cultivation",
@@ -5694,7 +5764,8 @@
           "amount": 4,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "nutrients-from-spoilage": {
       "name": "nutrients-from-spoilage",
@@ -5713,7 +5784,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "nutrients-from-yumako-mash": {
       "name": "nutrients-from-yumako-mash",
@@ -5732,7 +5804,8 @@
           "amount": 6,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "nutrients-from-bioflux": {
       "name": "nutrients-from-bioflux",
@@ -5751,7 +5824,8 @@
           "amount": 40,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "bioflux": {
       "name": "bioflux",
@@ -5775,7 +5849,8 @@
           "amount": 4,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "rocket-fuel-from-jelly": {
       "name": "rocket-fuel-from-jelly",
@@ -5804,7 +5879,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "biolubricant": {
       "name": "biolubricant",
@@ -5823,7 +5899,8 @@
           "amount": 20,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "bioplastic": {
       "name": "bioplastic",
@@ -5847,7 +5924,8 @@
           "amount": 3,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "biosulfur": {
       "name": "biosulfur",
@@ -5871,7 +5949,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "carbon-fiber": {
       "name": "carbon-fiber",
@@ -5895,7 +5974,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "burnt-spoilage": {
       "name": "burnt-spoilage",
@@ -5914,7 +5994,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "biter-egg": {
       "name": "biter-egg",
@@ -5954,9 +6035,11 @@
         {
           "name": "pentapod-egg",
           "amount": 2,
-          "type": "item"
+          "type": "item",
+          "ignored_by_productivity": 1
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "wood-processing": {
       "name": "wood-processing",
@@ -5975,7 +6058,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "fish-breeding": {
       "name": "fish-breeding",
@@ -6002,7 +6086,8 @@
         {
           "name": "raw-fish",
           "amount": 3,
-          "type": "item"
+          "type": "item",
+          "ignored_by_productivity": 2
         }
       ]
     },
@@ -6042,7 +6127,8 @@
           "amount": 20,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "ammoniacal-solution-separation": {
       "name": "ammoniacal-solution-separation",
@@ -6066,7 +6152,8 @@
           "amount": 50,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "solid-fuel-from-ammonia": {
       "name": "solid-fuel-from-ammonia",
@@ -6090,7 +6177,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "ammonia-rocket-fuel": {
       "name": "ammonia-rocket-fuel",
@@ -6119,7 +6207,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "fluoroketone": {
       "name": "fluoroketone",
@@ -6153,7 +6242,8 @@
           "amount": 50,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "fluoroketone-cooling": {
       "name": "fluoroketone-cooling",
@@ -6201,7 +6291,8 @@
           "amount": 5,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "lithium-plate": {
       "name": "lithium-plate",
@@ -6220,7 +6311,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "quantum-processor": {
       "name": "quantum-processor",
@@ -6267,9 +6359,11 @@
         {
           "name": "fluoroketone-hot",
           "amount": 5,
-          "type": "fluid"
+          "type": "fluid",
+          "ignored_by_productivity": 5
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "fusion-power-cell": {
       "name": "fusion-power-cell",
@@ -6298,7 +6392,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "automation-science-pack": {
       "name": "automation-science-pack",
@@ -6322,7 +6417,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "logistic-science-pack": {
       "name": "logistic-science-pack",
@@ -6346,7 +6442,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "military-science-pack": {
       "name": "military-science-pack",
@@ -6375,7 +6472,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "chemical-science-pack": {
       "name": "chemical-science-pack",
@@ -6404,7 +6502,8 @@
           "amount": 2,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "production-science-pack": {
       "name": "production-science-pack",
@@ -6433,7 +6532,8 @@
           "amount": 3,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "utility-science-pack": {
       "name": "utility-science-pack",
@@ -6462,7 +6562,8 @@
           "amount": 3,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "space-science-pack": {
       "name": "space-science-pack",
@@ -6491,7 +6592,8 @@
           "amount": 5,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "metallurgic-science-pack": {
       "name": "metallurgic-science-pack",
@@ -6520,7 +6622,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "agricultural-science-pack": {
       "name": "agricultural-science-pack",
@@ -6544,7 +6647,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "electromagnetic-science-pack": {
       "name": "electromagnetic-science-pack",
@@ -6578,7 +6682,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "cryogenic-science-pack": {
       "name": "cryogenic-science-pack",
@@ -6610,9 +6715,11 @@
         {
           "name": "fluoroketone-hot",
           "amount": 3,
-          "type": "fluid"
+          "type": "fluid",
+          "ignored_by_productivity": 3
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "promethium-science-pack": {
       "name": "promethium-science-pack",
@@ -6641,7 +6748,8 @@
           "amount": 10,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "rocket-silo": {
       "name": "rocket-silo",
@@ -6709,7 +6817,8 @@
           "amount": 1,
           "type": "item"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "cargo-landing-pad": {
       "name": "cargo-landing-pad",
@@ -6902,7 +7011,8 @@
           "amount": 75,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "advanced-thruster-fuel": {
       "name": "advanced-thruster-fuel",
@@ -6931,7 +7041,8 @@
           "amount": 1500,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "thruster-oxidizer": {
       "name": "thruster-oxidizer",
@@ -6955,7 +7066,8 @@
           "amount": 75,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "advanced-thruster-oxidizer": {
       "name": "advanced-thruster-oxidizer",
@@ -6984,7 +7096,8 @@
           "amount": 1500,
           "type": "fluid"
         }
-      ]
+      ],
+      "allow_productivity": true
     },
     "pistol": {
       "name": "pistol",
@@ -8856,70 +8969,80 @@
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-1": {
       "name": "parameter-1",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-2": {
       "name": "parameter-2",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-3": {
       "name": "parameter-3",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-4": {
       "name": "parameter-4",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-5": {
       "name": "parameter-5",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-6": {
       "name": "parameter-6",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-7": {
       "name": "parameter-7",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-8": {
       "name": "parameter-8",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "parameter-9": {
       "name": "parameter-9",
       "category": "parameters",
       "energy": 0.5,
       "ingredients": [],
-      "results": []
+      "results": [],
+      "allow_productivity": true
     },
     "heat-interface": {
       "name": "heat-interface",
@@ -16765,11 +16888,23 @@
   },
   "machines": {
     "centrifuge": {
-      "crafting_speed": 1
+      "crafting_speed": 1,
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
+      ]
     },
     "assembling-machine-1": {
       "crafting_speed": 0.5,
-      "ingredient_slots": 2
+      "ingredient_slots": 2,
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "speed"
+      ]
     },
     "assembling-machine-2": {
       "crafting_speed": 0.75,
@@ -16798,6 +16933,13 @@
           ],
           "production_type": "output"
         }
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
       ]
     },
     "assembling-machine-3": {
@@ -16827,6 +16969,13 @@
           ],
           "production_type": "output"
         }
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
       ]
     },
     "chemical-plant": {
@@ -16880,10 +17029,24 @@
           ],
           "production_type": "output"
         }
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
       ]
     },
     "electric-furnace": {
-      "crafting_speed": 2
+      "crafting_speed": 2,
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
+      ]
     },
     "oil-refinery": {
       "crafting_speed": 1,
@@ -16948,13 +17111,29 @@
           ],
           "production_type": "output"
         }
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "speed"
       ]
     },
     "stone-furnace": {
-      "crafting_speed": 1
+      "crafting_speed": 1,
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "speed"
+      ]
     },
     "steel-furnace": {
-      "crafting_speed": 2
+      "crafting_speed": 2,
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "speed"
+      ]
     },
     "foundry": {
       "crafting_speed": 4,
@@ -17007,7 +17186,15 @@
           ],
           "production_type": "output"
         }
-      ]
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
+      ],
+      "base_effect_productivity": 0.5
     },
     "electromagnetic-plant": {
       "crafting_speed": 2,
@@ -17060,7 +17247,15 @@
           ],
           "production_type": "output"
         }
-      ]
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
+      ],
+      "base_effect_productivity": 0.5
     },
     "cryogenic-plant": {
       "crafting_speed": 2,
@@ -17137,6 +17332,13 @@
           ],
           "production_type": "output"
         }
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
       ]
     },
     "biochamber": {
@@ -17190,13 +17392,34 @@
           ],
           "production_type": "output"
         }
-      ]
+      ],
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
+      ],
+      "base_effect_productivity": 0.5
     },
     "recycler": {
-      "crafting_speed": 0.5
+      "crafting_speed": 0.5,
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "quality",
+        "speed"
+      ]
     },
     "crusher": {
-      "crafting_speed": 1
+      "crafting_speed": 1,
+      "allowed_effects": [
+        "consumption",
+        "pollution",
+        "productivity",
+        "quality",
+        "speed"
+      ]
     }
   }
 }

--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -762,6 +762,7 @@ mod tests {
                     items: vec![ModuleItem {
                         item: "productivity-module-3".into(),
                         count: 4,
+                        quality: None,
                     }],
                     ..Default::default()
                 },
@@ -773,6 +774,7 @@ mod tests {
                     items: vec![ModuleItem {
                         item: "speed-module-3".into(),
                         count: 2,
+                        quality: None,
                     }],
                     ..Default::default()
                 },

--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -53,6 +53,43 @@ struct BlueprintEntity<'a> {
     /// stamped upstream by the layout's functional-only stamp pass.
     #[serde(skip_serializing_if = "Option::is_none")]
     quality: Option<&'static str>,
+    /// Modules in this entity, as 2.0 insert plans (RFC-044 Phase 0).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    items: Vec<BlueprintInsertPlan<'a>>,
+}
+
+/// Lua-api `BlueprintInsertPlan`: one entry per distinct module
+/// (item, quality) with explicit per-unit slot positions. This is the
+/// ONLY module encoding Factorio 2.0 honors in a 2.0-versioned envelope
+/// (which ours is — there is no 1.x-migration fallback for a name→count
+/// map here).
+#[derive(Serialize)]
+struct BlueprintInsertPlan<'a> {
+    id: BlueprintItemId<'a>,
+    items: ItemInventoryPositions,
+}
+
+/// Lua-api `ItemIDAndQualityIDPair`. Quality omitted at normal.
+#[derive(Serialize)]
+struct BlueprintItemId<'a> {
+    name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quality: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+struct ItemInventoryPositions {
+    in_inventory: Vec<InventoryPosition>,
+}
+
+/// Lua-api `InventoryPosition`: `inventory` is the per-entity-class
+/// `defines.inventory` id from `common::module_inventory_id`; `stack` is
+/// the 0-based module slot. `count` is omitted (defaults to 1 — one
+/// entry per module unit, matching the game's own emission).
+#[derive(Serialize)]
+struct InventoryPosition {
+    inventory: u8,
+    stack: u32,
 }
 
 #[derive(Serialize)]
@@ -131,6 +168,34 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
                     .quality
                     .filter(|q| *q != crate::common::QualityTier::Normal)
                     .map(|q| q.name()),
+                items: {
+                    // Slot positions run sequentially across ALL modules
+                    // in the entity: module A ×2 takes stacks 0,1; the
+                    // next module starts at 2.
+                    let inventory = crate::common::module_inventory_id(&ent.name);
+                    let mut stack = 0u32;
+                    ent.items
+                        .iter()
+                        .map(|m| BlueprintInsertPlan {
+                            id: BlueprintItemId {
+                                name: &m.item,
+                                quality: m
+                                    .quality
+                                    .filter(|q| *q != crate::common::QualityTier::Normal)
+                                    .map(|q| q.name()),
+                            },
+                            items: ItemInventoryPositions {
+                                in_inventory: (0..m.count)
+                                    .map(|_| {
+                                        let p = InventoryPosition { inventory, stack };
+                                        stack += 1;
+                                        p
+                                    })
+                                    .collect(),
+                            },
+                        })
+                        .collect()
+                },
             }
         })
         .collect();
@@ -242,6 +307,151 @@ mod tests {
         assert!(ents[0].get("mirror").is_none());
         // recipe should be absent for belt
         assert!(ents[1].get("recipe").is_none());
+    }
+
+    /// The exported module encoding must match the game's own emission
+    /// byte-shape (draftsman 2.0.76 reference, RFC-044 Phase 0): one
+    /// insert-plan per module id, one `in_inventory` entry per module
+    /// unit with sequential 0-based stacks, NO `count` field, quality
+    /// omitted at normal, `inventory` per entity class.
+    #[test]
+    fn module_items_match_insert_plan_reference_shape() {
+        use crate::common::QualityTier;
+        use crate::models::ModuleItem;
+
+        let layout = LayoutResult {
+            entities: vec![PlacedEntity {
+                name: "assembling-machine-3".into(),
+                x: 0,
+                y: 0,
+                direction: EntityDirection::North,
+                recipe: Some("iron-gear-wheel".into()),
+                items: vec![ModuleItem {
+                    item: "productivity-module-3".into(),
+                    count: 4,
+                    quality: Some(QualityTier::Legendary),
+                }],
+                ..Default::default()
+            }],
+            width: 3,
+            height: 3,
+            ..Default::default()
+        };
+        let bp = decode_blueprint(&export(&layout, "ref"));
+        let items = &bp["entities"][0]["items"];
+
+        // Exact shape from the draftsman-emitted reference blueprint.
+        let expected = serde_json::json!([{
+            "id": {"name": "productivity-module-3", "quality": "legendary"},
+            "items": {"in_inventory": [
+                {"inventory": 4, "stack": 0},
+                {"inventory": 4, "stack": 1},
+                {"inventory": 4, "stack": 2},
+                {"inventory": 4, "stack": 3}
+            ]}
+        }]);
+        assert_eq!(items, &expected);
+    }
+
+    /// Export → parse round trip preserves modules (item, count, quality)
+    /// across three entity classes, and the raw JSON carries the
+    /// per-class inventory id (assembler=4, beacon=1, drill=2). NOTE:
+    /// the parser discards the inventory field, so only the raw-JSON leg
+    /// of this test sees a wrong id — and only for classes exercised
+    /// here; the in-game paste anchor (RFC-044 KC2) is the real gate.
+    #[test]
+    fn moduled_entities_round_trip_with_quality() {
+        use crate::common::QualityTier;
+        use crate::models::ModuleItem;
+
+        let mk = |name: &str, x: i32, items: Vec<ModuleItem>| PlacedEntity {
+            name: name.into(),
+            x,
+            y: 0,
+            direction: EntityDirection::North,
+            items,
+            ..Default::default()
+        };
+        let layout = LayoutResult {
+            entities: vec![
+                mk(
+                    "assembling-machine-3",
+                    0,
+                    vec![
+                        ModuleItem {
+                            item: "productivity-module-3".into(),
+                            count: 2,
+                            quality: Some(QualityTier::Legendary),
+                        },
+                        // Normal quality: `quality` key must be absent,
+                        // and stacks continue from the previous module.
+                        ModuleItem {
+                            item: "speed-module".into(),
+                            count: 1,
+                            quality: None,
+                        },
+                    ],
+                ),
+                mk(
+                    "beacon",
+                    4,
+                    vec![ModuleItem {
+                        item: "speed-module-3".into(),
+                        count: 2,
+                        quality: Some(QualityTier::Rare),
+                    }],
+                ),
+                mk(
+                    "electric-mining-drill",
+                    8,
+                    vec![ModuleItem {
+                        item: "efficiency-module".into(),
+                        count: 3,
+                        quality: None,
+                    }],
+                ),
+            ],
+            width: 11,
+            height: 3,
+            ..Default::default()
+        };
+        let s = export(&layout, "modtrip");
+
+        // Raw-JSON leg: per-class inventory ids + normal-quality omission
+        // + sequential stacks across modules within one entity.
+        let bp = decode_blueprint(&s);
+        let ents = bp["entities"].as_array().unwrap();
+        let asm = &ents[0]["items"];
+        assert_eq!(asm[0]["id"]["quality"], "legendary");
+        assert!(asm[1]["id"].get("quality").is_none());
+        assert_eq!(asm[1]["items"]["in_inventory"][0]["stack"], 2);
+        assert_eq!(asm[0]["items"]["in_inventory"][0]["inventory"], 4);
+        assert_eq!(ents[1]["items"][0]["items"]["in_inventory"][0]["inventory"], 1);
+        assert_eq!(ents[2]["items"][0]["items"]["in_inventory"][0]["inventory"], 2);
+
+        // Parser leg: everything the model holds survives the trip.
+        let parsed = crate::blueprint_parser::parse_blueprint_string(&s).unwrap();
+        let find = |name: &str| {
+            parsed
+                .entities
+                .iter()
+                .find(|e| e.name == name)
+                .unwrap_or_else(|| panic!("{name} missing after round trip"))
+        };
+        let asm = find("assembling-machine-3");
+        assert_eq!(asm.items.len(), 2);
+        assert_eq!(asm.items[0].item, "productivity-module-3");
+        assert_eq!(asm.items[0].count, 2);
+        assert_eq!(asm.items[0].quality, Some(QualityTier::Legendary));
+        assert_eq!(asm.items[1].item, "speed-module");
+        assert_eq!(asm.items[1].count, 1);
+        assert_eq!(asm.items[1].quality, None);
+        let beacon = find("beacon");
+        assert_eq!(beacon.items[0].count, 2);
+        assert_eq!(beacon.items[0].quality, Some(QualityTier::Rare));
+        let drill = find("electric-mining-drill");
+        assert_eq!(drill.items[0].count, 3);
+        assert_eq!(drill.items[0].quality, None);
     }
 
     /// Decode an exported blueprint string back to its JSON `blueprint` object.

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -55,9 +55,12 @@ struct BpData {
 }
 
 /// Parsed module item. All three Factorio formats collapse into this.
+/// Only the 2.0 insert-plan format carries a quality; 1.x formats leave
+/// it `None` (= normal).
 struct BpEntityItem {
     item: String,
     count: u32,
+    quality: Option<String>,
 }
 
 /// Factorio uses multiple formats for items within an entity:
@@ -111,6 +114,7 @@ impl<'de> serde::Deserialize<'de> for BpEntityItems {
                     items.push(BpEntityItem {
                         item: key,
                         count: value,
+                        quality: None,
                     });
                 }
                 Ok(BpEntityItems(items))
@@ -134,10 +138,11 @@ fn parse_item_value(val: &serde_json::Value) -> Option<BpEntityItem> {
         return Some(BpEntityItem {
             item: item_name.to_string(),
             count,
+            quality: None,
         });
     }
 
-    // 2.0 format: {"id": {"name": "efficiency-module"}, "items": {...}}
+    // 2.0 format: {"id": {"name": "efficiency-module", "quality": "rare"?}, "items": {...}}
     if let Some(id_val) = obj.get("id") {
         if let Some(item_name) = extract_id(id_val) {
             // Count from nested items.in_inventory array length, or default 1
@@ -147,9 +152,14 @@ fn parse_item_value(val: &serde_json::Value) -> Option<BpEntityItem> {
                 .and_then(|v| v.as_array())
                 .map(|arr| arr.len() as u32)
                 .unwrap_or(1);
+            let quality = id_val
+                .get("quality")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             return Some(BpEntityItem {
                 item: item_name,
                 count,
+                quality,
             });
         }
     }
@@ -333,6 +343,12 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
             .map(|it| crate::models::ModuleItem {
                 item: it.item,
                 count: it.count,
+                // Same permissiveness as entity quality: unknown (modded)
+                // quality names fall back to None/normal.
+                quality: it
+                    .quality
+                    .as_deref()
+                    .and_then(crate::common::QualityTier::from_name),
             })
             .collect();
 
@@ -821,5 +837,75 @@ mod tests {
         assert_eq!(machine.items.len(), 1);
         assert_eq!(machine.items[0].item, "productivity-module-3");
         assert_eq!(machine.items[0].count, 4);
+    }
+
+    #[test]
+    fn parses_insert_plan_items_with_quality() {
+        // 2.0 insert-plan format (BlueprintInsertPlan): count comes from
+        // the in_inventory array length, quality from id.quality. Also
+        // covers the bare-string id variant and explicit "normal".
+        use base64::Engine;
+        let bp_json = serde_json::json!({
+            "blueprint": {
+                "entities": [
+                    {
+                        "entity_number": 1,
+                        "name": "assembling-machine-3",
+                        "position": {"x": 1.5, "y": 1.5},
+                        "recipe": "iron-gear-wheel",
+                        "items": [
+                            {
+                                "id": {"name": "productivity-module-3", "quality": "legendary"},
+                                "items": {"in_inventory": [
+                                    {"inventory": 4, "stack": 0},
+                                    {"inventory": 4, "stack": 1}
+                                ]}
+                            },
+                            {
+                                "id": {"name": "speed-module-2", "quality": "normal"},
+                                "items": {"in_inventory": [{"inventory": 4, "stack": 2}]}
+                            },
+                            {
+                                "id": "speed-module",
+                                "items": {"in_inventory": [{"inventory": 4, "stack": 3}]}
+                            }
+                        ],
+                        "item": "blueprint"
+                    }
+                ],
+                "item": "blueprint",
+                "version": 562949954076673u64
+            }
+        });
+
+        let json_bytes = serde_json::to_vec(&bp_json).unwrap();
+        let mut encoder =
+            flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut encoder, &json_bytes).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&compressed);
+        let layout = parse_blueprint_string(&format!("0{}", b64)).unwrap();
+
+        let machine = &layout.entities[0];
+        assert_eq!(machine.items.len(), 3);
+
+        assert_eq!(machine.items[0].item, "productivity-module-3");
+        assert_eq!(machine.items[0].count, 2);
+        assert_eq!(
+            machine.items[0].quality,
+            Some(crate::common::QualityTier::Legendary)
+        );
+
+        assert_eq!(machine.items[1].item, "speed-module-2");
+        assert_eq!(machine.items[1].count, 1);
+        assert_eq!(
+            machine.items[1].quality,
+            Some(crate::common::QualityTier::Normal)
+        );
+
+        // Bare-string id: no quality information.
+        assert_eq!(machine.items[2].item, "speed-module");
+        assert_eq!(machine.items[2].count, 1);
+        assert_eq!(machine.items[2].quality, None);
     }
 }

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -1073,6 +1073,24 @@ pub fn module_slots(entity: &str) -> u32 {
     }
 }
 
+/// Factorio `defines.inventory` id for an entity's module slots — the
+/// `in_inventory[].inventory` value in the 2.0 blueprint insert-plan
+/// format. Per entity CLASS, not a single constant: crafting machines /
+/// furnaces / rocket silo = 4, lab = 3, mining drills = 2, beacon = 1
+/// (RFC-044 game-rule model, verified against draftsman InventoryType).
+/// A wrong id fails SILENTLY on paste — modules request into the wrong
+/// inventory or an unfulfillable one — and the parser discards the field
+/// on import, so round-trip tests structurally cannot catch a regression
+/// here; the RFC-044 KC2 in-game paste anchor is the only gate.
+pub fn module_inventory_id(entity: &str) -> u8 {
+    match entity {
+        "beacon" => 1,
+        "electric-mining-drill" | "big-mining-drill" | "burner-mining-drill" => 2,
+        "lab" | "biolab" => 3,
+        _ => 4,
+    }
+}
+
 /// Beacon supply area distance (tiles from edge of 3×3 beacon).
 pub const BEACON_SUPPLY_DISTANCE: i32 = 3;
 

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -124,6 +124,11 @@ pub enum EntityDirection {
 pub struct ModuleItem {
     pub item: String,
     pub count: u32,
+    /// Quality of the module itself (`None` = normal, omitted from
+    /// export). Parsed from the 2.0 insert-plan `id.quality` field;
+    /// scales the module's beneficial effects (RFC-044 game-rule model).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality: Option<crate::common::QualityTier>,
 }
 
 /// A single entity placed in the blueprint grid.

--- a/crates/core/src/recipe_db.rs
+++ b/crates/core/src/recipe_db.rs
@@ -62,6 +62,11 @@ pub struct Product {
     pub type_: String,
     #[serde(default = "default_probability")]
     pub probability: f64,
+    /// Catalyst portion exempt from productivity crediting (RFC-044;
+    /// e.g. kovarex: 40 of the 41 U-235). Productivity applies to
+    /// `amount - ignored_by_productivity` only. 0 = fully eligible.
+    #[serde(default)]
+    pub ignored_by_productivity: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -75,11 +80,30 @@ pub struct Recipe {
     pub ingredients: Vec<Ingredient>,
     #[serde(default, alias = "results")]
     pub products: Vec<Product>,
+    /// Productivity-module eligibility whitelist (RFC-044). Omitted =
+    /// false in the data file; prod modules are forbidden on this recipe.
+    #[serde(default)]
+    pub allow_productivity: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MachineData {
     pub crafting_speed: f64,
+    /// Machine-level module-effect restrictions (RFC-044): the set of
+    /// effect names this machine accepts (`"productivity"`, `"speed"`,
+    /// `"quality"`, `"consumption"`, `"pollution"`). `None` = no
+    /// restriction (the game default when the prototype omits it).
+    /// Recycler notably forbids `productivity`; oil-refinery forbids
+    /// `quality`.
+    #[serde(default)]
+    pub allowed_effects: Option<Vec<String>>,
+    /// Built-in productivity from `effect_receiver.base_effect`
+    /// (RFC-044): foundry / biochamber / electromagnetic-plant = 0.5.
+    /// NOT yet credited by the solver — see RFC-044 Phase 3 for the
+    /// gating (module-aware path only) and the recorded none-path
+    /// followup.
+    #[serde(default)]
+    pub base_effect_productivity: f64,
     /// Maximum number of solid+fluid ingredient slots. `None` = unbounded
     /// (Factorio represents this as `-1` on prototypes; we treat absence in
     /// the data file as unbounded). Today only `assembling-machine-1` has a
@@ -515,6 +539,7 @@ mod tests {
             energy: 1.0,
             ingredients: vec![],
             products: vec![],
+            allow_productivity: false,
         };
         assert_eq!(machine_for_recipe(&recipe, "assembling-machine-3"), "electromagnetic-plant");
 
@@ -566,6 +591,7 @@ mod tests {
             energy: 1.0,
             ingredients: vec![],
             products: vec![],
+            allow_productivity: false,
         }
     }
 
@@ -654,6 +680,7 @@ mod tests {
                 },
             ],
             products: vec![],
+            allow_productivity: false,
         };
         let err = machine_can_run_recipe("assembling-machine-1", &synthetic).unwrap_err();
         assert!(matches!(err, MachineIncompatibility::FluidNotSupported { .. }));
@@ -683,6 +710,37 @@ mod tests {
         let recipe = make_recipe("smelting");
         machine_can_run_recipe("stone-furnace", &recipe)
             .expect("stone-furnace handles smelting");
+    }
+
+    /// RFC-044 KC3 regression gate: the module-eligibility extraction
+    /// must be present in the bundled recipes.json. Pins the four facts
+    /// the adversarial review verified against Factorio 2.0.76 data.
+    #[test]
+    fn module_eligibility_data_is_bundled() {
+        // Recipe whitelist landed (116 eligible recipes in our set).
+        let eligible = db().recipes.values().filter(|r| r.allow_productivity).count();
+        assert!(eligible > 100, "allow_productivity extraction missing: {eligible}");
+        assert!(db().recipes["kovarex-enrichment-process"].allow_productivity);
+        assert!(!db().recipes["iron-chest"].allow_productivity);
+
+        // Kovarex catalyst amounts: prod credits only the net +1 U-235.
+        let kov = &db().recipes["kovarex-enrichment-process"];
+        let u235 = kov.products.iter().find(|p| p.name == "uranium-235").unwrap();
+        assert_eq!((u235.amount, u235.ignored_by_productivity), (41.0, 40.0));
+        let u238 = kov.products.iter().find(|p| p.name == "uranium-238").unwrap();
+        assert_eq!((u238.amount, u238.ignored_by_productivity), (2.0, 2.0));
+
+        // Machine-level restrictions: recycler forbids productivity.
+        let recycler = &db().machines["recycler"];
+        let effects = recycler.allowed_effects.as_ref().unwrap();
+        assert!(!effects.iter().any(|e| e == "productivity"));
+        assert!(effects.iter().any(|e| e == "speed"));
+
+        // Built-in productivity on the three Space Age machines.
+        for m in ["foundry", "biochamber", "electromagnetic-plant"] {
+            assert_eq!(db().machines[m].base_effect_productivity, 0.5, "{m}");
+        }
+        assert_eq!(db().machines["assembling-machine-3"].base_effect_productivity, 0.0);
     }
 
     #[test]

--- a/docs/rfc-044-machine-modules.md
+++ b/docs/rfc-044-machine-modules.md
@@ -337,3 +337,23 @@ Works on imported blueprints immediately; no solver dependency.
   found to contain zero 2.0 insert-plan examples — draftsman-emitted
   reference promoted to primary byte-shape source. Script name corrected
   (`extract_factorio_data.py`).*
+- *2026-07-21 — Phase 0 landed (branch `rfc044-phase0-module-export`):
+  0a module quality in `ModuleItem` + parser (the 2.0 parse path gained
+  its first test coverage — it was live but untested); 0b insert-plan
+  export byte-matched against a regenerated draftsman reference, with
+  `common::module_inventory_id` as the per-class table and round-trip +
+  byte-shape tests; 0c data extraction. **Discovered en route**: a full
+  `extract_factorio_data.py` regeneration silently DROPS the ~300
+  surgically-appended recycling recipes (their categories are excluded on
+  the default path) — added an `--augment` in-place mode as the required
+  update path and diff-audited zero drift beyond the new keys. Bonus
+  catalysts surfaced by the data: coal-liquefaction heavy-oil (25),
+  pentapod-egg, fish-breeding, and the fluoroketone-hot returns on
+  quantum-processor / cryogenic-science-pack. KC1 evidence: full suite
+  green (34 e2e + lib), `SPAGHETTIO_STRESS_GOLDEN=check` clean (53
+  passed, every stress fixture matched its committed golden — check mode
+  panics on both missing-golden and drift, so a pass is non-vacuous).
+  KC3 now pinned by a bundled-data regression test
+  (`module_eligibility_data_is_bundled`). KC2 anchor string generated
+  (`crates/core/examples/rfc044_anchor.rs`, local-only) covering all
+  four inventory classes — **open, user-run**.*

--- a/scripts/extract_factorio_data.py
+++ b/scripts/extract_factorio_data.py
@@ -29,6 +29,10 @@ MACHINES = [
     "biochamber",
     "recycler",
     "crusher",
+    # RFC-044: kovarex host; crafting_speed 1.0 == the Rust-side default,
+    # so adding it is bit-identical for the solver — it's here for the
+    # module-eligibility fields below.
+    "centrifuge",
 ]
 
 
@@ -73,6 +77,11 @@ def extract_recipes(include_categories: set[str] | None = None) -> dict:
             prob = prod.get("probability", 1.0)
             if prob != 1.0:
                 entry["probability"] = prob
+            # RFC-044: catalyst portion exempt from productivity (e.g.
+            # kovarex: 40 of 41 U-235). Omitted when zero.
+            ignored = prod.get("ignored_by_productivity", 0)
+            if ignored:
+                entry["ignored_by_productivity"] = ignored
             results.append(entry)
 
         recipe = {
@@ -82,6 +91,10 @@ def extract_recipes(include_categories: set[str] | None = None) -> dict:
             "ingredients": ingredients,
             "results": results,
         }
+        # RFC-044: productivity-module eligibility whitelist. Omitted when
+        # false (the overwhelming majority) to keep the embedded file lean.
+        if raw.get("allow_productivity", False):
+            recipe["allow_productivity"] = True
         recipes[name] = recipe
 
     return recipes
@@ -98,6 +111,20 @@ def extract_machines() -> dict:
         entry = {
             "crafting_speed": raw.get("crafting_speed", 1.0),
         }
+
+        # RFC-044: machine-level module-effect restrictions (e.g. recycler
+        # forbids productivity). Absent = no restriction (game default).
+        allowed = raw.get("allowed_effects")
+        if allowed is not None:
+            entry["allowed_effects"] = sorted(allowed)
+
+        # RFC-044: built-in productivity (foundry/biochamber/EMP = 0.5).
+        # Omitted when absent/zero.
+        base_prod = (raw.get("effect_receiver") or {}).get("base_effect", {}).get(
+            "productivity", 0
+        )
+        if base_prod:
+            entry["base_effect_productivity"] = base_prod
 
         # Extract fluid box definitions if present
         fluid_boxes = raw.get("fluid_boxes")
@@ -140,6 +167,50 @@ def extract_machines() -> dict:
 RECYCLING_CATEGORIES = {"recycling", "recycling-or-hand-crafting"}
 
 
+def augment_in_place(path: Path) -> None:
+    """RFC-044: add module-eligibility fields to an EXISTING recipes.json
+    without regenerating it.
+
+    The committed recipes.json = default extraction + surgically-appended
+    recycling recipes (--recycling-out); a full regeneration DROPS the
+    appended recipes. This mode preserves the file's full recipe set and
+    only adds: per-recipe allow_productivity, per-result
+    ignored_by_productivity, per-machine allowed_effects +
+    base_effect_productivity, and the centrifuge machine entry.
+    """
+    data = json.load(open(path))
+
+    for name, recipe in data["recipes"].items():
+        raw = _recipes.raw.get(name)
+        if raw is None:
+            continue
+        if raw.get("allow_productivity", False):
+            recipe["allow_productivity"] = True
+        raw_results = raw.get("results", [])
+        for entry in recipe["results"]:
+            ignored = next(
+                (
+                    p.get("ignored_by_productivity", 0)
+                    for p in raw_results
+                    if p["name"] == entry["name"]
+                ),
+                0,
+            )
+            if ignored:
+                entry["ignored_by_productivity"] = ignored
+
+    fresh_machines = extract_machines()
+    for name, fresh in fresh_machines.items():
+        entry = data["machines"].setdefault(name, {"crafting_speed": fresh["crafting_speed"]})
+        for key in ("allowed_effects", "base_effect_productivity"):
+            if key in fresh:
+                entry[key] = fresh[key]
+
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"Augmented {path} in place (RFC-044 module fields)")
+
+
 def main():
     import argparse
 
@@ -153,7 +224,23 @@ def main():
             "the main recipes.json write below."
         ),
     )
+    parser.add_argument(
+        "--augment",
+        action="store_true",
+        help=(
+            "Augment the existing recipes.json with RFC-044 module fields "
+            "instead of regenerating it. USE THIS, not the default mode, "
+            "while the recycling recipes remain a surgical append: a full "
+            "regeneration drops them."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.augment:
+        augment_in_place(
+            Path(__file__).parent.parent / "crates" / "core" / "data" / "recipes.json"
+        )
+        return
 
     data = {
         "recipes": extract_recipes(),


### PR DESCRIPTION
## Intent

Phase 0 of [RFC-044 machine modules](docs/rfc-044-machine-modules.md) (merged in #319): the artifact-boundary and data groundwork. Closes the round-trip asymmetry (modules used to vanish on export), adds module quality to the model/parser, and lands the module-eligibility data extraction.

## Scope

- **0a** — `ModuleItem.quality: Option<QualityTier>`; parser captures 2.0 `id.quality` (permissive, entity-quality precedent). The 2.0 insert-plan parse path gains its first test coverage.
- **0b** — export `items` as lua-api `BlueprintInsertPlan` (one `in_inventory` entry per module unit, sequential 0-based stacks, no `count`, quality omitted at normal). `common::module_inventory_id` per-class table (crafting/furnace/silo=4, lab=3, drills=2, beacon=1). Byte-shape test pinned against a draftsman 2.0.76 reference emission; round-trip test across three inventory classes.
- **0c** — `extract_factorio_data.py --augment`: adds `allow_productivity` (116 recipes), per-result `ignored_by_productivity` (kovarex 40/41+2/2; plus coal-liquefaction and fluoroketone catalysts), machine `allowed_effects`, and `effect_receiver` `base_effect_productivity` (foundry/biochamber/EMP 0.5) to recipes.json **in place** — a full regeneration silently drops the ~300 surgically-appended recycling recipes (verified live), hence the new mode. Rust structs gain matching serde-default fields; `base_effect` deliberately NOT credited by the solver yet (Phase 3 gating per the RFC).

## Verification actually run

- Full core suite green (lib 716 + e2e 53/22-ignored + doc-tests), exit 0.
- **KC1**: `SPAGHETTIO_STRESS_GOLDEN=check` clean — every stress fixture matched its committed golden (check mode panics on missing-golden AND drift, so the pass is non-vacuous).
- **KC3** regression gate: new `module_eligibility_data_is_bundled` test pins the extracted facts.
- recipes.json diff-audited: zero drift beyond the new keys (script in session scratchpad).
- Workspace clippy clean on changed files; wasm-pack build green; `ModuleItem.quality` present in generated TS types; `web` tsc clean.
- Anchor blueprint verified through blueprint-analyze (+60% speed / +20% prod readout exactly matches the loadout math).

## Deviations from agreed approach

None. **KC2 (in-game paste anchor) remains open and user-run** — anchor string covers all four inventory classes and is in the PR conversation below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA