### PR TITLE
feat(web): RFC-044 Phase 2 — module-slot overlay + toggle

### DIFF
--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -155,6 +155,14 @@ pub fn default_machine_for_item(item: &str, fallback: &str) -> String {
     recipe_db::default_machine_for_item(item, fallback)
 }
 
+/// Module slot count for a machine entity, wrapping `common::module_slots`
+/// (RFC-044 Phase 2) — single source of truth for the web module-slot
+/// overlay, no duplicated TS table.
+#[wasm_bindgen]
+pub fn module_slots(entity: &str) -> u32 {
+    spaghettio_core::common::module_slots(entity)
+}
+
 #[wasm_bindgen]
 pub fn layout(
     solver_result: SolverResult,

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -114,6 +114,7 @@ function appendSatCacheRecord(recordBytes: Uint8Array): void {
 let itemsCache: string[] = [];
 let machinesCache: string[] = [];
 let defaultMachineCache = new Map<string, string>();
+let moduleSlotsCache = new Map<string, number>();
 
 let activeCountListeners = new Set<(active: number) => void>();
 let activeCount = 0;
@@ -218,6 +219,19 @@ export async function initEngine(): Promise<void> {
     fallback: "assembling-machine-3",
   });
   defaultMachineCache = new Map(defaults);
+
+  // module_slots is a static Rust table (RFC-044 Phase 2) — prefetch once
+  // for every producer machine plus "beacon" (not itself recipe-producing,
+  // so absent from `machinesCache`, but a legitimate module host in
+  // imported blueprints) and cache synchronously, mirroring
+  // `defaultMachineCache`. Entity names outside this set (e.g. mining
+  // drills — module_slots doesn't cover them yet, RFC-044 Phase 1
+  // territory) fall back to 0 via `moduleSlots`.
+  const moduleSlotEntries = await call<[string, number][]>({
+    method: "moduleSlotsForEntities",
+    entities: [...machinesCache, "beacon"],
+  });
+  moduleSlotsCache = new Map(moduleSlotEntries);
 }
 
 async function solve(
@@ -346,6 +360,14 @@ function exportBlueprint(layout: LayoutResult, label: string): Promise<string> {
 
 function defaultMachineForItem(item: string, fallback: string): string {
   return defaultMachineCache.get(item) ?? fallback;
+}
+
+/** Module slot count for a machine entity, from the `moduleSlotsCache`
+ *  prefetched in `initEngine`. Unknown entities → 0 (same as the Rust
+ *  table's own fallback). Synchronous so the module-slot overlay
+ *  (`renderer/moduleSlotsOverlay.ts`) can call it per-entity at draw time. */
+function moduleSlots(entity: string): number {
+  return moduleSlotsCache.get(entity) ?? 0;
 }
 
 function validateLayout(
@@ -579,6 +601,7 @@ export type Engine = {
   buildLayoutStreaming: typeof buildLayoutStreaming;
   exportBlueprint: typeof exportBlueprint;
   defaultMachineForItem: typeof defaultMachineForItem;
+  moduleSlots: typeof moduleSlots;
   validateLayout: typeof validateLayout;
   solveFixture: typeof solveFixture;
   improveRegion: typeof improveRegion;
@@ -596,6 +619,7 @@ export function getEngine(): Engine {
     buildLayoutStreaming,
     exportBlueprint,
     defaultMachineForItem,
+    moduleSlots,
     validateLayout,
     solveFixture,
     improveRegion,

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -221,15 +221,21 @@ export async function initEngine(): Promise<void> {
   defaultMachineCache = new Map(defaults);
 
   // module_slots is a static Rust table (RFC-044 Phase 2) — prefetch once
-  // for every producer machine plus "beacon" (not itself recipe-producing,
-  // so absent from `machinesCache`, but a legitimate module host in
-  // imported blueprints) and cache synchronously, mirroring
-  // `defaultMachineCache`. Entity names outside this set (e.g. mining
-  // drills — module_slots doesn't cover them yet, RFC-044 Phase 1
-  // territory) fall back to 0 via `moduleSlots`.
+  // and cache synchronously, mirroring `defaultMachineCache`. The extras
+  // beyond `machinesCache` are module hosts that aren't recipe-producing
+  // machines but appear in imported blueprints (beacons, labs, drills —
+  // drill slot counts land with RFC-044 Phase 1). Entity names outside
+  // this set fall back to 0 via `moduleSlots`.
   const moduleSlotEntries = await call<[string, number][]>({
     method: "moduleSlotsForEntities",
-    entities: [...machinesCache, "beacon"],
+    entities: [
+      ...machinesCache,
+      "beacon",
+      "lab",
+      "biolab",
+      "electric-mining-drill",
+      "big-mining-drill",
+    ],
   });
   moduleSlotsCache = new Map(moduleSlotEntries);
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -20,6 +20,7 @@ import { renderTraceOverlay, getTracePhases, eventsUpToPhase, type TraceEvent, t
 import { renderValidationOverlay } from "./renderer/validationOverlay";
 import { renderStarvationHeatmap } from "./renderer/heatmapOverlay";
 import { renderPowerWiresOverlay } from "./renderer/powerWiresOverlay";
+import { renderModuleSlotsOverlay } from "./renderer/moduleSlotsOverlay";
 import { renderRegionOverlayDetailed, type RegionOverlayItem } from "./renderer/regionOverlay";
 import { renderJunctionZoneOverlay } from "./renderer/junctionZoneOverlay";
 import { createSatZoneOverlay } from "./renderer/satZoneOverlay";
@@ -127,7 +128,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
 
   // --- Modules ---
   const overlayControls = createOverlayPanel(container);
-  const { debugCb, colorCb, heatmapCb, powerWiresCb, regionsCb, soloRegionsCb, ghostTilesCb, traceOverlayCb } = overlayControls;
+  const { debugCb, colorCb, heatmapCb, powerWiresCb, moduleSlotsCb, regionsCb, soloRegionsCb, ghostTilesCb, traceOverlayCb } = overlayControls;
   const retryPanel = createRetryPanel(container);
   // Sync the item-coloring flag with the persisted checkbox state so
   // a user who turned colours off stays off across reloads.
@@ -490,6 +491,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
   let heatmapLayer: Container | null = null;
   let lastHeatmapIssues: ValidationIssue[] = [];
   let powerWiresLayer: Container | null = null;
+  let moduleSlotsLayer: Container | null = null;
   let lastTileCtx: TileContext | null = null;
   let validationInFlightFor: LayoutResult | null = null;
 
@@ -674,6 +676,27 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     powerWiresLayer = renderPowerWiresOverlay(
       lastLayout.power_wires,
       lastLayout.entities,
+      entityLayer,
+    );
+    requestRender();
+  }
+
+  /** Module slot overlay (RFC-044 Phase 2): in-game-style module slot
+   *  row on entities carrying `items`. Rebuilt whenever a layout lands
+   *  or the toggle changes, same shape as `updatePowerWiresOverlay`. */
+  function updateModuleSlotsOverlay(): void {
+    if (moduleSlotsLayer) {
+      entityLayer.removeChild(moduleSlotsLayer);
+      moduleSlotsLayer.destroy({ children: true });
+      moduleSlotsLayer = null;
+    }
+    if (!moduleSlotsCb.checked || !lastLayout?.entities?.length) {
+      requestRender();
+      return;
+    }
+    moduleSlotsLayer = renderModuleSlotsOverlay(
+      lastLayout.entities,
+      getEngine().moduleSlots,
       entityLayer,
     );
     requestRender();
@@ -1312,6 +1335,7 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     updateRegionOverlay();
     updateGhostTilesOverlay();
     updatePowerWiresOverlay();
+    updateModuleSlotsOverlay();
     // External-input trunk labels (issue #196). Rebuilt on every layout
     // commit. Skips when there's no SolverResult — corpus / snapshot
     // load paths arrive without one and we don't fabricate labels there.
@@ -1466,6 +1490,9 @@ async function initGenerator(engine: ReturnType<typeof getEngine>): Promise<void
     });
     powerWiresCb.addEventListener("change", () => {
       updatePowerWiresOverlay();
+    });
+    moduleSlotsCb.addEventListener("change", () => {
+      updateModuleSlotsOverlay();
     });
     regionsCb.addEventListener("change", () => {
       updateRegionOverlay();

--- a/web/src/renderer/entities.ts
+++ b/web/src/renderer/entities.ts
@@ -979,8 +979,10 @@ export function drawEntityGraphic(entity: PlacedEntity, ctx: DrawContext): Graph
 
 /** Game-style quality tier colors (uncommon green, rare blue, epic
  *  purple, legendary orange). Fallback only — the real in-game badge
- *  icons are preferred (see [`addQualityBadge`]). */
-const QUALITY_BADGE_COLORS: Record<string, number> = {
+ *  icons are preferred (see [`addQualityBadge`]). Exported so other
+ *  overlays needing the same tier→color convention (e.g. module quality
+ *  tints in `moduleSlotsOverlay.ts`) share one table. */
+export const QUALITY_BADGE_COLORS: Record<string, number> = {
   uncommon: 0x4fca4f,
   rare: 0x4f8bca,
   epic: 0xa64fca,

--- a/web/src/renderer/moduleSlotsOverlay.ts
+++ b/web/src/renderer/moduleSlotsOverlay.ts
@@ -1,0 +1,114 @@
+import { Graphics, Container } from "pixi.js";
+import { TILE_PX, MACHINE_SIZES, QUALITY_BADGE_COLORS } from "./entities";
+import type { PlacedEntity } from "../engine";
+
+/** Module slot overlay (RFC-044 Phase 2): an in-game-style row of module
+ *  slot squares near each machine's bottom edge, filled from
+ *  `PlacedEntity.items` — `module_slots(entity.name)` total slots,
+ *  filled slots colored by module family, empty slots as neutral
+ *  outlines. Read-only; reflects data only, nothing stamps modules into
+ *  generated layouts until Phase 3 (today's source is imported
+ *  blueprints).
+ *
+ *  Follows the `powerWiresOverlay`/`heatmapOverlay` shape: a fresh
+ *  Graphics layer built straight from `LayoutResult.entities` positions
+ *  on every layout commit. It never touches the particle atlas, so it
+ *  needs no special handling for the two-renderer split (`web/CLAUDE.md`)
+ *  — unlike a baked-texture feature, this one is just redrawn from
+ *  scratch regardless of which renderer placed the entities.
+ */
+
+type ModuleFamily = "speed" | "productivity" | "efficiency" | "quality" | "unknown";
+
+/** Family from the item name's prefix (`speed-module-3` → `speed`, etc).
+ *  Recycling byproducts (`speed-module-recycling`) and the
+ *  `empty-module-slot` placeholder never appear as real `items` entries;
+ *  anything unrecognized (modded modules) falls through to `unknown`. */
+function moduleFamily(itemName: string): ModuleFamily {
+  if (itemName.startsWith("speed-module")) return "speed";
+  if (itemName.startsWith("productivity-module")) return "productivity";
+  if (itemName.startsWith("efficiency-module")) return "efficiency";
+  if (itemName.startsWith("quality-module")) return "quality";
+  return "unknown";
+}
+
+// In-game module family palette (speed blue, productivity red,
+// efficiency green, quality teal); unrecognized/modded modules get
+// neutral grey rather than silently misrepresenting a family.
+const FAMILY_COLORS: Record<ModuleFamily, number> = {
+  speed: 0x4a90d0,
+  productivity: 0xd9432e,
+  efficiency: 0x4caf50,
+  quality: 0x2fb8b0,
+  unknown: 0x8a8a8a,
+};
+
+const SLOT_SIZE = TILE_PX * 0.16;
+const SLOT_GAP = TILE_PX * 0.05;
+const ROW_PAD = 1.5;
+
+export function renderModuleSlotsOverlay(
+  entities: PlacedEntity[],
+  slotsFor: (entityName: string) => number,
+  container: Container,
+): Container | null {
+  const layer = new Container();
+  // Purely decorative: never intercept pointer events — entity
+  // hover/pin stays in charge, same convention as the other overlays.
+  layer.eventMode = "none";
+  let drawn = false;
+
+  for (const entity of entities) {
+    if (!entity.items || entity.items.length === 0) continue;
+    const filledCount = entity.items.reduce((sum, it) => sum + it.count, 0);
+    // Total slots is the greater of the static table and the actual
+    // fill: entity classes module_slots doesn't cover yet (mining
+    // drills — RFC-044 Phase 1 territory) still show every module
+    // that's really there instead of clipping them to 0.
+    const totalSlots = Math.max(slotsFor(entity.name), filledCount);
+    if (totalSlots === 0) continue;
+
+    const [w, h] = MACHINE_SIZES[entity.name] ?? [1, 1];
+    const footprintW = w * TILE_PX;
+    const footprintH = h * TILE_PX;
+    const originX = (entity.x ?? 0) * TILE_PX;
+    const originY = (entity.y ?? 0) * TILE_PX;
+    const rowWidth = totalSlots * SLOT_SIZE + (totalSlots - 1) * SLOT_GAP;
+    // Right-aligned along the bottom edge — the quality badge
+    // (rfc-build-quality, `addQualityBadge`) already owns the
+    // bottom-left corner of the same footprint.
+    const rowX = originX + Math.max(footprintW - rowWidth - ROW_PAD, ROW_PAD);
+    const rowY = originY + footprintH - SLOT_SIZE - ROW_PAD;
+
+    const g = new Graphics();
+    let filled = 0;
+    for (const it of entity.items) {
+      const color = FAMILY_COLORS[moduleFamily(it.item)];
+      const qualityColor =
+        it.quality && it.quality !== "normal" ? QUALITY_BADGE_COLORS[it.quality] : undefined;
+      const borderColor = qualityColor ?? 0x000000;
+      const borderAlpha = qualityColor !== undefined ? 0.95 : 0.35;
+      const borderWidth = qualityColor !== undefined ? 1 : 0.75;
+      for (let i = 0; i < it.count && filled < totalSlots; i++, filled++) {
+        const sx = rowX + filled * (SLOT_SIZE + SLOT_GAP);
+        g.rect(sx, rowY, SLOT_SIZE, SLOT_SIZE)
+          .fill({ color, alpha: 0.9 })
+          .stroke({ color: borderColor, width: borderWidth, alpha: borderAlpha });
+      }
+    }
+    // Remaining empty slots: neutral outline, no fill — reads as "open"
+    // against the machine body underneath.
+    for (; filled < totalSlots; filled++) {
+      const sx = rowX + filled * (SLOT_SIZE + SLOT_GAP);
+      g.rect(sx, rowY, SLOT_SIZE, SLOT_SIZE)
+        .fill({ color: 0x1a1a1a, alpha: 0.35 })
+        .stroke({ color: 0x8a8a8a, width: 0.75, alpha: 0.55 });
+    }
+    layer.addChild(g);
+    drawn = true;
+  }
+
+  if (!drawn) return null;
+  container.addChild(layer);
+  return layer;
+}

--- a/web/src/state/debugState.ts
+++ b/web/src/state/debugState.ts
@@ -10,6 +10,9 @@ export interface DebugState {
   heatmap: boolean;
   /** Power connectivity: draw the pole copper-wire network. */
   powerWires: boolean;
+  /** Module slots (RFC-044 Phase 2): draw the in-game-style module slot
+   *  row on entities carrying `items`. */
+  moduleSlots: boolean;
 }
 
 type Subscriber = (state: DebugState) => void;
@@ -24,6 +27,7 @@ let state: DebugState = {
   traceOverlay: false,
   heatmap: false,
   powerWires: false,
+  moduleSlots: true,
 };
 
 const subs: Subscriber[] = [];
@@ -37,6 +41,7 @@ export function create(): void {
   const traceOverlayStored = localStorage.getItem("fk-trace-overlay") === "1";
   const heatmapStored = localStorage.getItem("fk-heatmap") === "1";
   const powerWiresStored = localStorage.getItem("fk-power-wires") === "1";
+  const moduleSlotsStored = localStorage.getItem("fk-module-slots");
   state = {
     ...state,
     master: fromParam || fromStorage,
@@ -46,6 +51,11 @@ export function create(): void {
     traceOverlay: traceOverlayStored,
     heatmap: heatmapStored,
     powerWires: powerWiresStored,
+    // Default ON (RFC-044 Phase 2) — the overlay only draws on entities
+    // that actually carry `items`, so a generated layout with no modules
+    // stays quiet by default; same "stored===null → default true"
+    // pattern as itemColors.
+    moduleSlots: moduleSlotsStored === null ? true : moduleSlotsStored === "1",
   };
 }
 
@@ -75,6 +85,9 @@ export function set(patch: Partial<DebugState>): void {
   }
   if ("powerWires" in patch) {
     localStorage.setItem("fk-power-wires", patch.powerWires ? "1" : "0");
+  }
+  if ("moduleSlots" in patch) {
+    localStorage.setItem("fk-module-slots", patch.moduleSlots ? "1" : "0");
   }
   for (const cb of subs) cb(state);
 }

--- a/web/src/ui/overlayPanel.ts
+++ b/web/src/ui/overlayPanel.ts
@@ -8,6 +8,7 @@ export interface OverlayPanelControls {
   colorCb: HTMLInputElement;
   heatmapCb: HTMLInputElement;
   powerWiresCb: HTMLInputElement;
+  moduleSlotsCb: HTMLInputElement;
   regionsCb: HTMLInputElement;
   soloRegionsCb: HTMLInputElement;
   ghostTilesCb: HTMLInputElement;
@@ -41,6 +42,10 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
   const heatmapCb = makeToggle(panel, "Starvation heatmap", state.heatmap);
   // User-facing (not under Debug): draw the pole copper-wire network.
   const powerWiresCb = makeToggle(panel, "Power wires", state.powerWires);
+  // User-facing (not under Debug): draw module slots on machines
+  // (RFC-044 Phase 2). Default on — quiet on generated layouts since
+  // nothing stamps modules yet; imported blueprints are today's data.
+  const moduleSlotsCb = makeToggle(panel, "Module slots", state.moduleSlots);
 
   const subPanel = document.createElement("div");
   subPanel.className = "overlay-sub-panel";
@@ -82,6 +87,9 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
   powerWiresCb.addEventListener("change", () => {
     debugState.set({ powerWires: powerWiresCb.checked });
   });
+  moduleSlotsCb.addEventListener("change", () => {
+    debugState.set({ moduleSlots: moduleSlotsCb.checked });
+  });
 
   return {
     setDebugEnabled(on: boolean): void {
@@ -93,6 +101,7 @@ export function createOverlayPanel(container: HTMLElement): OverlayPanelControls
     colorCb,
     heatmapCb,
     powerWiresCb,
+    moduleSlotsCb,
     regionsCb,
     soloRegionsCb,
     ghostTilesCb,

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -11,6 +11,7 @@ import wasmInit, {
   layout,
   layout_traced,
   layout_streaming,
+  module_slots,
   parse_blueprint,
   seed_zone_cache,
   validate_layout,
@@ -25,6 +26,7 @@ type Request =
   | { id: number; method: "allProducibleItems" }
   | { id: number; method: "allProducerMachines" }
   | { id: number; method: "defaultMachinesForItems"; items: string[]; fallback: string }
+  | { id: number; method: "moduleSlotsForEntities"; entities: string[] }
   | {
       id: number;
       method: "solve";
@@ -97,6 +99,14 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         const out: [string, string][] = [];
         for (const item of req.items) {
           out.push([item, default_machine_for_item(item, req.fallback)]);
+        }
+        result = out;
+        break;
+      }
+      case "moduleSlotsForEntities": {
+        const out: [string, number][] = [];
+        for (const entity of req.entities) {
+          out.push([entity, module_slots(entity)]);
         }
         result = out;
         break;


### PR DESCRIPTION
## Intent

Phase 2 of [RFC-044 machine modules](docs/rfc-044-machine-modules.md): read-only, in-game-style module slot display on machines, driven by `PlacedEntity.items`. Today's data source is imported blueprints; generated layouts light up when Phase 3 stamps modules.

## Scope

- `crates/wasm-bindings`: `module_slots(entity)` export wrapping `common::module_slots` (single source, no TS table copy).
- `web`: worker + engine.ts plumbing (batched prefetch, sync getter, `defaultMachineCache` pattern); new `renderer/moduleSlotsOverlay.ts` (slot row along the bottom edge, family colors speed/prod/eff/quality = blue/red/green/teal, module-quality border tint via the shared `QUALITY_BADGE_COLORS`, empty slots as neutral outlines); "Module slots" toggle in the overlay panel (default on, localStorage-persisted, `fk-power-wires` pattern).
- Prefetch covers beacons/labs/drills so Phase 1's drill slot counts display fully once both land.

Built by a worktree implementation agent; diff reviewed by the session lead, one ride-along commit (prefetch list). Overlay is a data-driven Graphics layer rebuilt per layout commit — per `web/CLAUDE.md` it deliberately does not touch the shared particle atlas.

## Verification actually run

- `wasm-pack build` (absolute out-dir) green; `tsc --noEmit` clean; `npm run build` green; `cargo clippy -p spaghettio_wasm` clean.
- Visuals are user-validated per house convention (no screenshot iteration). Known minor: entities missing from `MACHINE_SIZES` fall back to 1×1 for row placement (e.g. beacon), which may offset the row on such footprints — flagging for the visual pass.

## Deviations from agreed approach

None beyond the defensive `max(slots, filled)` widening the agent chose (documented in-code) so uncovered entity classes never clip their real modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA