### PR TITLE
feat(validate): RFC-044 Phase 1 — module-slots + module-eligibility checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
 1. **Solver** (`crates/core/src/solver.rs`) — Recursively resolves recipes, computes machine counts and flow rates. Loads `crates/core/data/recipes.json` via `include_str!`. Returns a `SolverResult`.
 2. **Bus layout** (`crates/core/src/bus/`) — Deterministic row-based layout. Machines group by recipe into rows, trunks run on parallel columns, tap-offs are routed via the ghost router (negotiated congestion A* + region-growth junction solver). See [`docs/ghost-pipeline-contracts.md`](docs/ghost-pipeline-contracts.md) for the phase-by-phase contracts the router promises.
 3. **Blueprint export** (`crates/core/src/blueprint.rs`) — Emits the JSON + zlib + base64 envelope directly (no draftsman dependency).
-4. **Validation** (`crates/core/src/validate/`) — 23 functional checks: pipe isolation, fluid port connectivity, inserter chains + direction, power coverage + pole connectivity, belt flow/structural, underground belt pairs + sideloading, lane throughput, input-rate delivery.
+4. **Validation** (`crates/core/src/validate/`) — 25 functional checks: pipe isolation, fluid port connectivity, inserter chains + direction, power coverage + pole connectivity, belt flow/structural, underground belt pairs + sideloading, lane throughput, input-rate delivery, module slots + eligibility.
 
 ## Key models (`crates/core/src/models.rs`)
 
@@ -143,7 +143,7 @@ Most-visited files. Full reference in [`docs/file-reference.md`](docs/file-refer
 | `crates/core/src/astar.rs` | `ghost_astar` + `astar_path` + `negotiate_lanes` pathfinder primitives |
 | `crates/core/src/sat.rs` | Varisat-backed crossing-zone SAT solver (see memory: `project_sat_crossing_solver`) |
 | `crates/core/src/validate/belt_flow.rs` | Lane-rate walker (Kahn topo sort with splitter pairing and balancer feedback-loop handling) |
-| `crates/core/src/validate/` | Rest of the 23 checks: `belt_structural`, `fluids`, `inserters`, `power`, `underground` |
+| `crates/core/src/validate/` | Rest of the 25 checks: `belt_structural`, `fluids`, `inserters`, `modules`, `power`, `underground` |
 | `crates/core/src/trace.rs` | Thread-local trace event collector; `TraceEvent` variants drive the snapshot debugger and stress scoreboards |
 | `crates/core/src/snapshot.rs` | `.fls` snapshot reader/writer for the layout debugger |
 | `crates/core/tests/e2e.rs` | End-to-end test harness: tier1–4 regression tests and stress corpus with scoreboards |
@@ -207,7 +207,7 @@ Layout bugs are easy to get wrong — zero validation errors can mean the check 
 | Balancer templates | `crates/core/src/bus/balancer_library.rs`. Regenerate: `python scripts/generate_balancer_library.py` (needs Factorio-SAT on `PATH`). |
 | Belt tier thresholds | `crates/core/src/common.rs` (`belt_entity_for_rate`, `ug_max_reach`) |
 | Entity sizes | `crates/core/src/common.rs` (`entity_size`) |
-| Validation checks | `crates/core/src/validate/` (23 checks, dispatched from `mod.rs`) |
+| Validation checks | `crates/core/src/validate/` (25 checks, dispatched from `mod.rs`) |
 | Snapshot format | `crates/core/src/snapshot.rs` + [`docs/layout-snapshot-debugger.md`](docs/layout-snapshot-debugger.md) |
 | Belt lane physics | [`docs/factorio-mechanics.md`](docs/factorio-mechanics.md) |
 | Ghost pipeline contracts | [`docs/ghost-pipeline-contracts.md`](docs/ghost-pipeline-contracts.md) |

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -1058,24 +1058,38 @@ pub fn module_effect(name: &str) -> ModuleEffect {
     }
 }
 
-/// Number of module slots for a machine entity.
-pub fn module_slots(entity: &str) -> u32 {
+/// Number of module slots for a KNOWN machine entity; `None` for
+/// entities outside the table (modded machines) — the module-slots
+/// validator must not assert slot counts it doesn't know (a modded
+/// `se-recycling-facility` with 4 modules is not "0 slots, surplus
+/// never fulfilled").
+pub fn module_slots_known(entity: &str) -> Option<u32> {
     match entity {
-        "assembling-machine-1" | "stone-furnace" | "steel-furnace" => 0,
-        "assembling-machine-2" | "electric-furnace" | "centrifuge" | "crusher" | "lab" => 2,
-        "chemical-plant" | "oil-refinery" => 3,
+        "assembling-machine-1" | "stone-furnace" | "steel-furnace" | "burner-mining-drill" => {
+            Some(0)
+        }
+        "assembling-machine-2" | "electric-furnace" | "centrifuge" | "crusher" | "lab"
+        | "pumpjack" => Some(2),
+        "chemical-plant" | "oil-refinery" => Some(3),
         "assembling-machine-3" | "rocket-silo" | "foundry" | "biochamber" | "biolab"
-        | "recycler" => 4,
-        "electromagnetic-plant" => 5,
-        "cryogenic-plant" => 8,
-        "beacon" => 2,
-        // Drills (RFC-044 Phase 1): the generator never places them, but
-        // moduled drills are ubiquitous in imported community blueprints
-        // and the module-slots check rates them too. burner stays 0.
-        "electric-mining-drill" => 3,
-        "big-mining-drill" => 4,
-        _ => 0,
+        | "recycler" => Some(4),
+        "electromagnetic-plant" => Some(5),
+        "cryogenic-plant" => Some(8),
+        "beacon" => Some(2),
+        // Drills + pumpjack (RFC-044 Phase 1): the generator never places
+        // them, but moduled ones are ubiquitous in imported community
+        // blueprints and the module-slots check rates them too.
+        "electric-mining-drill" => Some(3),
+        "big-mining-drill" => Some(4),
+        _ => None,
     }
+}
+
+/// Number of module slots for a machine entity (0 for unknown entities —
+/// consumers that need to distinguish unknown from known-0 use
+/// [`module_slots_known`]).
+pub fn module_slots(entity: &str) -> u32 {
+    module_slots_known(entity).unwrap_or(0)
 }
 
 /// Factorio `defines.inventory` id for an entity's module slots — the

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -1069,6 +1069,11 @@ pub fn module_slots(entity: &str) -> u32 {
         "electromagnetic-plant" => 5,
         "cryogenic-plant" => 8,
         "beacon" => 2,
+        // Drills (RFC-044 Phase 1): the generator never places them, but
+        // moduled drills are ubiquitous in imported community blueprints
+        // and the module-slots check rates them too. burner stays 0.
+        "electric-mining-drill" => 3,
+        "big-mining-drill" => 4,
         _ => 0,
     }
 }

--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -5,6 +5,7 @@
 pub mod belt_flow;
 pub mod inserters;
 mod fluids;
+pub mod modules;
 pub mod power;
 pub mod sushi;
 pub mod underground;
@@ -513,6 +514,8 @@ pub fn validate(
         Box::new(|| belt_structural::check_lane_throughput(layout, solver)),
         Box::new(|| check_input_rate_delivery(layout, solver)),
         Box::new(|| check_balancer_template_coverage(layout)),
+        Box::new(|| modules::check_module_slots(layout)),
+        Box::new(|| modules::check_module_eligibility(layout)),
     ];
 
     let issues: Vec<ValidationIssue> = checks.par_iter().flat_map(|f| f()).collect();

--- a/crates/core/src/validate/modules.rs
+++ b/crates/core/src/validate/modules.rs
@@ -1,0 +1,375 @@
+//! Module loadout checks (RFC-044 Phase 1).
+//!
+//! Two checks over `PlacedEntity.items`:
+//!
+//! - **module-slots** — the module count must fit the entity's slot count
+//!   (`common::module_slots`), and module-shaped names we don't recognize
+//!   (modded tiers) warn as unratable.
+//! - **module-eligibility** — productivity modules require the recipe's
+//!   `allow_productivity`, and every effect of a module must be in the
+//!   machine's `allowed_effects` (recycler forbids productivity,
+//!   oil-refinery forbids quality, ...).
+//!
+//! Both emit WARNINGS, not errors: an in-game paste doesn't fail on an
+//! invalid loadout — the offending module requests are silently never
+//! fulfilled, which is exactly the silent-failure class these checks
+//! surface. Keeping them non-fatal also means imported community
+//! blueprints can't be blocked from rendering by their module quirks.
+//!
+//! `items` carries ALL item requests (fuel, ammo, modules); only
+//! module-shaped names participate here — a coal request on a furnace is
+//! legitimate and ignored.
+
+use crate::common::module_slots;
+use crate::models::LayoutResult;
+use crate::recipe_db::db;
+use crate::validate::{Severity, ValidationIssue};
+
+/// Full effect set of a module family — a module is insertable only when
+/// EVERY effect it carries is in the machine's `allowed_effects` (this is
+/// why prod modules are rejected by AM1 even though AM1 allows their
+/// pollution/speed/consumption components: `productivity` itself is
+/// missing from the list).
+fn module_effects(family: &str) -> &'static [&'static str] {
+    match family {
+        "speed" => &["speed", "consumption"],
+        "productivity" => &["productivity", "speed", "consumption", "pollution"],
+        "efficiency" => &["consumption"],
+        "quality" => &["quality", "speed"],
+        _ => &[],
+    }
+}
+
+/// Classify an item-request name: `Some(family)` for the nine known
+/// module prototypes, `None` for non-module requests (fuel, ammo, ...).
+/// Module-SHAPED names outside the known nine (modded tiers like
+/// `speed-module-4`) return `Some("unknown")`.
+fn module_family(name: &str) -> Option<&'static str> {
+    match name {
+        "speed-module" | "speed-module-2" | "speed-module-3" => Some("speed"),
+        "productivity-module" | "productivity-module-2" | "productivity-module-3" => {
+            Some("productivity")
+        }
+        "efficiency-module" | "efficiency-module-2" | "efficiency-module-3" => Some("efficiency"),
+        "quality-module" | "quality-module-2" | "quality-module-3" => Some("quality"),
+        _ if name.contains("-module") => Some("unknown"),
+        _ => None,
+    }
+}
+
+/// `allowed_effects` for module hosts that aren't in the machines dict.
+/// Beacon is hand-tabled from the RFC-044 review (draftsman 2.0.76:
+/// beacon forbids productivity and quality). Labs and mining drills have
+/// no entry in either source — the machine-level check SKIPS them
+/// (documented gap; extend the extraction if it starts to matter).
+fn fallback_allowed_effects(entity: &str) -> Option<&'static [&'static str]> {
+    match entity {
+        "beacon" => Some(&["speed", "consumption", "pollution"]),
+        _ => None,
+    }
+}
+
+/// module-slots: per entity, Σ module counts ≤ `module_slots(entity)`;
+/// unknown module tiers warn (they can't be rated by the effect tables).
+pub fn check_module_slots(layout: &LayoutResult) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+    for ent in &layout.entities {
+        if ent.items.is_empty() {
+            continue;
+        }
+        let mut module_count: u32 = 0;
+        for it in &ent.items {
+            match module_family(&it.item) {
+                None => {}
+                Some("unknown") => {
+                    issues.push(ValidationIssue::with_pos(
+                        Severity::Warning,
+                        "module-slots",
+                        format!(
+                            "{} at ({}, {}): unknown module '{}' — not in the \
+                             known module tables, effects can't be rated",
+                            ent.name, ent.x, ent.y, it.item
+                        ),
+                        ent.x,
+                        ent.y,
+                    ));
+                    module_count += it.count;
+                }
+                Some(_) => module_count += it.count,
+            }
+        }
+        let slots = module_slots(&ent.name);
+        if module_count > slots {
+            issues.push(
+                ValidationIssue::with_pos(
+                    Severity::Warning,
+                    "module-slots",
+                    format!(
+                        "{} at ({}, {}): {} modules requested but the machine \
+                         has {} module slot{} — the surplus requests are never \
+                         fulfilled in game",
+                        ent.name,
+                        ent.x,
+                        ent.y,
+                        module_count,
+                        slots,
+                        if slots == 1 { "" } else { "s" }
+                    ),
+                    ent.x,
+                    ent.y,
+                )
+                .with_detail(slots as f64, module_count as f64),
+            );
+        }
+    }
+    issues
+}
+
+/// module-eligibility: productivity needs the recipe whitelist, and every
+/// module effect must be allowed by the machine.
+pub fn check_module_eligibility(layout: &LayoutResult) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+    for ent in &layout.entities {
+        if ent.items.is_empty() {
+            continue;
+        }
+        let machine = db().machines.get(ent.name.as_str());
+        let allowed: Option<Vec<&str>> = machine
+            .and_then(|m| m.allowed_effects.as_ref())
+            .map(|v| v.iter().map(|s| s.as_str()).collect())
+            .or_else(|| fallback_allowed_effects(&ent.name).map(|v| v.to_vec()));
+
+        for it in &ent.items {
+            let family = match module_family(&it.item) {
+                Some(f) if f != "unknown" => f,
+                _ => continue,
+            };
+
+            // Machine-level: every effect of the module must be allowed.
+            if let Some(allowed) = &allowed {
+                let forbidden: Vec<&str> = module_effects(family)
+                    .iter()
+                    .filter(|e| !allowed.contains(*e))
+                    .copied()
+                    .collect();
+                if !forbidden.is_empty() {
+                    issues.push(ValidationIssue::with_pos(
+                        Severity::Warning,
+                        "module-eligibility",
+                        format!(
+                            "{} at ({}, {}): {} not insertable — machine \
+                             forbids the '{}' effect",
+                            ent.name,
+                            ent.x,
+                            ent.y,
+                            it.item,
+                            forbidden.join("', '")
+                        ),
+                        ent.x,
+                        ent.y,
+                    ));
+                    continue; // recipe-level check would double-report
+                }
+            }
+
+            // Recipe-level: productivity modules only on whitelisted recipes.
+            if family == "productivity" {
+                if let Some(recipe_name) = &ent.recipe {
+                    if let Some(recipe) = db().recipes.get(recipe_name.as_str()) {
+                        if !recipe.allow_productivity {
+                            issues.push(ValidationIssue::with_pos(
+                                Severity::Warning,
+                                "module-eligibility",
+                                format!(
+                                    "{} at ({}, {}): {} not insertable — recipe \
+                                     '{}' does not allow productivity",
+                                    ent.name, ent.x, ent.y, it.item, recipe_name
+                                ),
+                                ent.x,
+                                ent.y,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    issues
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{EntityDirection, ModuleItem, PlacedEntity};
+
+    fn entity(name: &str, recipe: Option<&str>, items: Vec<(&str, u32)>) -> PlacedEntity {
+        PlacedEntity {
+            name: name.into(),
+            x: 0,
+            y: 0,
+            direction: EntityDirection::North,
+            recipe: recipe.map(|r| r.into()),
+            items: items
+                .into_iter()
+                .map(|(item, count)| ModuleItem {
+                    item: item.into(),
+                    count,
+                    quality: None,
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn layout(entities: Vec<PlacedEntity>) -> LayoutResult {
+        LayoutResult {
+            entities,
+            width: 20,
+            height: 10,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn overstuffed_machine_warns() {
+        // AM3 has 4 slots; 5 modules requested.
+        let l = layout(vec![entity(
+            "assembling-machine-3",
+            Some("iron-gear-wheel"),
+            vec![("productivity-module-3", 3), ("speed-module", 2)],
+        )]);
+        let issues = check_module_slots(&l);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].category, "module-slots");
+        let d = issues[0].detail.as_ref().unwrap();
+        assert_eq!((d.delivered, d.needed), (4.0, 5.0));
+    }
+
+    #[test]
+    fn zero_slot_machine_with_module_warns() {
+        // AM1 has zero module slots.
+        let l = layout(vec![entity(
+            "assembling-machine-1",
+            Some("iron-gear-wheel"),
+            vec![("speed-module", 1)],
+        )]);
+        assert_eq!(check_module_slots(&l).len(), 1);
+    }
+
+    #[test]
+    fn fuel_and_ammo_requests_are_not_modules() {
+        // Non-module item requests (fuel etc.) must not count toward
+        // slots or trip eligibility.
+        let l = layout(vec![entity("stone-furnace", None, vec![("coal", 50)])]);
+        assert!(check_module_slots(&l).is_empty());
+        assert!(check_module_eligibility(&l).is_empty());
+    }
+
+    #[test]
+    fn unknown_module_tier_warns_but_counts() {
+        let l = layout(vec![entity(
+            "assembling-machine-3",
+            None,
+            vec![("speed-module-4", 4)],
+        )]);
+        let issues = check_module_slots(&l);
+        // One unknown-module warning; count 4 still fits the 4 slots.
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("unknown module"));
+    }
+
+    #[test]
+    fn prod_in_recycler_warns_machine_level() {
+        let l = layout(vec![entity(
+            "recycler",
+            None,
+            vec![("productivity-module-3", 1)],
+        )]);
+        let issues = check_module_eligibility(&l);
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("productivity"));
+    }
+
+    #[test]
+    fn quality_module_in_refinery_warns() {
+        let l = layout(vec![entity(
+            "oil-refinery",
+            Some("advanced-oil-processing"),
+            vec![("quality-module-2", 1)],
+        )]);
+        let issues = check_module_eligibility(&l);
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("quality"));
+    }
+
+    #[test]
+    fn prod_in_beacon_warns_via_fallback_table() {
+        let l = layout(vec![entity(
+            "beacon",
+            None,
+            vec![("productivity-module", 2)],
+        )]);
+        assert_eq!(check_module_eligibility(&l).len(), 1);
+    }
+
+    #[test]
+    fn speed_in_beacon_is_clean() {
+        let l = layout(vec![entity("beacon", None, vec![("speed-module-3", 2)])]);
+        assert!(check_module_eligibility(&l).is_empty());
+    }
+
+    #[test]
+    fn prod_on_non_eligible_recipe_warns_recipe_level() {
+        // AM3 allows the productivity effect; iron-chest is not on the
+        // recipe whitelist — isolates the recipe-level rule.
+        let l = layout(vec![entity(
+            "assembling-machine-3",
+            Some("iron-chest"),
+            vec![("productivity-module-3", 1)],
+        )]);
+        let issues = check_module_eligibility(&l);
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("iron-chest"));
+    }
+
+    #[test]
+    fn prod_on_eligible_recipe_is_clean() {
+        let l = layout(vec![entity(
+            "assembling-machine-3",
+            Some("iron-gear-wheel"),
+            vec![("productivity-module-3", 4)],
+        )]);
+        assert!(check_module_eligibility(&l).is_empty());
+        assert!(check_module_slots(&l).is_empty());
+    }
+
+    #[test]
+    fn kovarex_prod_is_clean() {
+        // Kovarex is prod-eligible in 2.0 (catalyst-exempt crediting is
+        // solver business, not eligibility business).
+        let l = layout(vec![entity(
+            "centrifuge",
+            Some("kovarex-enrichment-process"),
+            vec![("productivity-module-3", 2)],
+        )]);
+        assert!(check_module_eligibility(&l).is_empty());
+    }
+
+    #[test]
+    fn drill_slot_counts_are_present() {
+        // Phase 1 prerequisite: drills in the slots table (electric 3,
+        // big 4) — moduled drills are ubiquitous in community imports.
+        let over = layout(vec![entity(
+            "electric-mining-drill",
+            None,
+            vec![("efficiency-module", 4)],
+        )]);
+        assert_eq!(check_module_slots(&over).len(), 1);
+        let ok = layout(vec![entity(
+            "big-mining-drill",
+            None,
+            vec![("efficiency-module", 4)],
+        )]);
+        assert!(check_module_slots(&ok).is_empty());
+    }
+}

--- a/crates/core/src/validate/modules.rs
+++ b/crates/core/src/validate/modules.rs
@@ -6,9 +6,10 @@
 //!   (`common::module_slots`), and module-shaped names we don't recognize
 //!   (modded tiers) warn as unratable.
 //! - **module-eligibility** — productivity modules require the recipe's
-//!   `allow_productivity`, and every effect of a module must be in the
-//!   machine's `allowed_effects` (recycler forbids productivity,
-//!   oil-refinery forbids quality, ...).
+//!   `allow_productivity`, and a module's BENEFICIAL effect must be in
+//!   the machine's `allowed_effects` (recycler forbids productivity,
+//!   oil-refinery forbids quality, ...). Harmful side-effects never gate
+//!   — see `module_gating_effect`.
 //!
 //! Both emit WARNINGS, not errors: an in-game paste doesn't fail on an
 //! invalid loadout — the offending module requests are silently never
@@ -20,51 +21,74 @@
 //! module-shaped names participate here — a coal request on a furnace is
 //! legitimate and ignored.
 
-use crate::common::module_slots;
+use crate::common::module_slots_known;
 use crate::models::LayoutResult;
 use crate::recipe_db::db;
 use crate::validate::{Severity, ValidationIssue};
 
-/// Full effect set of a module family — a module is insertable only when
-/// EVERY effect it carries is in the machine's `allowed_effects` (this is
-/// why prod modules are rejected by AM1 even though AM1 allows their
-/// pollution/speed/consumption components: `productivity` itself is
-/// missing from the list).
-fn module_effects(family: &str) -> &'static [&'static str] {
+/// The GATING effect of a module family. The game gates insertion on the
+/// module's BENEFICIAL effect only — harmful side-effects never gate
+/// (draftsman 2.0.76: speed modules carry a quality malus, yet
+/// speed-in-beacon is legal even though beacon's `allowed_effects` has no
+/// "quality"). So each family reduces to the one effect that must be in
+/// the machine's `allowed_effects`.
+fn module_gating_effect(family: &str) -> Option<&'static str> {
     match family {
-        "speed" => &["speed", "consumption"],
-        "productivity" => &["productivity", "speed", "consumption", "pollution"],
-        "efficiency" => &["consumption"],
-        "quality" => &["quality", "speed"],
-        _ => &[],
+        "speed" => Some("speed"),
+        "productivity" => Some("productivity"),
+        "efficiency" => Some("consumption"),
+        "quality" => Some("quality"),
+        _ => None,
     }
 }
 
-/// Classify an item-request name: `Some(family)` for the nine known
-/// module prototypes, `None` for non-module requests (fuel, ammo, ...).
-/// Module-SHAPED names outside the known nine (modded tiers like
-/// `speed-module-4`) return `Some("unknown")`.
+/// Classify an item-request name: `Some(family)` for known module
+/// prototypes, `None` for non-module requests (fuel, ammo, ...).
+/// The `effectivity-module*` names are the pre-2.0 spelling of
+/// `efficiency-module*` — the game migrates them on paste, and the
+/// community corpus is full of them, so they alias into the efficiency
+/// family rather than warning as unknown. Module-shaped names outside
+/// the known set (modded tiers like `speed-module-4`) return
+/// `Some("unknown")`; the shape test strips a trailing tier number and
+/// requires a `-module` SUFFIX so real items like `empty-module-slot`
+/// never match.
 fn module_family(name: &str) -> Option<&'static str> {
     match name {
         "speed-module" | "speed-module-2" | "speed-module-3" => Some("speed"),
         "productivity-module" | "productivity-module-2" | "productivity-module-3" => {
             Some("productivity")
         }
-        "efficiency-module" | "efficiency-module-2" | "efficiency-module-3" => Some("efficiency"),
+        "efficiency-module" | "efficiency-module-2" | "efficiency-module-3"
+        | "effectivity-module" | "effectivity-module-2" | "effectivity-module-3" => {
+            Some("efficiency")
+        }
         "quality-module" | "quality-module-2" | "quality-module-3" => Some("quality"),
-        _ if name.contains("-module") => Some("unknown"),
-        _ => None,
+        _ => {
+            let base = match name.rfind('-') {
+                Some(i) if name[i + 1..].chars().all(|c| c.is_ascii_digit()) => &name[..i],
+                _ => name,
+            };
+            if base.ends_with("-module") {
+                Some("unknown")
+            } else {
+                None
+            }
+        }
     }
 }
 
-/// `allowed_effects` for module hosts that aren't in the machines dict.
-/// Beacon is hand-tabled from the RFC-044 review (draftsman 2.0.76:
-/// beacon forbids productivity and quality). Labs and mining drills have
-/// no entry in either source — the machine-level check SKIPS them
-/// (documented gap; extend the extraction if it starts to matter).
+/// `allowed_effects` for module hosts that aren't in the machines dict,
+/// hand-tabled from draftsman 2.0.76. Labs and mining drills are
+/// deliberately ABSENT — their prototype `allowed_effects` is nil, which
+/// means "all effects allowed", so skipping them is exact, not a gap.
 fn fallback_allowed_effects(entity: &str) -> Option<&'static [&'static str]> {
     match entity {
+        // Forbids productivity and quality.
         "beacon" => Some(&["speed", "consumption", "pollution"]),
+        // Forbid quality only.
+        "rocket-silo" | "pumpjack" => {
+            Some(&["speed", "consumption", "pollution", "productivity"])
+        }
         _ => None,
     }
 }
@@ -81,7 +105,7 @@ pub fn check_module_slots(layout: &LayoutResult) -> Vec<ValidationIssue> {
         for it in &ent.items {
             match module_family(&it.item) {
                 None => {}
-                Some("unknown") => {
+                Some("unknown") if it.count > 0 => {
                     issues.push(ValidationIssue::with_pos(
                         Severity::Warning,
                         "module-slots",
@@ -95,31 +119,36 @@ pub fn check_module_slots(layout: &LayoutResult) -> Vec<ValidationIssue> {
                     ));
                     module_count += it.count;
                 }
+                Some("unknown") => {}
                 Some(_) => module_count += it.count,
             }
         }
-        let slots = module_slots(&ent.name);
+        // Unknown (modded) entities carry no slot claim we can check —
+        // asserting "0 slots" about se-recycling-facility would be wrong.
+        let Some(slots) = module_slots_known(&ent.name) else {
+            continue;
+        };
         if module_count > slots {
-            issues.push(
-                ValidationIssue::with_pos(
-                    Severity::Warning,
-                    "module-slots",
-                    format!(
-                        "{} at ({}, {}): {} modules requested but the machine \
-                         has {} module slot{} — the surplus requests are never \
-                         fulfilled in game",
-                        ent.name,
-                        ent.x,
-                        ent.y,
-                        module_count,
-                        slots,
-                        if slots == 1 { "" } else { "s" }
-                    ),
+            // No `.with_detail` here: IssueDetail is for rate-shaped
+            // issues, and the web starvation heatmap reads any detail
+            // pair category-blind — a slot overflow is not "80% starved".
+            issues.push(ValidationIssue::with_pos(
+                Severity::Warning,
+                "module-slots",
+                format!(
+                    "{} at ({}, {}): {} modules requested but the machine \
+                     has {} module slot{} — the surplus requests are never \
+                     fulfilled in game",
+                    ent.name,
                     ent.x,
                     ent.y,
-                )
-                .with_detail(slots as f64, module_count as f64),
-            );
+                    module_count,
+                    slots,
+                    if slots == 1 { "" } else { "s" }
+                ),
+                ent.x,
+                ent.y,
+            ));
         }
     }
     issues
@@ -145,25 +174,17 @@ pub fn check_module_eligibility(layout: &LayoutResult) -> Vec<ValidationIssue> {
                 _ => continue,
             };
 
-            // Machine-level: every effect of the module must be allowed.
-            if let Some(allowed) = &allowed {
-                let forbidden: Vec<&str> = module_effects(family)
-                    .iter()
-                    .filter(|e| !allowed.contains(*e))
-                    .copied()
-                    .collect();
-                if !forbidden.is_empty() {
+            // Machine-level: the module's beneficial (gating) effect must
+            // be in the machine's allowed_effects.
+            if let (Some(allowed), Some(gating)) = (&allowed, module_gating_effect(family)) {
+                if !allowed.contains(&gating) {
                     issues.push(ValidationIssue::with_pos(
                         Severity::Warning,
                         "module-eligibility",
                         format!(
                             "{} at ({}, {}): {} not insertable — machine \
                              forbids the '{}' effect",
-                            ent.name,
-                            ent.x,
-                            ent.y,
-                            it.item,
-                            forbidden.join("', '")
+                            ent.name, ent.x, ent.y, it.item, gating
                         ),
                         ent.x,
                         ent.y,
@@ -241,8 +262,8 @@ mod tests {
         let issues = check_module_slots(&l);
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].category, "module-slots");
-        let d = issues[0].detail.as_ref().unwrap();
-        assert_eq!((d.delivered, d.needed), (4.0, 5.0));
+        assert!(issues[0].message.contains("5 modules"));
+        assert!(issues[0].message.contains("4 module slots"));
     }
 
     #[test]
@@ -353,6 +374,81 @@ mod tests {
             vec![("productivity-module-3", 2)],
         )]);
         assert!(check_module_eligibility(&l).is_empty());
+    }
+
+    #[test]
+    fn effectivity_modules_alias_to_efficiency() {
+        // Pre-2.0 spelling, migrated by the game on paste; the corpus is
+        // full of it (review MAJOR-1: 94 false unknown-module warnings).
+        let l = layout(vec![entity(
+            "assembling-machine-2",
+            Some("iron-gear-wheel"),
+            vec![("effectivity-module", 2)],
+        )]);
+        assert!(check_module_slots(&l).is_empty());
+        assert!(check_module_eligibility(&l).is_empty());
+    }
+
+    #[test]
+    fn unknown_modded_entity_skips_slot_claim() {
+        // Review MAJOR-2: we know nothing about se-recycling-facility's
+        // slots — no overflow warning may be asserted.
+        let l = layout(vec![entity(
+            "se-recycling-facility",
+            None,
+            vec![("productivity-module-3", 4)],
+        )]);
+        assert!(check_module_slots(&l).is_empty());
+    }
+
+    #[test]
+    fn pumpjack_slots_and_quality_restriction() {
+        // Review MAJOR-3 + MINOR-6: pumpjack has 2 slots and forbids
+        // quality (draftsman 2.0.76).
+        let over = layout(vec![entity("pumpjack", None, vec![("speed-module-3", 3)])]);
+        assert_eq!(check_module_slots(&over).len(), 1);
+        let ok = layout(vec![entity("pumpjack", None, vec![("speed-module-3", 2)])]);
+        assert!(check_module_slots(&ok).is_empty());
+        let q = layout(vec![entity("pumpjack", None, vec![("quality-module", 1)])]);
+        assert_eq!(check_module_eligibility(&q).len(), 1);
+    }
+
+    #[test]
+    fn quality_in_rocket_silo_warns_via_fallback() {
+        let l = layout(vec![entity(
+            "rocket-silo",
+            None,
+            vec![("quality-module-3", 1)],
+        )]);
+        assert_eq!(check_module_eligibility(&l).len(), 1);
+    }
+
+    #[test]
+    fn empty_module_slot_item_is_not_a_module() {
+        // Review NIT-7: real hidden 2.0 item whose name contains
+        // "-module" but is not module-shaped (no `-module` suffix after
+        // tier-stripping).
+        let l = layout(vec![entity(
+            "assembling-machine-3",
+            None,
+            vec![("empty-module-slot", 1)],
+        )]);
+        assert!(check_module_slots(&l).is_empty());
+        assert!(check_module_eligibility(&l).is_empty());
+    }
+
+    #[test]
+    fn overflow_warning_carries_no_rate_detail() {
+        // Review MINOR-5: IssueDetail feeds the category-blind starvation
+        // heatmap; a slot overflow must not tint as starvation.
+        let l = layout(vec![entity(
+            "assembling-machine-3",
+            None,
+            vec![("speed-module", 5)],
+        )]);
+        let issues = check_module_slots(&l);
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].detail.is_none());
     }
 
     #[test]

--- a/docs/rfc-044-machine-modules.md
+++ b/docs/rfc-044-machine-modules.md
@@ -94,10 +94,13 @@ module tables; probe scripts recorded in the review.
   biochamber, EMP: +0.5). The per-recipe `maximum_productivity` cap
   (default 3.0) and research productivity never bind at module-only
   magnitudes in this RFC's scope — noted and ignored (non-goal).
-- **Eligibility is two-level**: per-recipe `allow_productivity` (122
-  recipes in our dataset) AND per-machine `allowed_effects` (recycler
-  forbids productivity; oil-refinery and rocket-silo forbid quality;
-  beacon forbids productivity and quality).
+- **Eligibility is two-level**: per-recipe `allow_productivity` (116
+  recipes in our dataset) AND per-machine `allowed_effects` — gated on
+  the module's BENEFICIAL effect only (corrected in the Phase 1 review:
+  speed modules carry a quality malus in 2.0, yet speed-in-beacon is
+  legal despite beacon forbidding quality — harmful side-effects never
+  gate). Recycler forbids productivity; oil-refinery, rocket-silo, and
+  pumpjack forbid quality; beacon forbids productivity and quality.
 - **Blueprint encoding** (2.0 insert-plan): `"items": [{"id": {"name": …,
   "quality": …?}, "items": {"in_inventory": [{"inventory": <class-id>,
   "stack": k}, …]}}]` — one `in_inventory` entry per module, `stack`
@@ -357,3 +360,32 @@ Works on imported blueprints immediately; no solver dependency.
   (`module_eligibility_data_is_bundled`). KC2 anchor string generated
   (`crates/core/examples/rfc044_anchor.rs`, local-only) covering all
   four inventory classes — **open, user-run**.*
+- *2026-07-21 — Phase 1 landed (branch `rfc044-phase1-module-validators`)
+  after deep local adversarial review (Fable, corpus-driven; verdict
+  ACCEPT-WITH-CHANGES, all findings folded in). Checks 24–25:
+  `module-slots` + `module-eligibility`, both WARNING severity by design
+  (an invalid loadout doesn't fail a paste — the requests are silently
+  unfulfilled; and imported blueprints must not be error-blocked by
+  module quirks). Calls made: non-module item requests (fuel/ammo)
+  classified out before counting; pre-2.0 `effectivity-module*` names
+  alias to the efficiency family (the game migrates them — 94
+  false-unknown warnings across the corpus otherwise); unknown modded
+  entities carry no slot claim (`common::module_slots_known` → `None`
+  skips the overflow warning — `se-recycling-facility` is not "0
+  slots"); pumpjack added (2 slots, forbids quality) alongside the
+  drills; rocket-silo + pumpjack join the beacon in the hand-tabled
+  `allowed_effects` fallback (labs/drills deliberately absent — nil
+  `allowed_effects` in game data means unrestricted, so skipping is
+  exact); **eligibility gates on the module's beneficial effect only**
+  (the rev-2 "effects ⊆ allowed_effects" rule was falsified by
+  draftsman data: speed modules carry a quality malus yet
+  speed-in-beacon is legal); slot-overflow issues carry no
+  `IssueDetail` (the web starvation heatmap reads detail pairs
+  category-blind). RFC-039 trace promise satisfied by the
+  `ValidationCompleted` rollup — no per-check emits (checks run under
+  rayon; thread-local trace would drop them), recorded as the
+  deviation. Evidence: 18 unit tests; full corpus sweep 198/198 files,
+  ZERO module warnings, with the census cross-validating Phase 0c's
+  `allow_productivity` extraction against every recipe the community
+  actually prod-modules; full suite green; KC1 safe by construction
+  (generated layouts never populate `items`).*


### PR DESCRIPTION
## Intent

Phase 1 of [RFC-044 machine modules](docs/rfc-044-machine-modules.md): the validator learns modules. Two new checks (24–25) over `PlacedEntity.items`, working on imported community blueprints today with zero solver dependency.

## Scope

- `validate/modules.rs`: **module-slots** (Σ module count vs `common::module_slots`, unknown modded tiers flagged) and **module-eligibility** (recipe `allow_productivity` + machine `allowed_effects`, gated on the module's *beneficial* effect — the literal effects-subset rule is falsified by 2.0 data). Both **Warning** severity by design: an invalid loadout doesn't fail an in-game paste (requests silently unfulfilled — the exact silent-failure class worth surfacing), and imports must not be error-blocked.
- `common.rs`: `module_slots_known → Option<u32>` (unknown modded entities carry no slot claim), drills + pumpjack added, `module_slots` keeps its `u32` shape for existing consumers incl. #322's wasm export.
- Fuel/ammo item requests classified out before counting (a coal request is not a module).
- CLAUDE.md check counts 23 → 25; full adjudication trail in the RFC decision log.

## Verification actually run

- 18 unit tests, incl. regressions for every review finding.
- **Deep local adversarial review** (required for validator-semantics changes): independent Fable reviewer, corpus-driven — verdict ACCEPT-WITH-CHANGES, all 3 majors + 3 minors + nits folded in.
- **Full community-corpus sweep: 198/198 files parse, ZERO module warnings** — prod-3 refineries (×162), quality-3 recyclers (×228), pre-2.0 effectivity modules, SE modded facilities, locomotive fuel requests all correctly clean. The census also cross-validates Phase 0c's `allow_productivity` extraction against every recipe the community actually prod-modules.
- Full lib suite (740) + e2e suite green. KC1 safe by construction: generated layouts never populate `items`, so no golden can move.

## Deviations from agreed approach

The RFC's "trace events per RFC-039" promise is satisfied by the `ValidationCompleted` rollup rather than per-check emits (checks run under rayon; thread-local trace events would drop) — recorded in the decision log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA