### PR TITLE
docs(rfc): RFC-044 registry status — Complete

### DIFF
--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -55,7 +55,7 @@ backfill the status next time the doc is touched.
 | RFC-041 | 2026-07-20 | [`rfc-build-quality.md`](rfc-build-quality.md) | Complete (in-game anchor open) |
 | RFC-042 | 2026-07-20 | [`rfc-power-reservation.md`](rfc-power-reservation.md) | Complete |
 | RFC-043 | 2026-07-20 | [`rfc-043-pole-band-thinning.md`](rfc-043-pole-band-thinning.md) | Complete (Phase 1; Phase 2 cross-row sharing deferred) |
-| RFC-044 | 2026-07-21 | [`rfc-044-machine-modules.md`](rfc-044-machine-modules.md) | Draft |
+| RFC-044 | 2026-07-21 | [`rfc-044-machine-modules.md`](rfc-044-machine-modules.md) | Complete (all 4 phases + KC2 in-game anchor; #321/#322/#323/#325) |
 | RFC-045 | 2026-07-21 | [`rfc-045-pole-wire-modes.md`](rfc-045-pole-wire-modes.md) | Complete (browser eyeball open) |
 
 Next number: **RFC-046**.


### PR DESCRIPTION
One-row registry flip: RFC-044 Draft → Complete. All four phases merged today (#321 export/data, #322 UI overlay, #323 validators, #325 solver policy) with the KC2 in-game anchor user-verified. Full trail in the RFC decision log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA