### PR TITLE
fix(ci): review bot has posted nothing since #305 — grant write permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,10 +19,16 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # `pull-requests`/`issues` must be WRITE: the review agent posts its
+    # findings as a PR review + inline/summary comments. The stock
+    # template ships read-only, which silently discarded every review
+    # from #305 through #324 — the job green-checked after a single
+    # permission denial (~20s, "No buffered inline comments") and no
+    # review was ever posted. Diagnosed 2026-07-21 on PR #324.
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Intent

The claude-code-review workflow has been silently toothless since it landed (#305): its job permissions were the stock template's `pull-requests: read` / `issues: read`, so the review agent could read the diff but was structurally forbidden from posting anything. Every run green-checked after ~20s with `permission_denials_count: 1` and "No buffered inline comments".

## Evidence (diagnosed on #324, 2026-07-21)

- Run 29865773886: 5 turns, 20s, $0.24, one permission denial, zero output posted.
- Zero bot review comments on ANY PR since #305 — the only bot comments repo-wide are the preview-deploy stickies; the substantive review comments on #317/#318 were session-lead reviews posted from the owner account.
- The sibling `clear-agent-reviewed.yml` already uses `pull-requests: write`, so write-scoped workflows are established practice here.

## Scope

One hunk: `pull-requests`/`issues` read → write, with a comment explaining why (so the template default doesn't get restored in a future sync).

## Verification actually run

This PR is the test: `pull_request` workflows run from the PR's own ref, so the claude-review run on this very PR uses the fixed permissions — if the bot posts a review below, the fix works. (Will confirm before merge.)

## Deviations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55