### PR TITLE
fix(ci): review bot never posts without --comment — add the flag

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,7 +44,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # `--comment` is LOAD-BEARING: the code-review plugin's own
+          # contract is "if --comment was NOT provided, stop here. Do not
+          # post any GitHub comments." Without it the review runs, prints
+          # to the action log, and posts nothing — which (together with
+          # the read-only perms fixed in #327) is why no PR ever received
+          # a bot review from #305 to #328.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Intent

Second (and primary) cause of the silent review bot: the code-review plugin's own contract says **"If \`--comment\` argument was NOT provided, stop here. Do not post any GitHub comments."** Our prompt never passed it, so even with #327's write permissions the plugin reviews into the action log and posts nothing. This adds the flag, with an in-file comment marking it load-bearing.

## Evidence

- Plugin source (anthropics/claude-code, plugins/code-review/commands/code-review.md), step 7 quoted above.
- Post-#327 run on #328: zero permission denials, green, still nothing posted — permissions alone were insufficient.
- Also explains the short runs: step 1 is a triviality gate (haiku agent skips PRs that "do not need code review"), so small docs PRs stop early by design.

## Verification actually run

The action self-skips on workflow-modifying PRs (anti-hijack guard), so this cannot test itself. Post-merge validation: a controlled PR with a deliberate high-signal bug, expecting the bot's first-ever inline comment; will report the result on this PR before closing the loop.

## Deviations

None — one prompt hunk plus comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55