### PR TITLE
fix(ci): review bot tool allowlist (claude_args) — third silent-bot cause

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,6 +51,13 @@ jobs:
           # the read-only perms fixed in #327) is why no PR ever received
           # a bot review from #305 to #328.
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Third load-bearing piece (with write perms #327 and --comment
+          # #329): the harness-level tool allowlist. Without it the agent
+          # runs the review but every posting/diff tool call is denied
+          # (11 denials on the #330 canary run). Mirrors the plugin's
+          # frontmatter allowed-tools + the action's own examples.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Intent

Third and (per the canary evidence) final cause of the never-posting review bot. The #330 canary run — with #327's write perms and #329's `--comment` both live — executed a real multi-agent review (262s, 23 turns, \$2.11) but hit **11 harness-level tool denials** and posted nothing: the action was never given `claude_args --allowedTools`, so the plugin's posting (`mcp__github_inline_comment__create_inline_comment`, `gh pr comment`) and diff-fetching (`gh pr diff/view`) tools were all denied. The action's own examples pass exactly this allowlist.

## Verification actually run

Cannot self-test (workflow-modifying PRs skip the action). Post-merge: re-trigger the #330 canary (which carries a planted, unambiguous logic bug) via synchronize and confirm the bot posts an inline comment on it. Result will be reported here.

## Deviations

None — one workflow hunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55