### PR TITLE
fix(blueprint): RFC-044 retro-review fixes — pumpjack inventory id, module-only export filter

### DIFF
--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -172,10 +172,23 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
                     // Slot positions run sequentially across ALL modules
                     // in the entity: module A ×2 takes stacks 0,1; the
                     // next module starts at 2.
+                    //
+                    // Only MODULE-shaped requests are emitted: the parser
+                    // collapses every item request (fuel, ammo) into
+                    // `items`, and re-emitting those into the MODULE
+                    // inventory would mis-target them (a coal request is
+                    // not a module — retro-review m1). Dropping them
+                    // matches pre-RFC-044 export behavior; full
+                    // inventory/count fidelity is a recorded followup
+                    // (docs/module-followups.md). count-0 entries carry
+                    // no slot positions and are skipped outright.
                     let inventory = crate::common::module_inventory_id(&ent.name);
                     let mut stack = 0u32;
                     ent.items
                         .iter()
+                        .filter(|m| {
+                            m.count > 0 && crate::common::game_module_family(&m.item).is_some()
+                        })
                         .map(|m| BlueprintInsertPlan {
                             id: BlueprintItemId {
                                 name: &m.item,
@@ -454,6 +467,66 @@ mod tests {
         let drill = find("electric-mining-drill");
         assert_eq!(drill.items[0].count, 3);
         assert_eq!(drill.items[0].quality, None);
+    }
+
+    /// Pumpjack is a mining-drill prototype: its modules export to
+    /// inventory 2, not the crafting default 4 (retro-review M1 — wrong
+    /// id fails silently on paste and round-trips can't see it).
+    #[test]
+    fn pumpjack_modules_export_to_drill_inventory() {
+        use crate::models::ModuleItem;
+        let layout = LayoutResult {
+            entities: vec![PlacedEntity {
+                name: "pumpjack".into(),
+                x: 0,
+                y: 0,
+                direction: EntityDirection::North,
+                items: vec![ModuleItem {
+                    item: "speed-module-3".into(),
+                    count: 2,
+                    quality: None,
+                }],
+                ..Default::default()
+            }],
+            width: 3,
+            height: 3,
+            ..Default::default()
+        };
+        let bp = decode_blueprint(&export(&layout, "pj"));
+        let positions = &bp["entities"][0]["items"][0]["items"]["in_inventory"];
+        assert_eq!(positions[0]["inventory"], 2);
+        assert_eq!(positions[1]["inventory"], 2);
+    }
+
+    /// Non-module item requests (fuel, ammo) parsed off imported
+    /// blueprints must NOT re-export as module-inventory insert plans —
+    /// a coal request is not a module (retro-review m1; dropping them
+    /// matches pre-RFC-044 behavior, full fidelity is a followup).
+    #[test]
+    fn non_module_item_requests_are_not_exported_as_modules() {
+        use crate::models::ModuleItem;
+        let layout = LayoutResult {
+            entities: vec![PlacedEntity {
+                name: "stone-furnace".into(),
+                x: 0,
+                y: 0,
+                direction: EntityDirection::North,
+                items: vec![
+                    ModuleItem { item: "coal".into(), count: 50, quality: None },
+                    // count-0 entries carry no positions; skipped too.
+                    ModuleItem { item: "speed-module".into(), count: 0, quality: None },
+                ],
+                ..Default::default()
+            }],
+            width: 2,
+            height: 2,
+            ..Default::default()
+        };
+        let bp = decode_blueprint(&export(&layout, "fuel"));
+        assert!(
+            bp["entities"][0].get("items").is_none(),
+            "fuel request leaked into module insert plans"
+        );
     }
 
     /// Decode an exported blueprint string back to its JSON `blueprint` object.

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -1217,6 +1217,40 @@ pub fn module_effect(name: &str) -> ModuleEffect {
     }
 }
 
+/// Classify an item-request name as a GAME module: `Some(family)` for
+/// known module prototypes ("speed" / "productivity" / "efficiency" /
+/// "quality"), `Some("unknown")` for module-shaped names outside the
+/// known set (modded tiers — tier-number-stripped `-module` suffix, so
+/// real items like `empty-module-slot` never match), `None` for
+/// non-module requests (fuel, ammo, ...). Pre-2.0 `effectivity-module*`
+/// spellings alias to the efficiency family (the game migrates them on
+/// paste). Shared by the module validators and the blueprint exporter's
+/// insert-plan filter.
+pub fn game_module_family(name: &str) -> Option<&'static str> {
+    match name {
+        "speed-module" | "speed-module-2" | "speed-module-3" => Some("speed"),
+        "productivity-module" | "productivity-module-2" | "productivity-module-3" => {
+            Some("productivity")
+        }
+        "efficiency-module" | "efficiency-module-2" | "efficiency-module-3"
+        | "effectivity-module" | "effectivity-module-2" | "effectivity-module-3" => {
+            Some("efficiency")
+        }
+        "quality-module" | "quality-module-2" | "quality-module-3" => Some("quality"),
+        _ => {
+            let base = match name.rfind('-') {
+                Some(i) if name[i + 1..].chars().all(|c| c.is_ascii_digit()) => &name[..i],
+                _ => name,
+            };
+            if base.ends_with("-module") {
+                Some("unknown")
+            } else {
+                None
+            }
+        }
+    }
+}
+
 /// Number of module slots for a KNOWN machine entity; `None` for
 /// entities outside the table (modded machines) — the module-slots
 /// validator must not assert slot counts it doesn't know (a modded
@@ -1263,7 +1297,11 @@ pub fn module_slots(entity: &str) -> u32 {
 pub fn module_inventory_id(entity: &str) -> u8 {
     match entity {
         "beacon" => 1,
-        "electric-mining-drill" | "big-mining-drill" | "burner-mining-drill" => 2,
+        // Pumpjack is a mining-drill prototype: inventory 2, NOT the
+        // crafting default — caught by the post-merge retro review
+        // (draftsman reference emission); the KC2 anchor's drill covered
+        // class 2 while this per-entity lookup stayed wrong.
+        "electric-mining-drill" | "big-mining-drill" | "burner-mining-drill" | "pumpjack" => 2,
         "lab" | "biolab" => 3,
         _ => 4,
     }

--- a/crates/core/src/validate/modules.rs
+++ b/crates/core/src/validate/modules.rs
@@ -53,28 +53,7 @@ fn module_gating_effect(family: &str) -> Option<&'static str> {
 /// requires a `-module` SUFFIX so real items like `empty-module-slot`
 /// never match.
 fn module_family(name: &str) -> Option<&'static str> {
-    match name {
-        "speed-module" | "speed-module-2" | "speed-module-3" => Some("speed"),
-        "productivity-module" | "productivity-module-2" | "productivity-module-3" => {
-            Some("productivity")
-        }
-        "efficiency-module" | "efficiency-module-2" | "efficiency-module-3"
-        | "effectivity-module" | "effectivity-module-2" | "effectivity-module-3" => {
-            Some("efficiency")
-        }
-        "quality-module" | "quality-module-2" | "quality-module-3" => Some("quality"),
-        _ => {
-            let base = match name.rfind('-') {
-                Some(i) if name[i + 1..].chars().all(|c| c.is_ascii_digit()) => &name[..i],
-                _ => name,
-            };
-            if base.ends_with("-module") {
-                Some("unknown")
-            } else {
-                None
-            }
-        }
-    }
+    crate::common::game_module_family(name)
 }
 
 /// `allowed_effects` for module hosts that aren't in the machines dict,

--- a/docs/module-followups.md
+++ b/docs/module-followups.md
@@ -1,0 +1,50 @@
+# Module-support followups
+
+Status: **all items open** (created 2026-07-21 at the RFC-044 retro-review
+close-out). Deferred-work backlog with pick-up notes, per the
+followups-doc convention. Owner RFC: `rfc-044-machine-modules.md`.
+
+## 1. Full item-request fidelity through the model (retro m1)
+
+The parser collapses ALL entity `items` (fuel, ammo, modules) into
+`ModuleItem`, discarding the insert-plan `inventory` id and per-position
+`count` (a `{"count": 50}` coal request parses as count 1). The exporter
+now filters to module-shaped names (restoring pre-RFC-044 drop semantics
+for the rest), so nothing mis-encodes — but import → re-export still
+LOSES non-module requests. Pick-up: carry `inventory: Option<u8>` and the
+true count through `ModuleItem` (or a sibling type) and re-emit verbatim;
+the export filter then becomes "module-shaped OR carried-verbatim".
+
+## 2. Modded module hosts default to inventory 4 (retro n3)
+
+`common::module_inventory_id` returns 4 for unknown entities — wrong for
+modded labs/beacons/drills. Acceptable and documented; revisit only if
+modded-blueprint fidelity becomes a goal (would need a prototype-type
+field through the parser).
+
+## 3. Parser footprints missing big-mining-drill and pumpjack
+
+`blueprint_parser::entity_footprint` lacks `big-mining-drill` (5×5) and
+`pumpjack` (3×3) → both fall to the 1×1 default, so imported blueprints
+containing them get wrong top-left anchors (center − size/2). Pre-existing
+(predates RFC-044), spotted during the retro-fix pass but not
+adversarially reviewed — fix with a targeted parse-position test. The web
+`MACHINE_SIZES` half of this was fixed in the retro-fix PR.
+
+## 4. analysis.rs is module-quality-blind (Phase 1 close-out note)
+
+`blueprint-analyze` computes module effects at base values — a
+quality-moduled blueprint's rate estimate ignores the ×(1+0.3·level)
+1%-floored scaling that `module_policy::quality_scaled` implements. The
+RFC's verification plan confines the re-analysis gate to normal-quality
+modules because of this. Pick-up: route analysis.rs through the shared
+scaling fn (it now exists) and lift the gate's restriction.
+
+## 5. Beacon arc (deliberate RFC-044 non-goal)
+
+Geometry work: 3×3 rows, supply distance 3, count-based transmission
+falloff (the `BEACON_DISTRIBUTION_EFFECTIVITY = 0.5` constant is a
+documented 1.x-era simplification of 2.0's ~1.5/√N profile), beacon power
+draw. Starts as its own RFC; all module math (`module_policy.rs`,
+per-quality scaling, insert-plan export incl. beacon inventory 1) is
+already in place.

--- a/docs/rfc-044-machine-modules.md
+++ b/docs/rfc-044-machine-modules.md
@@ -436,3 +436,27 @@ Works on imported blueprints immediately; no solver dependency.
   honest movement). KC4 satisfied: prod fit the LP as per-column
   constant coefficients, no split needed. KC5 both parts pinned by
   tests.*
+- *2026-07-21 — **record correction + retro review.** The CI review bot
+  was silently broken across this entire arc (the #305–#327 window: the
+  check stayed green while reviews were discarded on a permission
+  denial — see CLAUDE.md). Every "bot-clean" claim in this log was
+  therefore vacuous; the REAL review coverage was: #319/#323/#325 —
+  independent Fable adversarial reviews (unaffected); #321/#322 —
+  merged on the phantom bot floor alone. A post-merge retro review of
+  both diffs (Fable) closed the gap: **#322 CLEAN**; **#321 one MAJOR**
+  — pumpjack's modules exported to inventory 4 instead of the
+  mining-drill class 2 (per-entity table gap; silent on paste,
+  structurally invisible to round-trips, and the KC2 anchor's drill
+  covered class 2 while pumpjack stayed wrong) — fixed same day in the
+  retro-fix PR along with: export-side filter so non-module item
+  requests (fuel/ammo) no longer re-emit into module inventories (a
+  #321 regression vs the old drop-them behavior; full fidelity tracked
+  in `docs/module-followups.md`), count-0 insert-plan suppression, the
+  shared `common::game_module_family` classifier, and web
+  prefetch/footprint entries for pumpjack + big-mining-drill. The retro
+  review also EXHAUSTIVELY re-verified the Phase 0c extraction against
+  draftsman (all 649 recipes, 1005 result entries, 15 machines — zero
+  mismatches), retroactively solidifying the data Phases 1/3 built on.
+  KC2 addendum: the anchor string gains a pumpjack so inventory class 2
+  is covered per-prototype-family, not just per-class — re-paste is a
+  cheap optional re-check.*

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -235,6 +235,7 @@ export async function initEngine(): Promise<void> {
       "biolab",
       "electric-mining-drill",
       "big-mining-drill",
+      "pumpjack",
     ],
   });
   moduleSlotsCache = new Map(moduleSlotEntries);

--- a/web/src/renderer/entities.ts
+++ b/web/src/renderer/entities.ts
@@ -196,6 +196,8 @@ export const MACHINE_SIZES: Record<string, [number, number]> = {
   "big-electric-pole": [2, 2],
   substation: [2, 2],
   "electric-mining-drill": [3, 3],
+  "big-mining-drill": [5, 5],
+  pumpjack: [3, 3],
 };
 
 /** Convert a kebab-case slug to a display name: "assembling-machine-3" → "Assembling Machine 3" */


### PR DESCRIPTION
## Intent

Fixes from the post-merge adversarial review of #321/#322 — run because the CI review bot was silently broken across the #305–#327 window (green check, discarded reviews), so both PRs had merged on a phantom review floor. #322 came back clean; #321 had one MAJOR and a regression, both fixed here.

## Scope

- **M1 (MAJOR)**: `module_inventory_id` sent pumpjack modules to inventory 4 (crafting default) — pumpjack is a mining-drill prototype, inventory 2 (draftsman-verified). Silent on paste, invisible to round-trips; the KC2 anchor's drill covered class 2 while this per-entity lookup stayed wrong. Fixed + byte-shape test; the anchor example now includes a pumpjack.
- **m1 (regression)**: fuel/ammo requests parsed off imported blueprints were re-exported into *module* inventories. Export now filters to module-shaped names via a new shared `common::game_module_family` (the Phase 1 validator delegates to it) — restoring pre-RFC-044 drop semantics. Full inventory/count fidelity is tracked in the new `docs/module-followups.md`.
- **n1**: count-0 insert plans suppressed. **m2/n2**: web slot-prefetch + `MACHINE_SIZES` gain pumpjack and big-mining-drill.
- **RFC decision log**: record correction — the silent-bot window, the real review coverage per PR, the retro-review verdicts, and the exhaustive re-verification of the Phase 0c extraction (649 recipes / 1005 result entries / 15 machines against draftsman: zero mismatches).

## Verification actually run

773 core lib tests green (incl. the two new regression tests); web tsc clean; anchor regenerated and round-tripped. The retro review itself independently reproduced the pumpjack reference emission via draftsman and audited both merged diffs for drive-by edits (none).

## Deviations from agreed approach

One process wobble, recovered with SHA guards: the shared checkout switched to main mid-flow (concurrent session), the commit briefly landed on local main, and was rehomed to this branch before anything was pushed to origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA