### PR TITLE
fix(blueprint): inserters export with game direction semantics (180° flip at the artifact boundary)

### DIFF
--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -156,7 +156,17 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
                         y: ent.y as f64 + h as f64 / 2.0,
                     }
                 },
-                direction: ent.direction as u8,
+                // GAME QUIRK (found by the RFC-050 harness, 2026-07-22):
+                // Factorio reads an INSERTER's direction as its PICKUP
+                // side ("inserters point backwards"), while the engine's
+                // convention is drop-side. Flip 180° at the artifact
+                // boundary — the parser un-flips on import — or every
+                // exported inserter runs backwards in-game.
+                direction: if ent.name.contains("inserter") {
+                    (ent.direction as u8 + 8) % 16
+                } else {
+                    ent.direction as u8
+                },
                 recipe: ent.recipe.as_deref(),
                 io_type: ent.io_type.as_deref(),
                 mirror: ent.mirror,
@@ -322,6 +332,77 @@ mod tests {
         assert!(ents[0].get("mirror").is_none());
         // recipe should be absent for belt
         assert!(ents[1].get("recipe").is_none());
+    }
+
+    /// Factorio reads an inserter's `direction` as its PICKUP side
+    /// ("inserters point backwards" — found by the RFC-050 harness when
+    /// every exported factory deadlocked in-sim: input inserters pulled
+    /// from empty machines, outputs from empty belts). The engine's
+    /// convention is drop-side, so export must flip 180° and ONLY for
+    /// inserters.
+    #[test]
+    fn inserter_directions_flip_to_game_convention() {
+        let layout = LayoutResult {
+            entities: vec![
+                PlacedEntity {
+                    name: "stack-inserter".into(),
+                    x: 0,
+                    y: 0,
+                    direction: EntityDirection::South,
+                    ..Default::default()
+                },
+                PlacedEntity {
+                    name: "long-handed-inserter".into(),
+                    x: 2,
+                    y: 0,
+                    direction: EntityDirection::North,
+                    ..Default::default()
+                },
+                PlacedEntity {
+                    name: "transport-belt".into(),
+                    x: 4,
+                    y: 0,
+                    direction: EntityDirection::South,
+                    ..Default::default()
+                },
+            ],
+            width: 5,
+            height: 1,
+            ..Default::default()
+        };
+        let bp = decode_blueprint(&export(&layout, "dirflip"));
+        let ents = bp["entities"].as_array().unwrap();
+        // Engine South (8) exports as game North (0) for inserters…
+        assert_eq!(ents[0]["direction"], 0);
+        // …engine North (0) as game South (8)…
+        assert_eq!(ents[1]["direction"], 8);
+        // …and non-inserters are untouched.
+        assert_eq!(ents[2]["direction"], 8);
+    }
+
+    /// The parser applies the inverse flip so imported game-convention
+    /// inserters read correctly under engine semantics, and round-trips
+    /// are identity.
+    #[test]
+    fn inserter_direction_round_trip_is_identity() {
+        let layout = LayoutResult {
+            entities: vec![PlacedEntity {
+                name: "fast-inserter".into(),
+                x: 0,
+                y: 0,
+                direction: EntityDirection::East,
+                ..Default::default()
+            }],
+            width: 1,
+            height: 1,
+            ..Default::default()
+        };
+        let s = export(&layout, "rt");
+        // Artifact carries the game convention (East 4 → West 12)…
+        assert_eq!(decode_blueprint(&s)["entities"][0]["direction"], 12);
+        // …and parsing restores the engine convention.
+        let parsed = crate::blueprint_parser::parse_blueprint_string(&s).unwrap();
+        assert_eq!(parsed.entities[0].direction, EntityDirection::East);
     }
 
     /// The exported module encoding must match the game's own emission

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -287,6 +287,18 @@ fn parse_direction(d: u8) -> EntityDirection {
     }
 }
 
+/// 180° rotation in `EntityDirection` space — the inserter
+/// pickup-vs-drop convention flip (see the import site and the
+/// exporter's mirror-image flip).
+fn flip180(d: EntityDirection) -> EntityDirection {
+    match d {
+        EntityDirection::North => EntityDirection::South,
+        EntityDirection::East => EntityDirection::West,
+        EntityDirection::South => EntityDirection::North,
+        EntityDirection::West => EntityDirection::East,
+    }
+}
+
 // ---- Public API ----
 
 /// A parsed blueprint with an optional label.
@@ -333,10 +345,15 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
         // direction is the PICKUP side; the engine's convention is
         // drop-side. Un-flip on import so imported inserters read
         // correctly under engine semantics (the exporter flips back).
+        // The flip happens AFTER parsing, in EntityDirection space —
+        // raw-byte arithmetic would destroy legacy v0/v1 8-way values
+        // (E=2/W=6 both landed on the catch-all) and could overflow on
+        // garbage bytes (PR #348 review).
+        let parsed = parse_direction(raw.direction);
         let dir = if raw.name.contains("inserter") {
-            parse_direction((raw.direction + 8) % 16)
+            flip180(parsed)
         } else {
-            parse_direction(raw.direction)
+            parsed
         };
         let (w, h) = entity_footprint(&raw.name, dir);
 
@@ -589,6 +606,51 @@ mod tests {
         let parsed = parse_blueprint_string(&bp).expect("should parse");
         assert_eq!(parsed.entities.len(), 1);
         assert_eq!(parsed.entities[0].name, "stack-inserter");
+    }
+
+    /// PR #348 review MAJOR: the pickup→drop un-flip must happen in
+    /// EntityDirection space, after legacy 8-way decoding — raw-byte
+    /// `+8` collapsed legacy E(2)/W(6) onto the catch-all.
+    #[test]
+    fn legacy_8way_inserters_unflip_correctly() {
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "entities": [
+                    // Legacy East (2): game pickup=east → engine drop-side = West.
+                    {"entity_number": 1, "name": "fast-inserter",
+                     "position": {"x": 0.5, "y": 0.5}, "direction": 2},
+                    // Legacy West (6) → engine East.
+                    {"entity_number": 2, "name": "inserter",
+                     "position": {"x": 2.5, "y": 0.5}, "direction": 6},
+                    // Legacy East belt stays East (no flip for non-inserters).
+                    {"entity_number": 3, "name": "transport-belt",
+                     "position": {"x": 4.5, "y": 0.5}, "direction": 2},
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.entities[0].direction, EntityDirection::West);
+        assert_eq!(parsed.entities[1].direction, EntityDirection::East);
+        assert_eq!(parsed.entities[2].direction, EntityDirection::East);
+    }
+
+    /// PR #348 review MINOR: garbage direction bytes must not panic
+    /// (the old raw `+8` overflowed u8 for values ≥ 248 in debug).
+    #[test]
+    fn garbage_direction_bytes_do_not_panic() {
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "entities": [
+                    {"entity_number": 1, "name": "inserter",
+                     "position": {"x": 0.5, "y": 0.5}, "direction": 250},
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        // Catch-all North, flipped to engine South.
+        assert_eq!(parsed.entities[0].direction, EntityDirection::South);
     }
 
     #[test]

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -329,7 +329,15 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
     for (pos, raw) in bp_data.entities.into_iter().enumerate() {
         let entity_number = raw.entity_number.unwrap_or((pos + 1) as u64);
         num_to_idx.insert(entity_number, entities.len());
-        let dir = parse_direction(raw.direction);
+        // GAME QUIRK (RFC-050 harness, 2026-07-22): Factorio's inserter
+        // direction is the PICKUP side; the engine's convention is
+        // drop-side. Un-flip on import so imported inserters read
+        // correctly under engine semantics (the exporter flips back).
+        let dir = if raw.name.contains("inserter") {
+            parse_direction((raw.direction + 8) % 16)
+        } else {
+            parse_direction(raw.direction)
+        };
         let (w, h) = entity_footprint(&raw.name, dir);
 
         // Factorio stores center position; convert to top-left tile

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -162,7 +162,12 @@ pub struct PlacedEntity {
     /// Recipe assigned to crafting machines (`None` for belts, inserters, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recipe: Option<String>,
-    /// I/O role tag for bus entities: `"input"`, `"output"`, or `"passthrough"`.
+    /// Underground-belt half marker (`"input"` = entrance, `"output"` =
+    /// exit) — serialized as the Factorio blueprint `type` field. Set
+    /// ONLY on UG pairs (trunk renderer, ghost router, balancer library,
+    /// merger hops); despite the old docstring, it never tagged bus
+    /// boundary belts and `"passthrough"` was never assigned (RFC-050
+    /// review finding — the false claim it seeded cost a design cycle).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub io_type: Option<String>,
     /// Item or fluid name this belt/pipe is currently carrying.


### PR DESCRIPTION
## Intent

Every blueprint this project has ever exported had **all inserters running backwards in-game** — Factorio reads an inserter's `direction` as its *pickup* side (the famous "inserters point backwards" quirk); the engine's convention is drop-side; the exporter never translated. Input inserters pulled from empty machines, outputs from empty belts: total deadlock, invisible to the validator/renderer/docs because all three share the engine convention.

Found by the RFC-050 headless harness on its first real measurement run (a fully-built, powered, fed 5108-entity factory produced *nothing*; the sim-state/layout join showed `waiting_for_source_items` inserters with full pickup belts one flip away). The game rule was verified empirically twice: a `create_entity` probe (facing-the-chest feeds 179/s onto a stacked belt) and `pickup_position` dumps on the pasted factory.

## Scope

- `blueprint.rs`: inserter-named entities export `direction = (engine + 8) % 16`; everything else unchanged.
- `blueprint_parser.rs`: inverse flip on import, so imported community blueprints read correctly under engine semantics and round-trips are identity.
- `models.rs`: corrects the stale `io_type` docstring (it's the UG entrance/exit marker, never a bus-boundary tag — the misdoc that seeded RFC-050's falsified boundary claim).
- New tests pin the artifact bytes both ways + round-trip identity.

Engine internals, validator semantics, layouts: untouched by construction.

## Verification actually run

- Full suite + `SPAGHETTIO_STRESS_GOLDEN=check`: 16/16 targets green, exit 0 (goldens hash layouts, which don't change).
- **Operational proof in the headless sim**: pre-fix factory dead (zero crafts, all inserters waiting); post-fix the full chain runs — ore→plates→cable flowing (9k copper plates, 7.1k cables, 3.6k iron plates on belts), 114 furnaces crafted to full buffers.
- **Recommended user anchor before/at merge**: paste one small generated factory (e.g. gear@10/s) in the game client and watch it actually run — the harness says it works; the client is the final word.

## Deviations from agreed approach

None. Deep local adversarial review being spawned in addition to the bot (artifact-semantics change, maximal blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA