### PR TITLE
fix(blueprint): splitter export centers are direction-aware

### DIFF
--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -158,18 +158,11 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
                     // adjacent column, and belt connectivity silently broke
                     // in-game (found by the RFC-050 harness: the gear
                     // fixture's merger splitter buffered 56 items into a
-                    // void). The parser's `entity_footprint` was already
-                    // direction-aware, so round-trips never saw it.
-                    let (w, h) = if ent.name.ends_with("splitter") {
-                        match ent.direction {
-                            crate::models::EntityDirection::North
-                            | crate::models::EntityDirection::South => (2, 1),
-                            crate::models::EntityDirection::East
-                            | crate::models::EntityDirection::West => (1, 2),
-                        }
-                    } else {
-                        crate::common::entity_size(&ent.name)
-                    };
+                    // void). The shared `oriented_splitter_dims` covers the
+                    // exact 2-wide family — NOT `lane-splitter`, which is
+                    // 1×1 despite the name (PR #350 review).
+                    let (w, h) = crate::common::oriented_splitter_dims(&ent.name, ent.direction)
+                        .unwrap_or_else(|| crate::common::entity_size(&ent.name));
                     Position {
                         x: ent.x as f64 + w as f64 / 2.0,
                         y: ent.y as f64 + h as f64 / 2.0,
@@ -383,6 +376,41 @@ mod tests {
             assert_eq!(bp["entities"][0]["position"]["x"], cx, "{dir:?}");
             assert_eq!(bp["entities"][0]["position"]["y"], cy, "{dir:?}");
         }
+    }
+
+    /// PR #350 review: the 2-wide family is exactly {splitter, fast-,
+    /// express-, turbo-}; `lane-splitter` is 1×1 despite the name and
+    /// must NOT be widened.
+    #[test]
+    fn splitter_family_subset_is_exact() {
+        let layout = LayoutResult {
+            entities: vec![
+                PlacedEntity {
+                    name: "turbo-splitter".into(),
+                    x: 0,
+                    y: 0,
+                    direction: EntityDirection::South,
+                    ..Default::default()
+                },
+                PlacedEntity {
+                    name: "lane-splitter".into(),
+                    x: 4,
+                    y: 0,
+                    direction: EntityDirection::South,
+                    ..Default::default()
+                },
+            ],
+            width: 6,
+            height: 2,
+            ..Default::default()
+        };
+        let bp = decode_blueprint(&export(&layout, "fam"));
+        // turbo: 2-wide → integer center on x.
+        assert_eq!(bp["entities"][0]["position"]["x"], 1.0);
+        assert_eq!(bp["entities"][0]["position"]["y"], 0.5);
+        // lane-splitter: 1×1 → half centers on both axes.
+        assert_eq!(bp["entities"][1]["position"]["x"], 4.5);
+        assert_eq!(bp["entities"][1]["position"]["y"], 0.5);
     }
 
     /// Factorio reads an inserter's `direction` as its PICKUP side

--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -150,7 +150,26 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
                     // Footprint center from the shared `entity_size` (RFC
                     // Phase 3a-i): a 2×2 substation exports at x+1.0, not the
                     // x+0.5 the old machine-only lookup produced.
-                    let (w, h) = crate::common::entity_size(&ent.name);
+                    //
+                    // Splitters are direction-dependent (2 wide perpendicular
+                    // to flow) and `entity_size` is direction-blind (1×1
+                    // fallback) — without this arm every exported splitter
+                    // sat half a tile off, the game snapped the ghost to an
+                    // adjacent column, and belt connectivity silently broke
+                    // in-game (found by the RFC-050 harness: the gear
+                    // fixture's merger splitter buffered 56 items into a
+                    // void). The parser's `entity_footprint` was already
+                    // direction-aware, so round-trips never saw it.
+                    let (w, h) = if ent.name.ends_with("splitter") {
+                        match ent.direction {
+                            crate::models::EntityDirection::North
+                            | crate::models::EntityDirection::South => (2, 1),
+                            crate::models::EntityDirection::East
+                            | crate::models::EntityDirection::West => (1, 2),
+                        }
+                    } else {
+                        crate::common::entity_size(&ent.name)
+                    };
                     Position {
                         x: ent.x as f64 + w as f64 / 2.0,
                         y: ent.y as f64 + h as f64 / 2.0,
@@ -332,6 +351,38 @@ mod tests {
         assert!(ents[0].get("mirror").is_none());
         // recipe should be absent for belt
         assert!(ents[1].get("recipe").is_none());
+    }
+
+    /// Splitters are 2 tiles wide PERPENDICULAR to flow; the exporter's
+    /// center math must be direction-aware or every splitter sits half a
+    /// tile off and the game snaps it into the wrong column, silently
+    /// severing belt connectivity (found by the RFC-050 harness: the
+    /// gear fixture's merger splitter buffered items into a void; the
+    /// #345 fixture's balancers are full of these).
+    #[test]
+    fn splitter_export_center_is_direction_aware() {
+        for (dir, cx, cy) in [
+            (EntityDirection::South, 6.0, 3.5), // 2 wide, 1 tall
+            (EntityDirection::North, 6.0, 3.5),
+            (EntityDirection::East, 5.5, 4.0), // 1 wide, 2 tall
+            (EntityDirection::West, 5.5, 4.0),
+        ] {
+            let layout = LayoutResult {
+                entities: vec![PlacedEntity {
+                    name: "express-splitter".into(),
+                    x: 5,
+                    y: 3,
+                    direction: dir,
+                    ..Default::default()
+                }],
+                width: 8,
+                height: 6,
+                ..Default::default()
+            };
+            let bp = decode_blueprint(&export(&layout, "split"));
+            assert_eq!(bp["entities"][0]["position"]["x"], cx, "{dir:?}");
+            assert_eq!(bp["entities"][0]["position"]["y"], cy, "{dir:?}");
+        }
     }
 
     /// Factorio reads an inserter's `direction` as its PICKUP side

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -254,12 +254,15 @@ fn entity_footprint(name: &str, direction: EntityDirection) -> (i32, i32) {
         "recycler" => (2, 4),
         "crusher" => (2, 3),
 
-        // Splitters: 2 tiles wide perpendicular to flow direction
-        "splitter" | "fast-splitter" | "express-splitter" => {
-            match direction {
-                EntityDirection::North | EntityDirection::South => (2, 1),
-                EntityDirection::East | EntityDirection::West => (1, 2),
-            }
+        // Splitters: 2 tiles wide perpendicular to flow direction. The
+        // shared helper covers turbo-splitter too (115 corpus instances
+        // were misparsed half a tile off before PR #350's review caught
+        // the exporter/parser table divergence) and correctly excludes
+        // the 1×1 lane-splitter.
+        "splitter" | "fast-splitter" | "express-splitter" | "turbo-splitter" => {
+            let (w, h) = crate::common::oriented_splitter_dims(name, direction)
+                .expect("splitter family covered by oriented_splitter_dims");
+            (w as i32, h as i32)
         }
 
         _ => (1, 1),

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -173,6 +173,31 @@ pub fn machine_dims(entity: &str) -> (u32, u32) {
 /// poles, belts, inserters, pipes) is 1×1. Before this, `blueprint.rs` hard-
 /// coded `(1,1)` for every non-machine, so a substation would have exported at
 /// center `x+0.5` instead of `x+1.0`.
+/// Direction-aware footprint for the 2-wide splitter family — the ONE
+/// source both the blueprint exporter's center math and the parser's
+/// footprint table consume (PR #350 review: exporter and parser keeping
+/// divergent geometry tables has now caused three artifact-boundary
+/// bugs). Returns `None` for everything else, including `lane-splitter`
+/// which is genuinely 1×1 despite the name.
+pub fn oriented_splitter_dims(
+    entity: &str,
+    direction: crate::models::EntityDirection,
+) -> Option<(u32, u32)> {
+    match entity {
+        "splitter" | "fast-splitter" | "express-splitter" | "turbo-splitter" => {
+            Some(match direction {
+                crate::models::EntityDirection::North | crate::models::EntityDirection::South => {
+                    (2, 1)
+                }
+                crate::models::EntityDirection::East | crate::models::EntityDirection::West => {
+                    (1, 2)
+                }
+            })
+        }
+        _ => None,
+    }
+}
+
 pub fn entity_size(entity: &str) -> (u32, u32) {
     if is_machine_entity(entity) {
         machine_dims(entity)


### PR DESCRIPTION
## Intent

Second artifact-boundary bug found by the RFC-050 harness (sibling of #348): `entity_size` is direction-blind, so every exported **splitter** sat half a tile off-center — the game snapped it into the wrong column and belt connectivity silently broke in-game. Every balancer in every exported blueprint carried this. Engine model, validator, and renderer all agreed the layout was fine (same self-consistency blindness as #348).

## Scope

Export-only: direction-aware dims (2×1 vs 1×2) for splitter-named entities at the center calculation. The parser's `entity_footprint` was already direction-aware, so round-trips never saw the bug and continue to hold. Byte-pinning test across all four directions.

## Verification actually run

- 784 lib tests green; full suite + STRESSGOLD gates running (layouts untouched by construction — export-only).
- **Operational proof**: the gear@10/s KC2 calibration run delivers a sustained 10.0/s *through* the merger splitter post-fix; pre-fix the splitter buffered 56 items into a void and the factory deadlocked.
- The in-game entity dump confirmed the game placed the old exports' splitters one column off their intended tiles.

## Deviations from agreed approach

None. Focused delta review requested from the #348 reviewer (same bug class, narrower blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA