### PR TITLE
feat(sim-harness): spaghettio-sim crate — RFC-050 Phases 0–1 (fetch, run, check-data)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "spaghettio_sim_harness"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "spaghettio_wasm"
 version = "0.1.0"
 dependencies = [

--- a/crates/sim-harness/Cargo.toml
+++ b/crates/sim-harness/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "spaghettio_sim_harness"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "spaghettio-sim"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Deliberately no HTTP/tar/xz crate: `fetch` shells out to the system
+# `curl` and `tar` binaries (see docs/headless-verification-discovery.md's
+# own repro, which does the same) rather than adding a TLS stack + archive
+# dependency to an offline engineer tool that runs a handful of times.
+# Deliberately no dependency on spaghettio_core: this crate consumes the
+# `export_with_manifest` JSON schema only (RFC-050 Phase 0/1 constraint) —
+# Phase 1 wiring (generating bp+manifest from a fixture name in-process)
+# is a later phase.

--- a/crates/sim-harness/src/checkdata.rs
+++ b/crates/sim-harness/src/checkdata.rs
@@ -1,0 +1,296 @@
+//! `spaghettio-sim check-data` — RFC-050 KC1: run `factorio --dump-data`
+//! on the pinned install and compare a fixed fact set (crafting speeds of
+//! the 15 machines; energy + ingredient/result yields for
+//! `iron-gear-wheel`, `electronic-circuit`, `copper-cable`, and the
+//! `iron-plate` smelting recipe) against `crates/core/data/recipes.json`.
+//!
+//! Deliberately does NOT depend on `spaghettio_core` (RFC-050 constraint):
+//! `RECIPES_JSON` below is the same data FILE core embeds via its own
+//! `include_str!`, embedded here directly by relative path — this reads
+//! core's data, it does not call core's code.
+//!
+//! Any mismatch is a hard error per KC1: "there is no 'reconcile in a
+//! day' option (re-baselining recipes.json invalidates the corpus
+//! goldens wholesale)".
+
+use crate::paths;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+
+const RECIPES_JSON: &str = include_str!("../../core/data/recipes.json");
+
+/// The 15 machines recipes.json tracks crafting speed for (RFC-050 KC1:
+/// "crafting speeds of the 15 machines").
+const MACHINES: &[&str] = &[
+    "centrifuge",
+    "assembling-machine-1",
+    "assembling-machine-2",
+    "assembling-machine-3",
+    "chemical-plant",
+    "electric-furnace",
+    "oil-refinery",
+    "stone-furnace",
+    "steel-furnace",
+    "foundry",
+    "electromagnetic-plant",
+    "cryogenic-plant",
+    "biochamber",
+    "recycler",
+    "crusher",
+];
+
+/// The ladder recipes KC1 spot-checks energy + ingredient/result yields
+/// for. `iron-plate` here is the SMELTING recipe (category "smelting"),
+/// not the item.
+const RECIPES: &[&str] = &["iron-gear-wheel", "electronic-circuit", "copper-cable", "iron-plate"];
+
+/// Run `factorio --dump-data`, load the resulting `data-raw-dump.json`,
+/// and return a list of human-readable mismatch descriptions (empty =
+/// KC1 clean).
+pub fn run(install_dir: &Path) -> Result<Vec<String>, String> {
+    let dump_path = dump_data(install_dir)?;
+    let dump_str = std::fs::read_to_string(&dump_path)
+        .map_err(|e| format!("reading dumped data at {dump_path:?}: {e}"))?;
+    let dump: serde_json::Value =
+        serde_json::from_str(&dump_str).map_err(|e| format!("parsing dumped data JSON: {e}"))?;
+    let baseline: serde_json::Value =
+        serde_json::from_str(RECIPES_JSON).map_err(|e| format!("parsing embedded recipes.json: {e}"))?;
+
+    Ok(compare(&dump, &baseline))
+}
+
+fn dump_data(install_dir: &Path) -> Result<std::path::PathBuf, String> {
+    let binary = paths::factorio_binary_path(install_dir);
+    let status = Command::new(&binary)
+        .current_dir(install_dir)
+        .arg("--dump-data")
+        .status()
+        .map_err(|e| format!("failed to launch {binary:?} --dump-data: {e}"))?;
+    if !status.success() {
+        return Err(format!("factorio --dump-data exited with {status}"));
+    }
+    let path = install_dir.join("script-output").join("data-raw-dump.json");
+    if !path.is_file() {
+        return Err(format!(
+            "--dump-data reported success but {path:?} doesn't exist (dump path may have changed)"
+        ));
+    }
+    Ok(path)
+}
+
+/// Scan every top-level prototype-type category in the dumped `data.raw`
+/// tree for a prototype named `name`. Generic on purpose: this crate
+/// doesn't hardcode which Factorio prototype `type` each machine belongs
+/// to (furnace vs. assembling-machine vs. whatever a future version
+/// calls it), so it just looks for the name wherever it lives.
+fn find_prototype<'a>(dump: &'a serde_json::Value, name: &str) -> Option<&'a serde_json::Value> {
+    let root = dump.as_object()?;
+    for (_category, entries) in root {
+        if let Some(obj) = entries.as_object() {
+            if let Some(proto) = obj.get(name) {
+                return Some(proto);
+            }
+        }
+    }
+    None
+}
+
+fn compare(dump: &serde_json::Value, baseline: &serde_json::Value) -> Vec<String> {
+    let mut mismatches = Vec::new();
+
+    let baseline_machines = baseline.get("machines").and_then(|m| m.as_object());
+    for &name in MACHINES {
+        let expected = baseline_machines
+            .and_then(|m| m.get(name))
+            .and_then(|m| m.get("crafting_speed"))
+            .and_then(|v| v.as_f64());
+        let Some(expected) = expected else {
+            mismatches.push(format!("machine '{name}': no crafting_speed in baseline recipes.json"));
+            continue;
+        };
+        match find_prototype(dump, name) {
+            None => mismatches.push(format!("machine '{name}': not found in dumped data.raw")),
+            Some(proto) => match proto.get("crafting_speed").and_then(|v| v.as_f64()) {
+                None => mismatches.push(format!("machine '{name}': dumped prototype has no crafting_speed field")),
+                Some(actual) if (actual - expected).abs() > 1e-9 => mismatches.push(format!(
+                    "machine '{name}': crafting_speed baseline={expected} dumped={actual}"
+                )),
+                Some(_) => {}
+            },
+        }
+    }
+
+    let baseline_recipes = baseline.get("recipes").and_then(|r| r.as_object());
+    for &name in RECIPES {
+        let Some(expected) = baseline_recipes.and_then(|r| r.get(name)) else {
+            mismatches.push(format!("recipe '{name}': not present in baseline recipes.json"));
+            continue;
+        };
+        let Some(actual) = find_prototype(dump, name) else {
+            mismatches.push(format!("recipe '{name}': not found in dumped data.raw"));
+            continue;
+        };
+
+        // energy / energy_required
+        if let Some(expected_energy) = expected.get("energy").and_then(|v| v.as_f64()) {
+            match actual.get("energy_required").and_then(|v| v.as_f64()) {
+                None => mismatches.push(format!("recipe '{name}': dumped prototype has no energy_required field")),
+                Some(actual_energy) if (actual_energy - expected_energy).abs() > 1e-9 => mismatches.push(format!(
+                    "recipe '{name}': energy baseline={expected_energy} dumped={actual_energy}"
+                )),
+                Some(_) => {}
+            }
+        }
+
+        compare_item_amounts(name, "ingredients", expected, actual, &mut mismatches);
+        compare_item_amounts(name, "results", expected, actual, &mut mismatches);
+    }
+
+    mismatches
+}
+
+/// Compare an `ingredients`/`results` list as a `name -> total amount`
+/// multiset, order-independent (the dump and our baseline aren't
+/// guaranteed to list entries in the same order).
+fn compare_item_amounts(
+    recipe: &str,
+    field: &str,
+    expected: &serde_json::Value,
+    actual: &serde_json::Value,
+    mismatches: &mut Vec<String>,
+) {
+    let to_map = |v: &serde_json::Value| -> BTreeMap<String, f64> {
+        let mut m = BTreeMap::new();
+        if let Some(arr) = v.get(field).and_then(|x| x.as_array()) {
+            for entry in arr {
+                let Some(name) = entry.get("name").and_then(|n| n.as_str()) else { continue };
+                let amount = entry.get("amount").and_then(|a| a.as_f64()).unwrap_or(0.0);
+                *m.entry(name.to_string()).or_insert(0.0) += amount;
+            }
+        }
+        m
+    };
+    let expected_map = to_map(expected);
+    let actual_map = to_map(actual);
+    if expected_map != actual_map {
+        mismatches.push(format!(
+            "recipe '{recipe}' {field}: baseline={expected_map:?} dumped={actual_map:?}"
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn baseline_fixture() -> serde_json::Value {
+        serde_json::json!({
+            "machines": {
+                "assembling-machine-2": {"crafting_speed": 0.75}
+            },
+            "recipes": {
+                "iron-gear-wheel": {
+                    "name": "iron-gear-wheel", "category": "crafting", "energy": 0.5,
+                    "ingredients": [{"name": "iron-plate", "amount": 2, "type": "item"}],
+                    "results": [{"name": "iron-gear-wheel", "amount": 1, "type": "item"}]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn matching_dump_produces_no_mismatches() {
+        let baseline = baseline_fixture();
+        let dump = serde_json::json!({
+            "assembling-machine": {
+                "assembling-machine-2": {"crafting_speed": 0.75}
+            },
+            "recipe": {
+                "iron-gear-wheel": {
+                    "energy_required": 0.5,
+                    "ingredients": [{"name": "iron-plate", "amount": 2}],
+                    "results": [{"name": "iron-gear-wheel", "amount": 1}]
+                }
+            }
+        });
+        // Restrict to the fixture's own small fact set rather than the
+        // full MACHINES/RECIPES lists, which the fixture doesn't cover.
+        let mut mismatches = Vec::new();
+        let name = "assembling-machine-2";
+        let expected = baseline["machines"][name]["crafting_speed"].as_f64().unwrap();
+        let actual = find_prototype(&dump, name).unwrap()["crafting_speed"].as_f64().unwrap();
+        assert!((expected - actual).abs() < 1e-9);
+        compare_item_amounts(
+            "iron-gear-wheel",
+            "ingredients",
+            &baseline["recipes"]["iron-gear-wheel"],
+            &dump["recipe"]["iron-gear-wheel"],
+            &mut mismatches,
+        );
+        compare_item_amounts(
+            "iron-gear-wheel",
+            "results",
+            &baseline["recipes"]["iron-gear-wheel"],
+            &dump["recipe"]["iron-gear-wheel"],
+            &mut mismatches,
+        );
+        assert!(mismatches.is_empty(), "{mismatches:?}");
+    }
+
+    #[test]
+    fn crafting_speed_mismatch_is_detected() {
+        let baseline = baseline_fixture();
+        let dump = serde_json::json!({
+            "assembling-machine": {
+                "assembling-machine-2": {"crafting_speed": 0.80}
+            },
+            "recipe": {}
+        });
+        let expected = baseline["machines"]["assembling-machine-2"]["crafting_speed"].as_f64().unwrap();
+        let actual = find_prototype(&dump, "assembling-machine-2").unwrap()["crafting_speed"].as_f64().unwrap();
+        assert!((expected - actual).abs() > 1e-9, "fixture should disagree");
+    }
+
+    #[test]
+    fn ingredient_amount_mismatch_is_detected() {
+        let baseline = baseline_fixture();
+        let dump = serde_json::json!({
+            "recipe": {
+                "iron-gear-wheel": {
+                    "energy_required": 0.5,
+                    "ingredients": [{"name": "iron-plate", "amount": 3}],
+                    "results": [{"name": "iron-gear-wheel", "amount": 1}]
+                }
+            }
+        });
+        let mut mismatches = Vec::new();
+        compare_item_amounts(
+            "iron-gear-wheel",
+            "ingredients",
+            &baseline["recipes"]["iron-gear-wheel"],
+            &dump["recipe"]["iron-gear-wheel"],
+            &mut mismatches,
+        );
+        assert_eq!(mismatches.len(), 1);
+    }
+
+    #[test]
+    fn missing_prototype_is_a_mismatch() {
+        let dump = serde_json::json!({});
+        assert!(find_prototype(&dump, "assembling-machine-2").is_none());
+    }
+
+    #[test]
+    fn embedded_recipes_json_parses_and_covers_the_probe_set() {
+        let baseline: serde_json::Value = serde_json::from_str(RECIPES_JSON).unwrap();
+        let machines = baseline["machines"].as_object().unwrap();
+        for &name in MACHINES {
+            assert!(machines.contains_key(name), "recipes.json missing machine {name}");
+        }
+        let recipes = baseline["recipes"].as_object().unwrap();
+        for &name in RECIPES {
+            assert!(recipes.contains_key(name), "recipes.json missing recipe {name}");
+        }
+    }
+}

--- a/crates/sim-harness/src/checkdata.rs
+++ b/crates/sim-harness/src/checkdata.rs
@@ -84,16 +84,35 @@ fn dump_data(install_dir: &Path) -> Result<std::path::PathBuf, String> {
 /// doesn't hardcode which Factorio prototype `type` each machine belongs
 /// to (furnace vs. assembling-machine vs. whatever a future version
 /// calls it), so it just looks for the name wherever it lives.
-fn find_prototype<'a>(dump: &'a serde_json::Value, name: &str) -> Option<&'a serde_json::Value> {
+///
+/// LIVE FINDING (running this against the real pinned 2.0.76 dump): every
+/// entity name also has a same-named `item` prototype (the thing you hold
+/// to place it), and every recipe name commonly has a same-named `item`
+/// prototype too (the crafted result) — a bare "first name match wins"
+/// scan non-deterministically returns the wrong category depending on
+/// serde_json's map ordering (BTreeMap-sorted here: `assembling-machine`/
+/// `furnace` sort before `item`, so machines happened to resolve
+/// correctly, but `item` sorts before `recipe`, so every one of the 4
+/// probe recipes silently matched its OWN OUTPUT ITEM prototype instead —
+/// caught by running the real dump, not by reasoning about it). Fixed by
+/// requiring a field that's diagnostic of the RIGHT prototype shape
+/// (`crafting_speed` for machines, `ingredients` for recipes — items have
+/// neither), with a fallback to a plain name match so "wrong shape" and
+/// "not present anywhere" still produce distinct errors.
+fn find_prototype<'a>(dump: &'a serde_json::Value, name: &str, disambiguating_field: &str) -> Option<&'a serde_json::Value> {
     let root = dump.as_object()?;
+    let mut any_match = None;
     for (_category, entries) in root {
         if let Some(obj) = entries.as_object() {
             if let Some(proto) = obj.get(name) {
-                return Some(proto);
+                if proto.get(disambiguating_field).is_some() {
+                    return Some(proto);
+                }
+                any_match.get_or_insert(proto);
             }
         }
     }
-    None
+    any_match
 }
 
 fn compare(dump: &serde_json::Value, baseline: &serde_json::Value) -> Vec<String> {
@@ -109,7 +128,7 @@ fn compare(dump: &serde_json::Value, baseline: &serde_json::Value) -> Vec<String
             mismatches.push(format!("machine '{name}': no crafting_speed in baseline recipes.json"));
             continue;
         };
-        match find_prototype(dump, name) {
+        match find_prototype(dump, name, "crafting_speed") {
             None => mismatches.push(format!("machine '{name}': not found in dumped data.raw")),
             Some(proto) => match proto.get("crafting_speed").and_then(|v| v.as_f64()) {
                 None => mismatches.push(format!("machine '{name}': dumped prototype has no crafting_speed field")),
@@ -127,19 +146,28 @@ fn compare(dump: &serde_json::Value, baseline: &serde_json::Value) -> Vec<String
             mismatches.push(format!("recipe '{name}': not present in baseline recipes.json"));
             continue;
         };
-        let Some(actual) = find_prototype(dump, name) else {
+        let Some(actual) = find_prototype(dump, name, "ingredients") else {
             mismatches.push(format!("recipe '{name}': not found in dumped data.raw"));
             continue;
         };
 
-        // energy / energy_required
+        // energy / energy_required. LIVE FINDING: the dump OMITS
+        // energy_required entirely when it equals Factorio's prototype
+        // default (0.5s) — iron-gear-wheel/electronic-circuit/
+        // copper-cable all dump with no energy_required field at all,
+        // while iron-plate (3.2s, non-default) dumps it explicitly.
+        // Treating an absent field as a mismatch would have been a
+        // false-positive KC1 trip on every default-energy recipe.
+        const DEFAULT_ENERGY_REQUIRED: f64 = 0.5;
         if let Some(expected_energy) = expected.get("energy").and_then(|v| v.as_f64()) {
-            match actual.get("energy_required").and_then(|v| v.as_f64()) {
-                None => mismatches.push(format!("recipe '{name}': dumped prototype has no energy_required field")),
-                Some(actual_energy) if (actual_energy - expected_energy).abs() > 1e-9 => mismatches.push(format!(
+            let actual_energy = actual
+                .get("energy_required")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(DEFAULT_ENERGY_REQUIRED);
+            if (actual_energy - expected_energy).abs() > 1e-9 {
+                mismatches.push(format!(
                     "recipe '{name}': energy baseline={expected_energy} dumped={actual_energy}"
-                )),
-                Some(_) => {}
+                ));
             }
         }
 
@@ -219,7 +247,9 @@ mod tests {
         let mut mismatches = Vec::new();
         let name = "assembling-machine-2";
         let expected = baseline["machines"][name]["crafting_speed"].as_f64().unwrap();
-        let actual = find_prototype(&dump, name).unwrap()["crafting_speed"].as_f64().unwrap();
+        let actual = find_prototype(&dump, name, "crafting_speed").unwrap()["crafting_speed"]
+            .as_f64()
+            .unwrap();
         assert!((expected - actual).abs() < 1e-9);
         compare_item_amounts(
             "iron-gear-wheel",
@@ -248,7 +278,9 @@ mod tests {
             "recipe": {}
         });
         let expected = baseline["machines"]["assembling-machine-2"]["crafting_speed"].as_f64().unwrap();
-        let actual = find_prototype(&dump, "assembling-machine-2").unwrap()["crafting_speed"].as_f64().unwrap();
+        let actual = find_prototype(&dump, "assembling-machine-2", "crafting_speed").unwrap()["crafting_speed"]
+            .as_f64()
+            .unwrap();
         assert!((expected - actual).abs() > 1e-9, "fixture should disagree");
     }
 
@@ -278,7 +310,63 @@ mod tests {
     #[test]
     fn missing_prototype_is_a_mismatch() {
         let dump = serde_json::json!({});
-        assert!(find_prototype(&dump, "assembling-machine-2").is_none());
+        assert!(find_prototype(&dump, "assembling-machine-2", "crafting_speed").is_none());
+    }
+
+    /// Regression test for a bug caught by running this tool against the
+    /// REAL 2.0.76 dump (see `find_prototype`'s doc comment): a recipe
+    /// name that also has a same-named `item` prototype must resolve to
+    /// the recipe, not the item, even when `item` would otherwise be
+    /// found first.
+    #[test]
+    fn disambiguates_recipe_from_same_named_item_prototype() {
+        let dump = serde_json::json!({
+            "item": {
+                "iron-gear-wheel": {"stack_size": 100}
+            },
+            "recipe": {
+                "iron-gear-wheel": {
+                    "ingredients": [{"name": "iron-plate", "amount": 2}],
+                    "results": [{"name": "iron-gear-wheel", "amount": 1}]
+                }
+            }
+        });
+        let proto = find_prototype(&dump, "iron-gear-wheel", "ingredients").unwrap();
+        assert!(proto.get("ingredients").is_some(), "must resolve to the recipe, not the item");
+    }
+
+    /// Regression test for the live finding that `energy_required` is
+    /// omitted from the dump entirely when it equals Factorio's 0.5s
+    /// default — `compare()` must not treat that as a mismatch.
+    #[test]
+    fn default_energy_required_omitted_from_dump_is_not_a_mismatch() {
+        let baseline = serde_json::json!({
+            "machines": {},
+            "recipes": {
+                "copper-cable": {
+                    "energy": 0.5,
+                    "ingredients": [{"name": "copper-plate", "amount": 1}],
+                    "results": [{"name": "copper-cable", "amount": 2}]
+                }
+            }
+        });
+        let dump = serde_json::json!({
+            "recipe": {
+                "copper-cable": {
+                    "ingredients": [{"name": "copper-plate", "amount": 1}],
+                    "results": [{"name": "copper-cable", "amount": 2}]
+                }
+            }
+        });
+        // compare() only walks the fixed MACHINES/RECIPES probe lists, so
+        // exercise the energy-comparison branch directly against this
+        // ad hoc single-recipe baseline instead.
+        let expected = &baseline["recipes"]["copper-cable"];
+        let actual = find_prototype(&dump, "copper-cable", "ingredients").unwrap();
+        assert!(actual.get("energy_required").is_none(), "fixture must omit the field like the real dump does");
+        let expected_energy = expected["energy"].as_f64().unwrap();
+        let actual_energy = actual.get("energy_required").and_then(|v| v.as_f64()).unwrap_or(0.5);
+        assert!((expected_energy - actual_energy).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/sim-harness/src/fetch.rs
+++ b/crates/sim-harness/src/fetch.rs
@@ -1,0 +1,189 @@
+//! `spaghettio-sim fetch` — download the PINNED headless build, extract
+//! it, and stamp the config files the scenario/orchestrator require.
+//!
+//! Deliberately pinned: RFC-050 KC1 requires the harness to match
+//! `crates/core/data/recipes.json`'s 2.0.76 baseline exactly, and the
+//! discovery spike found `latest` had already drifted to 2.1.12 (new
+//! `recycler` prototype module) by the time this RFC was written. NEVER
+//! pass `latest` to the download URL.
+
+use crate::paths::{self, PINNED_VERSION};
+use std::path::Path;
+use std::process::Command;
+
+const DOWNLOAD_URL: &str = "https://factorio.com/get-download/2.0.76/headless/linux64";
+
+/// The server settings the RFC's empirical base requires: `auto_pause`
+/// false (dedicated servers otherwise never tick with no players
+/// connected) and `autosave_interval` 0 (a multi-minute run has no use
+/// for mid-run autosaves, and they cost wall-clock KC4 is tight on).
+/// Layered onto the game's own `server-settings.example.json` shape so
+/// unrelated fields keep sane defaults, `serde_json::Value`-merged so we
+/// don't have to hand-maintain every field the game ships.
+fn harness_server_settings() -> serde_json::Value {
+    serde_json::json!({
+        "name": "spaghettio-sim harness",
+        "description": "RFC-050 headless measurement run",
+        "tags": ["spaghettio-sim"],
+        "max_players": 0,
+        "visibility": {"public": false, "lan": false},
+        "username": "",
+        "password": "",
+        "token": "",
+        "game_password": "",
+        "require_user_verification": false,
+        "max_upload_in_kilobytes_per_second": 0,
+        "max_upload_slots": 5,
+        "minimum_latency_in_ticks": 0,
+        "max_heartbeats_per_second": 60,
+        "ignore_player_limit_for_returning_players": false,
+        "allow_commands": "admins-only",
+        "autosave_interval": 0,
+        "autosave_slots": 1,
+        "afk_autokick_interval": 0,
+        "auto_pause": false,
+        "auto_pause_when_players_connect": false,
+        "only_admins_can_pause_the_game": true,
+        "autosave_only_on_server": true,
+        "non_blocking_saving": false,
+    })
+}
+
+fn mod_list() -> serde_json::Value {
+    serde_json::json!({
+        "mods": [
+            {"name": "base", "enabled": true},
+            {"name": "elevated-rails", "enabled": true},
+            {"name": "quality", "enabled": true},
+            {"name": "space-age", "enabled": true},
+        ]
+    })
+}
+
+pub fn run(force: bool) -> Result<(), String> {
+    let install_dir = paths::target_install_dir()?;
+    let binary = paths::factorio_binary_path(&install_dir);
+
+    if binary.is_file() && !force {
+        println!("Factorio {PINNED_VERSION} already present at {install_dir:?} (skipping download; pass --force to re-fetch)");
+    } else {
+        download_and_extract(&install_dir)?;
+    }
+
+    stamp_config(&install_dir)?;
+    std::fs::create_dir_all(paths::scenarios_dir(&install_dir))
+        .map_err(|e| format!("creating scenarios dir: {e}"))?;
+    std::fs::create_dir_all(paths::script_output_dir(&install_dir))
+        .map_err(|e| format!("creating script-output dir: {e}"))?;
+
+    println!("Factorio {PINNED_VERSION} ready at {install_dir:?}");
+    Ok(())
+}
+
+fn download_and_extract(install_dir: &Path) -> Result<(), String> {
+    let parent = install_dir
+        .parent()
+        .ok_or_else(|| format!("install dir {install_dir:?} has no parent"))?;
+    std::fs::create_dir_all(parent).map_err(|e| format!("creating cache dir {parent:?}: {e}"))?;
+
+    let tmp_archive = parent.join(format!(".spaghettio-sim-download-{}.tar.xz", std::process::id()));
+    let extract_root = parent.join(format!(".spaghettio-sim-extract-{}", std::process::id()));
+
+    println!("Downloading pinned Factorio {PINNED_VERSION} from {DOWNLOAD_URL} ...");
+    let status = Command::new("curl")
+        .args(["-fL", "-o"])
+        .arg(&tmp_archive)
+        .arg(DOWNLOAD_URL)
+        .status()
+        .map_err(|e| format!("failed to spawn curl (is it installed?): {e}"))?;
+    if !status.success() {
+        let _ = std::fs::remove_file(&tmp_archive);
+        return Err(format!("curl exited with {status}"));
+    }
+
+    std::fs::create_dir_all(&extract_root).map_err(|e| format!("creating extract dir: {e}"))?;
+    println!("Extracting ...");
+    let status = Command::new("tar")
+        .arg("-xJf")
+        .arg(&tmp_archive)
+        .arg("-C")
+        .arg(&extract_root)
+        .status()
+        .map_err(|e| format!("failed to spawn tar (is it installed?): {e}"))?;
+    let _ = std::fs::remove_file(&tmp_archive);
+    if !status.success() {
+        let _ = std::fs::remove_dir_all(&extract_root);
+        return Err(format!("tar exited with {status}"));
+    }
+
+    // The headless tarball extracts a single top-level `factorio/` dir;
+    // move it into place at the versioned target path.
+    let extracted_factorio = extract_root.join("factorio");
+    if !extracted_factorio.is_dir() {
+        return Err(format!(
+            "expected {extracted_factorio:?} after extraction, but it doesn't exist \
+             (tarball layout may have changed)"
+        ));
+    }
+    if install_dir.exists() {
+        std::fs::remove_dir_all(install_dir).map_err(|e| format!("removing stale install dir: {e}"))?;
+    }
+    std::fs::rename(&extracted_factorio, install_dir)
+        .map_err(|e| format!("moving extracted install into place: {e}"))?;
+    let _ = std::fs::remove_dir_all(&extract_root);
+
+    let binary = paths::factorio_binary_path(install_dir);
+    if !binary.is_file() {
+        return Err(format!("extraction completed but {binary:?} is missing"));
+    }
+    Ok(())
+}
+
+fn stamp_config(install_dir: &Path) -> Result<(), String> {
+    let mod_list_path = paths::mod_list_path(install_dir);
+    if let Some(parent) = mod_list_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("creating mods dir: {e}"))?;
+    }
+    write_json(&mod_list_path, &mod_list())?;
+
+    let settings_path = paths::server_settings_path(install_dir);
+    write_json(&settings_path, &harness_server_settings())?;
+    Ok(())
+}
+
+fn write_json(path: &Path, value: &serde_json::Value) -> Result<(), String> {
+    let s = serde_json::to_string_pretty(value).map_err(|e| e.to_string())?;
+    std::fs::write(path, s).map_err(|e| format!("writing {path:?}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harness_settings_disable_auto_pause_and_autosave() {
+        let v = harness_server_settings();
+        assert_eq!(v["auto_pause"], false);
+        assert_eq!(v["autosave_interval"], 0);
+    }
+
+    #[test]
+    fn mod_list_enables_space_age_stack() {
+        let v = mod_list();
+        let names: Vec<&str> = v["mods"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["name"].as_str().unwrap())
+            .collect();
+        for expect in ["base", "space-age", "quality", "elevated-rails"] {
+            assert!(names.contains(&expect), "missing mod {expect}");
+        }
+    }
+
+    #[test]
+    fn download_url_is_pinned_never_latest() {
+        assert!(DOWNLOAD_URL.contains("2.0.76"));
+        assert!(!DOWNLOAD_URL.contains("latest"));
+    }
+}

--- a/crates/sim-harness/src/main.rs
+++ b/crates/sim-harness/src/main.rs
@@ -1,0 +1,185 @@
+//! `spaghettio-sim` — RFC-050 headless simulation harness CLI.
+//!
+//! Subcommands: `fetch` (pinned Factorio download), `run` (measurement
+//! pipeline), `check-data` (KC1 dump-data parity spot-check). See
+//! `docs/rfc-050-headless-sim-harness.md`.
+
+mod checkdata;
+mod fetch;
+mod manifest;
+mod orchestrate;
+mod paths;
+mod report;
+mod scenario;
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let sub = args.first().map(|s| s.as_str());
+
+    let result = match sub {
+        Some("fetch") => cmd_fetch(&args[1..]),
+        Some("run") => cmd_run(&args[1..]),
+        Some("check-data") => cmd_check_data(&args[1..]),
+        Some("--help") | Some("-h") | None => {
+            print_help();
+            return ExitCode::SUCCESS;
+        }
+        Some(other) => Err(format!("unknown subcommand '{other}'; see --help")),
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_help() {
+    eprintln!(
+        r#"spaghettio-sim — RFC-050 headless simulation harness
+
+USAGE:
+  spaghettio-sim fetch [--force]
+  spaghettio-sim run --bp <file> --manifest <file> [--ticks N] [--speed N]
+                      [--out report.json] [--timeout-secs N]
+  spaghettio-sim check-data
+
+ENV:
+  SPAGHETTIO_FACTORIO_DIR   Override the install dir (default:
+                            ~/.cache/spaghettio-sim/factorio-2.0.76)
+"#
+    );
+}
+
+fn flag_value<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.as_str())
+}
+
+fn has_flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|a| a == name)
+}
+
+fn cmd_fetch(args: &[String]) -> Result<(), String> {
+    fetch::run(has_flag(args, "--force"))
+}
+
+fn cmd_run(args: &[String]) -> Result<(), String> {
+    let bp_path = flag_value(args, "--bp").ok_or("run requires --bp <file>")?;
+    let manifest_path = flag_value(args, "--manifest").ok_or("run requires --manifest <file>")?;
+    let ticks: Option<u32> = flag_value(args, "--ticks")
+        .map(|s| s.parse().map_err(|_| format!("--ticks must be an integer, got '{s}'")))
+        .transpose()?;
+    let speed: u32 = flag_value(args, "--speed")
+        .map(|s| s.parse().map_err(|_| format!("--speed must be an integer, got '{s}'")))
+        .transpose()?
+        .unwrap_or(16);
+    let timeout_secs: u64 = flag_value(args, "--timeout-secs")
+        .map(|s| s.parse().map_err(|_| format!("--timeout-secs must be an integer, got '{s}'")))
+        .transpose()?
+        .unwrap_or(900);
+    let out_path = flag_value(args, "--out");
+
+    let install_dir = paths::resolve_existing_install()?;
+
+    let bp = std::fs::read_to_string(bp_path)
+        .map_err(|e| format!("reading blueprint file {bp_path}: {e}"))?
+        .trim()
+        .to_string();
+    let manifest_str = std::fs::read_to_string(manifest_path)
+        .map_err(|e| format!("reading manifest file {manifest_path}: {e}"))?;
+    let manifest = manifest::Manifest::from_str(&manifest_str)?;
+
+    let scenario_name = sanitize_scenario_name(&manifest.label);
+    let params = scenario::RunParams::defaults_for(&manifest, scenario_name.clone(), speed, ticks);
+    let lua = scenario::build_control_lua(&manifest, &bp, &params);
+
+    orchestrate::write_scenario(&install_dir, &scenario_name, &lua)?;
+    println!(
+        "Launching scenario '{scenario_name}' (warmup={} window={} ceiling={} speed={})...",
+        params.warmup_ticks, params.window_ticks, params.end_tick, params.speed
+    );
+    let outcome = orchestrate::launch_and_wait(&install_dir, &scenario_name, timeout_secs)?;
+
+    let rpt = report::compute(&manifest, &outcome.result);
+    report::print_human(&rpt);
+
+    if let Some(out_path) = out_path {
+        let full = serde_json::json!({
+            "report": rpt,
+            "raw_result": outcome.result,
+            "sim_state": outcome.sim_state,
+            "run_params": {
+                "end_tick": params.end_tick,
+                "speed": params.speed,
+                "warmup_ticks": params.warmup_ticks,
+                "window_ticks": params.window_ticks,
+                "scenario_name": params.scenario_name,
+            },
+            "game_version": paths::PINNED_VERSION,
+        });
+        std::fs::write(out_path, serde_json::to_string_pretty(&full).map_err(|e| e.to_string())?)
+            .map_err(|e| format!("writing {out_path}: {e}"))?;
+        println!("Full report written to {out_path}");
+    }
+    println!("(factorio log: {:?})", outcome.log_path);
+
+    Ok(())
+}
+
+fn cmd_check_data(_args: &[String]) -> Result<(), String> {
+    let install_dir = paths::resolve_existing_install()?;
+    let mismatches = checkdata::run(&install_dir)?;
+    if mismatches.is_empty() {
+        println!("check-data: OK — no mismatches between the pinned install's dumped data and recipes.json's baseline.");
+        Ok(())
+    } else {
+        eprintln!("check-data: {} mismatch(es) found (RFC-050 KC1):", mismatches.len());
+        for m in &mismatches {
+            eprintln!("  - {m}");
+        }
+        Err(format!("{} KC1 mismatch(es); see above", mismatches.len()))
+    }
+}
+
+fn sanitize_scenario_name(label: &str) -> String {
+    let cleaned: String = label
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    let cleaned = if cleaned.is_empty() { "spaghettio-sim".to_string() } else { cleaned };
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("spaghettio-sim-{cleaned}-{ts}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_scenario_name_strips_bad_chars() {
+        let n = sanitize_scenario_name("electronic circuit @10/s!");
+        assert!(n.starts_with("spaghettio-sim-electronic-circuit"));
+        assert!(!n.contains('/'));
+        assert!(!n.contains('!'));
+        assert!(!n.contains(' '));
+        assert!(!n.contains('@'));
+    }
+
+    #[test]
+    fn flag_value_parses_pairs() {
+        let args = vec!["--bp".to_string(), "foo.txt".to_string(), "--speed".to_string(), "16".to_string()];
+        assert_eq!(flag_value(&args, "--bp"), Some("foo.txt"));
+        assert_eq!(flag_value(&args, "--speed"), Some("16"));
+        assert_eq!(flag_value(&args, "--missing"), None);
+    }
+}

--- a/crates/sim-harness/src/manifest.rs
+++ b/crates/sim-harness/src/manifest.rs
@@ -1,0 +1,225 @@
+//! Types for the RFC-050 verification manifest emitted by
+//! `spaghettio_core::blueprint::export_with_manifest` (branch
+//! `rfc050-phase0-manifest`, commit `3030855`).
+//!
+//! This crate does NOT depend on `spaghettio_core` (RFC-050 constraint:
+//! "consumes the manifest schema only") — these types are a hand-written
+//! mirror of the JSON the engine emits, kept honest by the fixture in
+//! `tests/fixtures/manifest_gear10.json` (a hand-transcribed instance of
+//! the real schema, not the pre-Phase-0 ad hoc `feeds`/`drain` shape that
+//! circulated during the discovery spike).
+//!
+//! Field-by-field provenance (from reading `export_with_manifest` directly,
+//! per the task brief — NOT from the RFC prose, which promises a couple of
+//! fields the landed Phase 0 code doesn't actually emit yet; see the
+//! `validator_errors`/`validator_warnings` note below):
+//!
+//! - `label`, `targets`, `external_inputs`, `planned_rates`,
+//!   `boundary_inputs`, `boundary_outputs`, `surplus_exits`, `bbox_min`,
+//!   `dims`, `entities`, `stacking`, `inserter_capacity` are all emitted
+//!   verbatim by the `serde_json::json!` call in `export_with_manifest`.
+//! - The RFC's Design section says the manifest carries "validator
+//!   error/warning counts at export time" — the actual Phase 0 commit's
+//!   `export_with_manifest` does NOT include such fields. Resolved as: treat
+//!   them as optional/absent-tolerant (`validator_errors`/
+//!   `validator_warnings` are not modeled at all here; nothing in Phase 0/1
+//!   reads them). If a later Phase 0 revision adds them before merge, this
+//!   module only needs a new optional field, not a rewrite.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// Factorio's 4-way direction constants (the engine only ever emits one of
+/// these four; `EntityDirection` on the core side is `#[repr(u8)]` and
+/// serializes to the same numbers via `serde`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    North,
+    East,
+    South,
+    West,
+}
+
+impl Direction {
+    pub fn from_u8(v: u8) -> Option<Direction> {
+        match v {
+            0 => Some(Direction::North),
+            4 => Some(Direction::East),
+            8 => Some(Direction::South),
+            12 => Some(Direction::West),
+            _ => None,
+        }
+    }
+
+    /// Unit vector this direction moves an item: `(dx, dy)` in layout/world
+    /// tile coordinates, where +y is south (down) — matches Factorio's and
+    /// the layout engine's shared convention.
+    pub fn vector(self) -> (i32, i32) {
+        match self {
+            Direction::North => (0, -1),
+            Direction::East => (1, 0),
+            Direction::South => (0, 1),
+            Direction::West => (-1, 0),
+        }
+    }
+
+}
+
+/// Rotate a unit vector 90 degrees to get a lateral (perpendicular) axis.
+/// Verified against the calibrated south-facing prototype
+/// (`gen_harness_scenario.py`'s drain rig): for south `(0,1)` this yields
+/// `(1,0)` (east), and the prototype's `side=-1` (west offset, direction
+/// east pickup) / `side=1` (east offset, direction west pickup) fall out
+/// exactly from `offset = lateral*side`, `pickup_dir = -offset`.
+pub fn rot90((dx, dy): (i32, i32)) -> (i32, i32) {
+    (dy, -dx)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ItemRate {
+    pub item: String,
+    pub rate: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExternalInput {
+    pub item: String,
+    pub rate: f64,
+    #[serde(default)]
+    pub is_fluid: bool,
+}
+
+/// One boundary point: `direction` is the DIRECTION FIELD AS EXPORTED —
+/// deliberately not translated by the artifact-boundary inserter-direction
+/// flip (that flip only applies to `entities[].direction` in the blueprint
+/// JSON itself; the manifest's `BoundaryRecord::direction` is a plain
+/// `EntityDirection as u8` cast in `export_with_manifest`, i.e. the
+/// engine's own drop-side/flow convention, matching Factorio's own belt
+/// `direction` semantics 1:1 — belts (unlike inserters) don't have a
+/// pickup/drop-side ambiguity).
+#[derive(Debug, Clone, Deserialize)]
+pub struct BoundaryRecord {
+    pub item: String,
+    pub x: i32,
+    pub y: i32,
+    pub direction: u8,
+    #[serde(default)]
+    pub is_fluid: bool,
+    pub entity: String,
+}
+
+impl BoundaryRecord {
+    pub fn direction(&self) -> Direction {
+        Direction::from_u8(self.direction).unwrap_or_else(|| {
+            panic!(
+                "boundary record for {} at ({},{}) has non-cardinal direction {}",
+                self.item, self.x, self.y, self.direction
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Manifest {
+    pub label: String,
+    #[serde(default)]
+    pub targets: Vec<ItemRate>,
+    #[serde(default)]
+    pub external_inputs: Vec<ExternalInput>,
+    #[serde(default)]
+    pub planned_rates: BTreeMap<String, f64>,
+    #[serde(default)]
+    pub boundary_inputs: Vec<BoundaryRecord>,
+    #[serde(default)]
+    pub boundary_outputs: Vec<BoundaryRecord>,
+    /// `(item, x, y)` — matches `LayoutResult::surplus_exits`'s tuple
+    /// shape, which serde serializes as a 3-element JSON array.
+    #[serde(default)]
+    pub surplus_exits: Vec<(String, i32, i32)>,
+    pub bbox_min: [i32; 2],
+    pub dims: [i32; 2],
+    #[serde(default)]
+    pub entities: usize,
+    #[serde(default)]
+    pub stacking: u8,
+    #[serde(default)]
+    pub inserter_capacity: u8,
+}
+
+impl Manifest {
+    pub fn from_str(s: &str) -> Result<Manifest, String> {
+        serde_json::from_str(s).map_err(|e| format!("manifest parse error: {e}"))
+    }
+
+    /// True if any boundary (input, output, or surplus exit) is fluid —
+    /// the RFC requires fluid-fed runs to be flagged UNCALIBRATED in the
+    /// report (no fixture has exercised the infinity-pipe feed/void paths).
+    pub fn has_fluid_boundary(&self) -> bool {
+        self.boundary_inputs.iter().any(|b| b.is_fluid)
+            || self.boundary_outputs.iter().any(|b| b.is_fluid)
+            || !self.surplus_exits.is_empty()
+    }
+
+    /// True if every boundary direction is one this harness has live
+    /// calibration evidence for. The #345 dogfood + gear10 PASS artifact
+    /// only ever exercised south-facing inputs into a top-fed bus; the
+    /// vector-generalized jog (see `scenario::rot90`) is a faithful,
+    /// low-risk extension of that exact mechanism to the other three
+    /// cardinal directions, but has never been measured against a live
+    /// server. Callers should surface this as an UNCALIBRATED flag, not
+    /// silently treat every direction as equally trustworthy.
+    pub fn has_uncalibrated_direction(&self) -> bool {
+        self.boundary_inputs
+            .iter()
+            .any(|b| b.direction().vector() != (0, 1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_json() -> &'static str {
+        include_str!("../tests/fixtures/manifest_gear10.json")
+    }
+
+    #[test]
+    fn parses_real_schema_fixture() {
+        let m = Manifest::from_str(fixture_json()).expect("parse");
+        assert_eq!(m.label, "gear");
+        assert_eq!(m.targets.len(), 1);
+        assert_eq!(m.targets[0].item, "iron-gear-wheel");
+        assert_eq!(m.boundary_inputs.len(), 2);
+        assert_eq!(m.boundary_outputs.len(), 1);
+        assert_eq!(m.bbox_min, [1, 0]);
+        assert_eq!(m.planned_rates["iron-gear-wheel"], 10.0);
+    }
+
+    #[test]
+    fn boundary_direction_decodes() {
+        let m = Manifest::from_str(fixture_json()).expect("parse");
+        for b in &m.boundary_inputs {
+            assert_eq!(b.direction(), Direction::South);
+        }
+        assert!(!m.has_uncalibrated_direction());
+    }
+
+    #[test]
+    fn rot90_matches_calibrated_drain_convention() {
+        // south (0,1) -> east (1,0): side=-1 offset is west, pickup faces
+        // east (toward the belt column) exactly as the calibrated
+        // gen_harness_scenario.py drain rig hardcodes.
+        assert_eq!(rot90((0, 1)), (1, 0));
+        // east (1,0) -> south (0,-1)... sanity check the rotation is a
+        // consistent quarter-turn in one direction for every axis.
+        assert_eq!(rot90((1, 0)), (0, -1));
+        assert_eq!(rot90((0, -1)), (-1, 0));
+        assert_eq!(rot90((-1, 0)), (0, 1));
+    }
+
+    #[test]
+    fn no_fluid_boundary_in_gear_fixture() {
+        let m = Manifest::from_str(fixture_json()).expect("parse");
+        assert!(!m.has_fluid_boundary());
+    }
+}

--- a/crates/sim-harness/src/orchestrate.rs
+++ b/crates/sim-harness/src/orchestrate.rs
@@ -1,0 +1,136 @@
+//! Process orchestration: write the scenario, launch headless Factorio,
+//! poll `script-output/` for the result, and tear the server down.
+//!
+//! We hold the `Child` handle directly and call `child.kill()` to tear
+//! the server down — this sidesteps the RFC brief's "pkill patterns must
+//! not match your own process" footgun entirely (that concern only
+//! applies when a shell script backgrounds the process and kills it by
+//! pattern-matching `ps`/`pgrep` output later; owning the exact PID via
+//! `std::process::Child` makes pattern matching unnecessary).
+
+use crate::paths;
+use std::io::Read;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+pub struct RunOutcome {
+    pub result: serde_json::Value,
+    pub sim_state: Option<serde_json::Value>,
+    pub log_path: PathBuf,
+}
+
+/// Grab an OS-assigned free port, then release it immediately. There is
+/// an inherent (small) race between releasing and Factorio binding it;
+/// acceptable for an offline engineer tool run a handful of times, and
+/// this is the standard "ephemeral port" pattern absent a way to hand an
+/// already-open socket to a non-Rust child process.
+fn free_port() -> Result<u16, String> {
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| format!("binding ephemeral port: {e}"))?;
+    let port = listener.local_addr().map_err(|e| e.to_string())?.port();
+    drop(listener);
+    Ok(port)
+}
+
+fn clear_stale_outputs(install_dir: &Path, scenario_name: &str) {
+    let dir = paths::script_output_dir(install_dir);
+    for name in ["harness-result.json", "sim-state.json"] {
+        let _ = std::fs::remove_file(dir.join(name));
+    }
+    let _ = scenario_name;
+}
+
+pub fn write_scenario(install_dir: &Path, scenario_name: &str, control_lua: &str) -> Result<(), String> {
+    let dir = paths::scenarios_dir(install_dir).join(scenario_name);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("creating scenario dir {dir:?}: {e}"))?;
+    std::fs::write(dir.join("control.lua"), control_lua)
+        .map_err(|e| format!("writing control.lua: {e}"))
+}
+
+/// Launch the scenario, poll for `harness-result.json`, then kill the
+/// server. `timeout_secs` bounds wall-clock (KC4: a USP-scale cycle
+/// should stay under ~6 min; the default here is deliberately generous
+/// to cover slower dev machines / cold caches, per the RFC's own
+/// "rescope to nightly batch" escape hatch above that).
+pub fn launch_and_wait(
+    install_dir: &Path,
+    scenario_name: &str,
+    timeout_secs: u64,
+) -> Result<RunOutcome, String> {
+    clear_stale_outputs(install_dir, scenario_name);
+
+    let binary = paths::factorio_binary_path(install_dir);
+    let settings = paths::server_settings_path(install_dir);
+    let port = free_port()?;
+
+    let log_path = std::env::temp_dir().join(format!("spaghettio-sim-{scenario_name}.log"));
+    let log_file = std::fs::File::create(&log_path).map_err(|e| format!("creating log file {log_path:?}: {e}"))?;
+    let log_file_err = log_file.try_clone().map_err(|e| e.to_string())?;
+
+    let mut child: Child = Command::new(&binary)
+        .current_dir(install_dir)
+        .arg("--start-server-load-scenario")
+        .arg(scenario_name)
+        .arg("--server-settings")
+        .arg(&settings)
+        .arg("--port")
+        .arg(port.to_string())
+        .stdout(Stdio::from(log_file))
+        .stderr(Stdio::from(log_file_err))
+        .spawn()
+        .map_err(|e| format!("failed to launch {binary:?}: {e}"))?;
+
+    let result_path = paths::script_output_dir(install_dir).join("harness-result.json");
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    let outcome = loop {
+        if result_path.is_file() {
+            break Ok(());
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            break Err(format!(
+                "factorio exited early (status {status}) before writing a result; see log at {log_path:?}"
+            ));
+        }
+        if Instant::now() >= deadline {
+            break Err(format!(
+                "timed out after {timeout_secs}s waiting for {result_path:?}; see log at {log_path:?}"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(1000));
+    };
+
+    // Always tear the server down, whether we succeeded or timed out.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    outcome?;
+
+    let result = read_json(&result_path)?;
+    let sim_state_path = paths::script_output_dir(install_dir).join("sim-state.json");
+    let sim_state = if sim_state_path.is_file() {
+        Some(read_json(&sim_state_path)?)
+    } else {
+        None
+    };
+
+    Ok(RunOutcome { result, sim_state, log_path })
+}
+
+fn read_json(path: &Path) -> Result<serde_json::Value, String> {
+    let mut f = std::fs::File::open(path).map_err(|e| format!("opening {path:?}: {e}"))?;
+    let mut s = String::new();
+    f.read_to_string(&mut s).map_err(|e| format!("reading {path:?}: {e}"))?;
+    serde_json::from_str(&s).map_err(|e| format!("parsing {path:?} as JSON: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn free_port_is_nonzero_and_reusable_ish() {
+        let p1 = free_port().unwrap();
+        assert!(p1 > 0);
+    }
+}

--- a/crates/sim-harness/src/paths.rs
+++ b/crates/sim-harness/src/paths.rs
@@ -1,0 +1,74 @@
+//! Install-directory resolution shared by `fetch`, `run`, and `check-data`.
+
+use std::path::PathBuf;
+
+pub const PINNED_VERSION: &str = "2.0.76";
+
+/// Default cache dir: `~/.cache/spaghettio-sim/factorio-2.0.76`.
+pub fn default_install_dir() -> Result<PathBuf, String> {
+    let home = std::env::var("HOME").map_err(|_| "HOME is not set; cannot resolve the default cache dir (set SPAGHETTIO_FACTORIO_DIR instead)".to_string())?;
+    Ok(PathBuf::from(home)
+        .join(".cache")
+        .join("spaghettio-sim")
+        .join(format!("factorio-{PINNED_VERSION}")))
+}
+
+/// The directory `fetch` targets: `SPAGHETTIO_FACTORIO_DIR` if set
+/// (even if it doesn't exist yet — `fetch` will create it), else the
+/// default cache path.
+pub fn target_install_dir() -> Result<PathBuf, String> {
+    match std::env::var_os("SPAGHETTIO_FACTORIO_DIR") {
+        Some(v) => Ok(PathBuf::from(v)),
+        None => default_install_dir(),
+    }
+}
+
+/// Resolve an EXISTING install for `run`/`check-data`. Errors cleanly
+/// (rather than panicking) when nothing is found at either location —
+/// per the RFC-050 brief's constraint that these subcommands "error
+/// cleanly when SPAGHETTIO_FACTORIO_DIR is absent". Resolution: absence
+/// of the env var doesn't error by itself as long as a prior `fetch` has
+/// already populated the default cache dir; what must error cleanly is
+/// having NO usable install by either route.
+pub fn resolve_existing_install() -> Result<PathBuf, String> {
+    let candidate = target_install_dir()?;
+    let binary = factorio_binary_path(&candidate);
+    if binary.is_file() {
+        return Ok(candidate);
+    }
+    Err(format!(
+        "no Factorio install found at {candidate:?} (looked for {binary:?}).\n\
+         Run `spaghettio-sim fetch` first, or set SPAGHETTIO_FACTORIO_DIR to an existing install."
+    ))
+}
+
+pub fn factorio_binary_path(install_dir: &std::path::Path) -> PathBuf {
+    install_dir.join("bin").join("x64").join("factorio")
+}
+
+pub fn server_settings_path(install_dir: &std::path::Path) -> PathBuf {
+    install_dir.join("harness-server-settings.json")
+}
+
+pub fn mod_list_path(install_dir: &std::path::Path) -> PathBuf {
+    install_dir.join("mods").join("mod-list.json")
+}
+
+pub fn scenarios_dir(install_dir: &std::path::Path) -> PathBuf {
+    install_dir.join("scenarios")
+}
+
+pub fn script_output_dir(install_dir: &std::path::Path) -> PathBuf {
+    install_dir.join("script-output")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_path_matches_headless_layout() {
+        let p = factorio_binary_path(std::path::Path::new("/foo/factorio-2.0.76"));
+        assert_eq!(p, PathBuf::from("/foo/factorio-2.0.76/bin/x64/factorio"));
+    }
+}

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -1,0 +1,424 @@
+//! Report computation: planned vs measured per item, PASS/WARN/FAIL
+//! verdict per RFC-050 KC2 (one-sided — overshoot is expected because
+//! placed machine counts are ceil'd above the fractional plan, and is
+//! reported informationally, never penalized).
+
+use crate::manifest::Manifest;
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// KC2's PASS boundary, verbatim from the RFC: "Measured target rate >=
+/// 0.98 x planned ... at steady state".
+const PASS_RATIO: f64 = 0.98;
+/// WARN/FAIL split. The RFC only pins the PASS boundary; this floor is a
+/// resolved ambiguity (documented here rather than silently invented) —
+/// below it the shortfall looks like more than measurement noise and
+/// should read as a hard failure rather than "close but under".
+const WARN_RATIO: f64 = 0.90;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    Pass,
+    Warn,
+    Fail,
+    /// No measurement was available to judge (e.g. the run never reached
+    /// a stability checkpoint AND produced no samples either).
+    NoData,
+}
+
+impl fmt::Display for Verdict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Verdict::Pass => "PASS",
+            Verdict::Warn => "WARN",
+            Verdict::Fail => "FAIL",
+            Verdict::NoData => "NO DATA",
+        })
+    }
+}
+
+fn verdict_for_ratio(ratio: Option<f64>) -> Verdict {
+    match ratio {
+        None => Verdict::NoData,
+        Some(r) if r >= PASS_RATIO => Verdict::Pass,
+        Some(r) if r >= WARN_RATIO => Verdict::Warn,
+        _ => Verdict::Fail,
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ItemReport {
+    pub item: String,
+    pub planned_rate: f64,
+    pub measured_produced_rate: Option<f64>,
+    pub measured_delivered_rate: Option<f64>,
+    pub delta_pct_produced: Option<f64>,
+    pub delta_pct_delivered: Option<f64>,
+    pub is_target: bool,
+    pub verdict: Option<Verdict>,
+}
+
+impl serde::Serialize for Verdict {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Report {
+    pub label: String,
+    pub items: Vec<ItemReport>,
+    pub import_rc: i64,
+    pub ghosts: u64,
+    pub revived: u64,
+    pub pole_networks: u64,
+    pub factory_eeis: u64,
+    pub proxies_fulfilled: u64,
+    pub converged: bool,
+    pub final_tick: u64,
+    pub fluid_fed: bool,
+    pub uncalibrated_direction: bool,
+    pub fluid_errors: BTreeMap<String, String>,
+    pub machine_census: BTreeMap<String, u64>,
+    pub overall_verdict: Verdict,
+    /// Manifest context (RFC-050: "config axes (quality/stacking/
+    /// inserter-capacity)" and "external_inputs" are report context, not
+    /// measurements — surfaced here rather than dropped).
+    pub entities: usize,
+    pub stacking: u8,
+    pub inserter_capacity: u8,
+    pub external_inputs: Vec<(String, f64, bool)>,
+}
+
+fn get_u64(v: &serde_json::Value, key: &str) -> u64 {
+    v.get(key).and_then(|x| x.as_u64()).unwrap_or(0)
+}
+fn get_i64(v: &serde_json::Value, key: &str) -> i64 {
+    v.get(key).and_then(|x| x.as_i64()).unwrap_or(0)
+}
+fn get_bool(v: &serde_json::Value, key: &str) -> bool {
+    v.get(key).and_then(|x| x.as_bool()).unwrap_or(false)
+}
+
+/// `(tick, produced_count_for_item)` pairs pulled out of the `samples`
+/// array for a single item.
+fn sample_series(result: &serde_json::Value, item: &str) -> Vec<(f64, f64)> {
+    result
+        .get("samples")
+        .and_then(|s| s.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|s| {
+            let tick = s.get("tick")?.as_f64()?;
+            let produced = s.get("produced")?.get(item)?.as_f64()?;
+            Some((tick, produced))
+        })
+        .collect()
+}
+
+/// Rate from the last two entries of a `(tick, cumulative_count)` series.
+fn rate_from_last_two(series: &[(f64, f64)]) -> Option<f64> {
+    if series.len() < 2 {
+        return None;
+    }
+    let (t0, v0) = series[series.len() - 2];
+    let (t1, v1) = series[series.len() - 1];
+    let dt = (t1 - t0) / 60.0;
+    if dt <= 0.0 {
+        None
+    } else {
+        Some((v1 - v0) / dt)
+    }
+}
+
+fn delta_pct(measured: Option<f64>, planned: f64) -> Option<f64> {
+    if planned <= 0.0 {
+        return None;
+    }
+    measured.map(|m| (m - planned) / planned * 100.0)
+}
+
+pub fn compute(manifest: &Manifest, result: &serde_json::Value) -> Report {
+    let target_items: Vec<&str> = manifest.targets.iter().map(|t| t.item.as_str()).collect();
+
+    let checkpoints = result
+        .get("checkpoints")
+        .and_then(|c| c.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let checkpoint_series: Vec<(f64, f64, f64)> = checkpoints
+        .iter()
+        .filter_map(|c| {
+            Some((
+                c.get("tick")?.as_f64()?,
+                c.get("produced")?.as_f64()?,
+                c.get("delivered")?.as_f64()?,
+            ))
+        })
+        .collect();
+    let (target_produced_rate, target_delivered_rate) = if checkpoint_series.len() >= 2 {
+        let (t0, p0, d0) = checkpoint_series[checkpoint_series.len() - 2];
+        let (t1, p1, d1) = checkpoint_series[checkpoint_series.len() - 1];
+        let dt = (t1 - t0) / 60.0;
+        if dt > 0.0 {
+            (Some((p1 - p0) / dt), Some((d1 - d0) / dt))
+        } else {
+            (None, None)
+        }
+    } else {
+        (None, None)
+    };
+
+    let mut items = Vec::new();
+    for (item, planned_rate) in &manifest.planned_rates {
+        let is_target = target_items.contains(&item.as_str());
+        let measured_produced_rate = if is_target && target_produced_rate.is_some() {
+            target_produced_rate
+        } else {
+            rate_from_last_two(&sample_series(result, item))
+        };
+        let measured_delivered_rate = if is_target { target_delivered_rate } else { None };
+        let verdict = if is_target {
+            Some(verdict_for_ratio(measured_delivered_rate.map(|m| m / planned_rate)))
+        } else {
+            None
+        };
+        items.push(ItemReport {
+            item: item.clone(),
+            planned_rate: *planned_rate,
+            measured_produced_rate,
+            measured_delivered_rate,
+            delta_pct_produced: delta_pct(measured_produced_rate, *planned_rate),
+            delta_pct_delivered: delta_pct(measured_delivered_rate, *planned_rate),
+            is_target,
+            verdict,
+        });
+    }
+    items.sort_by(|a, b| b.is_target.cmp(&a.is_target).then_with(|| a.item.cmp(&b.item)));
+
+    let overall_verdict = items
+        .iter()
+        .filter(|i| i.is_target)
+        .map(|i| i.verdict.unwrap_or(Verdict::NoData))
+        .fold(Verdict::Pass, worst);
+
+    let mut machine_census = BTreeMap::new();
+    if let Some(obj) = result.get("machine_census").and_then(|c| c.as_object()) {
+        for (k, v) in obj {
+            machine_census.insert(k.clone(), v.as_u64().unwrap_or(0));
+        }
+    }
+    let mut fluid_errors = BTreeMap::new();
+    if let Some(obj) = result.get("fluid_errors").and_then(|c| c.as_object()) {
+        for (k, v) in obj {
+            fluid_errors.insert(k.clone(), v.as_str().unwrap_or_default().to_string());
+        }
+    }
+
+    Report {
+        label: manifest.label.clone(),
+        items,
+        import_rc: get_i64(result, "import_rc"),
+        ghosts: get_u64(result, "ghosts"),
+        revived: get_u64(result, "revived"),
+        pole_networks: get_u64(result, "pole_networks"),
+        factory_eeis: get_u64(result, "factory_eeis"),
+        proxies_fulfilled: get_u64(result, "proxies_fulfilled"),
+        converged: get_bool(result, "converged"),
+        final_tick: get_u64(result, "final_tick"),
+        fluid_fed: manifest.has_fluid_boundary(),
+        uncalibrated_direction: manifest.has_uncalibrated_direction(),
+        fluid_errors,
+        machine_census,
+        overall_verdict,
+        entities: manifest.entities,
+        stacking: manifest.stacking,
+        inserter_capacity: manifest.inserter_capacity,
+        external_inputs: manifest
+            .external_inputs
+            .iter()
+            .map(|i| (i.item.clone(), i.rate, i.is_fluid))
+            .collect(),
+    }
+}
+
+fn worst(a: Verdict, b: Verdict) -> Verdict {
+    fn rank(v: Verdict) -> u8 {
+        match v {
+            Verdict::Pass => 0,
+            Verdict::Warn => 1,
+            Verdict::NoData => 2,
+            Verdict::Fail => 3,
+        }
+    }
+    if rank(b) > rank(a) {
+        b
+    } else {
+        a
+    }
+}
+
+pub fn print_human(report: &Report) {
+    println!("=== spaghettio-sim report: {} ===", report.label);
+    println!(
+        "import: rc={} ghosts={} revived={} (failed={})",
+        report.import_rc,
+        report.ghosts,
+        report.revived,
+        report.ghosts.saturating_sub(report.revived)
+    );
+    println!(
+        "power: {} pole network(s), {} factory EEI(s)",
+        report.pole_networks, report.factory_eeis
+    );
+    println!("module proxies fulfilled: {}", report.proxies_fulfilled);
+    println!(
+        "run: final_tick={} converged={}",
+        report.final_tick, report.converged
+    );
+    println!(
+        "layout: {} entities, stacking={} inserter_capacity={}",
+        report.entities, report.stacking, report.inserter_capacity
+    );
+    if !report.external_inputs.is_empty() {
+        let inputs: Vec<String> = report
+            .external_inputs
+            .iter()
+            .map(|(item, rate, is_fluid)| format!("{item}@{rate:.1}/s{}", if *is_fluid { " (fluid)" } else { "" }))
+            .collect();
+        println!("external inputs: {}", inputs.join(", "));
+    }
+    if report.fluid_fed {
+        println!("NOTE: this run has fluid boundaries — infinity-pipe feed/void paths are UNCALIBRATED (no fixture has exercised them; RFC-050 Phase 1).");
+    }
+    if report.uncalibrated_direction {
+        println!("NOTE: at least one boundary is not south-facing — the jog geometry is a faithful vector generalization of the calibrated south-only prototype, but has never been measured live.");
+    }
+    if !report.fluid_errors.is_empty() {
+        println!("fluid rig errors:");
+        for (k, v) in &report.fluid_errors {
+            println!("  {k}: {v}");
+        }
+    }
+    println!();
+    println!(
+        "{:<28} {:>10} {:>12} {:>10} {:>12} {:>10} {:>8}",
+        "item", "planned/s", "produced/s", "d%", "delivered/s", "d%", "verdict"
+    );
+    for item in &report.items {
+        println!(
+            "{:<28} {:>10.2} {:>12} {:>10} {:>12} {:>10} {:>8}",
+            item.item,
+            item.planned_rate,
+            fmt_opt(item.measured_produced_rate),
+            fmt_pct(item.delta_pct_produced),
+            fmt_opt(item.measured_delivered_rate),
+            fmt_pct(item.delta_pct_delivered),
+            item.verdict.map(|v| v.to_string()).unwrap_or_default(),
+        );
+    }
+    println!();
+    if !report.machine_census.is_empty() {
+        println!("machine census:");
+        for (status, count) in &report.machine_census {
+            println!("  {status}: {count}");
+        }
+    }
+    println!();
+    println!("OVERALL: {}", report.overall_verdict);
+}
+
+fn fmt_opt(v: Option<f64>) -> String {
+    v.map(|x| format!("{x:.2}")).unwrap_or_else(|| "-".to_string())
+}
+fn fmt_pct(v: Option<f64>) -> String {
+    v.map(|x| format!("{x:+.1}%")).unwrap_or_else(|| "-".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::Manifest;
+
+    fn fixture_manifest() -> Manifest {
+        Manifest::from_str(include_str!("../tests/fixtures/manifest_gear10.json")).unwrap()
+    }
+
+    #[test]
+    fn pass_at_or_above_98_percent() {
+        assert_eq!(verdict_for_ratio(Some(0.98)), Verdict::Pass);
+        assert_eq!(verdict_for_ratio(Some(1.5)), Verdict::Pass, "overshoot is informational, still PASS");
+        assert_eq!(verdict_for_ratio(Some(0.979999)), Verdict::Warn);
+    }
+
+    #[test]
+    fn warn_band_between_90_and_98_percent() {
+        assert_eq!(verdict_for_ratio(Some(0.95)), Verdict::Warn);
+        assert_eq!(verdict_for_ratio(Some(0.90)), Verdict::Warn);
+    }
+
+    #[test]
+    fn fail_below_90_percent() {
+        assert_eq!(verdict_for_ratio(Some(0.89999)), Verdict::Fail);
+        assert_eq!(verdict_for_ratio(Some(0.0)), Verdict::Fail);
+    }
+
+    #[test]
+    fn no_data_when_ratio_missing() {
+        assert_eq!(verdict_for_ratio(None), Verdict::NoData);
+    }
+
+    #[test]
+    fn compute_reads_checkpoints_for_target_rate() {
+        let m = fixture_manifest();
+        let result = serde_json::json!({
+            "import_rc": 0, "ghosts": 428, "revived": 428,
+            "pole_networks": 1, "factory_eeis": 1, "proxies_fulfilled": 0,
+            "converged": true, "final_tick": 12600,
+            "checkpoints": [
+                {"tick": 9000, "produced": 1000.0, "delivered": 980.0},
+                {"tick": 10800, "produced": 1300.0, "delivered": 1276.0}
+            ],
+            "samples": [],
+            "machine_census": {"full_output": 5}
+        });
+        let report = compute(&m, &result);
+        let target = report.items.iter().find(|i| i.item == "iron-gear-wheel").unwrap();
+        // (1300-1000)/((10800-9000)/60) = 300/30 = 10.0/s
+        assert!((target.measured_produced_rate.unwrap() - 10.0).abs() < 1e-9);
+        // (1276-980)/30 = 9.866...
+        assert!((target.measured_delivered_rate.unwrap() - 9.8666666667).abs() < 1e-6);
+        assert_eq!(target.verdict, Some(Verdict::Pass));
+        assert_eq!(report.overall_verdict, Verdict::Pass);
+    }
+
+    #[test]
+    fn compute_flags_fail_when_delivered_short() {
+        let m = fixture_manifest();
+        let result = serde_json::json!({
+            "import_rc": 0, "ghosts": 428, "revived": 428,
+            "pole_networks": 1, "factory_eeis": 1, "proxies_fulfilled": 0,
+            "converged": true, "final_tick": 12600,
+            "checkpoints": [
+                {"tick": 9000, "produced": 1000.0, "delivered": 700.0},
+                {"tick": 10800, "produced": 1300.0, "delivered": 850.0}
+            ],
+            "samples": [],
+            "machine_census": {}
+        });
+        let report = compute(&m, &result);
+        let target = report.items.iter().find(|i| i.item == "iron-gear-wheel").unwrap();
+        // (850-700)/30 = 5.0/s vs planned 10.0/s -> 50%, FAIL
+        assert_eq!(target.verdict, Some(Verdict::Fail));
+        assert_eq!(report.overall_verdict, Verdict::Fail);
+    }
+
+    #[test]
+    fn no_fluid_or_uncalibrated_flags_on_gear_fixture() {
+        let m = fixture_manifest();
+        let result = serde_json::json!({"checkpoints": [], "samples": []});
+        let report = compute(&m, &result);
+        assert!(!report.fluid_fed);
+        assert!(!report.uncalibrated_direction);
+    }
+}

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -435,34 +435,40 @@ script.on_init(function()
 
   storage.proxies_fulfilled = fulfill_module_proxies(s)
 
-  -- power every factory pole network: EEI just west of each network's
-  -- min-x pole (can_place scan across a few candidate offsets to dodge
-  -- dense layouts).
+  -- Power every factory pole network: one hidden-electric-energy-
+  -- interface placed AT (overlapping) a representative pole's own
+  -- position. hidden-EEI has a 0x0 collision box, so this ALWAYS
+  -- succeeds regardless of how densely packed the surrounding tiles are,
+  -- and 0-distance-from-a-real-pole guarantees the auto-wire connection
+  -- lands in the right network.
+  --
+  -- LIVE FINDING (this harness, EC10@84x90 fixture): the west-of-pole
+  -- can_place scan this replaced (ported verbatim from
+  -- gen_harness_scenario.py, which only ever ran on the small, sparse
+  -- gear10 fixture) found SOME empty tile in a big dense layout and
+  -- reported success, but the placed substation/EEI pair wasn't
+  -- necessarily within wire reach of anything real -- 60 machines came
+  -- back `no_power`, 0 items measured. The RFC's own empirical base
+  -- names the fix directly: "hidden-electric-energy-interface -- 0x0
+  -- collision box, placeable AT a pole's position -- avoids the 2x2
+  -- siting problem in dense layouts". Adopted here after the scan
+  -- version failed live; the boundary-kit feed/drain rigs' OWN local
+  -- power islands (regular EEI+substation, built in open space the rig
+  -- constructs itself) are unaffected -- they measured correctly on the
+  -- gear10 PASS run.
   local nets = {}
   for _, p in pairs(s.find_entities_filtered{type = "electric-pole"}) do
     local id = p.electric_network_id
-    if id and (not nets[id] or p.position.x < nets[id].position.x) then nets[id] = p end
+    if id then nets[id] = p end
   end
   storage.net_count, storage.factory_eeis = 0, 0
   for _, pole in pairs(nets) do
     storage.net_count = storage.net_count + 1
-    local placed = false
-    for _, dy in ipairs({0, 4, -4, 8, -8}) do
-      if placed then break end
-      for dx = -4, -16, -1 do
-        local spos = {pole.position.x + dx, pole.position.y + dy}
-        local epos = {pole.position.x + dx - 3, pole.position.y + dy}
-        if s.can_place_entity{name = "substation", position = spos, force = force}
-           and s.can_place_entity{name = "electric-energy-interface", position = epos, force = force} then
-          s.create_entity{name = "substation", position = spos, force = force, quality = "legendary"}
-          local eei = s.create_entity{name = "electric-energy-interface", position = epos, force = force}
-          eei.electric_buffer_size = 1e13
-          table.insert(storage.eeis, eei)
-          storage.factory_eeis = storage.factory_eeis + 1
-          placed = true
-          break
-        end
-      end
+    local eei = s.create_entity{name = "hidden-electric-energy-interface", position = pole.position, force = force}
+    if eei then
+      eei.electric_buffer_size = 1e13
+      table.insert(storage.eeis, eei)
+      storage.factory_eeis = storage.factory_eeis + 1
     end
   end
 

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1,0 +1,710 @@
+//! Lua scenario templating: ports `gen_harness_scenario.py` (the calibrated
+//! prototype that measured 10.0/s on the tier-1 gear fixture — see
+//! `docs/rfc-050-headless-sim-harness.md`'s "Empirical base") from Python
+//! string templating to Rust, generalized to consume the REAL
+//! `export_with_manifest` schema (`boundary_inputs`/`boundary_outputs` with
+//! explicit `direction`/`entity` fields) instead of the pre-Phase-0 ad hoc
+//! `feeds`/`drain` heuristic the prototype's manifest.json actually used.
+//!
+//! # Generalization from the calibrated south-only prototype
+//!
+//! The prototype hardcoded "westward jog, south-facing head" because every
+//! fixture it ever ran (`iron-gear-wheel`@10/s, `electronic-circuit`@10/s,
+//! the r120/r150 dogfood pair) only ever had south-facing `boundary_inputs`
+//! (bus layouts always feed external inputs from the y=0 north edge,
+//! flowing south into the row area — a structural invariant of
+//! `crates/core/src/bus/placer.rs`'s row-based layout). This module
+//! generalizes the SAME geometric mechanism to all four cardinal
+//! directions via a small vector algebra (`outward`/`lateral` unit
+//! vectors + a 90-degree rotation), rather than inventing a new mechanism:
+//! every formula below was checked by hand against the literal prototype
+//! source for the south case and reduces to the exact original numbers
+//! (see `manifest::tests::rot90_matches_calibrated_drain_convention` and
+//! this module's own golden-fragment tests). Non-south directions are
+//! geometrically faithful but UNCALIBRATED — nothing has measured them
+//! against a live server yet (`Manifest::has_uncalibrated_direction`
+//! flags this for the report, same treatment as fluid boundaries).
+//!
+//! # Feed vs. drain pickup-side asymmetry
+//!
+//! Feed inserters move CHEST -> BELT (refilling); drain inserters move
+//! BELT -> CHEST (draining). Since Factorio inserters read `direction` as
+//! their PICKUP side, the two rigs use opposite axes for their
+//! flanking-inserter geometry:
+//! - feed: flanking axis = the head's own `direction` vector (the
+//!   "into-layout" axis); pickup points toward the chest (same sign as
+//!   the chest's own offset).
+//! - drain: flanking axis = `rot90(direction)` (lateral to the exit
+//!   belt's flow); pickup points toward the belt (opposite sign from the
+//!   chest's offset).
+//!
+//! Getting this backwards was the exact shape of bug the RFC's Motivation
+//! section describes for the export path; ported very deliberately here,
+//! checked tile-by-tile against `gen_harness_scenario.py`'s literal
+//! south-case numbers in this module's tests.
+
+use crate::manifest::{rot90, BoundaryRecord, Manifest};
+use std::fmt::Write as _;
+
+/// Baseline warmup before stability windows start (ticks). Chosen to match
+/// `gen_harness_scenario.py`'s own `ev.tick == 3600` early-checkpoint
+/// constant — the one number in the prototype that reads like a
+/// deliberately chosen "warmup is roughly done" marker rather than an
+/// arbitrary end-of-run value. Not given a precise number by the RFC text
+/// ("base + 2x(W+H)x32 ticks"); this is the resolved base constant.
+pub const BASE_WARMUP_TICKS: u32 = 3600;
+
+/// Dim-scaling factor from the RFC design section 6: "base + 2x(W+H)x32".
+const DIM_WARMUP_FACTOR: u32 = 32;
+
+/// Floor on the stability-check window so tiny/fast fixtures don't judge
+/// stability from a handful of ticks.
+const MIN_WINDOW_TICKS: u32 = 600;
+
+/// Expected item count per stability window (RFC: "windows sized so
+/// expected items >= ~300").
+const WINDOW_ITEM_FLOOR: f64 = 300.0;
+
+/// Two consecutive stability windows must agree within this fraction to
+/// call the run converged (RFC: "loop-until-stable ... within tolerance" —
+/// not given a specific number; resolved to match KC2's own 2% scale).
+const STABILITY_TOLERANCE: f64 = 0.02;
+
+/// `base + 2*(W+H)*32`, rounded up to a multiple of 60 (the tick handler's
+/// own cadence — a non-multiple-of-60 ceiling could never be hit exactly
+/// by an `on_nth_tick(60, ...)` check).
+pub fn default_warmup_ticks(width: i32, height: i32) -> u32 {
+    let raw = BASE_WARMUP_TICKS + 2 * (width.max(0) as u32 + height.max(0) as u32) * DIM_WARMUP_FACTOR;
+    round_up_60(raw)
+}
+
+/// Window length so `rate * window_seconds >= WINDOW_ITEM_FLOOR`, floored
+/// at `MIN_WINDOW_TICKS`, rounded to a multiple of 60.
+pub fn default_window_ticks(target_rate: f64) -> u32 {
+    if target_rate <= 0.0 {
+        return round_up_60(MIN_WINDOW_TICKS);
+    }
+    let seconds = WINDOW_ITEM_FLOOR / target_rate;
+    let ticks = (seconds * 60.0).ceil() as u32;
+    round_up_60(ticks.max(MIN_WINDOW_TICKS))
+}
+
+fn round_up_60(t: u32) -> u32 {
+    t.div_ceil(60) * 60
+}
+
+/// Parameters controlling one `run` invocation, independent of the
+/// manifest itself.
+#[derive(Debug, Clone)]
+pub struct RunParams {
+    /// Ceiling tick (`--ticks`; the ONE thing that can force-finalize a
+    /// run that never stabilizes — KC4's wall-clock budget lives here).
+    pub end_tick: u32,
+    /// `game.speed` (RFC: live-server pacing is 60 UPS unless raised).
+    pub speed: u32,
+    pub warmup_ticks: u32,
+    pub window_ticks: u32,
+    pub scenario_name: String,
+}
+
+impl RunParams {
+    /// Build defaults from the manifest's own dims + target rate, leaving
+    /// `end_tick`/`speed`/`scenario_name` for the caller (CLI flags or
+    /// generated identity) to fill in.
+    pub fn defaults_for(manifest: &Manifest, scenario_name: String, speed: u32, end_tick: Option<u32>) -> RunParams {
+        let warmup = default_warmup_ticks(manifest.dims[0], manifest.dims[1]);
+        let target_rate = manifest.targets.first().map(|t| t.rate).unwrap_or(1.0);
+        let window = default_window_ticks(target_rate);
+        // Ceiling must clear at least one warmup + one window, or the run
+        // can never take a first stability sample.
+        let default_ceiling = round_up_60(warmup + window * 4);
+        RunParams {
+            end_tick: end_tick.unwrap_or(default_ceiling).max(warmup + window),
+            speed,
+            warmup_ticks: warmup,
+            window_ticks: window,
+            scenario_name,
+        }
+    }
+}
+
+/// A world-space cardinal vector, used only inside this module's Lua
+/// codegen for `outward`/`lateral`/`into` axis arithmetic.
+type Vec2 = (i32, i32);
+
+fn neg((x, y): Vec2) -> Vec2 {
+    (-x, -y)
+}
+
+
+/// Emit the shared `add_feed`/`add_drain` Lua functions plus the module-
+/// proxy fulfillment helper. Shared (not unrolled per-boundary) so the
+/// generated script stays small and each call site is a single line —
+/// easier to golden-test and to eyeball when debugging a specific feed.
+fn write_shared_functions(out: &mut String) {
+    out.push_str(
+        r#"
+-- FEED rig: chest -> stack-inserter -> belt, staggered on a jog OUTWARD
+-- from the boundary head (RFC-050 "6 legendary stack-inserter banks on a
+-- westward jog per input head"), generalized from the calibrated
+-- south-facing case via outward/lateral vector rotation (see scenario.rs
+-- module docs for the derivation). `ox,oy` = outward unit vector (away
+-- from the layout); `lx,ly` = lateral unit vector (rot90 of the belt's
+-- own into-layout direction).
+local function add_feed(s, force, head_x, head_y, ox, oy, lx, ly, depth, item, belt_name)
+  local into_x, into_y = -ox, -oy
+  local neg_lx, neg_ly = -lx, -ly
+  local corner_x, corner_y = head_x + ox * depth, head_y + oy * depth
+  -- outward extension: belts from the corner back down to the head,
+  -- continuing the head's own into-layout flow direction.
+  for t = 1, depth do
+    s.create_entity{name = belt_name, position = {head_x + ox * t, head_y + oy * t},
+                    direction = dir_from_vec(into_x, into_y), force = force}
+  end
+  -- lateral jog run: 12 tiles out from the corner, flowing back into it.
+  for k = 1, 12 do
+    s.create_entity{name = belt_name, position = {corner_x + neg_lx * k, corner_y + neg_ly * k},
+                    direction = dir_from_vec(lx, ly), force = force}
+  end
+  -- 6-inserter bank on the 3 farthest jog tiles.
+  local chests = {}
+  for k = 10, 12 do
+    local bx, by = corner_x + neg_lx * k, corner_y + neg_ly * k
+    for _, side in ipairs({-1, 1}) do
+      local cx, cy = bx + into_x * 2 * side, by + into_y * 2 * side
+      local ix, iy = bx + into_x * side, by + into_y * side
+      local c = s.create_entity{name = "steel-chest", position = {cx, cy}, force = force}
+      s.create_entity{name = "stack-inserter", position = {ix, iy},
+        direction = dir_from_vec(into_x * side, into_y * side), force = force, quality = "legendary"}
+      table.insert(chests, c)
+    end
+  end
+  -- local power island, further out along the jog run.
+  local subx, suby = corner_x + neg_lx * 15, corner_y + neg_ly * 15
+  local eeix, eeiy = corner_x + neg_lx * 18, corner_y + neg_ly * 18
+  s.create_entity{name = "substation", position = {subx, suby}, force = force, quality = "legendary"}
+  local eei = s.create_entity{name = "electric-energy-interface", position = {eeix, eeiy}, force = force}
+  eei.electric_buffer_size = 1e13
+  table.insert(storage.eeis, eei)
+  storage.feeds[item] = storage.feeds[item] or {}
+  for _, c in ipairs(chests) do table.insert(storage.feeds[item], c) end
+end
+
+-- Fluid FEED: infinity-pipe adjacent to the boundary tile, auto-maintained
+-- by the game (no periodic script refill needed). UNCALIBRATED (RFC-050:
+-- "mark clearly ... fluid paths are UNCALIBRATED, no fixture has exercised
+-- them yet") — geometry and API verified live only for a standalone
+-- infinity-pipe (kit-probe), never against a real fluid-consuming factory.
+local function add_fluid_feed(s, force, head_x, head_y, ox, oy, item)
+  local px, py = head_x + ox, head_y + oy
+  local ok, err = pcall(function()
+    local ip = s.create_entity{name = "infinity-pipe", position = {px, py}, force = force}
+    ip.set_infinity_pipe_filter{name = item, percentage = 1, mode = "exactly"}
+  end)
+  if not ok then storage.fluid_errors[item .. "@feed"] = tostring(err) end
+end
+
+-- DRAIN rig: extension belt (always express/blue -- "drain tier >= belt
+-- tier or backpressure falsifies the run") + flanking stack-inserter bank
+-- picking FROM the belt (pickup = belt side, per the artifact-boundary
+-- inserter-direction lesson).
+local function add_drain(s, force, exit_x, exit_y, fx, fy, lx, ly, ext_len, item)
+  for t = 1, ext_len do
+    s.create_entity{name = "express-transport-belt", position = {exit_x + fx * t, exit_y + fy * t},
+                    direction = dir_from_vec(fx, fy), force = force}
+  end
+  local chests = {}
+  for t = ext_len - 2, ext_len do
+    local bx, by = exit_x + fx * t, exit_y + fy * t
+    for _, side in ipairs({-1, 1}) do
+      local cx, cy = bx + lx * 2 * side, by + ly * 2 * side
+      local ix, iy = bx + lx * side, by + ly * side
+      local c = s.create_entity{name = "steel-chest", position = {cx, cy}, force = force}
+      s.create_entity{name = "stack-inserter", position = {ix, iy},
+        direction = dir_from_vec(-lx * side, -ly * side), force = force, quality = "legendary"}
+      table.insert(chests, c)
+    end
+  end
+  local subx, suby = exit_x + lx * 4 + fx, exit_y + ly * 4 + fy
+  local eeix, eeiy = exit_x + lx * 7 + fx, exit_y + ly * 7 + fy
+  s.create_entity{name = "substation", position = {subx, suby}, force = force, quality = "legendary"}
+  local eei = s.create_entity{name = "electric-energy-interface", position = {eeix, eeiy}, force = force}
+  eei.electric_buffer_size = 1e13
+  table.insert(storage.eeis, eei)
+  storage.drains[item] = storage.drains[item] or {}
+  for _, c in ipairs(chests) do table.insert(storage.drains[item], c) end
+end
+
+-- Fluid surplus VOID (RFC: "infinity-pipe voids at every fluid surplus
+-- exit -- undrained surplus dead-ends fill and stall AOP-class fixtures").
+-- UNCALIBRATED. Pipes have no meaningful orientation for connectivity, so
+-- this just tries the 4 adjacent tiles and takes the first placeable one.
+local function add_fluid_void(s, force, x, y, item)
+  local ok, err = pcall(function()
+    for _, d in ipairs({{0, -1}, {0, 1}, {1, 0}, {-1, 0}}) do
+      local px, py = x + d[1], y + d[2]
+      if s.can_place_entity{name = "infinity-pipe", position = {px, py}} then
+        local ip = s.create_entity{name = "infinity-pipe", position = {px, py}, force = force}
+        ip.set_infinity_pipe_filter{name = item, percentage = 0, mode = "at-most"}
+        return
+      end
+    end
+    error("no placeable tile adjacent to surplus exit (" .. x .. "," .. y .. ")")
+  end)
+  if not ok then storage.fluid_errors[item .. "@void"] = tostring(err) end
+end
+
+-- Module proxies (RFC-050: "insert into get_module_inventory(), destroy
+-- proxy, effect live" -- verified live by the kit-probe). Generic over
+-- whatever modules the factory actually requested via `proxy.insert_plan`
+-- (grouped per distinct (name, quality), matching the 2.0 insert-plan
+-- shape `export_with_manifest`'s sibling `blueprint::export` emits).
+local function fulfill_module_proxies(s)
+  local n = 0
+  for _, proxy in pairs(s.find_entities_filtered{type = "item-request-proxy"}) do
+    if proxy.valid then
+      local target = proxy.proxy_target
+      if target and target.valid then
+        local inv = target.get_module_inventory()
+        if inv then
+          for _, entry in pairs(proxy.insert_plan) do
+            local count = 0
+            for _, pos in pairs(entry.items.in_inventory) do count = count + (pos.count or 1) end
+            if count > 0 then
+              inv.insert{name = entry.id.name, count = count, quality = entry.id.quality}
+            end
+          end
+        end
+      end
+      proxy.destroy()
+      n = n + 1
+    end
+  end
+  return n
+end
+"#,
+    );
+}
+
+/// One `add_feed`/`add_fluid_feed` call site, with all the outward/lateral
+/// vector arithmetic resolved at Rust-codegen time (only the runtime-only
+/// `storage.offx`/`storage.offy` piece stays symbolic in the emitted Lua).
+fn feed_call(out: &mut String, idx: usize, rec: &BoundaryRecord) {
+    let into = rec.direction().vector();
+    let outward = neg(into);
+    let lateral = rot90(into);
+    let depth = 4 + 4 * (idx as i32);
+    let _ = writeln!(
+        out,
+        "  do\n    local head_x, head_y = {x} - LX0 + storage.offx, {y} - LY0 + storage.offy",
+        x = rec.x,
+        y = rec.y,
+    );
+    if rec.is_fluid {
+        let _ = writeln!(
+            out,
+            "    add_fluid_feed(s, force, head_x, head_y, {ox}, {oy}, \"{item}\")",
+            ox = outward.0,
+            oy = outward.1,
+            item = rec.item,
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "    add_feed(s, force, head_x, head_y, {ox}, {oy}, {lx}, {ly}, {depth}, \"{item}\", \"{belt}\")",
+            ox = outward.0,
+            oy = outward.1,
+            lx = lateral.0,
+            ly = lateral.1,
+            depth = depth,
+            item = rec.item,
+            belt = rec.entity,
+        );
+    }
+    let _ = writeln!(out, "  end -- feed[{idx}] {} at ({},{})", rec.item, rec.x, rec.y);
+}
+
+fn drain_call(out: &mut String, idx: usize, rec: &BoundaryRecord) {
+    let flow = rec.direction().vector();
+    let lateral = rot90(flow);
+    let ext_len = 5 + 2 * (idx as i32);
+    let _ = writeln!(
+        out,
+        "  do\n    local exit_x, exit_y = {x} - LX0 + storage.offx, {y} - LY0 + storage.offy",
+        x = rec.x,
+        y = rec.y,
+    );
+    let _ = writeln!(
+        out,
+        "    add_drain(s, force, exit_x, exit_y, {fx}, {fy}, {lx}, {ly}, {ext}, \"{item}\")",
+        fx = flow.0,
+        fy = flow.1,
+        lx = lateral.0,
+        ly = lateral.1,
+        ext = ext_len,
+        item = rec.item,
+    );
+    let _ = writeln!(out, "  end -- drain[{idx}] {} at ({},{})", rec.item, rec.x, rec.y);
+}
+
+/// Build the full `control.lua` for one measurement run.
+pub fn build_control_lua(manifest: &Manifest, bp: &str, params: &RunParams) -> String {
+    let mut out = String::new();
+    let target_item = manifest
+        .targets
+        .first()
+        .map(|t| t.item.as_str())
+        .unwrap_or("");
+
+    let _ = writeln!(out, "-- Generated by spaghettio-sim (RFC-050). DO NOT EDIT.");
+    let _ = writeln!(out, "-- label: {}", manifest.label);
+    let _ = writeln!(out, "local BP = \"{bp}\"");
+    let _ = writeln!(out, "local TARGET = \"{target_item}\"");
+    let _ = writeln!(out, "local END_TICK = {}", params.end_tick);
+    let _ = writeln!(out, "local WARMUP_TICKS = {}", params.warmup_ticks);
+    let _ = writeln!(out, "local WINDOW_TICKS = {}", params.window_ticks);
+    let _ = writeln!(out, "local STABILITY_TOL = {STABILITY_TOLERANCE}");
+    let _ = writeln!(out, "local LX0, LY0 = {}, {}", manifest.bbox_min[0], manifest.bbox_min[1]);
+    let _ = writeln!(out, "local DIMS_X, DIMS_Y = {}, {}", manifest.dims[0], manifest.dims[1]);
+    {
+        let items: Vec<String> = manifest.planned_rates.keys().map(|k| format!("\"{k}\"")).collect();
+        let _ = writeln!(out, "local PLANNED_ITEMS = {{{}}}", items.join(", "));
+    }
+
+    out.push_str(
+        r#"
+local function dir_from_vec(dx, dy)
+  if dx == 0 and dy == -1 then return defines.direction.north end
+  if dx == 1 and dy == 0 then return defines.direction.east end
+  if dx == 0 and dy == 1 then return defines.direction.south end
+  if dx == -1 and dy == 0 then return defines.direction.west end
+  error("non-cardinal vector (" .. dx .. "," .. dy .. ")")
+end
+"#,
+    );
+
+    write_shared_functions(&mut out);
+
+    out.push_str(
+        r#"
+script.on_init(function()
+  storage.eeis, storage.feeds, storage.fed_total = {}, {}, {}
+  storage.drains, storage.drained_total = {}, {}
+  storage.samples, storage.checkpoints = {}, {}
+  storage.fluid_errors = {}
+  storage.finalized = false
+  storage.converged = false
+  game.speed = "#,
+    );
+    let _ = writeln!(out, "{}", params.speed);
+    out.push_str(
+        r#"  local force = game.forces.player
+  force.research_all_technologies()
+  local s = game.create_surface("lab")
+  s.generate_with_lab_tiles = true
+  s.request_to_generate_chunks({0, 0}, 12)
+  s.request_to_generate_chunks({DIMS_X, DIMS_Y}, 12)
+  s.force_generate_chunk_requests()
+
+  local inv = game.create_inventory(1)
+  local stack = inv[1]
+  stack.set_stack("blueprint")
+  storage.import_rc = stack.import_stack(BP)
+  local ghosts = stack.build_blueprint{surface = s, force = force,
+    position = {0, 0}, build_mode = defines.build_mode.superforced}
+  storage.ghosts, storage.revived = #ghosts, 0
+  for _, g in pairs(ghosts) do
+    if g.valid then
+      local _, e = g.revive()
+      if e then storage.revived = storage.revived + 1 end
+    end
+  end
+
+  -- world offset: paste is CENTERED on the build position, so derive the
+  -- layout->world translation from the revived bbox min, anchored to the
+  -- manifest's own bbox_min (LX0, LY0).
+  local minx, miny = math.huge, math.huge
+  for _, e in pairs(s.find_entities_filtered{force = force}) do
+    if e.type ~= "character" then
+      local bb = e.bounding_box
+      if bb.left_top.x < minx then minx = bb.left_top.x end
+      if bb.left_top.y < miny then miny = bb.left_top.y end
+    end
+  end
+  storage.offx, storage.offy = math.floor(minx + 0.5), math.floor(miny + 0.5)
+
+  storage.proxies_fulfilled = fulfill_module_proxies(s)
+
+  -- power every factory pole network: EEI just west of each network's
+  -- min-x pole (can_place scan across a few candidate offsets to dodge
+  -- dense layouts).
+  local nets = {}
+  for _, p in pairs(s.find_entities_filtered{type = "electric-pole"}) do
+    local id = p.electric_network_id
+    if id and (not nets[id] or p.position.x < nets[id].position.x) then nets[id] = p end
+  end
+  storage.net_count, storage.factory_eeis = 0, 0
+  for _, pole in pairs(nets) do
+    storage.net_count = storage.net_count + 1
+    local placed = false
+    for _, dy in ipairs({0, 4, -4, 8, -8}) do
+      if placed then break end
+      for dx = -4, -16, -1 do
+        local spos = {pole.position.x + dx, pole.position.y + dy}
+        local epos = {pole.position.x + dx - 3, pole.position.y + dy}
+        if s.can_place_entity{name = "substation", position = spos, force = force}
+           and s.can_place_entity{name = "electric-energy-interface", position = epos, force = force} then
+          s.create_entity{name = "substation", position = spos, force = force, quality = "legendary"}
+          local eei = s.create_entity{name = "electric-energy-interface", position = epos, force = force}
+          eei.electric_buffer_size = 1e13
+          table.insert(storage.eeis, eei)
+          storage.factory_eeis = storage.factory_eeis + 1
+          placed = true
+          break
+        end
+      end
+    end
+  end
+
+"#,
+    );
+
+    for (idx, rec) in manifest.boundary_inputs.iter().enumerate() {
+        feed_call(&mut out, idx, rec);
+    }
+    for (idx, rec) in manifest.boundary_outputs.iter().enumerate() {
+        drain_call(&mut out, idx, rec);
+    }
+    for (item, x, y) in &manifest.surplus_exits {
+        let _ = writeln!(
+            out,
+            "  add_fluid_void(s, force, {x} - LX0 + storage.offx, {y} - LY0 + storage.offy, \"{item}\")",
+        );
+    }
+
+    out.push_str(
+        r#"end)
+
+local function stn(st)
+  for k, v in pairs(defines.entity_status) do if v == st then return k end end
+  return tostring(st)
+end
+
+local function dump_sim_state(s)
+  local belts, machines, inserters = {}, {}, {}
+  for _, b in pairs(s.find_entities_filtered{type = {"transport-belt", "underground-belt", "splitter"}}) do
+    local n = 0
+    for li = 1, b.get_max_transport_line_index() do
+      n = n + b.get_transport_line(li).get_item_count()
+    end
+    if n > 0 then
+      table.insert(belts, {math.floor(b.position.x - storage.offx) + LX0,
+                           math.floor(b.position.y - storage.offy) + LY0, n})
+    end
+  end
+  for _, m in pairs(s.find_entities_filtered{type = {"assembling-machine", "furnace"}}) do
+    table.insert(machines, {math.floor(m.position.x - storage.offx) + LX0,
+                            math.floor(m.position.y - storage.offy) + LY0, m.name, stn(m.status)})
+  end
+  for _, i in pairs(s.find_entities_filtered{type = "inserter"}) do
+    table.insert(inserters, {math.floor(i.position.x - storage.offx) + LX0,
+                             math.floor(i.position.y - storage.offy) + LY0, stn(i.status)})
+  end
+  helpers.write_file("sim-state.json", helpers.table_to_json{
+    offx = storage.offx, offy = storage.offy, fed = storage.fed_total,
+    belts = belts, machines = machines, inserters = inserters}, false)
+end
+
+local function finalize(s, converged)
+  storage.finalized = true
+  storage.converged = converged
+  dump_sim_state(s)
+  local census = {}
+  for _, m in pairs(s.find_entities_filtered{type = {"assembling-machine", "furnace"}}) do
+    local st = m.status
+    for k, v in pairs(defines.entity_status) do
+      if v == st then census[k] = (census[k] or 0) + 1 end
+    end
+  end
+  helpers.write_file("harness-result.json", helpers.table_to_json{
+    import_rc = storage.import_rc, ghosts = storage.ghosts, revived = storage.revived,
+    factory_eeis = storage.factory_eeis, pole_networks = storage.net_count,
+    proxies_fulfilled = storage.proxies_fulfilled,
+    samples = storage.samples, checkpoints = storage.checkpoints,
+    machine_census = census, converged = storage.converged, final_tick = game.tick,
+    fluid_errors = storage.fluid_errors}, false)
+  print("HARNESS_DONE")
+  script.on_nth_tick(60, nil)
+end
+
+script.on_nth_tick(60, function(ev)
+  if storage.finalized then return end
+  for _, e in ipairs(storage.eeis) do if e.valid then e.energy = 1e13 end end
+  for item, chests in pairs(storage.feeds) do
+    for _, c in ipairs(chests) do
+      if c.valid then
+        local n = c.get_item_count(item)
+        if n < 400 then
+          local got = c.insert{name = item, count = 400 - n}
+          storage.fed_total[item] = (storage.fed_total[item] or 0) + got
+        end
+      end
+    end
+  end
+  for item, chests in pairs(storage.drains) do
+    local got = 0
+    for _, d in ipairs(chests) do
+      if d.valid then
+        local n = d.get_item_count(item)
+        if n > 0 then d.remove_item{name = item, count = n}; got = got + n end
+      end
+    end
+    storage.drained_total[item] = (storage.drained_total[item] or 0) + got
+  end
+
+  local s = game.get_surface("lab")
+  local stats = game.forces.player.get_item_production_statistics(s)
+
+  if ev.tick % 1200 == 0 then
+    local produced = {}
+    for _, item in ipairs(PLANNED_ITEMS) do produced[item] = stats.get_input_count(item) end
+    table.insert(storage.samples, {tick = ev.tick, drained = storage.drained_total,
+      produced = produced, fed = storage.fed_total})
+  end
+
+  if ev.tick >= WARMUP_TICKS and ev.tick % WINDOW_TICKS == 0 then
+    local cp = {tick = ev.tick, produced = stats.get_input_count(TARGET),
+      delivered = storage.drained_total[TARGET] or 0}
+    table.insert(storage.checkpoints, cp)
+    local n = #storage.checkpoints
+    -- Need two consecutive WINDOW-length rates to compare (three
+    -- checkpoints: a->b is window 1, b->c is window 2) -- "loop-until-
+    -- stable", not a single retry.
+    if n >= 3 then
+      local a, b, c = storage.checkpoints[n - 2], storage.checkpoints[n - 1], storage.checkpoints[n]
+      local dt1, dt2 = (b.tick - a.tick) / 60, (c.tick - b.tick) / 60
+      local rate1 = dt1 > 0 and (b.produced - a.produced) / dt1 or 0
+      local rate2 = dt2 > 0 and (c.produced - b.produced) / dt2 or 0
+      if rate1 > 0 and math.abs(rate2 - rate1) / rate1 <= STABILITY_TOL then
+        finalize(s, true)
+        return
+      end
+    end
+  end
+
+  if not storage.finalized and ev.tick >= END_TICK then
+    finalize(s, false)
+  end
+end)
+"#,
+    );
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::Manifest;
+
+    fn fixture() -> Manifest {
+        Manifest::from_str(include_str!("../tests/fixtures/manifest_gear10.json")).unwrap()
+    }
+
+    #[test]
+    fn warmup_scales_with_dims() {
+        assert_eq!(default_warmup_ticks(0, 0), round_up_60(BASE_WARMUP_TICKS));
+        // gear10: 53x34 -> base + 2*(87)*32 = 3600 + 5568 = 9168 -> round to 9180
+        assert_eq!(default_warmup_ticks(53, 34), round_up_60(3600 + 2 * 87 * 32));
+    }
+
+    #[test]
+    fn window_floors_at_min_and_scales_inversely_with_rate() {
+        // 10 items/s -> 300/10 = 30s = 1800 ticks
+        assert_eq!(default_window_ticks(10.0), 1800);
+        // 1000 items/s -> 0.3s -> floored to MIN_WINDOW_TICKS
+        assert_eq!(default_window_ticks(1000.0), round_up_60(MIN_WINDOW_TICKS));
+    }
+
+    #[test]
+    fn gear10_feed_reduces_to_calibrated_prototype_numbers() {
+        let m = fixture();
+        let params = RunParams::defaults_for(&m, "test-gear".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+
+        // south-facing feed: outward=(0,-1), lateral=(1,0) -- matches the
+        // literal gen_harness_scenario.py call shape (o=north, l=east).
+        assert!(lua.contains("add_feed(s, force, head_x, head_y, 0, -1, 1, 0, 4, \"iron-ore\", \"transport-belt\")"));
+        assert!(lua.contains("add_feed(s, force, head_x, head_y, 0, -1, 1, 0, 8, \"iron-ore\", \"transport-belt\")"));
+        // head world-position translation, anchored to the manifest bbox_min
+        assert!(lua.contains("local head_x, head_y = 1 - LX0 + storage.offx, 0 - LY0 + storage.offy"));
+        assert!(lua.contains("local head_x, head_y = 2 - LX0 + storage.offx, 0 - LY0 + storage.offy"));
+    }
+
+    #[test]
+    fn gear10_drain_reduces_to_calibrated_prototype_numbers() {
+        let m = fixture();
+        let params = RunParams::defaults_for(&m, "test-gear".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+
+        // south-facing exit: flow=(0,1), lateral=(1,0) -- matches
+        // gen_harness_scenario.py's drain (fx=south, lx=east), ext_len=5.
+        assert!(lua.contains("add_drain(s, force, exit_x, exit_y, 0, 1, 1, 0, 5, \"iron-gear-wheel\")"));
+        assert!(lua.contains("local exit_x, exit_y = 13 - LX0 + storage.offx, 33 - LY0 + storage.offy"));
+    }
+
+    #[test]
+    fn no_fluid_call_sites_when_no_fluid_boundaries() {
+        // The shared helper *definitions* are always emitted (boilerplate,
+        // cheap to keep even when unused); what must NOT appear without a
+        // fluid boundary is a *call site*. Both the definition line and a
+        // call site contain the substring "add_fluid_feed(s, force", so
+        // distinguish by occurrence count: exactly 1 (the definition)
+        // means zero call sites.
+        let m = fixture();
+        let params = RunParams::defaults_for(&m, "test-gear".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+        assert_eq!(lua.matches("add_fluid_feed(s, force").count(), 1, "only the definition, no calls");
+        assert_eq!(lua.matches("add_fluid_void(s, force").count(), 1, "only the definition, no calls");
+    }
+
+    #[test]
+    fn fluid_input_uses_infinity_pipe_feed() {
+        let mut m = fixture();
+        m.boundary_inputs.push(BoundaryRecord {
+            item: "water".into(),
+            x: 5,
+            y: 0,
+            direction: 8,
+            is_fluid: true,
+            entity: "pipe".into(),
+        });
+        let params = RunParams::defaults_for(&m, "test-fluid".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+        assert!(lua.contains("add_fluid_feed(s, force, head_x, head_y, 0, -1, \"water\")"));
+    }
+
+    #[test]
+    fn contains_calibrated_mechanics_markers() {
+        let m = fixture();
+        let params = RunParams::defaults_for(&m, "test-gear".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+        assert!(lua.contains("research_all_technologies()"));
+        assert!(lua.contains("build_mode.superforced"));
+        assert!(lua.contains("quality = \"legendary\""));
+        assert!(lua.contains("fulfill_module_proxies"));
+        assert!(lua.contains("game.speed"));
+        assert!(lua.contains("HARNESS_DONE"));
+        assert!(lua.contains("local PLANNED_ITEMS ="));
+        assert!(lua.contains("\"iron-gear-wheel\"") && lua.contains("\"iron-ore\""));
+    }
+
+    #[test]
+    fn scenario_name_and_bp_are_embedded() {
+        let m = fixture();
+        let params = RunParams::defaults_for(&m, "my-scenario".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNSOMEBP", &params);
+        assert!(lua.contains("local BP = \"0eNSOMEBP\""));
+        assert!(lua.contains("local TARGET = \"iron-gear-wheel\""));
+    }
+}

--- a/crates/sim-harness/tests/fixtures/manifest_gear10.json
+++ b/crates/sim-harness/tests/fixtures/manifest_gear10.json
@@ -1,0 +1,19 @@
+{
+  "label": "gear",
+  "targets": [{"item": "iron-gear-wheel", "rate": 10.0}],
+  "external_inputs": [{"item": "iron-ore", "rate": 20.0, "is_fluid": false}],
+  "planned_rates": {"iron-gear-wheel": 10.0, "iron-ore": 20.0},
+  "boundary_inputs": [
+    {"item": "iron-ore", "x": 1, "y": 0, "direction": 8, "is_fluid": false, "entity": "transport-belt"},
+    {"item": "iron-ore", "x": 2, "y": 0, "direction": 8, "is_fluid": false, "entity": "transport-belt"}
+  ],
+  "boundary_outputs": [
+    {"item": "iron-gear-wheel", "x": 13, "y": 33, "direction": 8, "is_fluid": false, "entity": "transport-belt"}
+  ],
+  "surplus_exits": [],
+  "bbox_min": [1, 0],
+  "dims": [53, 34],
+  "entities": 428,
+  "stacking": 1,
+  "inserter_capacity": 0
+}

--- a/docs/rfc-050-headless-sim-harness.md
+++ b/docs/rfc-050-headless-sim-harness.md
@@ -271,3 +271,50 @@ design, so blessed measured baselines are **shareable** — keyed on
   #348 with operational proof, and produced the sim-state debug tooling
   now specced as a deliverable. The measured #345 numbers land when the
   dogfood reruns on the fixed exporter.*
+- *2026-07-22 — Phase 0/1 crate landed (`crates/sim-harness`, branch
+  `rfc050-sim-harness-crate`): `fetch`/`run`/`check-data` subcommands,
+  the scenario templating generalized from the calibrated south-only
+  prototype to all four cardinal directions via outward/lateral vector
+  rotation (every formula checked tile-by-tile against the literal
+  prototype numbers), and dim-scaled warmup + loop-until-stable
+  measurement windows. **KC1 exercised live**: `check-data` against a
+  freshly fetched real 2.0.76 install passed clean, but only after
+  fixing two dump-parsing traps the tool itself caught by running the
+  real dump instead of reasoning about the schema — (1) a bare
+  first-name-match prototype scan non-deterministically resolved to a
+  same-named `item` prototype instead of the intended `recipe`/machine
+  prototype for every one of the 4 probe recipes (fixed: require a
+  disambiguating field per lookup — `crafting_speed` for machines,
+  `ingredients` for recipes); (2) the dump OMITS `energy_required`
+  entirely when it equals Factorio's 0.5s default (iron-gear-wheel,
+  electronic-circuit, and copper-cable all hit this — only iron-plate's
+  non-default 3.2s energy dumps explicitly), which a naive "field
+  missing = mismatch" read would have reported as 3 false-positive KC1
+  trips. **KC2 gear@10/s PASS on a live server**: freshly generated
+  gear10 bp+manifest (`export_with_manifest` on
+  `rfc050-phase0-manifest`), measured 10.13/s delivered vs 10.0/s
+  planned (+1.3%, well inside the 0.98× floor), 428/428 ghosts revived,
+  36/36 machines `working`, loop-until-stable converged — matching the
+  RFC's own gear10 PASS precedent. **EC@10/s (AM1, yellow, from ore)
+  found and fixed a real power-siting bug**: the factory-network EEI
+  placement (ported verbatim from `gen_harness_scenario.py`'s
+  west-of-min-x-pole `can_place_entity` scan) placed successfully by
+  its own collision check but left the entity out of wire reach on the
+  bigger, denser 84×90/1110-entity fixture — 60/65 machines came back
+  `no_power`, 0 measured. Root-caused with an isolated probe (single
+  pole + machine: hidden-EEI-at-pole-position worked correctly) and a
+  targeted probe against the real EC10 factory (confirmed one true
+  74-pole electric network, `no_power` only when placement used the
+  west-scan). Fixed per the RFC's own empirical-base note — swapped the
+  factory-network scan for a `hidden-electric-energy-interface` placed
+  directly AT (0×0 collision, always placeable) a representative pole's
+  own position, guaranteeing wire-reach adjacency regardless of layout
+  density. Confirmed no regression: gear10 re-measured identically
+  (10.13/s, PASS) on the fixed code. **EC10 still measured -20% short
+  after the power fix** (8.0/s vs 10.0/s, `converged=true`, 4 machines
+  `full_output`, a jammed 144-item belt tile visible in the sim-state
+  dump) — open per KC2's own fork ("harness-boundary artifact" vs "real
+  engine defect"); not resolved in this session, left for whoever closes
+  out Phase 1's calibration gate. Quality-scoped-statistics question
+  (KC2's other Phase 1 exit item) not investigated this session — no
+  quality>normal fixture was run.*

--- a/docs/rfc-050-headless-sim-harness.md
+++ b/docs/rfc-050-headless-sim-harness.md
@@ -318,3 +318,21 @@ design, so blessed measured baselines are **shareable** — keyed on
   out Phase 1's calibration gate. Quality-scoped-statistics question
   (KC2's other Phase 1 exit item) not investigated this session — no
   quality>normal fixture was run.*
+- *2026-07-22 — **Phase 1 calibration gate (KC2) PASSED; Phase-1 exit
+  items resolved.** Lead reconciliation runs with the released tool on
+  the merged Phase-0 manifest: gear@10/s **PASS** (10.00/s produced
+  +0.0%, 10.13/s delivered, 36/36 working, converged) — now verified on
+  two independent implementations (python prototype + Rust crate).
+  EC@10/s **FAIL −50%** (5.00/s), matching the prototype's dogfood
+  number exactly; the crate agent's interim −20% came from a
+  differently-configured fixture (1110 vs 805 entities). Per-item
+  attribution seals the KC2 fork as REAL ENGINE DEFECT: copper-plate
+  produces at exactly plan (feeds proven good) while iron-plate −43.5%
+  and copper-cable −48% are the starved stages — #352 stands, and the
+  constraint web is wider than the four warned EC machines. The
+  quality-scoped-statistics question is RESOLVED as a non-issue: the
+  r150 legendary-machine run reported production stats correctly
+  (18.8/s); the earlier zeros were genuine zero production under the
+  pre-#348/#350 broken exports. Remaining phases: 2 (sweeps/anchor
+  retirements), 3 (bless/check), 4 (web sim-state overlay — pulled
+  forward at user request, 2026-07-22).*


### PR DESCRIPTION
## Intent

The `spaghettio-sim` binary — RFC-050's harness productionized from the dogfood prototypes. Fetches the pinned 2.0.76 headless build, runs a blueprint+manifest through the full lab-world measurement pipeline, and reports planned-vs-measured per item with KC2 verdicts.

## Scope

New workspace crate `crates/sim-harness/` (no core changes; consumes the #353 manifest schema). Subcommands: `fetch` (pinned 2.0.76, never latest; idempotent; stamps mods + auto_pause=false settings), `run` (scenario templating porting the calibrated boundary kit — generalized to four cardinals via vector rotation with the south case reducing to the calibrated prototype's exact numbers; dim-scaled warmup; loop-until-stable windows; owned-Child orchestration; sim-state debug dump), `check-data` (KC1 parity spot-check via --dump-data). Non-south directions and fluid paths are flagged UNCALIBRATED in code and report output. 33 unit tests.

Built by a worktree agent from the battle-tested prototypes; two real bugs found and fixed during its own live testing (check-data prototype-name collision; factory power placement at scale → the RFC's hidden-EEI technique).

## Verification actually run

- **Live end-to-end by two parties**: agent's smoke runs, then lead reconciliation runs from clean artifacts on merged main — gear@10/s **PASS** (10.00/s produced +0.0%, 10.13/s delivered, 36/36 machines working, converged); EC@10/s **FAIL −50%** exactly matching the python prototype (per-item attribution: copper-plate at plan proves the instrument; iron-plate/copper-cable are the real starved stages — #352).
- **KC2 calibration gate: PASSED** (instrument verified on known-good, true-positive confirmed on known-bad); KC1 `check-data` clean against the live pinned install; quality-stats Phase-1 question resolved as non-issue (decision log).
- `cargo test --workspace` green, clippy clean on the crate, builds without the game present, errors cleanly when the install is absent.

## Deviations from agreed approach

Resolved ambiguities documented in the decision log (WARN/FAIL split at 90/98%, warmup base 3600, stability tolerance 2%). Phase 4 (web sim-state overlay) pulled forward at user request — next arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA