### PR TITLE
docs+feat: RFC-050 close-out — first blessed baselines, registry Complete

### DIFF
--- a/crates/sim-harness/baselines/README.md
+++ b/crates/sim-harness/baselines/README.md
@@ -1,0 +1,12 @@
+# Blessed measured baselines (RFC-050 Phase 3)
+
+Game-measured per-item rates, frozen by `spaghettio-sim bless`, checked by
+`spaghettio-sim check --report <fresh> --baselines <this dir>`. Keyed on
+(label, game 2.0.76, SA mod set, research_all) — a pin bump demands a
+deliberate re-bless. Opt-in like STRESSGOLD, not CI-enforced.
+
+First blessing (2026-07-22, the RFC-050 close-out sweep): gear10 PASS
+(+0.0%), ec10 FAIL −50% (#352), automation WARN −4% delivered,
+logistic FAIL −40% and military FAIL −48% (both validator-clean — #357).
+FAIL baselines are deliberately blessed too: they freeze today's honest
+floor so fixes must MOVE the number and regressions can't hide.

--- a/crates/sim-harness/baselines/automation-science-pack.json
+++ b/crates/sim-harness/baselines/automation-science-pack.json
@@ -1,0 +1,22 @@
+{
+  "label": "automation-science-pack",
+  "game_version": "2.0.76",
+  "mods": [
+    "base",
+    "space-age",
+    "quality",
+    "elevated-rails"
+  ],
+  "tech_state": "research_all_technologies",
+  "entities": 196,
+  "produced": {
+    "automation-science-pack": 1.0,
+    "copper-plate": 1.0,
+    "iron-gear-wheel": 0.8,
+    "iron-plate": 2.15
+  },
+  "delivered": {
+    "automation-science-pack": 0.96
+  },
+  "overall_verdict": "WARN"
+}

--- a/crates/sim-harness/baselines/ec10.json
+++ b/crates/sim-harness/baselines/ec10.json
@@ -1,0 +1,22 @@
+{
+  "label": "ec10",
+  "game_version": "2.0.76",
+  "mods": [
+    "base",
+    "space-age",
+    "quality",
+    "elevated-rails"
+  ],
+  "tech_state": "research_all_technologies",
+  "entities": 805,
+  "produced": {
+    "copper-cable": 15.6,
+    "copper-plate": 15.0,
+    "electronic-circuit": 5.0,
+    "iron-plate": 5.65
+  },
+  "delivered": {
+    "electronic-circuit": 4.8
+  },
+  "overall_verdict": "FAIL"
+}

--- a/crates/sim-harness/baselines/gear10.json
+++ b/crates/sim-harness/baselines/gear10.json
@@ -1,0 +1,20 @@
+{
+  "label": "gear10",
+  "game_version": "2.0.76",
+  "mods": [
+    "base",
+    "space-age",
+    "quality",
+    "elevated-rails"
+  ],
+  "tech_state": "research_all_technologies",
+  "entities": 428,
+  "produced": {
+    "iron-gear-wheel": 10.0,
+    "iron-plate": 20.1
+  },
+  "delivered": {
+    "iron-gear-wheel": 10.133333333333333
+  },
+  "overall_verdict": "PASS"
+}

--- a/crates/sim-harness/baselines/logistic-science-pack.json
+++ b/crates/sim-harness/baselines/logistic-science-pack.json
@@ -1,0 +1,26 @@
+{
+  "label": "logistic-science-pack",
+  "game_version": "2.0.76",
+  "mods": [
+    "base",
+    "space-age",
+    "quality",
+    "elevated-rails"
+  ],
+  "tech_state": "research_all_technologies",
+  "entities": 593,
+  "produced": {
+    "copper-cable": 1.6,
+    "copper-plate": 0.65,
+    "electronic-circuit": 0.4,
+    "inserter": 0.45,
+    "iron-gear-wheel": 1.1,
+    "iron-plate": 2.95,
+    "logistic-science-pack": 0.5966666666666667,
+    "transport-belt": 0.6
+  },
+  "delivered": {
+    "logistic-science-pack": 0.5866666666666667
+  },
+  "overall_verdict": "FAIL"
+}

--- a/crates/sim-harness/baselines/military-science-pack.json
+++ b/crates/sim-harness/baselines/military-science-pack.json
@@ -1,0 +1,27 @@
+{
+  "label": "military-science-pack",
+  "game_version": "2.0.76",
+  "mods": [
+    "base",
+    "space-age",
+    "quality",
+    "elevated-rails"
+  ],
+  "tech_state": "research_all_technologies",
+  "entities": 919,
+  "produced": {
+    "copper-plate": 0.6,
+    "firearm-magazine": 0.25,
+    "grenade": 0.6,
+    "iron-plate": 5.35,
+    "military-science-pack": 0.52,
+    "piercing-rounds-magazine": 0.3,
+    "steel-plate": 0.3,
+    "stone-brick": 5.1,
+    "stone-wall": 0.95
+  },
+  "delivered": {
+    "military-science-pack": 0.5333333333333333
+  },
+  "overall_verdict": "FAIL"
+}

--- a/crates/sim-harness/src/main.rs
+++ b/crates/sim-harness/src/main.rs
@@ -50,7 +50,7 @@ USAGE:
   spaghettio-sim run --bp <file> --manifest <file> [--ticks N] [--speed N]
                       [--out report.json] [--timeout-secs N]
   spaghettio-sim check-data
-  spaghettio-sim bless --report <report.json> --baselines <dir>
+  spaghettio-sim bless --report <report.json> --baselines <dir> [--label <name>]
   spaghettio-sim check --report <report.json> --baselines <dir> [--tolerance 0.02]
 
 ENV:
@@ -65,7 +65,12 @@ fn cmd_bless(args: &[String]) -> Result<(), String> {
     let dir = flag_value(args, "--baselines").ok_or("bless requires --baselines <dir>")?;
     let raw = std::fs::read_to_string(report_path).map_err(|e| format!("{report_path}: {e}"))?;
     let json: serde_json::Value = serde_json::from_str(&raw).map_err(|e| e.to_string())?;
-    let b = baseline::baseline_from_report(&json)?;
+    let mut b = baseline::baseline_from_report(&json)?;
+    // Optional relabel: report labels come from the exporter and may not
+    // be unique per fixture (the baseline file is keyed on label).
+    if let Some(label) = flag_value(args, "--label") {
+        b.label = label.to_string();
+    }
     std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
     let path = baseline::baseline_path(std::path::Path::new(dir), &b.label);
     std::fs::write(&path, serde_json::to_string_pretty(&b).map_err(|e| e.to_string())?)

--- a/docs/rfc-050-headless-sim-harness.md
+++ b/docs/rfc-050-headless-sim-harness.md
@@ -336,3 +336,21 @@ design, so blessed measured baselines are **shareable** — keyed on
   pre-#348/#350 broken exports. Remaining phases: 2 (sweeps/anchor
   retirements), 3 (bless/check), 4 (web sim-state overlay — pulled
   forward at user request, 2026-07-22).*
+- *2026-07-22 — **IMPLEMENTATION COMPLETE; RFC closed out.** Phases 0
+  (#353 manifest), 1 (#354 crate — KC2 calibration gate passed), 3
+  (#355 bless/check), 4 (#356 web sim overlay, pulled forward at user
+  request) all merged same-day. Phase 2 sweep, solid fixtures: gear10
+  PASS +0.0%; ec10 FAIL −50% (#352); automation-science 1.00/s produced
+  (delivered −4%, quantization attribution open); logistic −40% and
+  military −48% — both VALIDATOR-CLEAN (#357), the confidence-chain
+  critique proven at gauntlet scale. Five baselines blessed into
+  `crates/sim-harness/baselines/` (FAILs deliberately included as
+  honest floors). Open items carried forward: fluid-path calibration
+  (blocks the chemical/production/utility sweep), non-south boundary
+  calibration, automation delivered-quantization attribution, #345
+  re-measurement through the released tool, USP-scale timing (KC4
+  formally unmeasured at USP size). Arc summary: the harness found two
+  artifact bugs that made every prior export inert (#348, #350), one
+  half-rate warning class (#352), and one clean-but-failing class
+  (#357) — four finding classes in its first two days.*
+

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -61,6 +61,6 @@ backfill the status next time the doc is touched.
 | RFC-047 | 2026-07-21 | [`rfc-047-lane-aware-tap-delivery.md`](rfc-047-lane-aware-tap-delivery.md) | Complete (browser eyeball open) |
 | RFC-048 | 2026-07-22 | [`rfc-048-cell-composition.md`](rfc-048-cell-composition.md) | Draft (spike, PR #341 — other session) |
 | RFC-049 | 2026-07-22 | [`rfc-049-inserter-capacity-research.md`](rfc-049-inserter-capacity-research.md) | Complete (in-game anchor open; input-side data gap #343) |
-| RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Draft |
+| RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Complete (fluid-path calibration + fluid-pack sweep open; #345 re-measure pending) |
 
 Next number: **RFC-051**.


### PR DESCRIPTION
## Intent

RFC-050 close-out: all implementation phases merged today; this PR lands the Phase-2 solid-fixture sweep's blessed baselines, the `bless --label` override the sweep exposed as needed, the decision-log close-out entry, and the registry flip.

## Scope

- `crates/sim-harness/baselines/` — five game-measured baselines + README (FAILs deliberately blessed as honest floors: fixes must move the number).
- `bless --label` override (report labels aren't unique per fixture — found live).
- RFC decision log + registry: Complete, with open items carried forward explicitly (fluid calibration → fluid packs, #345 re-measure, automation quantization, USP timing).

## Verification actually run

37 crate tests green; all five bless/check paths exercised live; sweep results cross-checked against the calibrated instrument (gear +0.0%). Findings filed: #357 (validator-clean logistic/military at ~55% of plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA