### PR TITLE
Add claude GitHub actions 1784750114724

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,16 +19,10 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    # `pull-requests`/`issues` must be WRITE: the review agent posts its
-    # findings as a PR review + inline/summary comments. The stock
-    # template ships read-only, which silently discarded every review
-    # from #305 through #324 — the job green-checked after a single
-    # permission denial (~20s, "No buffered inline comments") and no
-    # review was ever posted. Diagnosed 2026-07-21 on PR #324.
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
 
     steps:
@@ -44,20 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          # `--comment` is LOAD-BEARING: the code-review plugin's own
-          # contract is "if --comment was NOT provided, stop here. Do not
-          # post any GitHub comments." Without it the review runs, prints
-          # to the action log, and posts nothing — which (together with
-          # the read-only perms fixed in #327) is why no PR ever received
-          # a bot review from #305 to #328.
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
-          # Third load-bearing piece (with write perms #327 and --comment
-          # #329): the harness-level tool allowlist. Without it the agent
-          # runs the review but every posting/diff tool call is denied
-          # (11 denials on the #330 canary run). Mirrors the plugin's
-          # frontmatter allowed-tools + the action's own examples.
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,15 +12,11 @@ on:
 
 jobs:
   claude:
-    # Public repo: gate on sender to prevent outsiders from burning tokens
-    # by writing "@claude" in an issue/comment.
     if: |
-      (github.event.sender.login == github.repository_owner) && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!--
Keep this short. The goal is to capture intent and surface deviations,
not to ceremony-ise small changes. Trivial PRs (typo, one-liner, obvious
bug from a stack trace) can delete sections that don't apply — say so
explicitly rather than leaving them blank.
-->

## Intent

What problem this solves and why now. 1–3 sentences. If this implements an
RFC or closes an issue, link it.

## Scope

- **In:** what's included
- **Out:** what was deliberately not done (and why, if non-obvious)

## Verification

What was actually run — not "tests pass," but *which* tests, *which* URL in
the web app, *which* snapshot. For layout-engine changes follow the
verification protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protocol-for-layout-engine-changes).

- [ ] `cargo test --manifest-path crates/core/Cargo.toml`
- [ ] `cargo clippy -- -D warnings`
- [ ] WASM rebuild + browser eyeball (URL: …)
- [ ] Snapshot inspected for the specific bug being fixed (if applicable)

## Deviations from intent

Anything that differs from what was discussed or RFC'd, judgement calls
made mid-flight, things intentionally deferred. **"None" is a valid answer
— write it explicitly so it's clear nothing was glossed over.**

## Models / contracts touched

Which abstraction this affects (e.g. `ghost-pipeline-contracts.md`,
`factorio-mechanics.md`, the tier ladder in `docs/status.md`). If a contract
changed, the doc update is part of this PR. "None" is fine for chores.
