### PR TITLE
fix(ci): restore review-bot fixes wiped by /install-github-app template overwrite

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,10 +19,16 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # `pull-requests`/`issues` must be WRITE: the review agent posts its
+    # findings as a PR review + inline/summary comments. The stock
+    # template ships read-only, which silently discarded every review
+    # from #305 through #324 — the job green-checked after a single
+    # permission denial (~20s, "No buffered inline comments") and no
+    # review was ever posted. Diagnosed 2026-07-21 on PR #324.
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,7 +44,20 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # `--comment` is LOAD-BEARING: the code-review plugin's own
+          # contract is "if --comment was NOT provided, stop here. Do not
+          # post any GitHub comments." Without it the review runs, prints
+          # to the action log, and posts nothing — which (together with
+          # the read-only perms fixed in #327) is why no PR ever received
+          # a bot review from #305 to #328.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Third load-bearing piece (with write perms #327 and --comment
+          # #329): the harness-level tool allowlist. Without it the agent
+          # runs the review but every posting/diff tool call is denied
+          # (11 denials on the #330 canary run). Mirrors the plugin's
+          # frontmatter allowed-tools + the action's own examples.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude:
+    # Public repo: gate on sender to prevent outsiders from burning tokens
+    # by writing "@claude" in an issue/comment.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event.sender.login == github.repository_owner) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Intent

PR #367 (generated by `/install-github-app`, merged 2026-07-22) overwrote both Claude workflow files with the stock template, silently wiping every documented fix from the #305–#331 saga. Result: the review bot is back to green-check-with-no-review — confirmed by canary PR #368 (planted off-by-one, bot ran with `prompt` missing `--comment`, posted nothing). This restores the last known-good versions.

## Scope

- **In:** byte-restore of `.github/workflows/claude-code-review.yml` and `claude.yml` to their `a7ba8af` (pre-#367) versions. Recovers, for the review workflow: `pull-requests`/`issues: write` (#327), the `--comment` flag (#329), the `claude_args --allowedTools` allowlist (#331), and the warning comments explaining each. For `claude.yml`: the owner-only sender gate (public repo, prevents outsiders burning tokens via `@claude`).
- **Out:** guarding against future template overwrites (worth a followup — e.g. a CI check that greps the review workflow for its three load-bearing pieces); the #366-run-1 silence (predates the overwrite; 31 turns + 3 denials with fixes in place — most consistent with the triviality gate on a docs-only PR, unproven).

## Verification

`git diff a7ba8af origin/restore-review-bot-fixes -- <file>` is empty for both files (byte-identical to the versions that produced the bot's only confirmed working review, canary #330). Diff of #367's overwrite reviewed hunk-by-hunk: it only removed customizations, added nothing, so a pure restore loses nothing from the new template. End-to-end validation plan: after merge, re-trigger canary PR #368 (its `pull_request` runs take the workflow from the merge ref, so it picks up fixed main) and confirm the bot flags the planted bug.

## Deviations from intent

None.

## Models / contracts touched

None (CI config only). Note: the review bot self-skips PRs that modify its own workflow file (anti-hijack), so no bot review is expected here — verification is the byte-identity check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)