### PR TITLE
docs: /install-github-app overwrite is review-bot failure cause #4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,13 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   denied every posting/diff call (fixed #331). Validated 2026-07-21 via
   a planted-bug canary (#330): the bot's first-ever comment correctly
   flagged the bug inline with a committable fix. All substantive PR
-  review feedback before then was session-side. Expected behavior now:
+  review feedback before then was session-side. **A fourth cause class
+  surfaced 2026-07-22: re-running `/install-github-app` overwrote both
+  workflow files with the stock template, silently wiping all three
+  fixes at once (plus `claude.yml`'s owner-only sender gate). Restored
+  in #369, re-validated via canary #368. If anyone reruns the installer,
+  diff the workflow files against main before merging its PR.**
+  Expected behavior now:
   inline comments on findings, or a "no issues" summary comment on
   clean substantive PRs — a green check with *neither* on a
   non-trivial PR means it's broken again. Known benign no-comment


### PR DESCRIPTION
## Intent

Record today's review-bot outage cause in the CLAUDE.md review-bot section so the trap is documented where the other three causes live: re-running `/install-github-app` overwrote both workflow files with the stock template (#367), wiping the #327/#329/#331 fixes and `claude.yml`'s sender gate in one commit. Restored in #369, re-validated via canary #368.

## Scope

- **In:** one paragraph in the CI-review-bot bullet + the rerun-the-installer precaution.
- **Out:** an automated guard (CI check grepping the workflow for its load-bearing pieces) — noted as a followup candidate in #369.

## Verification

Docs-only; renders clean. Facts cross-checked against #367's diff, #369, and the #368 canary run.

## Deviations from intent

None.

## Models / contracts touched

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)