### PR TITLE
RFC-051 Phase B/C: chain auto-placer + CellComposedCandidate — gate PASSED (AC-from-plates 0/0, sim at plan)

### DIFF
--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -1,0 +1,626 @@
+//! RFC-051 Phase B: the linear/fan-out chain auto-placer.
+//!
+//! Generalizes the Phase-1 hand composers: cells are engine-generated
+//! per chain recipe (K=1 — one cell per recipe sized by the chain
+//! solve's machine counts; ratio quantization is a later optimization),
+//! placed west→east in dependency order, wired with template corridors
+//! only (straight, corner, UG-hop, 2→1 merge splitter, 1→2 fan-out
+//! splitter). Fan-out past an intervening cell routes through a SOUTH
+//! BYPASS lane below the cell band — the south side is empty except the
+//! final drain, so the only crossings are known corridor rows, each
+//! resolved by a local UG hop.
+//!
+//! Geometry-mode decision (Phase B, 2026-07-22): there is ONE geometry —
+//! the calibrated (sim-kit-compatible) form, 4-tile feed pitch included.
+//! The RFC's calibrated-twin invariant demands bit-identical
+//! non-boundary entities between production and sim forms; a compacted
+//! production form would shift cell origins and violate it. Bit-identity
+//! outranks the area optimization (that overhead is ~24% and honest);
+//! compacting under a translation-aware invariant is future work.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use crate::models::{BoundaryRecord, EntityDirection, LayoutResult, PlacedEntity, SolverResult};
+
+use super::extract::{extract_cell, generate_cell_layout, Cell, Port};
+use super::compose::stamp_path;
+
+/// Feed columns need >=4 tiles of lateral separation (#363: sim-kit
+/// rigs collide at construction below that).
+const FEED_PITCH: i32 = 4;
+/// North margin: boundary row at y=0, then clearance for feed corners.
+const CELL_Y: i32 = 3;
+/// Horizontal clearance east of each cell for merges/fan-out/corridors.
+const CORRIDOR_GAP: i32 = 6;
+/// Vertical lanes reserved on the east side of each slot's feed block
+/// for bypass descents/ascents.
+const VLANES: i32 = 2;
+
+/// Why a solve is not chain-composable. Stable strings — the candidate
+/// reports these as its `accepted_reason`.
+pub fn chain_eligible(sr: &SolverResult) -> Result<(), String> {
+    if sr.machines.is_empty() {
+        return Err("cells: empty chain".into());
+    }
+    let mut producers: FxHashMap<&str, usize> = FxHashMap::default();
+    for m in &sr.machines {
+        if m.count <= 0.0 {
+            return Err(format!("cells: zero-count spec {}", m.recipe));
+        }
+        for o in &m.outputs {
+            if o.is_fluid {
+                return Err(format!("cells: fluid output {} (solid-only Phase B)", o.item));
+            }
+            *producers.entry(o.item.as_str()).or_default() += 1;
+        }
+        for i in &m.inputs {
+            if i.is_fluid {
+                return Err(format!("cells: fluid input {} (solid-only Phase B)", i.item));
+            }
+        }
+        if !m.self_loop.is_empty() {
+            return Err(format!("cells: self-loop recipe {}", m.recipe));
+        }
+    }
+    for (item, n) in &producers {
+        if *n > 1 {
+            return Err(format!("cells: {item} produced by {n} specs (need exactly 1)"));
+        }
+    }
+    // Fan-out cap: one splitter = 2 consumers.
+    for m in &sr.machines {
+        for o in &m.outputs {
+            let consumers = sr
+                .machines
+                .iter()
+                .filter(|c| c.inputs.iter().any(|i| i.item == o.item))
+                .count();
+            if consumers > 2 {
+                return Err(format!("cells: {} feeds {consumers} recipes (fan-out cap 2)", o.item));
+            }
+        }
+    }
+    Ok(())
+}
+
+struct Placed {
+    cell: Cell,
+    /// Absolute x of the cell's west edge.
+    x: i32,
+    /// Absolute x of the slot's west edge (feed block start).
+    slot_x: i32,
+    /// Vertical-lane x's available in this slot (east of feed columns).
+    vlanes: [i32; VLANES as usize],
+    recipe: String,
+    ext_inputs: Vec<String>,
+}
+
+fn port_abs(p: &Port, cell_x: i32) -> (i32, i32) {
+    (cell_x + p.x, CELL_Y + p.y)
+}
+
+/// Crossing-aware corridor stamper. Horizontal runs hop under
+/// registered vertical columns; vertical legs hop under registered
+/// horizontal rows; whichever is stamped LATER does the hopping, so
+/// stamp order between two crossing corridors doesn't matter. All hops
+/// are span-3 UG pairs (within every belt tier's reach) — template
+/// machinery only (kill 5).
+struct Router {
+    h_rows: Vec<(i32, i32, i32)>, // (y, x0, x1) inclusive
+    v_cols: Vec<(i32, i32, i32)>, // (x, y0, y1) inclusive
+}
+
+impl Router {
+    fn new() -> Self {
+        Router { h_rows: Vec::new(), v_cols: Vec::new() }
+    }
+
+    /// Register an externally stamped column (feed columns).
+    fn register_col(&mut self, x: i32, y0: i32, y1: i32) {
+        self.v_cols.push((x, y0.min(y1), y0.max(y1)));
+    }
+    fn register_row(&mut self, y: i32, x0: i32, x1: i32) {
+        self.h_rows.push((y, x0.min(x1), x0.max(x1)));
+    }
+
+    /// Eastward row from x0..=x1 at y, hopping under crossing columns.
+    #[allow(clippy::too_many_arguments)]
+    fn hrow(
+        &mut self,
+        out: &mut Vec<PlacedEntity>,
+        y: i32,
+        x0: i32,
+        x1: i32,
+        item: &str,
+        belt: &str,
+        ug: &str,
+        seg: &str,
+    ) {
+        let mut cols: Vec<i32> = self
+            .v_cols
+            .iter()
+            .filter(|(cx, cy0, cy1)| *cx > x0 && *cx < x1 && y >= *cy0 && y <= *cy1)
+            .map(|(cx, _, _)| *cx)
+            .collect();
+        cols.sort_unstable();
+        cols.dedup();
+        let push_east = |out: &mut Vec<PlacedEntity>, xa: i32, xb: i32| {
+            for x in xa..=xb {
+                out.push(PlacedEntity {
+                    name: belt.into(), x, y,
+                    direction: EntityDirection::East,
+                    carries: Some(item.into()),
+                    segment_id: Some(seg.into()),
+                    ..Default::default()
+                });
+            }
+        };
+        let mut x = x0;
+        for c in cols {
+            if c - 2 >= x {
+                push_east(out, x, c - 2);
+            }
+            for (hx, io) in [(c - 1, "input"), (c + 1, "output")] {
+                out.push(PlacedEntity {
+                    name: ug.into(),
+                    x: hx,
+                    y,
+                    direction: EntityDirection::East,
+                    io_type: Some(io.into()),
+                    carries: Some(item.into()),
+                    segment_id: Some(seg.into()),
+                    ..Default::default()
+                });
+            }
+            x = c + 2;
+        }
+        if x <= x1 {
+            push_east(out, x, x1);
+        }
+        self.register_row(y, x0, x1);
+    }
+
+    /// Vertical leg from y0 toward y1 at x (either direction), hopping
+    /// under crossing rows.
+    #[allow(clippy::too_many_arguments)]
+    fn vcol(
+        &mut self,
+        out: &mut Vec<PlacedEntity>,
+        x: i32,
+        y0: i32,
+        y1: i32,
+        item: &str,
+        belt: &str,
+        ug: &str,
+        seg: &str,
+    ) {
+        let (lo, hi) = (y0.min(y1), y0.max(y1));
+        let down = y1 > y0;
+        let (dir, io_near, io_far) = if down {
+            (EntityDirection::South, "input", "output")
+        } else {
+            (EntityDirection::North, "input", "output")
+        };
+        let mut rows: Vec<i32> = self
+            .h_rows
+            .iter()
+            .filter(|(ry, rx0, rx1)| *ry > lo && *ry < hi && x >= *rx0 && x <= *rx1)
+            .map(|(ry, _, _)| *ry)
+            .collect();
+        rows.sort_unstable();
+        if !down {
+            rows.reverse();
+        }
+        let step = if down { 1 } else { -1 };
+        let push_v = |out: &mut Vec<PlacedEntity>, ya: i32, yb: i32| {
+            let (lo2, hi2) = (ya.min(yb), ya.max(yb));
+            for y in lo2..=hi2 {
+                out.push(PlacedEntity {
+                    name: belt.into(), x, y,
+                    direction: dir,
+                    carries: Some(item.into()),
+                    segment_id: Some(seg.into()),
+                    ..Default::default()
+                });
+            }
+        };
+        let mut y = y0;
+        for r in rows {
+            if (r - 2 * step - y) * step >= 0 {
+                push_v(out, y, r - 2 * step);
+            }
+            for (hy, io) in [(r - step, io_near), (r + step, io_far)] {
+                out.push(PlacedEntity {
+                    name: ug.into(),
+                    x,
+                    y: hy,
+                    direction: dir,
+                    io_type: Some(io.into()),
+                    carries: Some(item.into()),
+                    segment_id: Some(seg.into()),
+                    ..Default::default()
+                });
+            }
+            y = r + 2 * step;
+        }
+        if (y1 - y) * step >= 0 {
+            push_v(out, y, y1);
+        }
+        self.register_col(x, lo, hi);
+    }
+
+    /// East-facing corner belt at (x, y): single perpendicular input =
+    /// lane-preserving corner (the post-review splitter-merge idiom).
+    fn corner_east(&mut self, out: &mut Vec<PlacedEntity>, x: i32, y: i32, item: &str, belt: &str, seg: &str) {
+        out.push(PlacedEntity {
+            name: belt.into(),
+            x,
+            y,
+            direction: EntityDirection::East,
+            carries: Some(item.into()),
+            segment_id: Some(seg.into()),
+            ..Default::default()
+        });
+        self.register_row(y, x, x);
+    }
+}
+
+/// Compose an eligible chain solve into one layout. K=1: one cell per
+/// recipe at the chain rate. Returns the composed layout with boundary
+/// records populated (calibrated orientation: north feeds, south drain,
+/// west→east record order — #363).
+pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
+    chain_eligible(sr)?;
+
+    let produced: FxHashSet<&str> = sr
+        .machines
+        .iter()
+        .flat_map(|m| m.outputs.iter().map(|o| o.item.as_str()))
+        .collect();
+
+    // Place producers-first, west→east. `sr.dependency_order` is
+    // TARGET-FIRST (the solver's DFS pushes a recipe before recursing
+    // into its ingredients), so reverse it; unlisted recipes go last.
+    let mut specs: Vec<&crate::models::MachineSpec> = sr.machines.iter().collect();
+    let pos: FxHashMap<&str, usize> = sr
+        .dependency_order
+        .iter()
+        .enumerate()
+        .map(|(i, r)| (r.as_str(), i))
+        .collect();
+    specs.sort_by_key(|m| match pos.get(m.recipe.as_str()) {
+        Some(&i) => (0, std::cmp::Reverse(i)),
+        None => (1, std::cmp::Reverse(usize::MAX)),
+    });
+
+    let mut entities: Vec<PlacedEntity> = Vec::new();
+    let mut b_in: Vec<BoundaryRecord> = Vec::new();
+    let mut b_out: Vec<BoundaryRecord> = Vec::new();
+    let mut placed: Vec<Placed> = Vec::new();
+    let mut cursor = 0i32;
+
+    for m in &specs {
+        let out_item = m
+            .outputs
+            .first()
+            .ok_or_else(|| format!("cells: {} has no output", m.recipe))?
+            .item
+            .clone();
+        // outputs[].rate is PER-MACHINE; the cell serves the whole spec.
+        let rate = m.outputs[0].rate * m.count;
+        let input_names: Vec<&str> = m.inputs.iter().map(|i| i.item.as_str()).collect();
+        let (_csr, cl) = generate_cell_layout(&out_item, rate, &input_names);
+        let cell = extract_cell(&cl);
+        let ext_inputs: Vec<String> = m
+            .inputs
+            .iter()
+            .filter(|i| !produced.contains(i.item.as_str()))
+            .map(|i| i.item.clone())
+            .collect();
+        let n_feed_ports = cell
+            .ports
+            .iter()
+            .filter(|q| q.inbound && ext_inputs.contains(&q.item))
+            .count() as i32;
+
+        let slot_x = cursor;
+        let feed_w = FEED_PITCH * n_feed_ports + 1;
+        let vlane0 = slot_x + feed_w;
+        let x = vlane0 + VLANES + 1;
+        cursor = x + cell.width + CORRIDOR_GAP;
+
+        for e in &cell.entities {
+            let mut e = e.clone();
+            e.x += x;
+            e.y += CELL_Y;
+            entities.push(e);
+        }
+        placed.push(Placed {
+            cell,
+            x,
+            slot_x,
+            vlanes: [vlane0, vlane0 + 1],
+            recipe: m.recipe.clone(),
+            ext_inputs,
+        });
+    }
+
+    let band_bottom = CELL_Y
+        + placed.iter().map(|p| p.cell.height).max().unwrap_or(0)
+        + 1;
+
+    // --- External feeds: per cell, columns west of it (pitch 4), north
+    // boundary at y=0, corner east into the port terminal. Inner column
+    // serves the topmost port (no crossings among a slot's own feeds).
+    let mut router = Router::new();
+    for p in &placed {
+        // MULTI-ROW cells expose one in-port PER ROW for the same item —
+        // every port gets its own feed column (a single-port find left
+        // second-row machines unfed: belt-flow-reachability caught it).
+        let mut targets: Vec<(String, i32, i32)> = Vec::new();
+        for item in &p.ext_inputs {
+            let mut found = false;
+            for port in p.cell.ports.iter().filter(|q| q.inbound && q.item == *item) {
+                let (tx, ty) = port_abs(port, p.x);
+                targets.push((item.clone(), tx, ty));
+                found = true;
+            }
+            if !found {
+                return Err(format!("cells: {} lacks in-port for {item}", p.recipe));
+            }
+        }
+        targets.sort_by_key(|t| t.2);
+        for (i, (item, tx, ty)) in targets.iter().enumerate() {
+            let col_x = p.slot_x + targets.len() as i32 * FEED_PITCH
+                - FEED_PITCH * i as i32 - FEED_PITCH + 1;
+            stamp_path(
+                &mut entities,
+                &[(col_x, 0), (col_x, *ty), (tx - 1, *ty)],
+                item,
+                "express-transport-belt",
+                &format!("feed:{item}:{}", p.recipe),
+            );
+            router.register_col(col_x, 0, *ty);
+            router.register_row(*ty, col_x, tx - 1);
+            b_in.push(BoundaryRecord {
+                item: item.clone(),
+                x: col_x,
+                y: 0,
+                direction: EntityDirection::South,
+                is_fluid: false,
+                entity: "express-transport-belt".into(),
+            });
+        }
+    }
+
+    // Bypass rows sit between the band bottom and the drain row, so the
+    // sim's drain rig (which builds south of the drain head) never
+    // collides with them. Count bypass edges up front.
+    let n_bypass: i32 = placed
+        .iter()
+        .enumerate()
+        .map(|(pi, _)| {
+            let out_item = &specs[pi].outputs[0].item;
+            placed
+                .iter()
+                .enumerate()
+                .filter(|(ci, c)| {
+                    *ci != pi
+                        && *ci != pi + 1
+                        && specs[*ci].inputs.iter().any(|i| i.item == *out_item)
+                        && c.cell.ports.iter().any(|q| q.inbound && q.item == *out_item)
+                })
+                .count() as i32
+        })
+        .sum();
+    let drain_row = band_bottom + n_bypass + 2;
+
+    // --- Chain corridors: producer out → merge (if 2 runs) → fan-out
+    // split (if 2 consumers) → per-consumer routing via the Router.
+    let mut bypass_idx = 0i32;
+    for (pi, p) in placed.iter().enumerate() {
+        let out_item = specs[pi].outputs[0].item.clone();
+        let consumers: Vec<usize> = placed
+            .iter()
+            .enumerate()
+            .filter(|(ci, c)| {
+                *ci != pi
+                    && specs[*ci].inputs.iter().any(|i| i.item == out_item)
+                    && c.cell.ports.iter().any(|q| q.inbound && q.item == out_item)
+            })
+            .map(|(ci, _)| ci)
+            .collect();
+        let outs: Vec<&Port> = p.cell.ports.iter().filter(|q| !q.inbound).collect();
+        if consumers.is_empty() {
+            // Final product: corner south past the band, drain record.
+            let o1 = outs.first().ok_or_else(|| format!("cells: {} has no out port", p.recipe))?;
+            let (ox, oy) = port_abs(o1, p.x);
+            let drain_x = ox + 2;
+            let seg = format!("out:{}", p.recipe);
+            router.hrow(&mut entities, oy, ox + 1, drain_x - 1, &out_item,
+                "transport-belt", "underground-belt", &seg);
+            entities.push(PlacedEntity {
+                name: "transport-belt".into(), x: drain_x, y: oy,
+                direction: EntityDirection::South,
+                carries: Some(out_item.clone()),
+                segment_id: Some(seg.clone()), ..Default::default()
+            });
+            router.vcol(&mut entities, drain_x, oy + 1, drain_row, &out_item,
+                "transport-belt", "underground-belt", &seg);
+            b_out.push(BoundaryRecord {
+                item: out_item.clone(),
+                x: drain_x,
+                y: drain_row,
+                direction: EntityDirection::South,
+                is_fluid: false,
+                entity: "transport-belt".into(),
+            });
+            continue;
+        }
+
+        // Single collected run east of the cell: merge two out-runs via a
+        // splitter (Phase-1 geometry, generalized), else extend the one.
+        let sx = p.x + p.cell.width + 2;
+        let (run_x, run_y) = match outs.len() {
+            1 => {
+                let (ox, oy) = port_abs(outs[0], p.x);
+                stamp_path(&mut entities, &[(ox + 1, oy), (sx, oy)],
+                    &out_item, "fast-transport-belt", &format!("cc:a:{}", p.recipe));
+                router.register_row(oy, ox + 1, sx);
+                (sx + 1, oy)
+            }
+            2 => {
+                let (o1, o2) = if outs[0].y <= outs[1].y { (outs[0], outs[1]) } else { (outs[1], outs[0]) };
+                let (o1x, o1y) = port_abs(o1, p.x);
+                let (o2x, o2y) = port_abs(o2, p.x);
+                assert!(o2y > o1y + 1, "cells: merge assumes below-approach ({o2y} vs {o1y})");
+                stamp_path(&mut entities, &[(o1x + 1, o1y), (sx - 1, o1y)],
+                    &out_item, "fast-transport-belt", &format!("cc:a:{}", p.recipe));
+                router.register_row(o1y, o1x + 1, sx - 1);
+                stamp_path(&mut entities,
+                    &[(o2x + 1, o2y), (sx - 1, o2y), (sx - 1, o1y + 2)],
+                    &out_item, "fast-transport-belt", &format!("cc:b:{}", p.recipe));
+                router.register_row(o2y, o2x + 1, sx - 1);
+                router.register_col(sx - 1, o1y + 2, o2y);
+                entities.push(PlacedEntity {
+                    name: "fast-transport-belt".into(), x: sx - 1, y: o1y + 1,
+                    direction: EntityDirection::East,
+                    carries: Some(out_item.clone()),
+                    segment_id: Some(format!("cc:b:{}", p.recipe)), ..Default::default()
+                });
+                entities.push(PlacedEntity {
+                    name: "fast-splitter".into(), x: sx, y: o1y,
+                    direction: EntityDirection::East,
+                    carries: Some(out_item.clone()),
+                    segment_id: Some(format!("cc:m:{}", p.recipe)), ..Default::default()
+                });
+                (sx + 1, o1y)
+            }
+            n => return Err(format!("cells: {} has {n} out runs (max 2)", p.recipe)),
+        };
+
+        // Fan-out split point (if 2 consumers): a second splitter one
+        // tile east of the collected run.
+        let mut branch_origins: Vec<(i32, i32)> = Vec::new();
+        if consumers.len() == 2 {
+            entities.push(PlacedEntity {
+                name: "fast-splitter".into(), x: run_x, y: run_y,
+                direction: EntityDirection::East,
+                carries: Some(out_item.clone()),
+                segment_id: Some(format!("fan:{}", p.recipe)), ..Default::default()
+            });
+            branch_origins.push((run_x + 1, run_y));
+            branch_origins.push((run_x + 1, run_y + 1));
+        } else {
+            branch_origins.push((run_x, run_y));
+        }
+
+        // Route each branch. Adjacent-east consumer: port-row corridor
+        // (with a vertical jog on the consumer slot's first lane if the
+        // rows differ). Farther consumer: south bypass under the band.
+        let mut ordered = consumers.clone();
+        ordered.sort_by_key(|ci| placed[*ci].x);
+        for (bi, ci) in ordered.iter().enumerate() {
+            let c = &placed[*ci];
+            let port = c.cell.ports.iter()
+                .find(|q| q.inbound && q.item == out_item)
+                .expect("consumer port checked in eligibility");
+            let (tx, ty) = port_abs(port, c.x);
+            let (bx, by) = branch_origins[bi.min(branch_origins.len() - 1)];
+            let seg = format!("corr:{}:{}", p.recipe, c.recipe);
+            if *ci == pi + 1 {
+                if by == ty {
+                    router.hrow(&mut entities, ty, bx, tx - 1, &out_item,
+                        "fast-transport-belt", "fast-underground-belt", &seg);
+                } else {
+                    // Early jog: one east tile at the branch origin, then
+                    // vertical at bx+1 down/up to the TARGET port row, then
+                    // east all the way. The stagger keeps a sibling
+                    // fan-out branch's row clear of this jog column (it
+                    // hops under it via the registry).
+                    let vdir = (ty - by).signum();
+                    router.corner_east(&mut entities, bx, by, &out_item, "fast-transport-belt", &seg);
+                    router.vcol(&mut entities, bx + 1, by, ty - vdir, &out_item,
+                        "fast-transport-belt", "fast-underground-belt", &seg);
+                    router.corner_east(&mut entities, bx + 1, ty, &out_item, "fast-transport-belt", &seg);
+                    router.hrow(&mut entities, ty, bx + 2, tx - 1, &out_item,
+                        "fast-transport-belt", "fast-underground-belt", &seg);
+                }
+            } else {
+                // South bypass below the cell band.
+                let lane_down = placed[pi + 1].vlanes[1];
+                let lane_up = c.vlanes[1];
+                let by_y = band_bottom + 1 + bypass_idx;
+                bypass_idx += 1;
+                router.hrow(&mut entities, by, bx, lane_down - 1, &out_item,
+                    "fast-transport-belt", "fast-underground-belt", &seg);
+                router.vcol(&mut entities, lane_down, by, by_y - 1, &out_item,
+                    "fast-transport-belt", "fast-underground-belt", &seg);
+                router.corner_east(&mut entities, lane_down, by_y, &out_item, "fast-transport-belt", &seg);
+                router.hrow(&mut entities, by_y, lane_down + 1, lane_up - 1, &out_item,
+                    "fast-transport-belt", "fast-underground-belt", &seg);
+                entities.push(PlacedEntity {
+                    name: "fast-transport-belt".into(), x: lane_up, y: by_y,
+                    direction: EntityDirection::North,
+                    carries: Some(out_item.clone()),
+                    segment_id: Some(seg.clone()), ..Default::default()
+                });
+                router.vcol(&mut entities, lane_up, by_y - 1, ty + 1, &out_item,
+                    "fast-transport-belt", "fast-underground-belt", &seg);
+                router.corner_east(&mut entities, lane_up, ty, &out_item, "fast-transport-belt", &seg);
+                router.hrow(&mut entities, ty, lane_up + 1, tx - 1, &out_item,
+                    "fast-transport-belt", "fast-underground-belt", &seg);
+            }
+        }
+    }
+
+    // --- Poles: per-cell trio down the corridor gap + a spanning line
+    // along the band bottom (nudge-not-skip — Phase-1 pole lesson).
+    let occupied: FxHashSet<(i32, i32)> = entities.iter().map(|e| (e.x, e.y)).collect();
+    for p in &placed {
+        let px = p.x + p.cell.width + CORRIDOR_GAP - 1;
+        for y in [CELL_Y, CELL_Y + 7, CELL_Y + 14] {
+            if y < band_bottom {
+                let mut yy = y;
+                while occupied.contains(&(px, yy)) {
+                    yy += 1;
+                }
+                entities.push(PlacedEntity {
+                    name: "medium-electric-pole".into(), x: px, y: yy,
+                    direction: EntityDirection::North,
+                    segment_id: Some("pole".into()), ..Default::default()
+                });
+            }
+        }
+    }
+    let width = entities.iter().map(|e| e.x).max().unwrap_or(0) + 1;
+    let mut px = 1;
+    while px < width {
+        for nudge in 0..5 {
+            let x = px + nudge;
+            if !occupied.contains(&(x, band_bottom)) {
+                entities.push(PlacedEntity {
+                    name: "medium-electric-pole".into(), x, y: band_bottom,
+                    direction: EntityDirection::North,
+                    segment_id: Some("pole".into()), ..Default::default()
+                });
+                break;
+            }
+        }
+        px += 8;
+    }
+
+    let height = (entities.iter().map(|e| e.y).max().unwrap_or(0) + 1).max(band_bottom + 2);
+    Ok(LayoutResult {
+        entities,
+        width,
+        height,
+        stacking: 1,
+        boundary_inputs: {
+            let mut b = b_in;
+            b.sort_by_key(|r| r.x); // west→east (#363 rig-depth rule)
+            b
+        },
+        boundary_outputs: b_out,
+        ..Default::default()
+    })
+}

--- a/crates/core/src/bus/cells/mod.rs
+++ b/crates/core/src/bus/cells/mod.rs
@@ -6,6 +6,7 @@
 //! flag until Phase B wires `CellComposedCandidate` into the
 //! decomposition search.
 
+pub mod chain;
 pub mod compose;
 pub mod extract;
 

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -122,6 +122,32 @@ impl DecompositionCandidate for MergeTapCandidate {
     }
 }
 
+/// RFC-051 Phase B: the cell-composition candidate. Runs only under
+/// `LayoutOptions.cell_composition == Candidate` (default Off) on
+/// chain-eligible solves (solid tree-with-fan-out; `cells::chain::
+/// chain_eligible`). Deliberately UNBIASED: it competes on the same
+/// score/acceptance machinery as every other candidate — if it only
+/// wins where the bus engine refuses, that is the honest value
+/// statement (RFC-051 kill 3).
+pub struct CellComposedCandidate;
+
+impl DecompositionCandidate for CellComposedCandidate {
+    fn name(&self) -> &str {
+        "cell-composed"
+    }
+
+    fn produce(
+        &self,
+        solver_result: &SolverResult,
+        opts: &LayoutOptions,
+    ) -> Result<LayoutResult, String> {
+        if opts.cell_composition != crate::bus::cells::CellComposition::Candidate {
+            return Err("cell composition is Off".to_string());
+        }
+        crate::bus::cells::chain::compose_chain(solver_result)
+    }
+}
+
 /// Phase 1 candidate: split each multi-producer module into `k` sibling
 /// sub-modules, each with halved rate and independent bus presence.
 /// Targets coprime balancer shapes like `(4, 9)` on PU@3/s ore-red
@@ -719,6 +745,19 @@ pub fn select_best_decomposition(
         NativeCandidate.produce(s, &opts)
     });
 
+    // Cell-composition candidate (RFC-051 Phase B): flag-gated,
+    // eligibility-gated, and catch_unwind — the composer's internal
+    // asserts must degrade to the bus candidates, never abort the solve.
+    let try_cells = opts.cell_composition == crate::bus::cells::CellComposition::Candidate
+        && crate::bus::cells::chain::chain_eligible(solver_result).is_ok();
+    let cells_run = if try_cells {
+        run_candidate_catch_unwind("cell-composed", solver_result, || {
+            CellComposedCandidate.produce(solver_result, &opts)
+        })
+    } else {
+        CandidateRun::skipped("cell-composed")
+    };
+
     // K=1 shape-fix follow-up. When Native's layout has missing-balancer
     // warnings on K=1 items (the (4, 9) coprime trap on PU@3/s ore-red
     // copper-plate), enroll those items in the partition plan with a
@@ -832,6 +871,7 @@ pub fn select_best_decomposition(
         &k1_run.events,
         &split_run.events,
         &merge_tap_run.events,
+        &cells_run.events,
     ] {
         for ev in events {
             if matches!(ev, crate::trace::TraceEvent::DecompositionCandidateScored { .. }) {
@@ -845,17 +885,19 @@ pub fn select_best_decomposition(
     // layout — same behaviour as today's pipeline when shape-fix can't
     // resolve a (n, m) trap).
     // Index order MUST match NATIVE_IDX (0) / MERGE_TAP_IDX (3) above.
-    let (native_err, k1_err, split_err, merge_tap_err) = (
+    let (native_err, k1_err, split_err, merge_tap_err, cells_err) = (
         native_run.error.clone(),
         k1_run.error.clone(),
         split_run.error.clone(),
         merge_tap_run.error.clone(),
+        cells_run.error.clone(),
     );
-    let candidates: [(Option<(LayoutResult, CandidateScore)>, Vec<crate::trace::TraceEvent>, &str); 4] = [
+    let candidates: [(Option<(LayoutResult, CandidateScore)>, Vec<crate::trace::TraceEvent>, &str); 5] = [
         (native_run.outcome, native_run.events, "native"),
         (k1_run.outcome, k1_run.events, "k1-shape-fix"),
         (split_run.outcome, split_run.events, "size-split-2"),
         (merge_tap_run.outcome, merge_tap_run.events, "merge-tap"),
+        (cells_run.outcome, cells_run.events, "cell-composed"),
     ];
 
     // Find best accepted candidate (highest score).
@@ -887,7 +929,7 @@ pub fn select_best_decomposition(
         let details: Vec<String> = candidates
             .iter()
             .map(|(_, _, name)| name.to_string())
-            .zip([&native_err, &k1_err, &split_err, &merge_tap_err])
+            .zip([&native_err, &k1_err, &split_err, &merge_tap_err, &cells_err])
             .map(|(name, err)| {
                 format!("{name}: {}", err.as_deref().unwrap_or("did not run"))
             })

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -223,3 +223,150 @@ fn export_engine_plastic_for_sim() {
         serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
     println!("wrote engine plastic artifacts ({} boundary in)", l.boundary_inputs.len());
 }
+
+/// Phase-B dev probe: the chain auto-placer on the two dev fixtures.
+#[test]
+#[ignore = "exploration probe while the auto-placer stabilizes"]
+fn probe_chain_autoplace() {
+    use spaghettio_core::bus::cells::chain::compose_chain;
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    for (label, item, rate, inputs) in [
+        ("ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
+        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+    ] {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item, rate, &inputs_set, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        println!("== {label}: {} specs ==", sr.machines.len());
+        for m in &sr.machines { println!("   {} x{:.2} out {:.2}/s", m.recipe, m.count, m.outputs[0].rate); }
+        match compose_chain(&sr) {
+            Ok(l) => {
+                println!("   composed {}x{} = {} tiles, {} entities", l.width, l.height, l.width * l.height, l.entities.len());
+                match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
+                    Ok(issues) => {
+                        let e = issues.iter().filter(|i| i.severity == Severity::Error).count();
+                        println!("   validation: {} errors / {} issues", e, issues.len());
+                        for i in issues.iter().take(15) {
+                            println!("     [{:?}] {} {}", i.severity, i.category, i.message);
+                        }
+                    }
+                    Err(er) => {
+                        for line in format!("{er}").lines().take(12) { println!("     {line}"); }
+                    }
+                }
+            }
+            Err(e) => println!("   REFUSED: {e}"),
+        }
+    }
+}
+
+/// Artifact producers for the chain auto-placer's sim runs (Phase B/C).
+#[test]
+#[ignore = "artifact producer"]
+fn export_chain_fixtures_for_sim() {
+    use spaghettio_core::bus::cells::chain::compose_chain;
+    for (label, item, rate, inputs) in [
+        ("chain-ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
+        ("chain-ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+    ] {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item, rate, &inputs_set, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        let l = compose_chain(&sr).unwrap();
+        let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, label);
+        std::fs::create_dir_all("target/tmp").unwrap();
+        std::fs::write(format!("target/tmp/{label}.bp"), &bp).unwrap();
+        std::fs::write(format!("target/tmp/{label}.manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+        println!("wrote target/tmp/{label}.bp ({} boundary in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
+    }
+}
+
+/// Phase-B differential scoreboard (kill-3 evidence): composed vs bus
+/// on every chain-eligible ladder fixture. Prints errors / warnings /
+/// area / refusals per path.
+#[test]
+#[ignore = "measurement probe — output goes to the RFC decision log"]
+fn probe_differential_scoreboard() {
+    use spaghettio_core::bus::cells::chain::{chain_eligible, compose_chain};
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    let fixtures: &[(&str, &str, f64, &[&str])] = &[
+        ("gear15", "iron-gear-wheel", 15.0, &["iron-plate"]),
+        ("ec5", "electronic-circuit", 5.0, &["iron-plate", "copper-plate"]),
+        ("ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"]),
+        ("ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"]),
+        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"]),
+        ("ac2", "advanced-circuit", 2.0, &["iron-plate", "copper-plate", "plastic-bar"]),
+    ];
+    for (label, item, rate, inputs) in fixtures {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item, *rate, &inputs_set, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        let bus = std::panic::catch_unwind(|| layout::build_bus_layout(&sr, layout::LayoutOptions::default()));
+        let bus_desc = match &bus {
+            Ok(Ok(l)) => match validate::validate(l, Some(&sr), LayoutStyle::Bus) {
+                Ok(issues) => {
+                    let e = issues.iter().filter(|i| i.severity == Severity::Error).count();
+                    format!("{}x{}={} tiles, {} errors / {} warnings", l.width, l.height, l.width * l.height, e, issues.len() - e)
+                }
+                Err(er) => format!("validate() Err: {}", format!("{er}").lines().next().unwrap_or("")),
+            },
+            Ok(Err(e)) => format!("REFUSED: {}", e.lines().next().unwrap_or("")),
+            Err(_) => "PANICKED".into(),
+        };
+        let comp_desc = match chain_eligible(&sr) {
+            Err(e) => format!("INELIGIBLE: {e}"),
+            Ok(()) => match compose_chain(&sr) {
+                Ok(l) => match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
+                    Ok(issues) => {
+                        let e = issues.iter().filter(|i| i.severity == Severity::Error).count();
+                        format!("{}x{}={} tiles, {} errors / {} warnings", l.width, l.height, l.width * l.height, e, issues.len() - e)
+                    }
+                    Err(er) => format!("validate() Err: {}", format!("{er}").lines().next().unwrap_or("")),
+                },
+                Err(e) => format!("REFUSED: {e}"),
+            },
+        };
+        println!("{label:8} bus:      {bus_desc}");
+        println!("{label:8} composed: {comp_desc}");
+    }
+}
+
+/// PERMANENT GATE (RFC-051 Phase B): with the flag ON, the decomposition
+/// search resolves EC@15-from-plates — the config the bus engine refuses
+/// outright (#336) — via the cell-composed candidate, at 0 errors with
+/// only the sim-adjudicated warning category. With the flag OFF
+/// (default) the refusal stands (inertness: the bus path is untouched).
+#[test]
+fn cell_candidate_resolves_ec15_refusal() {
+    use spaghettio_core::bus::cells::CellComposition;
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    let inputs: FxHashSet<String> =
+        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "electronic-circuit", 15.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+
+    // Flag OFF: the refusal stands.
+    let off = layout::build_bus_layout(&sr, layout::LayoutOptions::default());
+    assert!(off.is_err(), "flag-Off must preserve the bus refusal");
+
+    // Flag ON: the composed candidate wins and validates clean.
+    let opts = layout::LayoutOptions {
+        cell_composition: CellComposition::Candidate,
+        ..Default::default()
+    };
+    let l = layout::build_bus_layout(&sr, opts).expect("candidate must resolve the refusal");
+    let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).unwrap();
+    let errors = issues.iter().filter(|i| i.severity == Severity::Error).count();
+    assert_eq!(errors, 0, "composed candidate errors: {issues:?}");
+    assert!(issues.iter().all(|i| i.category == "inserter-item-throughput"),
+        "only the adjudicated category tolerated: {issues:?}");
+}

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -1,6 +1,6 @@
 # RFC-051: Cell composition integration (production path)
 
-Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phase A (lift) delivered; Phase B (candidate) next.**
+Registry: [`rfcs.md`](rfcs.md). Status: **Delivered — all phases complete (PRs #377 + Phase B/C); gate passed, kill criteria evaluated, flag default remains Off pending the flip decision.**
 
 ## Summary
 
@@ -167,7 +167,81 @@ value statement (see kill 3).
   at plan; kill 3/4 evaluated with the scoreboard; close-out with
   coverage datum and the flag-default decision.
 
+## Phase B/C close-out: kill-criteria evaluation and the flag decision (2026-07-22)
+
+**The gate (kill 4): PASS, same-session.** AC-from-plates (fan-out 2:
+cable → EC and AC; plastic external) composes through the production
+auto-placer at **0 errors / 0 warnings** and runs in headless Factorio
+at plan: **produced 1.00/s (−0.33%), 8/8 machines working, converged.**
+EC@15-from-plates (the #336 refusal config) through the same path:
+0 errors / 6 adjudicated warnings, sim **produced 15.0/s exactly
+(+0.0%), 15/15 working.**
+
+**Kill 1 (parallel stack): PASS.** Cells engine-generated; the
+auto-placer is placement arithmetic + the crossing Router (deterministic
+local span-3 UG hops — rows hop under registered columns, columns under
+registered rows); validation and scoring fully shared.
+
+**Kill 2 (corridor machinery): PASS.** The gate config used straight
+runs, corners, UG hops, one 2→1 merge splitter, one 1→2 fan-out
+splitter, and the south bypass — no negotiation, no growth, no junction
+solving. The Router is a fixed local rule, not a search.
+
+**Kill 3 (no-value): PASS via clause (a).** The differential scoreboard
+(all numbers from one probe run, in the decision log): EC@15-from-plates
+— bus REFUSES, composed delivers (now a permanent gate,
+`cell_candidate_resolves_ec15_refusal`, asserting BOTH directions:
+flag Off preserves the refusal, flag On resolves it). Clause (b)
+honestly untested as worded: EC@5 shows fewer composed warnings (2 vs
+4) but the strict-category-subset comparison wasn't run. Where both
+paths succeed, the bus wins on area (composed 1.5–3.1×) — recorded
+without spin; the unbiased scorer will pick the bus there, which is
+exactly the designed behavior.
+
+**Kill 5 (tripwire): coverage GREW.** Phase-1 baseline 2 chains → the
+auto-placer now composes gear@15, EC@5, EC@15, AC@1, AC@2 (three
+distinct chains) plus the hand-composed plastic geometry; EC@30
+refuses honestly (3 out-runs exceeds the merge cap — a known, named
+limitation, not a silent gap).
+
+**The flag decision: `Off` stays the default, deliberately.** Under
+`Candidate` the unbiased scorer would only ever pick composition where
+the bus refuses or fails acceptance (composed density is strictly worse
+where both succeed), so a flip is strictly additive — but the flip
+waits for: (1) the browser eyeball step of the house verification
+protocol on composed layouts, (2) wasm/web flag plumbing, (3) the
+Tier-1 sim-verified registry. Flipping is its own logged decision, with
+the user.
+
+**Deferred, honestly:** the geometry-hash sim-verified registry (Tier 1)
+is designed but not implemented — today's catalog is small enough that
+this RFC's decision log IS the registry (four sim-verified configs, all
+listed with their measurements). The mechanism becomes load-bearing at
+flag-flip or when the catalog outgrows the log; implement it then.
+EC@30's 3-run merge and ratio quantization (K>1 cells) are named
+follow-ups.
+
 ## Decision log
+
+- *2026-07-22 — Phase B/C delivered (same session as Phase A). The
+  chain auto-placer (`cells/chain.rs`): eligibility (solid
+  tree-with-fan-out, fan-out cap 2, one producer per item),
+  K=1 cells at spec rate × count, dependency-ordered west→east
+  placement, the two-registry crossing Router, early-jog corridors
+  (jog to the target port row in the producer's gap — where all rows
+  provably end before the splitter — so same-y row collisions are
+  structurally impossible), one feed column PER PORT (multi-row cells
+  taught this: a single-port find left second-row machines unfed and
+  belt-flow-reachability caught it), fan-out splitter + south bypass.
+  `CellComposedCandidate` competes unbiased in the decomposition
+  search, catch_unwind fail-soft, flag-gated. Differential scoreboard
+  (single probe run): gear15 bus 184 tiles/0/0 vs composed 462/0/0;
+  ec5 bus 325/0/4 vs composed 1008/0/2; ec15 bus REFUSED vs composed
+  1428/0/6; ec30 bus 1624/0/18 vs composed REFUSED (merge cap); ac1
+  bus 754/0/0 vs composed 1349/0/0; ac2 bus 1189/0/0 vs composed
+  1767/0/0. Sims: chain-ec15 15.0/s exactly, 15/15 working; chain-ac1
+  1.00/s (−0.33%), 8/8 working — both PASS, converged. Suite
+  889/0/48, goldens 8/8 (flag-Off inertness), clippy 0.*
 
 - *2026-07-22 — Phase A delivered (same session as the RFC's merge).
   The harness lifted verbatim into `src/bus/cells/{extract,compose}.rs`

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -62,6 +62,6 @@ backfill the status next time the doc is touched.
 | RFC-048 | 2026-07-22 | [`rfc-048-cell-composition.md`](rfc-048-cell-composition.md) | Phase 1 complete (PR #365) — GO for Phase-2 integration RFC |
 | RFC-049 | 2026-07-22 | [`rfc-049-inserter-capacity-research.md`](rfc-049-inserter-capacity-research.md) | Complete (in-game anchor open; input-side data gap #343) |
 | RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Complete (fluid feed CALIBRATED via #364 — first fluid factory PASS; fluid-pack sweep + #345 re-measure open) |
-| RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Draft (integration RFC commissioned by RFC-048 Phase 1 GO) |
+| RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Delivered — gate passed (AC-from-plates 0/0 + sim at plan); flag Off pending flip decision |
 
 Next number: **RFC-052**.

--- a/docs/status.md
+++ b/docs/status.md
@@ -198,6 +198,24 @@ bit-identical to pre-RFC (zero golden re-blesses). Mechanics:
 ore-routing warnings persist on legendary-express). Full trail:
 [`rfc-046-belt-stacking.md`](rfc-046-belt-stacking.md) decision log.
 
+**`rfc-051-cell-composition-integration.md` close-out (2026-07-22)**:
+cell composition became a **production path** — a flag-gated
+`CellComposedCandidate` (default Off, bus bit-identical) competing
+unbiased in the decomposition search for solid tree-with-fan-out
+chains. The chain auto-placer generalizes the Phase-1 hand composers
+(engine-generated K=1 cells, two-registry crossing Router, fan-out
+splitter + south bypass). Gate passed: **AC-from-plates composed at
+0 errors / 0 warnings and ran at plan in headless Factorio (1.00/s,
+8/8 working)**; EC@15-from-plates — the
+[#336](https://github.com/storkme/spaghettio/issues/336) refusal —
+resolves under the flag at 0 errors (permanent gate pins both
+directions) and measured 15.0/s exactly. Differential scoreboard:
+composition wins where the bus refuses, bus wins on area where both
+succeed (1.5–3.1×) — the unbiased scorer therefore only ever picks
+composition on refusals. Flag flip deferred (browser eyeball, wasm
+plumbing, sim-verified registry). Full trail:
+[`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md).
+
 **`rfc-048-cell-composition.md` Phase-1 close-out (2026-07-22, PR #365)**:
 the cell-composition method delivered its existence proof — a composed
 EC@15/s-from-plates factory (engine-generated cells, segment-crop


### PR DESCRIPTION
## Intent

Complete RFC-051 (Phases B and C): the chain auto-placer generalizing the Phase-1 hand composers, `CellComposedCandidate` competing unbiased in the decomposition search behind the default-Off flag, the differential scoreboard, and the phase gate — **advanced-circuit-from-plates composed through the production path at 0 errors / 0 warnings and sim-verified at plan**.

## Scope

- `cells/chain.rs`: `chain_eligible` (solid tree-with-fan-out, fan-out cap 2, one producer per item — stable refusal strings) + `compose_chain` (K=1 engine-generated cells at spec rate × count, dependency-ordered west→east placement, early-jog corridors, fan-out splitter + south bypass, one feed column per port).
- The **two-registry crossing Router**: horizontal runs hop under registered vertical columns, vertical legs hop under registered horizontal rows, all span-3 UG pairs — a fixed local rule, not a search (kill 2 stays honest).
- `CellComposedCandidate` in `select_best_decomposition`: flag-gated, eligibility-gated, `catch_unwind` fail-soft, **unbiased** (no score thumb — where both paths succeed, the bus's better density wins, by design).
- Permanent gate `cell_candidate_resolves_ec15_refusal`: flag Off ⇒ the #336 refusal stands (inertness); flag On ⇒ 0 errors, adjudicated warning category only.
- RFC close-out: kills 1–5 evaluated, scoreboard logged, flag decision (Off stays; flip is its own decision gated on browser eyeball + wasm plumbing + the sim registry), honest deferrals (geometry-hash registry designed-not-built with log-as-registry rationale, EC@30 merge cap, K>1 quantization).

## Models / contracts touched

None beyond Phase A's `LayoutOptions.cell_composition` (this PR adds behavior behind it). `CellComposedCandidate` implements the existing `DecompositionCandidate` trait; `CandidateScore` untouched.

## Verification actually run

- **Sims (Factorio 2.0.76)**: chain-ac1 — produced 1.00/s (−0.33%), 8/8 machines working, converged, PASS. chain-ec15 — produced **15.0/s exactly (+0.0%)**, 15/15 working, PASS.
- **Differential scoreboard** (single probe run, full table in the RFC log): composition delivers where the bus refuses (ec15), refuses honestly where its merge cap binds (ec30), and loses on area where both succeed (1.5–3.1×) — kill 3 passes via clause (a), with clause (b) recorded as untested-as-worded.
- Suite 890/0/48 single run, goldens 8/8 zero diffs (flag-Off inertness), clippy 0, WASM builds.

## Deviations from agreed approach

- The Tier-1 geometry-hash sim registry is **designed, not built** — with a four-config catalog, the RFC decision log is the registry; the mechanism becomes load-bearing at flag-flip and is a named follow-up. This is the one review-fold item (#375 finding 1) delivered as design + rationale rather than code.
- Single geometry for production and sim (the calibrated form, 4-pitch feeds included): the reviewer's bit-identity twin invariant outranks the area optimization; compacting under a translation-aware invariant is future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55