### PR TITLE
chore(sim-harness): re-bless baselines under tech-state parity (ec10 = honest -25% floor)

### DIFF
--- a/crates/sim-harness/baselines/automation-science-pack.json
+++ b/crates/sim-harness/baselines/automation-science-pack.json
@@ -7,16 +7,16 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0",
   "entities": 196,
   "produced": {
     "automation-science-pack": 1.0,
-    "copper-plate": 1.0033333333333334,
-    "iron-gear-wheel": 0.98,
-    "iron-plate": 2.01
+    "copper-plate": 0.9966666666666668,
+    "iron-gear-wheel": 1.0,
+    "iron-plate": 2.0033333333333334
   },
   "delivered": {
-    "automation-science-pack": 1.0133333333333334
+    "automation-science-pack": 1.0
   },
   "overall_verdict": "PASS"
 }

--- a/crates/sim-harness/baselines/ec10.json
+++ b/crates/sim-harness/baselines/ec10.json
@@ -7,16 +7,16 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0",
   "entities": 805,
   "produced": {
-    "copper-cable": 30.0,
-    "copper-plate": 15.0,
-    "electronic-circuit": 10.0,
-    "iron-plate": 10.0
+    "copper-cable": 22.4,
+    "copper-plate": 11.275,
+    "electronic-circuit": 7.5,
+    "iron-plate": 7.5
   },
   "delivered": {
-    "electronic-circuit": 10.133333333333333
+    "electronic-circuit": 7.6
   },
-  "overall_verdict": "PASS"
+  "overall_verdict": "FAIL"
 }

--- a/crates/sim-harness/baselines/gear10.json
+++ b/crates/sim-harness/baselines/gear10.json
@@ -7,14 +7,14 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0",
   "entities": 428,
   "produced": {
     "iron-gear-wheel": 10.0,
-    "iron-plate": 20.1
+    "iron-plate": 20.0
   },
   "delivered": {
-    "iron-gear-wheel": 10.133333333333333
+    "iron-gear-wheel": 9.8
   },
   "overall_verdict": "PASS"
 }

--- a/crates/sim-harness/baselines/logistic-science-pack.json
+++ b/crates/sim-harness/baselines/logistic-science-pack.json
@@ -7,20 +7,20 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0",
   "entities": 593,
   "produced": {
-    "copper-cable": 3.1,
-    "copper-plate": 1.5666666666666669,
-    "electronic-circuit": 1.0166666666666666,
-    "inserter": 1.0266666666666666,
-    "iron-gear-wheel": 1.3766666666666667,
-    "iron-plate": 5.213333333333333,
-    "logistic-science-pack": 1.0466666666666666,
-    "transport-belt": 1.0
+    "copper-cable": 3.1133333333333333,
+    "copper-plate": 1.5633333333333332,
+    "electronic-circuit": 1.04,
+    "inserter": 1.04,
+    "iron-gear-wheel": 1.39,
+    "iron-plate": 5.193333333333333,
+    "logistic-science-pack": 1.0333333333333334,
+    "transport-belt": 1.04
   },
   "delivered": {
-    "logistic-science-pack": 1.0666666666666669
+    "logistic-science-pack": 1.04
   },
   "overall_verdict": "PASS"
 }

--- a/crates/sim-harness/baselines/military-science-pack.json
+++ b/crates/sim-harness/baselines/military-science-pack.json
@@ -7,21 +7,21 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0",
   "entities": 919,
   "produced": {
-    "copper-plate": 0.55,
-    "firearm-magazine": 0.52,
-    "grenade": 0.58,
+    "copper-plate": 0.5466666666666666,
+    "firearm-magazine": 0.5233333333333333,
+    "grenade": 0.5533333333333333,
     "iron-plate": 6.233333333333333,
-    "military-science-pack": 1.0,
+    "military-science-pack": 0.9933333333333332,
     "piercing-rounds-magazine": 0.5133333333333333,
-    "steel-plate": 0.27,
-    "stone-brick": 4.993333333333333,
-    "stone-wall": 0.9966666666666668
+    "steel-plate": 0.2733333333333333,
+    "stone-brick": 4.986666666666666,
+    "stone-wall": 1.0
   },
   "delivered": {
-    "military-science-pack": 1.0133333333333334
+    "military-science-pack": 0.98
   },
   "overall_verdict": "PASS"
 }


### PR DESCRIPTION
Follow-up to #378: baselines re-measured with the harness running each fixture at its declared `inserter_capacity` (tech_state now keys on the level). Four PASS at plan; **ec10 FAILs at 7.50/10 (−25%)** — blessed deliberately as an honest floor: its four inserter-item-throughput warnings are **confirmed in-game** at the L0 semantics they were computed under. The prior clean-kit PASS was measured at research-inflated hands. Amendment posted on #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA