### PR TITLE
RFC-051 K-quantization: chain copies capped at express capacity; #383 root-caused; belt-tier guard

### DIFF
--- a/crates/core/data/cell-sim-registry.json
+++ b/crates/core/data/cell-sim-registry.json
@@ -2,10 +2,10 @@
   {
     "target": "advanced-circuit",
     "rate": 1.0,
-    "geometry_hash": "583cff7b2201de46",
+    "geometry_hash": "d7f2ea7165028274",
     "verdict": "PASS",
     "produced_per_s": 1.0,
-    "scenario": "spaghettio-sim chain-ac1 v3 (Factorio 2.0.76, 8/8 working, converged, +0.33%)",
+    "scenario": "spaghettio-sim chain-ac1 v3 (Factorio 2.0.76, 8/8 working, converged, +0.33%); hash re-encoded 2026-07-23 (recipe+modules added to geometry_hash, geometry unchanged)",
     "date": "2026-07-22"
   }
 ]

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -1,11 +1,16 @@
 //! RFC-051 Phase B: the linear/fan-out chain auto-placer.
 //!
 //! Generalizes the Phase-1 hand composers: cells are engine-generated
-//! per chain recipe (K=1 — one cell per recipe sized by the chain
-//! solve's machine counts; ratio quantization is a later optimization),
-//! placed west→east in dependency order, wired with template corridors
-//! only (straight, corner, UG-hop, 2→1 merge splitter, 1→2 fan-out
-//! splitter). Fan-out past an intervening cell routes through a SOUTH
+//! per chain recipe, placed west→east in dependency order, wired with
+//! template corridors only (straight, corner, UG-hop, 2→1 merge
+//! splitter, 1→2 fan-out splitter). Chains are RATIO-QUANTIZED
+//! (`required_copies`): K identical side-by-side copies each at 1/K of
+//! the chain rate, so no corridor or feed column ever exceeds express
+//! capacity — the Phase-1 K=3 pair topology generalized as a CAPACITY
+//! mechanism (its quality claim was falsified — see `QUANTUM_RATE`).
+//! K=1 chains compose bit-identically to the pre-quantization placer
+//! (the registry hashes depend on it).
+//! Fan-out past an intervening cell routes through a SOUTH
 //! BYPASS lane below the cell band — the south side is empty except the
 //! final drain, so the only crossings are known corridor rows, each
 //! resolved by a local UG hop.
@@ -34,6 +39,52 @@ const CORRIDOR_GAP: i32 = 6;
 /// Vertical lanes reserved on the east side of each slot's feed block
 /// for bypass descents/ascents.
 const VLANES: i32 = 2;
+/// Ratio-quantization quantum: the max rate any single belt carries —
+/// produced items ride one express corridor per copy, external inputs
+/// one express feed column per copy, both capped at express capacity.
+/// This is a PHYSICAL cap, deliberately not a quality tuning knob: a
+/// 15/s "measured-exact" quantum was tried and falsified — the Phase-1
+/// K=3 pairs' exact measurement was an artifact of pre-#378 harness
+/// tech state (researched inserter bonuses), and under declared
+/// capacity small rows measure WORSE (−24% vs −8%) because the row
+/// template's long-handed input inserters concentrate their deficit
+/// (#383; the fix is RFC-049 Phase 3 inserter sizing, not geometry).
+const QUANTUM_RATE: f64 = 45.0;
+/// Copy-count bound. Beyond this the footprint cost stops being honest
+/// scaling and the chain should be decomposed differently; refuse
+/// loudly.
+const K_MAX: i32 = 12;
+
+/// Smallest K such that every produced item and every external input
+/// item runs at ≤ `QUANTUM_RATE` per copy. Chains under the cap stay
+/// K=1 and compose bit-identically to the pre-quantization placer —
+/// quantization only activates where the placer previously refused.
+pub fn required_copies(sr: &SolverResult) -> i32 {
+    let produced: FxHashSet<&str> = sr
+        .machines
+        .iter()
+        .flat_map(|m| m.outputs.iter().map(|o| o.item.as_str()))
+        .collect();
+    let mut k = 1i32;
+    for m in &sr.machines {
+        for o in &m.outputs {
+            let total = o.rate * m.count;
+            k = k.max(((total / QUANTUM_RATE) - 1e-9).ceil() as i32);
+        }
+    }
+    let mut ext: FxHashMap<&str, f64> = FxHashMap::default();
+    for m in &sr.machines {
+        for i in &m.inputs {
+            if !produced.contains(i.item.as_str()) {
+                *ext.entry(i.item.as_str()).or_default() += i.rate * m.count;
+            }
+        }
+    }
+    for total in ext.values() {
+        k = k.max(((total / QUANTUM_RATE) - 1e-9).ceil() as i32);
+    }
+    k
+}
 
 /// Why a solve is not chain-composable. Stable strings — the candidate
 /// reports these as its `accepted_reason`.
@@ -66,19 +117,14 @@ pub fn chain_eligible(sr: &SolverResult) -> Result<(), String> {
             return Err(format!("cells: {item} produced by {n} specs (need exactly 1)"));
         }
     }
-    // Corridor capacity: every produced item rides ONE express corridor
-    // (45/s). Run-matching (bundled corridors) is future work — refuse
-    // honestly past the cap.
-    for m in &sr.machines {
-        for o in &m.outputs {
-            let total = o.rate * m.count;
-            if total > 45.0 + 1e-9 {
-                return Err(format!(
-                    "cells: {} at {total:.1}/s exceeds single-corridor capacity 45/s (run matching unimplemented)",
-                    o.item
-                ));
-            }
-        }
+    // Corridor capacity: ratio quantization bounds every copy's
+    // corridors at QUANTUM_RATE, so high rates raise the copy count
+    // instead of overloading a belt. Refuse only past the copy bound.
+    let k = required_copies(sr);
+    if k > K_MAX {
+        return Err(format!(
+            "cells: chain needs {k} quantized copies (max {K_MAX} at quantum {QUANTUM_RATE}/s)"
+        ));
     }
     Ok(())
 }
@@ -92,6 +138,13 @@ struct Placed {
     /// Base x of this slot's vertical-lane strip (east of feed columns).
     vlane_base: i32,
     recipe: String,
+    /// Segment-id name: the recipe, suffixed `#<copy>` when K>1 so the
+    /// belt validators never see two disjoint runs sharing a segment.
+    /// Equals `recipe` at K=1 (bit-identity).
+    seg: String,
+    /// Which quantized chain copy this slot belongs to. Corridors only
+    /// connect producer→consumer within one copy.
+    copy: i32,
     ext_inputs: Vec<String>,
 }
 
@@ -297,12 +350,17 @@ impl Router {
     }
 }
 
-/// Compose an eligible chain solve into one layout. K=1: one cell per
-/// recipe at the chain rate. Returns the composed layout with boundary
-/// records populated (calibrated orientation: north feeds, south drain,
-/// west→east record order — #363).
+/// Compose an eligible chain solve into one layout: K quantized copies
+/// (`required_copies`) of the chain placed side by side west→east, each
+/// copy one cell per recipe at 1/K of the chain rate with its own
+/// feeds, corridors, and drain — the Phase-1 pair-topology shape.
+/// Returns the composed layout with boundary records populated
+/// (calibrated orientation: north feeds, south drains, west→east
+/// record order — #363).
 pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
     chain_eligible(sr)?;
+    let kq = required_copies(sr);
+    let scale = 1.0 / kq as f64;
 
     let produced: FxHashSet<&str> = sr
         .machines
@@ -350,59 +408,74 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
     let mut placed: Vec<Placed> = Vec::new();
     let mut cursor = 0i32;
 
-    for m in &specs {
-        let out_item = m
-            .outputs
-            .first()
-            .ok_or_else(|| format!("cells: {} has no output", m.recipe))?
-            .item
-            .clone();
-        // outputs[].rate is PER-MACHINE; the cell serves the whole spec.
-        let rate = m.outputs[0].rate * m.count;
-        let input_names: Vec<&str> = m.inputs.iter().map(|i| i.item.as_str()).collect();
-        let (_csr, cl) = generate_cell_layout(&out_item, rate, &input_names);
-        let cell = extract_cell(&cl);
-        let ext_inputs: Vec<String> = m
-            .inputs
-            .iter()
-            .filter(|i| !produced.contains(i.item.as_str()))
-            .map(|i| i.item.clone())
-            .collect();
-        let n_feed_ports = cell
-            .ports
-            .iter()
-            .filter(|q| q.inbound && ext_inputs.contains(&q.item))
-            .count() as i32;
+    // Copies are identical — generate each spec's cell once (the cell
+    // generator runs the full engine; K=12 must not run it 12×).
+    let mut cell_cache: Vec<Cell> = Vec::with_capacity(n);
+    for copy in 0..kq {
+        for (si, m) in specs.iter().enumerate() {
+            let out_item = m
+                .outputs
+                .first()
+                .ok_or_else(|| format!("cells: {} has no output", m.recipe))?
+                .item
+                .clone();
+            // outputs[].rate is PER-MACHINE; the cell serves the whole
+            // spec's share of this copy.
+            let rate = m.outputs[0].rate * m.count * scale;
+            if copy == 0 {
+                let input_names: Vec<&str> = m.inputs.iter().map(|i| i.item.as_str()).collect();
+                let (_csr, cl) = generate_cell_layout(&out_item, rate, &input_names);
+                cell_cache.push(extract_cell(&cl));
+            }
+            let cell = cell_cache[si].clone();
+            let ext_inputs: Vec<String> = m
+                .inputs
+                .iter()
+                .filter(|i| !produced.contains(i.item.as_str()))
+                .map(|i| i.item.clone())
+                .collect();
+            let n_feed_ports = cell
+                .ports
+                .iter()
+                .filter(|q| q.inbound && ext_inputs.contains(&q.item))
+                .count() as i32;
 
-        let n_out_runs = cell.ports.iter().filter(|q| !q.inbound).count() as i32;
-        let n_consumers = sr
-            .machines
-            .iter()
-            .filter(|c| c.inputs.iter().any(|i| i.item == out_item))
-            .count() as i32;
-        // Gap: base + 2 per extra merge stage + 2 per extra fan-out stage.
-        let gap = CORRIDOR_GAP + 2 * (n_out_runs - 1).max(0) + 2 * (n_consumers - 1).max(0);
-        let slot_x = cursor;
-        let feed_w = FEED_PITCH * n_feed_ports + 1;
-        let vlane0 = slot_x + feed_w;
-        let strip = VLANES + lane_demand[placed.len()];
-        let x = vlane0 + strip + 1;
-        cursor = x + cell.width + gap;
+            let n_out_runs = cell.ports.iter().filter(|q| !q.inbound).count() as i32;
+            let n_consumers = sr
+                .machines
+                .iter()
+                .filter(|c| c.inputs.iter().any(|i| i.item == out_item))
+                .count() as i32;
+            // Gap: base + 2 per extra merge stage + 2 per extra fan-out stage.
+            let gap = CORRIDOR_GAP + 2 * (n_out_runs - 1).max(0) + 2 * (n_consumers - 1).max(0);
+            let slot_x = cursor;
+            let feed_w = FEED_PITCH * n_feed_ports + 1;
+            let vlane0 = slot_x + feed_w;
+            let strip = VLANES + lane_demand[si];
+            let x = vlane0 + strip + 1;
+            cursor = x + cell.width + gap;
 
-        for e in &cell.entities {
-            let mut e = e.clone();
-            e.x += x;
-            e.y += CELL_Y;
-            entities.push(e);
+            for e in &cell.entities {
+                let mut e = e.clone();
+                e.x += x;
+                e.y += CELL_Y;
+                entities.push(e);
+            }
+            placed.push(Placed {
+                cell,
+                x,
+                slot_x,
+                vlane_base: vlane0,
+                recipe: m.recipe.clone(),
+                seg: if kq > 1 {
+                    format!("{}#{}", m.recipe, copy + 1)
+                } else {
+                    m.recipe.clone()
+                },
+                copy,
+                ext_inputs,
+            });
         }
-        placed.push(Placed {
-            cell,
-            x,
-            slot_x,
-            vlane_base: vlane0,
-            recipe: m.recipe.clone(),
-            ext_inputs,
-        });
     }
 
     let band_bottom = CELL_Y
@@ -438,7 +511,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 &[(col_x, 0), (col_x, *ty), (tx - 1, *ty)],
                 item,
                 "express-transport-belt",
-                &format!("feed:{item}:{}", p.recipe),
+                &format!("feed:{item}:{}", p.seg),
             );
             router.register_col(col_x, 0, *ty);
             router.register_row(*ty, col_x, tx - 1);
@@ -455,20 +528,21 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
 
     // Bypass rows sit between the band bottom and the drain row, so the
     // sim's drain rig (which builds south of the drain head) never
-    // collides with them. Count bypass edges up front.
-    let n_bypass: i32 = placed
+    // collides with them. Count bypass edges up front — PER COPY: the
+    // copies' x-ranges are disjoint, so every copy reuses the same rows.
+    let n_bypass: i32 = specs
         .iter()
         .enumerate()
-        .map(|(pi, _)| {
-            let out_item = &specs[pi].outputs[0].item;
-            placed
+        .map(|(pi, m)| {
+            let out_item = &m.outputs[0].item;
+            specs
                 .iter()
                 .enumerate()
                 .filter(|(ci, c)| {
                     *ci != pi
                         && *ci != pi + 1
-                        && specs[*ci].inputs.iter().any(|i| i.item == *out_item)
-                        && c.cell.ports.iter().any(|q| q.inbound && q.item == *out_item)
+                        && c.inputs.iter().any(|i| i.item == *out_item)
+                        && cell_cache[*ci].ports.iter().any(|q| q.inbound && q.item == *out_item)
                 })
                 .count() as i32
         })
@@ -477,7 +551,8 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
 
     // --- Chain corridors: producer out → merge (if 2 runs) → fan-out
     // split (if 2 consumers) → per-consumer routing via the Router.
-    let mut bypass_idx = 0i32;
+    // Bypass rows allocate per copy (disjoint x-ranges share rows).
+    let mut bypass_idx: FxHashMap<i32, i32> = FxHashMap::default();
     // Per-slot vertical-lane allocation: each bypass descent/ascent
     // claims a fresh lane in its slot's strip (two edges sharing a lane
     // was the mil5-ore overlap class).
@@ -489,13 +564,16 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         x
     };
     for (pi, p) in placed.iter().enumerate() {
-        let out_item = specs[pi].outputs[0].item.clone();
+        let out_item = specs[pi % n].outputs[0].item.clone();
+        // Consumers within THIS copy only — the same item flows in every
+        // copy, and cross-copy corridors would defeat the quantization.
         let consumers: Vec<usize> = placed
             .iter()
             .enumerate()
             .filter(|(ci, c)| {
                 *ci != pi
-                    && specs[*ci].inputs.iter().any(|i| i.item == out_item)
+                    && c.copy == p.copy
+                    && specs[*ci % n].inputs.iter().any(|i| i.item == out_item)
                     && c.cell.ports.iter().any(|q| q.inbound && q.item == out_item)
             })
             .map(|(ci, _)| ci)
@@ -506,7 +584,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
             let o1 = outs.first().ok_or_else(|| format!("cells: {} has no out port", p.recipe))?;
             let (ox, oy) = port_abs(o1, p.x);
             let drain_x = ox + 2;
-            let seg = format!("out:{}", p.recipe);
+            let seg = format!("out:{}", p.seg);
             router.hrow(&mut entities, oy, ox + 1, drain_x - 1, &out_item,
                 "transport-belt", "underground-belt", &seg);
             entities.push(PlacedEntity {
@@ -537,12 +615,12 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         let (acc_x0, acc_y) = port_abs(outs_sorted[0], p.x);
         let base_sx = p.x + p.cell.width + 2;
         router.hrow(&mut entities, acc_y, acc_x0 + 1, base_sx - 1, &out_item,
-            "express-transport-belt", "express-underground-belt", &format!("cc:a:{}", p.recipe));
+            "express-transport-belt", "express-underground-belt", &format!("cc:a:{}", p.seg));
         let mut run_x = base_sx;
         for (k, o) in outs_sorted.iter().enumerate().skip(1) {
             let (ox, oy) = port_abs(o, p.x);
             assert!(oy > acc_y + 1, "cells: merge assumes below-approach ({oy} vs {acc_y})");
-            let seg = format!("cc:b{k}:{}", p.recipe);
+            let seg = format!("cc:b{k}:{}", p.seg);
             router.hrow(&mut entities, oy, ox + 1, run_x - 2, &out_item,
                 "express-transport-belt", "express-underground-belt", &seg);
             router.corner_north(&mut entities, run_x - 1, oy, &out_item, "express-transport-belt", &seg);
@@ -553,12 +631,12 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 name: "express-splitter".into(), x: run_x, y: acc_y,
                 direction: EntityDirection::East,
                 carries: Some(out_item.clone()),
-                segment_id: Some(format!("cc:m{k}:{}", p.recipe)), ..Default::default()
+                segment_id: Some(format!("cc:m{k}:{}", p.seg)), ..Default::default()
             });
             run_x += 2;
             if k < outs_sorted.len() - 1 {
                 // Bridge to the next merge stage's input tile.
-                router.corner_east(&mut entities, run_x - 1, acc_y, &out_item, "fast-transport-belt", &format!("cc:a:{}", p.recipe));
+                router.corner_east(&mut entities, run_x - 1, acc_y, &out_item, "fast-transport-belt", &format!("cc:a:{}", p.seg));
             }
         }
         let run_y = acc_y;
@@ -578,11 +656,11 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 name: "express-splitter".into(), x: fx, y: run_y,
                 direction: EntityDirection::East,
                 carries: Some(out_item.clone()),
-                segment_id: Some(format!("fan{b}:{}", p.recipe)), ..Default::default()
+                segment_id: Some(format!("fan{b}:{}", p.seg)), ..Default::default()
             });
             branch_origins.push((fx + 1, run_y + 1));
             if b < n_branches - 1 {
-                router.corner_east(&mut entities, fx + 1, run_y, &out_item, "fast-transport-belt", &format!("fan:{}", p.recipe));
+                router.corner_east(&mut entities, fx + 1, run_y, &out_item, "fast-transport-belt", &format!("fan:{}", p.seg));
             }
             fx += 2;
         }
@@ -601,7 +679,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 .expect("consumer port checked in eligibility");
             let (tx, ty) = port_abs(port, c.x);
             let (bx, by) = branch_origins[bi];
-            let seg = format!("corr:{}:{}", p.recipe, c.recipe);
+            let seg = format!("corr:{}:{}", p.seg, c.seg);
             if *ci == pi + 1 {
                 if by == ty {
                     router.hrow(&mut entities, ty, bx, tx - 1, &out_item,
@@ -624,8 +702,9 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 // South bypass below the cell band.
                 let lane_down = alloc_lane(&mut lane_next, pi + 1, placed[pi + 1].vlane_base);
                 let lane_up = alloc_lane(&mut lane_next, *ci, c.vlane_base);
-                let by_y = band_bottom + 1 + bypass_idx;
-                bypass_idx += 1;
+                let row = bypass_idx.entry(p.copy).or_insert(0);
+                let by_y = band_bottom + 1 + *row;
+                *row += 1;
                 router.hrow(&mut entities, by, bx, lane_down - 1, &out_item,
                     "express-transport-belt", "express-underground-belt", &seg);
                 router.vcol(&mut entities, lane_down, by, by_y - 1, &out_item,

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -700,6 +700,10 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 }
             } else {
                 // South bypass below the cell band.
+                // In-copy by construction: the last slot of a copy is
+                // always the sink (dependency order), which has no
+                // consumers and never reaches this branch.
+                debug_assert_eq!(placed[pi + 1].copy, p.copy, "bypass descent lane must stay in-copy");
                 let lane_down = alloc_lane(&mut lane_next, pi + 1, placed[pi + 1].vlane_base);
                 let lane_up = alloc_lane(&mut lane_next, *ci, c.vlane_base);
                 let row = bypass_idx.entry(p.copy).or_insert(0);

--- a/crates/core/src/bus/cells/registry.rs
+++ b/crates/core/src/bus/cells/registry.rs
@@ -42,7 +42,11 @@ fn registry() -> &'static [RegistryEntry] {
 
 /// Stable FNV-1a-64 over the sorted entity list. Deliberately NOT the
 /// std hasher (its output is not guaranteed stable across toolchains,
-/// and the registry is checked-in data).
+/// and the registry is checked-in data). Covers every field that
+/// changes measured behavior: name, position, direction, io role,
+/// carries, RECIPE, and module contents (#384 review finding 2 — a
+/// recipe reassignment or module change at the same tile must miss the
+/// registry, not keep a stale SIM-VERIFIED claim).
 pub fn geometry_hash(l: &LayoutResult) -> u64 {
     const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
     const PRIME: u64 = 0x0000_0100_0000_01b3;
@@ -50,14 +54,25 @@ pub fn geometry_hash(l: &LayoutResult) -> u64 {
         .entities
         .iter()
         .map(|e| {
+            let modules: String = {
+                let mut ms: Vec<String> = e
+                    .items
+                    .iter()
+                    .map(|m| format!("{}x{}", m.item, m.count))
+                    .collect();
+                ms.sort_unstable();
+                ms.join(",")
+            };
             format!(
-                "{}|{}|{}|{}|{}|{}",
+                "{}|{}|{}|{}|{}|{}|{}|{}",
                 e.name,
                 e.x,
                 e.y,
                 e.direction as u8,
                 e.io_type.as_deref().unwrap_or(""),
-                e.carries.as_deref().unwrap_or("")
+                e.carries.as_deref().unwrap_or(""),
+                e.recipe.as_deref().unwrap_or(""),
+                modules
             )
         })
         .collect();

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -157,6 +157,30 @@ impl DecompositionCandidate for CellComposedCandidate {
             }
         }
         let mut l = crate::bus::cells::chain::compose_chain(solver_result)?;
+        // Self-validate before competing: `score_layout.accepted` never
+        // runs the full validator, so an error-laden composition that
+        // "wins" on a bus refusal would reach real callers as a
+        // silently broken Ok (#387 review; mil5-ore's Router-overlap
+        // class). Composition's contract is pre-verified cells +
+        // template corridors — errors refuse, surfacing the bus
+        // refusal instead. Warnings pass (the adjudicated categories).
+        let issues =
+            crate::validate::validate(&l, Some(solver_result), crate::validate::LayoutStyle::Bus)
+                .map_err(|e| {
+                    format!(
+                        "cell composition failed validation: {}",
+                        e.to_string().lines().next().unwrap_or("")
+                    )
+                })?;
+        let n_err = issues
+            .iter()
+            .filter(|i| i.severity == crate::validate::Severity::Error)
+            .count();
+        if n_err > 0 {
+            return Err(format!(
+                "cell composition carries {n_err} validation errors (refusing a broken layout)"
+            ));
+        }
         // Tier-1 verification annotation (RFC-051 registry): sim-verified
         // geometries carry their measurement; unverified ones say so.
         if let Some(t) = solver_result.external_outputs.first() {

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -144,6 +144,18 @@ impl DecompositionCandidate for CellComposedCandidate {
         if opts.cell_composition != crate::bus::cells::CellComposition::Candidate {
             return Err("cell composition is Off".to_string());
         }
+        // Belt tier is a USER constraint, never a strategy knob: the
+        // composed corridors are express-only (quantization caps them
+        // at express capacity), so a lower tier cap refuses instead of
+        // silently exceeding it. Tier-parameterized corridors (quantum
+        // = allowed tier's capacity) are a followup.
+        if let Some(t) = opts.max_belt_tier.as_deref() {
+            if t != "express-transport-belt" {
+                return Err(format!(
+                    "cell composition uses express corridors, over the max belt tier {t}"
+                ));
+            }
+        }
         let mut l = crate::bus::cells::chain::compose_chain(solver_result)?;
         // Tier-1 verification annotation (RFC-051 registry): sim-verified
         // geometries carry their measurement; unverified ones say so.
@@ -755,6 +767,10 @@ pub fn select_best_decomposition(
     // eligibility-gated, and catch_unwind — the composer's internal
     // asserts must degrade to the bus candidates, never abort the solve.
     let try_cells = opts.cell_composition == crate::bus::cells::CellComposition::Candidate
+        && opts
+            .max_belt_tier
+            .as_deref()
+            .is_none_or(|t| t == "express-transport-belt")
         && crate::bus::cells::chain::chain_eligible(solver_result).is_ok();
     let cells_run = if try_cells {
         run_candidate_catch_unwind("cell-composed", solver_result, || {

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -417,6 +417,9 @@ fn probe_registry_hashes() {
 /// fix when it fires: re-run the sim on the new geometry, then update
 /// the hash + measurement in cell-sim-registry.json.
 #[test]
+// The registry currently carries one entry; the loop shape stays for
+// the ec15/ec30 entries that re-register after #381 (see below).
+#[allow(clippy::single_element_loop)]
 fn cell_registry_hashes_current() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::bus::cells::registry::{geometry_hash, lookup};

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -482,6 +482,51 @@ fn cell_quantization_copy_counts() {
     assert!(err.contains("quantized copies"), "K_MAX refusal, got: {err}");
 }
 
+/// PERMANENT GATE (belt-tier constraint): composed corridors are
+/// express-only, and belt tier is a USER constraint — under any lower
+/// max_belt_tier the candidate must be INERT: whatever the bus does
+/// (succeed, as it happens to here, or refuse), the Candidate flag
+/// changes nothing, and no express entity ever appears. (Latent from
+/// the flip until K-quantization surfaced it: an eligible chain whose
+/// bus path fails under a sub-express cap would have won with express
+/// corridors.)
+#[test]
+fn cell_candidate_respects_belt_tier_cap() {
+    use spaghettio_core::bus::cells::registry::geometry_hash;
+    use spaghettio_core::bus::cells::CellComposition;
+    let inputs: FxHashSet<String> =
+        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "electronic-circuit", 15.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    // EC@15 is chain-eligible, so only the tier guard keeps the
+    // candidate out under a red cap.
+    let build = |cc: CellComposition| {
+        layout::build_bus_layout(&sr, layout::LayoutOptions {
+            max_belt_tier: Some("fast-transport-belt".into()),
+            cell_composition: cc,
+            ..Default::default()
+        })
+    };
+    match (build(CellComposition::Candidate), build(CellComposition::Off)) {
+        (Ok(on), Ok(off)) => {
+            assert_eq!(geometry_hash(&on), geometry_hash(&off),
+                "sub-express cap: Candidate must be inert (bit-identical to Off)");
+            assert!(!on.entities.iter().any(|e| e.name.starts_with("express")),
+                "sub-express cap: no express entity may appear");
+        }
+        (on, off) => assert_eq!(on.is_err(), off.is_err(),
+            "sub-express cap: Candidate must not flip a refusal"),
+    }
+    // Express cap (explicit) still composes the #336 refusal.
+    let opts = layout::LayoutOptions {
+        max_belt_tier: Some("express-transport-belt".into()),
+        ..Default::default()
+    };
+    layout::build_bus_layout(&sr, opts).expect("express-capped EC@15 must compose");
+}
+
 #[test]
 #[ignore = "debug probe"]
 fn probe_mil5_errors() {

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -530,6 +530,27 @@ fn cell_candidate_respects_belt_tier_cap() {
     layout::build_bus_layout(&sr, opts).expect("express-capped EC@15 must compose");
 }
 
+/// PERMANENT GATE (#387 review finding): a composed candidate that
+/// carries validation ERRORS must refuse — never win a bus refusal as
+/// a silently broken Ok (`score_layout.accepted` doesn't run the full
+/// validator). mil5-ore is the live specimen: bus refuses on lane
+/// capacity, composition carries the Router-overlap class, so the
+/// whole build must Err until one of them is fixed. If this gate fails
+/// with an Ok layout, either the overlaps got fixed (move mil5-ore to
+/// the positive gates — a capability win) or the self-validation
+/// regressed (a bug).
+#[test]
+fn cell_candidate_refuses_error_laden_composition() {
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore", "stone", "coal"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "military-science-pack", 5.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let r = layout::build_bus_layout(&sr, layout::LayoutOptions::default());
+    assert!(r.is_err(), "mil5-ore must refuse (bus lane-capacity + composed overlaps), not return a broken layout");
+}
+
 #[test]
 #[ignore = "debug probe"]
 fn probe_mil5_errors() {

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -20,10 +20,13 @@ use spaghettio_core::solver;
 /// PERMANENT GATE (RFC-048 Phase 1; Phase-A parity pin): EC@15/s — the
 /// config the bus engine refuses (#336) — composes from
 /// engine-generated cells at 0 validation errors. The 6 carried
-/// warnings are validator-attribution conservatism DISPROVEN by
-/// measurement (sim: 15/15 machines working, produced exactly 15.0/s —
-/// see the RFC decision log 2026-07-22). Dims/entity count pinned to
-/// the sim-verified artifact (110×22, 461 entities).
+/// warnings measured harmless under the PRE-#378 harness (15/15
+/// working, 15.0/s exact) — but that run realized researched inserter
+/// bonuses; under tech-state parity (declared capacity 0) the same
+/// warnings are REAL long-handed-inserter shortfalls (#383). The
+/// warnings stay tolerated at the validator level; the fix is RFC-049
+/// Phase 3 inserter sizing (#381), after which they should vanish.
+/// Dims/entity count pinned to the sim artifact (110×22, 461 entities).
 #[test]
 fn cell_composed_ec15_zero_errors() {
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
@@ -270,6 +273,7 @@ fn export_chain_fixtures_for_sim() {
     for (label, item, rate, inputs) in [
         ("chain-ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
         ("chain-ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+        ("chain-ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..]),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
@@ -394,6 +398,7 @@ fn probe_registry_hashes() {
     for (label, item, rate, inputs) in [
         ("chain-ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
         ("chain-ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+        ("chain-ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..]),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
@@ -415,9 +420,13 @@ fn probe_registry_hashes() {
 fn cell_registry_hashes_current() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::bus::cells::registry::{geometry_hash, lookup};
-    // chain-ec15 is deliberately absent: its K=1 geometry measured -8%
-    // in the sim (#381) — the registry only carries measured-at-plan
-    // geometries, and the gate only pins what the registry claims.
+    // chain-ec15 is deliberately absent: under tech-state parity
+    // (declared inserter_capacity 0, #378) its long-handed input
+    // inserters genuinely under-deliver iron (#383, -8%) — the registry
+    // only carries measured-at-plan geometries. Re-measure and register
+    // once RFC-049 Phase 3 inserter sizing (#381) lands; chain-ac1's
+    // tiny rates never hit the bound, so its entry stands (re-verified
+    // PASS under the parity harness).
     for (item, rate, inputs) in [
         ("advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
     ] {
@@ -431,6 +440,46 @@ fn cell_registry_hashes_current() {
         assert!(lookup(item, rate, h).is_some(),
             "{item}@{rate}: composed geometry (hash {h:016x}) no longer matches the sim-verified registry entry — re-verify in the sim and update cell-sim-registry.json");
     }
+}
+
+/// PERMANENT GATE (RFC-051 K-quantization): the copy count is the
+/// smallest K putting every produced item AND every external input at
+/// ≤45/s (express capacity) per copy — a physical belt cap, not a
+/// quality knob (a 15/s "measured-exact" quantum was falsified: the
+/// Phase-1 exact measurement was pre-#378 harness tech state, and
+/// under declared capacity small rows measure WORSE — #383). Pins the
+/// ladder's K values: chains under the cap stay K=1 bit-identical
+/// (the registered chain-ac1 hash depends on it); ec30/ec60 — the
+/// pre-quantization corridor-cap refusals — now compose; K_MAX=12
+/// refuses loudly.
+#[test]
+fn cell_quantization_copy_counts() {
+    use spaghettio_core::bus::cells::chain::{chain_eligible, required_copies};
+    for (label, item, rate, inputs, want_k) in [
+        ("ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..], 1),
+        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..], 1),
+        ("ec5", "electronic-circuit", 5.0, &["iron-plate", "copper-plate"][..], 1),
+        // pre-quantization these two REFUSED on the 45/s corridor cap
+        ("ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..], 2),
+        ("ec60", "electronic-circuit", 60.0, &["iron-plate", "copper-plate"][..], 4),
+    ] {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item, rate, &inputs_set, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        assert_eq!(required_copies(&sr), want_k, "{label}: copy count");
+        assert!(chain_eligible(&sr).is_ok(), "{label}: must be chain-eligible");
+    }
+    // Past K_MAX=12 the chain refuses loudly (ec600 → cable 1800/s → K=40).
+    let inputs_set: FxHashSet<String> =
+        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "electronic-circuit", 600.0, &inputs_set, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let err = chain_eligible(&sr).unwrap_err();
+    assert!(err.contains("quantized copies"), "K_MAX refusal, got: {err}");
 }
 
 #[test]

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -223,6 +223,44 @@ follow-ups.
 
 ## Decision log
 
+- *2026-07-22 — K-quantization + #383 ROOT CAUSE (the premise
+  falsified mid-implementation). Ratio quantization landed in
+  `compose_chain`: K identical side-by-side copies at 1/K rate
+  (`required_copies`), copies generated once and stamped K times,
+  producer→consumer matching restricted within a copy, per-copy segment
+  suffixes, bypass rows reused across copies (disjoint x), K_MAX=12.
+  K=1 is bit-identical to the pre-quantization placer — proven by the
+  registered chain-ac1 hash surviving unchanged. **The plan's premise
+  died on first sim contact**: quantum=15/s ("the measured-exact
+  Phase-1 rate") produced ec15 K=3 at −23.7% — WORSE than K=1's −8%.
+  Belt-dump forensics + tile diff against the hand-composed pair showed
+  identical cell geometry, iron arriving on both lanes, and the east
+  machine's single long-handed iron inserter delivering ~1.2/s against
+  a 2.5/s need — exactly the validator's inserter-item-throughput
+  warning. The hand-composed K=3's "15.0/s EXACT" and the K=1 fixture's
+  earlier PASS both predate #378 (tech-state parity: the sim now forces
+  bonuses to the layout's declared inserter_capacity=0); the PASS-era
+  report lacks the realized-bonus fields entirely. So: the warnings
+  were RIGHT under declared tech, the "sim-adjudicated conservatism"
+  verdict was a researched-bonus artifact, the package-2 log's
+  splitter-saturation-loss speculation is retired (fast and express
+  measured identical deltas), and small rows CONCENTRATE the
+  per-machine inserter deficit rather than fixing it. Quantum reshaped
+  to 45/s = express capacity — a physical cap, not a quality knob:
+  quantization now activates only where the placer previously refused,
+  so every K=1 geometry (ec15, ec15-ore, ac1, ac2, mil5-plates) is
+  bit-identical to the flip package. Verification: ec30 K=2 (each copy
+  ≡ the ec15 K=1 shape) predicted ≈−8% and measured **−8.0% exactly**
+  (WARN, 28/30 working) — the deficit is per-row, K-invariant, and
+  belongs to RFC-049 Phase 3 (#381, in flight), after which cells
+  regenerate with honest inserter counts, every registry hash trips,
+  and ec15/ec30 get re-measured for registration. Scoreboard: ec30
+  REFUSED→140×21 0 err/12 warn; ec60 REFUSED→280×21 0/24 (bus
+  validation-fails there); mil5-ore goes K=2 (stone feed 50/s exceeds
+  the per-copy feed cap) and its Router-class overlaps persist (8, was
+  5 at K=1) — still the named next target. No registry additions: the
+  registry carries measured-at-plan only.*
+
 - *2026-07-22 — Coverage expansion (package 2, follows the flip). Caps
   lifted: n-run MERGE CASCADES (2→1 splitter chains, below-approach
   corner per stage) and FAN-OUT TREES (1→2 splitter chains) replace the

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -270,7 +270,23 @@ follow-ups.
   tier-matched belt entities) are the followup if tier-capped
   composition is ever wanted. Stress goldens under the lifted
   eligibility: 9 ran, 0 drift (bus wins all blessed fixtures on
-  density; the canonical `stress_` check-mode run).*
+  density; the canonical `stress_` check-mode run). **Adversarial
+  review folds** (bot silent on both PRs — known-broken class; local
+  reviews ran instead): #384's review (no blockers) → registry hash
+  extended to cover machine recipe + module contents (chain-ac1 entry
+  re-encoded, geometry unchanged — proven by recomputing the OLD
+  algorithm on the new geometry). #387's review (no blockers; all five
+  probed claims verified by measurement, incl. dual-worktree
+  bit-identity diffs on ec5/gear15) → the candidate now SELF-VALIDATES
+  and refuses on Severity::Error: `score_layout.accepted` never runs
+  the full validator, so an error-laden composed "win" on a bus
+  refusal previously reached callers as a silently broken Ok
+  (mil5-ore, pre-existing on main, blast radius widened by the
+  eligibility lift). Gate `cell_candidate_refuses_error_laden_
+  composition` pins mil5-ore as Err-until-fixed; the reviewer's
+  in-copy bypass invariant is now a debug_assert. Followup candidates
+  noted, not taken here: structural additivity enforcement (ties
+  currently resolve toward cells), tier-parameterized corridors.*
 
 - *2026-07-22 — Coverage expansion (package 2, follows the flip). Caps
   lifted: n-run MERGE CASCADES (2→1 splitter chains, below-approach

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -259,7 +259,18 @@ follow-ups.
   validation-fails there); mil5-ore goes K=2 (stone feed 50/s exceeds
   the per-copy feed cap) and its Router-class overlaps persist (8, was
   5 at K=1) — still the named next target. No registry additions: the
-  registry carries measured-at-plan only.*
+  registry carries measured-at-plan only. **Belt-tier guard**: the
+  eligibility lift exposed a latent flip-era hole — composed corridors
+  are express-only, and an eligible chain whose bus path fails under a
+  sub-express `max_belt_tier` would have won with express corridors,
+  violating the tier-is-a-user-constraint rule. The candidate now
+  refuses under any sub-express cap (gate:
+  `cell_candidate_respects_belt_tier_cap` proves flag-inertness there);
+  tier-parameterized corridors (quantum = allowed tier's capacity,
+  tier-matched belt entities) are the followup if tier-capped
+  composition is ever wanted. Stress goldens under the lifted
+  eligibility: 9 ran, 0 drift (bus wins all blessed fixtures on
+  density; the canonical `stress_` check-mode run).*
 
 - *2026-07-22 — Coverage expansion (package 2, follows the flip). Caps
   lifted: n-run MERGE CASCADES (2→1 splitter chains, below-approach

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -62,6 +62,6 @@ backfill the status next time the doc is touched.
 | RFC-048 | 2026-07-22 | [`rfc-048-cell-composition.md`](rfc-048-cell-composition.md) | Phase 1 complete (PR #365) — GO for Phase-2 integration RFC |
 | RFC-049 | 2026-07-22 | [`rfc-049-inserter-capacity-research.md`](rfc-049-inserter-capacity-research.md) | Complete (in-game anchor open; input-side data gap #343) |
 | RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Complete (fluid feed CALIBRATED via #364 — first fluid factory PASS; fluid-pack sweep + #345 re-measure open) |
-| RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Delivered — gate passed (AC-from-plates 0/0 + sim at plan); flag Off pending flip decision |
+| RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Complete — default Candidate; sim registry; K-quantization (corridor-cap); EC-row re-measure waits on #381 |
 
 Next number: **RFC-052**.

--- a/docs/status.md
+++ b/docs/status.md
@@ -198,22 +198,30 @@ bit-identical to pre-RFC (zero golden re-blesses). Mechanics:
 ore-routing warnings persist on legendary-express). Full trail:
 [`rfc-046-belt-stacking.md`](rfc-046-belt-stacking.md) decision log.
 
-**`rfc-051-cell-composition-integration.md` close-out (2026-07-22)**:
-cell composition became a **production path** — a flag-gated
-`CellComposedCandidate` (default Off, bus bit-identical) competing
-unbiased in the decomposition search for solid tree-with-fan-out
-chains. The chain auto-placer generalizes the Phase-1 hand composers
-(engine-generated K=1 cells, two-registry crossing Router, fan-out
-splitter + south bypass). Gate passed: **AC-from-plates composed at
-0 errors / 0 warnings and ran at plan in headless Factorio (1.00/s,
-8/8 working)**; EC@15-from-plates — the
-[#336](https://github.com/storkme/spaghettio/issues/336) refusal —
-resolves under the flag at 0 errors (permanent gate pins both
-directions) and measured 15.0/s exactly. Differential scoreboard:
-composition wins where the bus refuses, bus wins on area where both
-succeed (1.5–3.1×) — the unbiased scorer therefore only ever picks
-composition on refusals. Flag flip deferred (browser eyeball, wasm
-plumbing, sim-verified registry). Full trail:
+**`rfc-051-cell-composition-integration.md` close-out (2026-07-22,
+updated 2026-07-23)**: cell composition is a **production path ON BY
+DEFAULT** — `CellComposedCandidate` (default Candidate since the flip;
+`cc=off` escape hatch) competes unbiased in the decomposition search
+for solid tree-with-fan-out chains; strictly additive (bus wins on
+area where both succeed, composition surfaces only on refusals; suite
++ goldens unchanged under the flipped default). The chain auto-placer:
+engine-generated cells, two-registry crossing Router, merge cascades,
+fan-out trees, south bypass, and **ratio quantization** (K side-by-side
+copies at 1/K rate so no corridor/feed exceeds express 45/s; K=1
+bit-identical, proven by the registered geometry hash). Composed
+coverage at the validator level: EC@15 (the
+[#336](https://github.com/storkme/spaghettio/issues/336) refusal),
+EC@15-from-ore (furnace cells), EC@30 and EC@60 (pre-quantization
+refusals; bus validation-fails ec60). Measured-at-plan claims live in
+the sim-verified registry (geometry-hashed, checked-in): currently
+AC-from-plates (1.00/s, 8/8 working). EC-row geometries measure −8%
+under tech-state parity — the validator's inserter-item-throughput
+warnings turned out RIGHT under declared capacity (the Phase-1 "15.0/s
+exact" was a pre-#378 researched-bonus artifact;
+[#383](https://github.com/storkme/spaghettio/issues/383) has the
+forensics) — re-measure after RFC-049 Phase 3 inserter sizing
+([#381](https://github.com/storkme/spaghettio/issues/381)). Full
+trail:
 [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md).
 
 **`rfc-048-cell-composition.md` Phase-1 close-out (2026-07-22, PR #365)**:


### PR DESCRIPTION
> Supersedes #386 (auto-closed when its base branch was deleted after #384 merged).

## Intent

Pick up the "Phase-1 K=3 topology" follow-up: ratio quantization in the chain auto-placer. **The unit's premise was falsified mid-flight and the design was reshaped on the evidence** — this PR delivers quantization as a *corridor-capacity* mechanism, the #383 root cause with a confirmed prediction, and a belt-tier guard closing a latent flip-era hole.

## What's here

- **Ratio quantization** (`required_copies` in `cells/chain.rs`): a chain composes as K identical side-by-side copies at 1/K rate so no corridor or feed column exceeds express 45/s. Copies generate once and stamp K times; producer→consumer matching is copy-local; per-copy segment suffixes; bypass rows shared across copies (disjoint x); K_MAX=12. **K=1 is bit-identical** to the pre-quantization placer — the registered chain-ac1 geometry hash survives unchanged (gate-enforced).
- **Coverage**: ec30 (K=2, 140×21, 0 err/12 warn) and ec60 (K=4, 280×21, 0/24) flip from corridor-cap refusals to composition; the bus validation-fails ec60 outright, so that's a new capability rung. ec15/ec15-ore/ac1/ac2/mil5-plates are bit-identical to the flip package. mil5-ore goes K=2 (stone feed 50/s > cap) keeping its known Router overlap class (8, was 5) — still the named next target.
- **#383 root cause** (posted to the issue): the deficit is the row template's long-handed input inserters under declared `inserter_capacity=0` — tech-state parity (#378) landed between the PASS-era runs and every FAIL; the validator's `inserter-item-throughput` warnings were right all along. Confirming experiment: ec30 K=2 (each copy ≡ the ec15 K=1 shape) predicted ≈−8%, measured **−8.0% exactly** (WARN, 28/30 working). The Phase-1 "15.0/s exact" was a researched-bonus artifact; a quantum=15 build measured −23.7% (small rows concentrate the deficit) and was reshaped to 45. Fix vehicle: #381 (RFC-049 Phase 3); every registry hash trips by design when it lands, then EC rows re-measure.
- **Belt-tier guard**: composed corridors are express-only; under any sub-express `max_belt_tier` the candidate is now inert (refuses with a named reason at both `try_cells` and `produce`). Latent since the flip; the eligibility lift here would have widened it.

## Models / contracts touched

`chain_eligible`'s refusal contract changes: the ">45/s exceeds single-corridor capacity" refusal is replaced by a K_MAX copy-bound refusal ("needs N quantized copies (max 12…)"). `compose_chain` output for over-45/s chains is new geometry (K≥2 copies, K boundary records per side). No public API/WASM signature changes; `LayoutResult`/manifest shapes unchanged.

## Verification

- Suite **893/0/50** (single clean run; +2 gates: `cell_quantization_copy_counts`, `cell_candidate_respects_belt_tier_cap`).
- Cell gates 6/6; `cell_registry_hashes_current` proves ac1 hash unchanged (K=1 bit-identity).
- Stress goldens: canonical check-mode run, **9 ran, 0 drift** under the lifted eligibility.
- Sim (headless Factorio, parity harness): chain-ec30 K=2 measured −8.0% WARN as predicted; forensics (belt dump + tile diff vs the hand-composed pair) in the RFC decision log and #383.
- clippy clean on touched files; WASM-target check passes.

## Deviations

- The directive's premise ("reproduce the measured-exact K=3 pair topology as the #383 fix") is falsified by measurement and documented as such; quantum=15 was implemented, measured worse (−23.7%), and reshaped to 45 the same session. Decision log carries the full narrative.
- No registry additions this PR (measured-at-plan only; EC rows wait on #381).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55