### PR TITLE
RFC-051: pin the additive contract — tie-break to native, bus-wins regression gate

### DIFF
--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -946,7 +946,13 @@ pub fn select_best_decomposition(
         (cells_run.outcome, cells_run.events, "cell-composed"),
     ];
 
-    // Find best accepted candidate (highest score).
+    // Find best accepted candidate (highest score). The candidates
+    // array is a PREFERENCE ranking (native first, cell-composed
+    // last), so exact score ties resolve to the EARLIEST index — a
+    // bare `max_by` keeps the last maximum, which would hand a tie to
+    // cell-composed and silently break the additive contract (#384
+    // review finding 4: additivity rested on an empirical score
+    // margin, with the tie-break pointing the wrong way).
     let best_accepted_idx = candidates
         .iter()
         .enumerate()
@@ -959,7 +965,11 @@ pub fn select_best_decomposition(
                 }
             })
         })
-        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .max_by(|(ia, a), (ib, b)| {
+            a.partial_cmp(b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(ib.cmp(ia))
+        })
         .map(|(i, _)| i);
 
     // The scoped Pooled merge-tap decision (error-count metric, ties → Native)

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -530,6 +530,36 @@ fn cell_candidate_respects_belt_tier_cap() {
     layout::build_bus_layout(&sr, opts).expect("express-capped EC@15 must compose");
 }
 
+/// PERMANENT GATE (#384 review finding 4): the additive contract —
+/// where the BUS succeeds, the bus wins; composition surfaces only on
+/// refusals. This was empirically true (density margin 2–5×) but not
+/// pinned, and the selection tie-break used to point at cell-composed.
+/// Asserts native wins every chain-eligible fixture where both paths
+/// succeed, via the observable marker: composed winners carry the
+/// "cell-composed:" registry annotation in warnings; bus winners never
+/// do.
+#[test]
+fn cell_candidate_never_displaces_a_succeeding_bus() {
+    for (label, item, rate, inputs) in [
+        ("gear15", "iron-gear-wheel", 15.0, &["iron-plate"][..]),
+        ("ec5", "electronic-circuit", 5.0, &["iron-plate", "copper-plate"][..]),
+        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+        ("ac2", "advanced-circuit", 2.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+    ] {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item, rate, &inputs_set, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
+            .unwrap_or_else(|e| panic!("{label}: bus-succeeding fixture must lay out: {e}"));
+        assert!(
+            !l.warnings.iter().any(|w| w.starts_with("cell-composed:")),
+            "{label}: composition displaced a succeeding bus layout"
+        );
+    }
+}
+
 /// PERMANENT GATE (#387 review finding): a composed candidate that
 /// carries validation ERRORS must refuse — never win a bus refusal as
 /// a silently broken Ok (`score_layout.accepted` doesn't run the full


### PR DESCRIPTION
## Intent

Close out the last finding from the local adversarial review of #384 (finding 4, non-blocking): the "composition surfaces only on bus refusals" contract was empirically true but structurally unenforced, and the selection tie-break pointed the wrong way.

## What's here

- `best_accepted_idx` comparator: exact score ties now resolve to the EARLIEST candidate index (the array is a preference ranking, native first). Previously `max_by` kept the last maximum — an exact tie would have handed the win to cell-composed.
- Gate `cell_candidate_never_displaces_a_succeeding_bus`: native must win all four chain-eligible fixtures where both paths succeed (gear15, ec5, ac1, ac2), asserted via the observable marker (composed winners carry the `cell-composed:` registry annotation in warnings).

## Models / contracts touched

None — selection tie-break semantics only; no public API, geometry, or manifest changes. No fixture currently ties, so no layout changes anywhere (suite + goldens unaffected by construction).

## Verification

Suite 895/0/50 (single clean run, +1 gate); cell gates 8/8; clippy silent on touched files.

## Deviations

None. The remaining #384/#387 review followup candidates (tier-parameterized corridors) stay in the RFC decision log as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55