### PR TITLE
sim-harness: belt-stacking parity — sim world matches declared stacking (option A)

### DIFF
--- a/crates/sim-harness/baselines/automation-science-pack.json
+++ b/crates/sim-harness/baselines/automation-science-pack.json
@@ -7,7 +7,7 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies;inserter_capacity<=L0",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0;belt_stacking<=S1",
   "entities": 196,
   "produced": {
     "automation-science-pack": 1.0,

--- a/crates/sim-harness/baselines/ec10.json
+++ b/crates/sim-harness/baselines/ec10.json
@@ -7,16 +7,16 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies;inserter_capacity<=L0",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0;belt_stacking<=S1",
   "entities": 805,
   "produced": {
-    "copper-cable": 22.4,
-    "copper-plate": 11.275,
-    "electronic-circuit": 7.5,
-    "iron-plate": 7.5
+    "copper-cable": 15.25,
+    "copper-plate": 7.5,
+    "electronic-circuit": 5.0,
+    "iron-plate": 5.0
   },
   "delivered": {
-    "electronic-circuit": 7.6
+    "electronic-circuit": 5.0
   },
   "overall_verdict": "FAIL"
 }

--- a/crates/sim-harness/baselines/gear10.json
+++ b/crates/sim-harness/baselines/gear10.json
@@ -7,14 +7,14 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies;inserter_capacity<=L0",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0;belt_stacking<=S1",
   "entities": 428,
   "produced": {
     "iron-gear-wheel": 10.0,
     "iron-plate": 20.0
   },
   "delivered": {
-    "iron-gear-wheel": 9.8
+    "iron-gear-wheel": 10.0
   },
   "overall_verdict": "PASS"
 }

--- a/crates/sim-harness/baselines/logistic-science-pack.json
+++ b/crates/sim-harness/baselines/logistic-science-pack.json
@@ -7,16 +7,16 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies;inserter_capacity<=L0",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0;belt_stacking<=S1",
   "entities": 593,
   "produced": {
-    "copper-cable": 3.1133333333333333,
+    "copper-cable": 3.14,
     "copper-plate": 1.5633333333333332,
-    "electronic-circuit": 1.04,
-    "inserter": 1.04,
-    "iron-gear-wheel": 1.39,
-    "iron-plate": 5.193333333333333,
-    "logistic-science-pack": 1.0333333333333334,
+    "electronic-circuit": 1.0466666666666666,
+    "inserter": 1.0433333333333332,
+    "iron-gear-wheel": 1.393333333333333,
+    "iron-plate": 5.213333333333333,
+    "logistic-science-pack": 1.04,
     "transport-belt": 1.04
   },
   "delivered": {

--- a/crates/sim-harness/baselines/military-science-pack.json
+++ b/crates/sim-harness/baselines/military-science-pack.json
@@ -7,21 +7,21 @@
     "quality",
     "elevated-rails"
   ],
-  "tech_state": "research_all_technologies;inserter_capacity<=L0",
+  "tech_state": "research_all_technologies;inserter_capacity<=L0;belt_stacking<=S1",
   "entities": 919,
   "produced": {
-    "copper-plate": 0.5466666666666666,
-    "firearm-magazine": 0.5233333333333333,
-    "grenade": 0.5533333333333333,
-    "iron-plate": 6.233333333333333,
-    "military-science-pack": 0.9933333333333332,
-    "piercing-rounds-magazine": 0.5133333333333333,
-    "steel-plate": 0.2733333333333333,
-    "stone-brick": 4.986666666666666,
+    "copper-plate": 0.6,
+    "firearm-magazine": 0.61,
+    "grenade": 0.5,
+    "iron-plate": 6.266666666666667,
+    "military-science-pack": 1.0133333333333334,
+    "piercing-rounds-magazine": 0.6066666666666667,
+    "steel-plate": 0.27666666666666667,
+    "stone-brick": 5.0,
     "stone-wall": 1.0
   },
   "delivered": {
-    "military-science-pack": 0.98
+    "military-science-pack": 1.0
   },
   "overall_verdict": "PASS"
 }

--- a/crates/sim-harness/src/baseline.rs
+++ b/crates/sim-harness/src/baseline.rs
@@ -75,11 +75,12 @@ pub fn baseline_from_report(report: &serde_json::Value) -> Result<Baseline, Stri
     // baseline loudly in check_against, which is the failure mode we
     // want for stale artifacts.
     let capacity = r.get("inserter_capacity").and_then(|v| v.as_u64()).unwrap_or(0);
+    let stacking = r.get("stacking").and_then(|v| v.as_u64()).unwrap_or(1);
     Ok(Baseline {
         label,
         game_version,
         mods: HARNESS_MODS.iter().map(|s| s.to_string()).collect(),
-        tech_state: format!("{HARNESS_TECH_STATE};inserter_capacity<=L{capacity}"),
+        tech_state: format!("{HARNESS_TECH_STATE};inserter_capacity<=L{capacity};belt_stacking<=S{stacking}"),
         entities: r.get("entities").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
         produced,
         delivered,
@@ -197,8 +198,21 @@ mod tests {
         let mut at_l7 = report("gear", 10.0, 10.13, "2.0.76");
         at_l7["report"]["inserter_capacity"] = serde_json::json!(7);
         let blessed = baseline_from_report(&at_l0).unwrap();
-        assert!(blessed.tech_state.ends_with("inserter_capacity<=L0"));
+        assert!(blessed.tech_state.contains("inserter_capacity<=L0"));
         let drifts = check_against(&blessed, &at_l7, 0.02);
+        assert_eq!(drifts.len(), 1, "{drifts:?}");
+        assert!(drifts[0].contains("tech state"));
+    }
+
+    #[test]
+    fn stacking_mismatch_is_flagged_via_tech_state() {
+        let mut s1 = report("gear", 10.0, 10.13, "2.0.76");
+        s1["report"]["stacking"] = serde_json::json!(1);
+        let mut s4 = report("gear", 10.0, 10.13, "2.0.76");
+        s4["report"]["stacking"] = serde_json::json!(4);
+        let blessed = baseline_from_report(&s1).unwrap();
+        assert!(blessed.tech_state.ends_with("belt_stacking<=S1"));
+        let drifts = check_against(&blessed, &s4, 0.02);
         assert_eq!(drifts.len(), 1, "{drifts:?}");
         assert!(drifts[0].contains("tech state"));
     }

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -390,6 +390,7 @@ pub fn build_control_lua(manifest: &Manifest, bp: &str, params: &RunParams) -> S
     let _ = writeln!(out, "local LX0, LY0 = {}, {}", manifest.bbox_min[0], manifest.bbox_min[1]);
     let _ = writeln!(out, "local DIMS_X, DIMS_Y = {}, {}", manifest.dims[0], manifest.dims[1]);
     let _ = writeln!(out, "local INSERTER_CAPACITY = {}", manifest.inserter_capacity);
+    let _ = writeln!(out, "local STACKING = {}", manifest.stacking);
     {
         let items: Vec<String> = manifest.planned_rates.keys().map(|k| format!("\"{k}\"")).collect();
         let _ = writeln!(out, "local PLANNED_ITEMS = {{{}}}", items.join(", "));
@@ -451,6 +452,18 @@ script.on_init(function()
     table.insert(storage.kit_errors, "tech-state parity assignment did not take: nb="
       .. force.inserter_stack_size_bonus .. " bulk=" .. force.bulk_inserter_capacity_bonus
       .. " for level " .. INSERTER_CAPACITY)
+  end
+  -- Belt-stacking parity (option A, decided 2026-07-23 with user: the
+  -- sim's world matches the fixture's declared axes — early-game
+  -- layouts with low tech and no stacking are a real deployment
+  -- target, and research_all let stack inserters create 4-stacks on
+  -- belts declared stacking=1, inflating every stack belt-drop
+  -- measurement; #385 forensics). Same direct-assignment pattern as
+  -- inserter capacity: belt stack size = 1 + belt_stack_size_bonus.
+  force.belt_stack_size_bonus = STACKING - 1
+  if force.belt_stack_size_bonus ~= STACKING - 1 then
+    table.insert(storage.kit_errors, "belt-stacking parity assignment did not take: bonus="
+      .. force.belt_stack_size_bonus .. " for declared S=" .. STACKING)
   end
   local s = game.create_surface("lab")
   s.generate_with_lab_tiles = true
@@ -688,7 +701,8 @@ local function finalize(s, converged)
     -- Realized capacity bonuses after tech-state parity (#370) — the
     -- verification channel that the tech rollback actually took effect.
     inserter_stack_size_bonus = game.forces.player.inserter_stack_size_bonus,
-    bulk_inserter_capacity_bonus = game.forces.player.bulk_inserter_capacity_bonus}, false)
+    bulk_inserter_capacity_bonus = game.forces.player.bulk_inserter_capacity_bonus,
+    belt_stack_size_bonus = game.forces.player.belt_stack_size_bonus}, false)
   print("HARNESS_DONE")
   script.on_nth_tick(60, nil)
 end
@@ -792,6 +806,11 @@ mod tests {
         // The self-audit must reference kit_errors so a failed
         // assignment invalidates the run rather than passing silently.
         assert!(lua.contains("tech-state parity assignment did not take"));
+        // Belt-stacking parity (option A): declared S drives the force
+        // bonus; the self-audit must be able to invalidate the run.
+        assert!(lua.contains(&format!("local STACKING = {}", m.stacking)));
+        assert!(lua.contains("force.belt_stack_size_bonus = STACKING - 1"));
+        assert!(lua.contains("belt-stacking parity assignment did not take"));
     }
 
     #[test]


### PR DESCRIPTION
Completes tech-state parity across both research axes (#370 did inserter capacity; #385's forensics exposed the stacking sibling). Decision context and rationale in the commit message — the user's framing anchors it: *early-game layouts with low tech and no stacking are a real deployment target*.

- Scenario assigns `belt_stack_size_bonus = declared S − 1` with read-back self-audit → `kit_errors` → NO DATA on failure; realized bonus in every report.
- Baselines key `tech_state` on the stacking axis; S-mismatch between bless and check flags loudly. The five blessed baselines were measured with stacking research active — the full-parity re-sweep is running and re-blesses on this PR before merge.
- Measured impact already visible: solo stack belt-drop onto yellow at true S=1 is **6.50/s** vs the flat 12.0 credit (the S=4 world had shown 9.60) — corrected constants for #385 come from this world.

Verification: 44 harness tests green; live probe at S=1 shows `belt_bonus: 0`, kit-audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8hCJQi7fpKVwM2789KffA