### PR TITLE
RFC-051: mil5-ore composes — Router boundary-blindness fixed + westward bypass

### DIFF
--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -161,11 +161,49 @@ fn port_abs(p: &Port, cell_x: i32) -> (i32, i32) {
 struct Router {
     h_rows: Vec<(i32, i32, i32)>, // (y, x0, x1) inclusive
     v_cols: Vec<(i32, i32, i32)>, // (x, y0, y1) inclusive
+    /// Tiles stamped so far (cells + feeds seeded, then every Router
+    /// push). Crossing hops only cover STRICT INTERIORS of registered
+    /// runs — corners, terminals, and hop mouths sit on boundary tiles,
+    /// which is exactly the mil5-ore overlap class. Collision checks
+    /// against this set trigger the local fallbacks; collision-free
+    /// layouts take the legacy paths bit-identically.
+    occ: FxHashSet<(i32, i32)>,
 }
 
 impl Router {
     fn new() -> Self {
-        Router { h_rows: Vec::new(), v_cols: Vec::new() }
+        Router { h_rows: Vec::new(), v_cols: Vec::new(), occ: FxHashSet::default() }
+    }
+
+    /// Seed occupancy from already-stamped entities (cells, feeds,
+    /// merge/fan splitters). Splitters cover two tiles (their second
+    /// half extends one tile perpendicular to facing — south half for
+    /// east-facing).
+    fn seed(&mut self, entities: &[PlacedEntity]) {
+        for e in entities {
+            self.occ.insert((e.x, e.y));
+            if e.name.ends_with("splitter") {
+                self.occ.insert((e.x, e.y + 1));
+            }
+        }
+    }
+
+    /// Can an eastward `hrow` legally stamp y over [x0, x1]? Occupied
+    /// tiles are fine when they belong to a registered CROSSING column
+    /// strictly inside the span — the hrow hops under those. Anything
+    /// else occupied (parallel same-row runs, corners, boundary-tile
+    /// columns the strict hop filter skips) means no.
+    fn is_row_stampable(&self, y: i32, x0: i32, x1: i32) -> bool {
+        let (lo, hi) = (x0.min(x1), x0.max(x1));
+        (lo..=hi).all(|x| {
+            !self.occ.contains(&(x, y))
+                || (x > lo
+                    && x < hi
+                    && self
+                        .v_cols
+                        .iter()
+                        .any(|(cx, cy0, cy1)| *cx == x && y >= *cy0 && y <= *cy1))
+        })
     }
 
     /// Register an externally stamped column (feed columns).
@@ -197,8 +235,10 @@ impl Router {
             .collect();
         cols.sort_unstable();
         cols.dedup();
-        let push_east = |out: &mut Vec<PlacedEntity>, xa: i32, xb: i32| {
+        let occ = &mut self.occ;
+        let push_east = |out: &mut Vec<PlacedEntity>, occ: &mut FxHashSet<(i32, i32)>, xa: i32, xb: i32| {
             for x in xa..=xb {
+                occ.insert((x, y));
                 out.push(PlacedEntity {
                     name: belt.into(), x, y,
                     direction: EntityDirection::East,
@@ -221,9 +261,10 @@ impl Router {
         for (lo2, hi2) in clusters {
             assert!(hi2 - lo2 + 2 <= 9, "cells: hop cluster span exceeds express reach");
             if lo2 - 2 >= x {
-                push_east(out, x, lo2 - 2);
+                push_east(out, occ, x, lo2 - 2);
             }
             for (hx, io) in [(lo2 - 1, "input"), (hi2 + 1, "output")] {
+                occ.insert((hx, y));
                 out.push(PlacedEntity {
                     name: ug.into(),
                     x: hx,
@@ -238,9 +279,98 @@ impl Router {
             x = hi2 + 2;
         }
         if x <= x1 {
-            push_east(out, x, x1);
+            push_east(out, occ, x, x1);
         }
         self.register_row(y, x0, x1);
+    }
+
+    /// WESTWARD row from x0 down to x1 (x0 > x1) at y, hopping under
+    /// crossing columns — the mirror of `hrow`, for bypass edges whose
+    /// consumer sits WEST of the producer (the reversed-dependency
+    /// placement order does not guarantee eastward flow for items
+    /// consumed at several depths). Kept separate from `hrow` so the
+    /// eastward path stays bit-identical.
+    #[allow(clippy::too_many_arguments)]
+    fn hrow_west(
+        &mut self,
+        out: &mut Vec<PlacedEntity>,
+        y: i32,
+        x0: i32,
+        x1: i32,
+        item: &str,
+        belt: &str,
+        ug: &str,
+        seg: &str,
+    ) {
+        let mut cols: Vec<i32> = self
+            .v_cols
+            .iter()
+            .filter(|(cx, cy0, cy1)| *cx < x0 && *cx > x1 && y >= *cy0 && y <= *cy1)
+            .map(|(cx, _, _)| *cx)
+            .collect();
+        cols.sort_unstable_by(|a, b| b.cmp(a));
+        cols.dedup();
+        let occ = &mut self.occ;
+        let push_west = |out: &mut Vec<PlacedEntity>, occ: &mut FxHashSet<(i32, i32)>, xa: i32, xb: i32| {
+            for x in (xb..=xa).rev() {
+                occ.insert((x, y));
+                out.push(PlacedEntity {
+                    name: belt.into(), x, y,
+                    direction: EntityDirection::West,
+                    carries: Some(item.into()),
+                    segment_id: Some(seg.into()),
+                    ..Default::default()
+                });
+            }
+        };
+        let mut clusters: Vec<(i32, i32)> = Vec::new();
+        for c in cols {
+            match clusters.last_mut() {
+                Some((_, lo)) if *lo - c < 3 => *lo = c,
+                _ => clusters.push((c, c)),
+            }
+        }
+        let mut x = x0;
+        for (hi2, lo2) in clusters {
+            assert!(hi2 - lo2 + 2 <= 9, "cells: hop cluster span exceeds express reach");
+            if hi2 + 2 <= x {
+                push_west(out, occ, x, hi2 + 2);
+            }
+            for (hx, io) in [(hi2 + 1, "input"), (lo2 - 1, "output")] {
+                occ.insert((hx, y));
+                out.push(PlacedEntity {
+                    name: ug.into(),
+                    x: hx,
+                    y,
+                    direction: EntityDirection::West,
+                    io_type: Some(io.into()),
+                    carries: Some(item.into()),
+                    segment_id: Some(seg.into()),
+                    ..Default::default()
+                });
+            }
+            x = lo2 - 2;
+        }
+        if x >= x1 {
+            push_west(out, occ, x, x1);
+        }
+        self.register_row(y, x1, x0);
+    }
+
+    /// West-facing corner belt at (x, y): single perpendicular input
+    /// (a southbound descent turning west onto a bypass row).
+    fn corner_west(&mut self, out: &mut Vec<PlacedEntity>, x: i32, y: i32, item: &str, belt: &str, seg: &str) {
+        self.occ.insert((x, y));
+        out.push(PlacedEntity {
+            name: belt.into(),
+            x,
+            y,
+            direction: EntityDirection::West,
+            carries: Some(item.into()),
+            segment_id: Some(seg.into()),
+            ..Default::default()
+        });
+        self.register_row(y, x, x);
     }
 
     /// Vertical leg from y0 toward y1 at x (either direction), hopping
@@ -275,9 +405,11 @@ impl Router {
             rows.reverse();
         }
         let step = if down { 1 } else { -1 };
-        let push_v = |out: &mut Vec<PlacedEntity>, ya: i32, yb: i32| {
+        let occ = &mut self.occ;
+        let push_v = |out: &mut Vec<PlacedEntity>, occ: &mut FxHashSet<(i32, i32)>, ya: i32, yb: i32| {
             let (lo2, hi2) = (ya.min(yb), ya.max(yb));
             for y in lo2..=hi2 {
+                occ.insert((x, y));
                 out.push(PlacedEntity {
                     name: belt.into(), x, y,
                     direction: dir,
@@ -298,9 +430,10 @@ impl Router {
         for (first, last) in clusters {
             assert!((last - first).abs() + 2 <= 9, "cells: hop cluster span exceeds express reach");
             if (first - 2 * step - y) * step >= 0 {
-                push_v(out, y, first - 2 * step);
+                push_v(out, occ, y, first - 2 * step);
             }
             for (hy, io) in [(first - step, io_near), (last + step, io_far)] {
+                occ.insert((x, hy));
                 out.push(PlacedEntity {
                     name: ug.into(),
                     x,
@@ -315,13 +448,14 @@ impl Router {
             y = last + 2 * step;
         }
         if (y1 - y) * step >= 0 {
-            push_v(out, y, y1);
+            push_v(out, occ, y, y1);
         }
         self.register_col(x, lo, hi);
     }
 
     /// North-facing corner belt at (x, y): single perpendicular input.
     fn corner_north(&mut self, out: &mut Vec<PlacedEntity>, x: i32, y: i32, item: &str, belt: &str, seg: &str) {
+        self.occ.insert((x, y));
         out.push(PlacedEntity {
             name: belt.into(),
             x,
@@ -334,9 +468,27 @@ impl Router {
         self.register_col(x, y, y);
     }
 
+    /// South-facing corner belt at (x, y): single perpendicular input
+    /// (the in-gap descent entry — flow arrives eastbound from the
+    /// splitter's south output and turns down).
+    fn corner_south(&mut self, out: &mut Vec<PlacedEntity>, x: i32, y: i32, item: &str, belt: &str, seg: &str) {
+        self.occ.insert((x, y));
+        out.push(PlacedEntity {
+            name: belt.into(),
+            x,
+            y,
+            direction: EntityDirection::South,
+            carries: Some(item.into()),
+            segment_id: Some(seg.into()),
+            ..Default::default()
+        });
+        self.register_col(x, y, y);
+    }
+
     /// East-facing corner belt at (x, y): single perpendicular input =
     /// lane-preserving corner (the post-review splitter-merge idiom).
     fn corner_east(&mut self, out: &mut Vec<PlacedEntity>, x: i32, y: i32, item: &str, belt: &str, seg: &str) {
+        self.occ.insert((x, y));
         out.push(PlacedEntity {
             name: belt.into(),
             x,
@@ -348,6 +500,49 @@ impl Router {
         });
         self.register_row(y, x, x);
     }
+}
+
+/// Free the tile at (x, y) by putting the FEED ROW that crosses it
+/// underground: replace `feed → feed → feed` with `UG-in → (clear) →
+/// UG-out` centered on the collision tile. Only fires when an ascent's
+/// terminal (a boundary tile the crossing hops can't cover) lands on a
+/// feed row. Refuses loudly on any shape it doesn't recognize — a
+/// refusal is honest, a silent overlap is not.
+fn retrofit_feed_hop(
+    entities: &mut Vec<PlacedEntity>,
+    router: &mut Router,
+    x: i32,
+    y: i32,
+) -> Result<(), String> {
+    let mut idxs = [usize::MAX; 3];
+    for (k, cx) in [x - 1, x, x + 1].iter().enumerate() {
+        let i = entities
+            .iter()
+            .position(|e| {
+                e.x == *cx
+                    && e.y == y
+                    && e.direction == EntityDirection::East
+                    && e.name.ends_with("transport-belt")
+                    && e.segment_id.as_deref().is_some_and(|s| s.starts_with("feed:"))
+            })
+            .ok_or_else(|| {
+                format!("cells: ascent terminal collision at ({x},{y}) is not a plain feed row (tile x={cx})")
+            })?;
+        idxs[k] = i;
+    }
+    let ug = match entities[idxs[1]].name.as_str() {
+        "express-transport-belt" => "express-underground-belt",
+        "fast-transport-belt" => "fast-underground-belt",
+        "transport-belt" => "underground-belt",
+        other => return Err(format!("cells: unexpected feed belt tier {other}")),
+    };
+    for (k, io) in [(0usize, "input"), (2usize, "output")] {
+        entities[idxs[k]].name = ug.into();
+        entities[idxs[k]].io_type = Some(io.into());
+    }
+    entities.remove(idxs[1]);
+    router.occ.remove(&(x, y));
+    Ok(())
 }
 
 /// Compose an eligible chain solve into one layout: K quantized copies
@@ -451,7 +646,11 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
             let slot_x = cursor;
             let feed_w = FEED_PITCH * n_feed_ports + 1;
             let vlane0 = slot_x + feed_w;
-            let strip = VLANES + lane_demand[si];
+            // Multi-edge strips use 2-tile lane pitch: at pitch 1 a
+            // lane's corner + hrow-start tile sits ON the neighbor
+            // lane's column (a mil5-ore overlap class). Single-edge
+            // strips keep pitch 1 — bit-identical to before.
+            let strip = VLANES + lane_demand[si] * if lane_demand[si] >= 2 { 2 } else { 1 };
             let x = vlane0 + strip + 1;
             cursor = x + cell.width + gap;
 
@@ -547,22 +746,34 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 .count() as i32
         })
         .sum();
-    let drain_row = band_bottom + n_bypass + 2;
+    // Bypass rows sit at PITCH 3 (band_bottom+1, +4, +7, ...): at
+    // pitch 1 a leg crossing one row lands its hop mouths and terminal
+    // ON the neighboring rows (mouths sit at R±1, a descent terminal at
+    // its own row−1) — the residual mil5-ore overlap class. Pitch 2
+    // still fails (adjacent rows cluster into one hop whose mouths jump
+    // to the next row); pitch 3 keeps every crossing un-clustered with
+    // free mouth rows. n_bypass ≤ 1 is bit-identical to the old +n+2.
+    let drain_row = band_bottom + 2 + (3 * n_bypass - 2).max(0);
 
     // --- Chain corridors: producer out → merge (if 2 runs) → fan-out
     // split (if 2 consumers) → per-consumer routing via the Router.
     // Bypass rows allocate per copy (disjoint x-ranges share rows).
+    // Occupancy seeds here: cells + feeds are down, and collision
+    // fallbacks below check against everything stamped so far.
+    router.seed(&entities);
     let mut bypass_idx: FxHashMap<i32, i32> = FxHashMap::default();
     // Per-slot vertical-lane allocation: each bypass descent/ascent
     // claims a fresh lane in its slot's strip (two edges sharing a lane
-    // was the mil5-ore overlap class).
+    // was the mil5-ore overlap class); multi-edge strips step by 2
+    // (matching the strip sizing above).
     let mut lane_next: FxHashMap<usize, i32> = FxHashMap::default();
-    let alloc_lane = |lane_next: &mut FxHashMap<usize, i32>, slot: usize, base: i32| -> i32 {
+    let alloc_lane = |lane_next: &mut FxHashMap<usize, i32>, slot: usize, base: i32, step: i32| -> i32 {
         let n = lane_next.entry(slot).or_insert(0);
-        let x = base + *n;
+        let x = base + *n * step;
         *n += 1;
         x
     };
+    let lane_step = |demand: i32| if demand >= 2 { 2 } else { 1 };
     for (pi, p) in placed.iter().enumerate() {
         let out_item = specs[pi % n].outputs[0].item.clone();
         // Consumers within THIS copy only — the same item flows in every
@@ -587,6 +798,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
             let seg = format!("out:{}", p.seg);
             router.hrow(&mut entities, oy, ox + 1, drain_x - 1, &out_item,
                 "transport-belt", "underground-belt", &seg);
+            router.occ.insert((drain_x, oy));
             entities.push(PlacedEntity {
                 name: "transport-belt".into(), x: drain_x, y: oy,
                 direction: EntityDirection::South,
@@ -627,6 +839,8 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
             router.vcol(&mut entities, run_x - 1, oy - 1, acc_y + 2, &out_item,
                 "express-transport-belt", "express-underground-belt", &seg);
             router.corner_east(&mut entities, run_x - 1, acc_y + 1, &out_item, "express-transport-belt", &seg);
+            router.occ.insert((run_x, acc_y));
+            router.occ.insert((run_x, acc_y + 1));
             entities.push(PlacedEntity {
                 name: "express-splitter".into(), x: run_x, y: acc_y,
                 direction: EntityDirection::East,
@@ -652,6 +866,8 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         let mut branch_origins: Vec<(i32, i32)> = Vec::new();
         let mut fx = pass_x;
         for b in 1..n_branches {
+            router.occ.insert((fx, run_y));
+            router.occ.insert((fx, run_y + 1));
             entities.push(PlacedEntity {
                 name: "express-splitter".into(), x: fx, y: run_y,
                 direction: EntityDirection::East,
@@ -704,24 +920,70 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 // always the sink (dependency order), which has no
                 // consumers and never reaches this branch.
                 debug_assert_eq!(placed[pi + 1].copy, p.copy, "bypass descent lane must stay in-copy");
-                let lane_down = alloc_lane(&mut lane_next, pi + 1, placed[pi + 1].vlane_base);
-                let lane_up = alloc_lane(&mut lane_next, *ci, c.vlane_base);
+                let up_demand = lane_demand[*ci % n];
+                let lane_up = alloc_lane(&mut lane_next, *ci, c.vlane_base, lane_step(up_demand));
                 let row = bypass_idx.entry(p.copy).or_insert(0);
-                let by_y = band_bottom + 1 + *row;
+                let by_y = band_bottom + 1 + 3 * *row;
                 *row += 1;
-                router.hrow(&mut entities, by, bx, lane_down - 1, &out_item,
-                    "express-transport-belt", "express-underground-belt", &seg);
-                router.vcol(&mut entities, lane_down, by, by_y - 1, &out_item,
-                    "express-transport-belt", "express-underground-belt", &seg);
-                router.corner_east(&mut entities, lane_down, by_y, &out_item, "express-transport-belt", &seg);
-                router.hrow(&mut entities, by_y, lane_down + 1, lane_up - 1, &out_item,
-                    "express-transport-belt", "express-underground-belt", &seg);
-                entities.push(PlacedEntity {
-                    name: "express-transport-belt".into(), x: lane_up, y: by_y,
-                    direction: EntityDirection::North,
-                    carries: Some(out_item.clone()),
-                    segment_id: Some(seg.clone()), ..Default::default()
-                });
+                if lane_up < bx {
+                    // WESTWARD consumer: the reversed-dependency
+                    // placement can put an item's consumer west of its
+                    // producer (shared inputs pulled in at different
+                    // depths). Descend in-gap, run west along the
+                    // bypass row, corner north into the consumer's
+                    // strip lane; the ascent + port approach below are
+                    // position-relative and shared with the eastward
+                    // path.
+                    router.corner_south(&mut entities, bx, by, &out_item, "express-transport-belt", &seg);
+                    router.vcol(&mut entities, bx, by + 1, by_y - 1, &out_item,
+                        "express-transport-belt", "express-underground-belt", &seg);
+                    router.corner_west(&mut entities, bx, by_y, &out_item, "express-transport-belt", &seg);
+                    router.hrow_west(&mut entities, by_y, bx - 1, lane_up + 1, &out_item,
+                        "express-transport-belt", "express-underground-belt", &seg);
+                    router.corner_north(&mut entities, lane_up, by_y, &out_item, "express-transport-belt", &seg);
+                } else {
+                    // Descent: legacy path runs east on the branch row
+                    // to a lane in the NEXT slot's strip. When that row
+                    // segment is already occupied (sibling fan-out
+                    // branches share the branch row — a mil5-ore
+                    // overlap class), descend IN-GAP instead: corner
+                    // south at the branch origin and drop straight to
+                    // the bypass row inside the producer's own gap,
+                    // where nothing else runs.
+                    let down_demand = lane_demand[(pi + 1) % n];
+                    let legacy_lane_down = placed[pi + 1].vlane_base
+                        + *lane_next.get(&(pi + 1)).unwrap_or(&0) * lane_step(down_demand);
+                    let (drop_x, drop_top) = if router.is_row_stampable(by, bx, legacy_lane_down - 1) {
+                        let lane_down = alloc_lane(&mut lane_next, pi + 1, placed[pi + 1].vlane_base, lane_step(down_demand));
+                        router.hrow(&mut entities, by, bx, lane_down - 1, &out_item,
+                            "express-transport-belt", "express-underground-belt", &seg);
+                        (lane_down, by)
+                    } else {
+                        router.corner_south(&mut entities, bx, by, &out_item, "express-transport-belt", &seg);
+                        (bx, by + 1)
+                    };
+                    router.vcol(&mut entities, drop_x, drop_top, by_y - 1, &out_item,
+                        "express-transport-belt", "express-underground-belt", &seg);
+                    router.corner_east(&mut entities, drop_x, by_y, &out_item, "express-transport-belt", &seg);
+                    router.hrow(&mut entities, by_y, drop_x + 1, lane_up - 1, &out_item,
+                        "express-transport-belt", "express-underground-belt", &seg);
+                    router.occ.insert((lane_up, by_y));
+                    entities.push(PlacedEntity {
+                        name: "express-transport-belt".into(), x: lane_up, y: by_y,
+                        direction: EntityDirection::North,
+                        carries: Some(out_item.clone()),
+                        segment_id: Some(seg.clone()), ..Default::default()
+                    });
+                }
+                // Ascent terminal: the vcol ends at ty+1 to corner into
+                // the port row — but another item's FEED ROW can sit at
+                // exactly ty+1 (crossing hops only cover strict
+                // interiors; terminals are boundary tiles). Retrofit the
+                // feed with a local UG hop under this lane, freeing the
+                // terminal tile.
+                if router.occ.contains(&(lane_up, ty + 1)) {
+                    retrofit_feed_hop(&mut entities, &mut router, lane_up, ty + 1)?;
+                }
                 router.vcol(&mut entities, lane_up, by_y - 1, ty + 1, &out_item,
                     "express-transport-belt", "express-underground-belt", &seg);
                 router.corner_east(&mut entities, lane_up, ty, &out_item, "express-transport-belt", &seg);

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -560,25 +560,38 @@ fn cell_candidate_never_displaces_a_succeeding_bus() {
     }
 }
 
-/// PERMANENT GATE (#387 review finding): a composed candidate that
-/// carries validation ERRORS must refuse — never win a bus refusal as
-/// a silently broken Ok (`score_layout.accepted` doesn't run the full
-/// validator). mil5-ore is the live specimen: bus refuses on lane
-/// capacity, composition carries the Router-overlap class, so the
-/// whole build must Err until one of them is fixed. If this gate fails
-/// with an Ok layout, either the overlaps got fixed (move mil5-ore to
-/// the positive gates — a capability win) or the self-validation
-/// regressed (a bug).
+/// PERMANENT GATE (flipped 2026-07-23 — the capability win its
+/// predecessor anticipated): mil5-ore COMPOSES. The Router's overlap
+/// classes (boundary-blind hops, 1-pitch bypass rows/lanes) and the
+/// silent east-only bypass assumption (reversed-dependency placement
+/// can put consumers WEST of producers) are fixed, so the 9-spec
+/// scaling-wall fixture the bus refuses (stone-brick lane capacity,
+/// #336-class) now wins via composition at 0 validation errors. The
+/// self-validation contract (#387 review) stands behind it: if this
+/// geometry ever regresses to errors, the candidate refuses and this
+/// gate fails on the refusal — never on a silently broken Ok.
 #[test]
-fn cell_candidate_refuses_error_laden_composition() {
+fn cell_candidate_composes_mil5_ore() {
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
     let inputs: FxHashSet<String> =
         ["iron-ore", "copper-ore", "stone", "coal"].iter().map(|s| s.to_string()).collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
         "military-science-pack", 5.0, &inputs, &MachinePalette::default(),
         "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
     ).unwrap();
-    let r = layout::build_bus_layout(&sr, layout::LayoutOptions::default());
-    assert!(r.is_err(), "mil5-ore must refuse (bus lane-capacity + composed overlaps), not return a broken layout");
+    // Bus-only arm still refuses — composition is doing the winning.
+    let off = layout::build_bus_layout(&sr, layout::LayoutOptions {
+        cell_composition: spaghettio_core::bus::cells::CellComposition::Off,
+        ..Default::default()
+    });
+    assert!(off.is_err(), "bus-only mil5-ore must still refuse (else move this fixture to the bus ladder)");
+    let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
+        .expect("mil5-ore must compose");
+    assert!(l.warnings.iter().any(|w| w.starts_with("cell-composed:")),
+        "the composed candidate must be the winner");
+    let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).unwrap();
+    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    assert!(errors.is_empty(), "composed mil5-ore errors: {errors:?}");
 }
 
 #[test]

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -223,6 +223,43 @@ follow-ups.
 
 ## Decision log
 
+- *2026-07-23 — mil5-ore COMPOSES (the Router overlap classes fixed;
+  gate flipped to positive). Diagnosis: all 26 overlapping tiles were
+  BOUNDARY BLINDNESS — the two-registry Router hops strict interiors
+  of crossing runs, while corners, vcol terminals, and hop mouths sit
+  exactly on boundary tiles of other runs. Three structural causes,
+  each fixed collision-triggered so every clean fixture stays
+  bit-identical (the registered chain-ac1 hash is the enforced proof;
+  we cannot re-measure until #390 lands): (1) sibling fan-out bypass
+  entries share the branch row → occupancy-checked stamping
+  (`is_row_stampable`, which exempts hoppable interior crossings —
+  the naive version broke ac1 by counting feed columns the legacy
+  path legitimately hops) with an IN-GAP EARLY DESCENT fallback;
+  (2) 1-pitch bypass rows leave no legal hop (mouths land at R±1 =
+  other rows, a descent's terminal at its own row−1) → pitch 3
+  (pitch 2 still fails: adjacent rows cluster into one hop whose
+  mouths jump to the next row); n_bypass ≤ 1 keeps the old geometry
+  exactly; (3) 1-pitch strip lanes put corner/hrow-start tiles on
+  neighbor columns → pitch 2 in multi-edge strips only. Behind the
+  overlaps hid the REAL defect, pre-dating quantization: the bypass
+  machinery silently assumed eastward flow, but the
+  reversed-dependency placement puts consumers WEST of producers for
+  items consumed at several depths (mil5's iron sits east of grenade
+  and steel) — the westward `hrow(x0>x1)` stamped NOTHING, leaving
+  dead-end corners. Fixed with a westward bypass variant (`hrow_west`
+  + west/south corners, in-gap descent, north-corner entry into the
+  consumer strip). Results: mil5-ore 720×34, 0 errors / 1 warning,
+  composed candidate wins over the bus refusal
+  (`cell_candidate_composes_mil5_ore`); mil5-plates' composed
+  candidate went 0/0 (225×22) as a side effect — but the SEARCH still
+  returns the broken native layout there (accepted never runs full
+  validation; native outscores on density) — filed as #392, shared
+  scoring machinery, its own decision. Ascent-terminal-on-feed-row
+  gets a local feed UG retrofit (`retrofit_feed_hop`, fires on
+  collision only; refuses loudly on unrecognized shapes). Registry
+  world-axis gap filed as #391 (fold into the post-#390 declaration
+  package).*
+
 - *2026-07-22 — K-quantization + #383 ROOT CAUSE (the premise
   falsified mid-implementation). Ratio quantization landed in
   `compose_chain`: K identical side-by-side copies at 1/K rate


### PR DESCRIPTION
## Intent

Close the mil5-ore Router overlap class (the named next target after K-quantization) — pure geometry, no sim dependency, deliberately scheduled while #381/#390 own the harness.

## What's here

- **Boundary-blindness fixes, all collision-triggered** (clean fixtures bit-identical — the registered chain-ac1 hash gate is the proof): occupancy-aware stamping + in-gap early-descent fallback for sibling fan-out bypass entries; bypass rows at pitch 3 (1-pitch rows leave no legal hop — mouths land on neighboring rows; pitch 2 clusters wrong); strip lanes at pitch 2 in multi-edge slots only; local feed UG retrofit when an ascent terminal lands on a feed row (refuses loudly on unrecognized shapes).
- **Westward bypass support** — the real defect hiding behind the overlaps, pre-dating quantization: reversed-dependency placement can put consumers WEST of producers (mil5's iron sits east of grenade/steel); the east-only bypass `hrow` silently stamped nothing, leaving validator-caught dead ends. New `hrow_west` + west/south corners mirror the eastward idiom.
- **Gate flip**: `cell_candidate_refuses_error_laden_composition` → `cell_candidate_composes_mil5_ore`, exactly the capability win its docstring anticipated: the 9-spec scaling-wall fixture the bus refuses (stone-brick lane capacity, #336-class) now composes at **0 errors / 1 warning** (720×34) and wins the search; the #387 self-validation contract stands behind it.
- **Filed, not fixed here**: #392 (mil5-plates' composed candidate is now 0/0 but native still wins with a validate-failing layout — `accepted` never runs full validation; shared scoring machinery, own decision) and #391 (registry world-axis hardening, folds into the post-#390 declaration package).

## Models / contracts touched

None public. Router internals gain occupancy + westward variants; bypass row/lane pitch changes fire only for multi-bypass / multi-edge-slot layouts (mil5-*); `retrofit_feed_hop` can locally rewrite a feed row into a UG hop on collision.

## Verification

- Suite **895/0/50** (single clean run); cell gates 8/8 including the flipped positive gate and the bit-identity hash gate.
- Stress goldens: canonical check-mode run, **9 ran, 0 drift**.
- clippy clean on touched files; WASM-target check green.
- No sim runs (deliberate — #381/#390 own the harness right now; mil5-ore's measured-at-plan claim waits for the post-#390 declaration package like the EC rows).

## Deviations

An intermediate occupancy check broke ac1's bit-identity (it counted feed columns the legacy path legitimately hops); caught by the registry hash gate and fixed via the crossing-exempt `is_row_stampable` before commit — exactly the failure mode that gate exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55