### PR TITLE
RFC-051: validation-tiered selection — clean candidates outrank error-laden ones (#392)

### DIFF
--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -901,6 +901,47 @@ pub fn select_best_decomposition(
         }
     });
 
+    // Validation-tiered selection (#392), part 1: the per-candidate
+    // clean flags. `validate()` emits a `ValidationCompleted` trace
+    // event per call, so this MUST run before the sink reattach below,
+    // with peek/truncate discarding the emissions — otherwise every
+    // examined candidate's validation (including the losers') leaks
+    // into the winner's replayed stream and the web timing log /
+    // snapshot debugger report the wrong layout's error counts (#396
+    // review, blocking finding; same pattern as merge_tap_choice's
+    // classify_errors above). Lazy: the single-layout common case and
+    // merge-tap-decided solves skip validation entirely.
+    let tier_outcomes = [
+        native_run.outcome.as_ref(),
+        k1_run.outcome.as_ref(),
+        split_run.outcome.as_ref(),
+        merge_tap_run.outcome.as_ref(),
+        cells_run.outcome.as_ref(),
+    ];
+    let n_layouts = tier_outcomes.iter().filter(|o| o.is_some()).count();
+    let clean_flags: [Option<bool>; 5] = if merge_tap_choice.is_none() && n_layouts > 1 {
+        let start = crate::trace::peek_events_len();
+        let flags = tier_outcomes.map(|o| {
+            o.map(|(l, score)| {
+                score.accepted
+                    && match crate::validate::validate(
+                        l,
+                        Some(solver_result),
+                        crate::validate::LayoutStyle::Bus,
+                    ) {
+                        Ok(issues) => issues
+                            .iter()
+                            .all(|i| i.severity != crate::validate::Severity::Error),
+                        Err(_) => false,
+                    }
+            })
+        });
+        crate::trace::truncate_events(start);
+        flags
+    } else {
+        [None; 5]
+    };
+
     // Re-attach the sink before replaying the winner's events. Score
     // events for *every* candidate that actually ran are emitted (so
     // telemetry/snapshot debugger see what was tried), then the winner's
@@ -972,49 +1013,30 @@ pub fn select_best_decomposition(
         })
         .map(|(i, _)| i);
 
-    // Validation-tiered selection (#392): `accepted` never runs the
-    // full validator, so an error-laden native could outscore a CLEAN
-    // sibling on density and reach callers as a silently broken Ok
-    // (mil5-from-plates: native hard-fails validation while the
-    // composed candidate is 0/0). When more than one candidate holds a
-    // layout, prefer the best-scoring accepted candidate whose layout
-    // validates with ZERO errors; if none does, fall through to
+    // Validation-tiered selection (#392), part 2: `accepted` never
+    // runs the full validator, so an error-laden native could outscore
+    // a CLEAN sibling on density and reach callers as a silently
+    // broken Ok (mil5-from-plates: native hard-fails validation while
+    // the composed candidate is 0/0). Prefer the best-scoring accepted
+    // candidate whose layout validated with ZERO errors (clean_flags,
+    // computed pre-reattach above); if none is clean, fall through to
     // today's pick (still returns the error-laden best rather than
-    // refusing — callers see the errors, behavior unchanged). The
-    // single-layout common case skips validation entirely (the winner
-    // is fixed regardless), so the fast path costs nothing.
-    let n_layouts = candidates.iter().filter(|(o, _, _)| o.is_some()).count();
-    let best_error_free_idx = if merge_tap_choice.is_none() && n_layouts > 1 {
-        candidates
-            .iter()
-            .enumerate()
-            .filter_map(|(i, (outcome, _, _))| {
-                outcome.as_ref().and_then(|(l, score)| {
-                    if !score.accepted {
-                        return None;
-                    }
-                    let clean = match crate::validate::validate(
-                        l,
-                        Some(solver_result),
-                        crate::validate::LayoutStyle::Bus,
-                    ) {
-                        Ok(issues) => issues
-                            .iter()
-                            .all(|i| i.severity != crate::validate::Severity::Error),
-                        Err(_) => false,
-                    };
-                    if clean { Some((i, score.score)) } else { None }
-                })
-            })
-            .max_by(|(ia, a), (ib, b)| {
-                a.partial_cmp(b)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    .then(ib.cmp(ia))
-            })
-            .map(|(i, _)| i)
-    } else {
-        None
-    };
+    // refusing — callers see the errors, behavior unchanged).
+    let best_error_free_idx = candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(i, (outcome, _, _))| {
+            if clean_flags[i] != Some(true) {
+                return None;
+            }
+            outcome.as_ref().map(|(_, score)| (i, score.score))
+        })
+        .max_by(|(ia, a), (ib, b)| {
+            a.partial_cmp(b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(ib.cmp(ia))
+        })
+        .map(|(i, _)| i);
 
     // The scoped Pooled merge-tap decision (error-count metric, ties → Native)
     // overrides the generic accepted-by-score pick when it ran; then the

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -972,12 +972,58 @@ pub fn select_best_decomposition(
         })
         .map(|(i, _)| i);
 
+    // Validation-tiered selection (#392): `accepted` never runs the
+    // full validator, so an error-laden native could outscore a CLEAN
+    // sibling on density and reach callers as a silently broken Ok
+    // (mil5-from-plates: native hard-fails validation while the
+    // composed candidate is 0/0). When more than one candidate holds a
+    // layout, prefer the best-scoring accepted candidate whose layout
+    // validates with ZERO errors; if none does, fall through to
+    // today's pick (still returns the error-laden best rather than
+    // refusing — callers see the errors, behavior unchanged). The
+    // single-layout common case skips validation entirely (the winner
+    // is fixed regardless), so the fast path costs nothing.
+    let n_layouts = candidates.iter().filter(|(o, _, _)| o.is_some()).count();
+    let best_error_free_idx = if merge_tap_choice.is_none() && n_layouts > 1 {
+        candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (outcome, _, _))| {
+                outcome.as_ref().and_then(|(l, score)| {
+                    if !score.accepted {
+                        return None;
+                    }
+                    let clean = match crate::validate::validate(
+                        l,
+                        Some(solver_result),
+                        crate::validate::LayoutStyle::Bus,
+                    ) {
+                        Ok(issues) => issues
+                            .iter()
+                            .all(|i| i.severity != crate::validate::Severity::Error),
+                        Err(_) => false,
+                    };
+                    if clean { Some((i, score.score)) } else { None }
+                })
+            })
+            .max_by(|(ia, a), (ib, b)| {
+                a.partial_cmp(b)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(ib.cmp(ia))
+            })
+            .map(|(i, _)| i)
+    } else {
+        None
+    };
+
     // The scoped Pooled merge-tap decision (error-count metric, ties → Native)
-    // overrides the generic accepted-by-score pick when it ran; otherwise fall
-    // back to best-accepted, then to the first candidate that produced a
-    // layout (Native preferred — earliest in the array). Same degraded
-    // behaviour as today's pipeline when shape-fix can't resolve a (n, m) trap.
+    // overrides the generic accepted-by-score pick when it ran; then the
+    // error-free tier; then best-accepted; then the first candidate that
+    // produced a layout (Native preferred — earliest in the array). Same
+    // degraded behaviour as today's pipeline when shape-fix can't resolve
+    // a (n, m) trap.
     let winner_idx = merge_tap_choice
+        .or(best_error_free_idx)
         .or(best_accepted_idx)
         .or_else(|| candidates.iter().position(|(o, _, _)| o.is_some()));
 

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -619,6 +619,32 @@ fn cell_candidate_wins_mil5_plates_over_broken_native() {
     assert!(errors.is_empty(), "winner must validate clean: {errors:?}");
 }
 
+/// PERMANENT GATE (#396 review, blocking finding): the selection
+/// tier's validate() calls must never leak trace events into the
+/// winner's replayed stream — the web timing log reads the FIRST
+/// ValidationCompleted event, so a leaked loser-candidate validation
+/// makes the browser report a broken layout for a clean one. Exactly
+/// one ValidationCompleted may appear: the winning cells candidate's
+/// own self-check replay.
+#[test]
+fn selection_tier_validation_never_leaks_trace_events() {
+    let inputs: FxHashSet<String> =
+        ["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"]
+            .iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "military-science-pack", 5.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let l = layout::build_bus_layout_traced(&sr, layout::LayoutOptions::default())
+        .expect("mil5-plates must lay out");
+    let n_validation_events = l.trace.as_ref().expect("traced build carries trace")
+        .iter()
+        .filter(|e| matches!(e, spaghettio_core::trace::TraceEvent::ValidationCompleted { .. }))
+        .count();
+    assert_eq!(n_validation_events, 1,
+        "only the winner's own validation may appear in the trace (leaked tier validations corrupt the web timing log)");
+}
+
 #[test]
 #[ignore = "debug probe"]
 fn probe_mil5_errors() {

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -594,6 +594,31 @@ fn cell_candidate_composes_mil5_ore() {
     assert!(errors.is_empty(), "composed mil5-ore errors: {errors:?}");
 }
 
+/// PERMANENT GATE (#392): validation-tiered selection — when the
+/// best-scoring accepted candidate hard-fails validation and a CLEAN
+/// accepted sibling exists, the clean one wins. mil5-from-plates is
+/// the live specimen: the native bus layout fails validation while the
+/// composed candidate is 0 errors / 0 warnings; pre-#392 the search
+/// returned the broken native as Ok.
+#[test]
+fn cell_candidate_wins_mil5_plates_over_broken_native() {
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    let inputs: FxHashSet<String> =
+        ["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"]
+            .iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "military-science-pack", 5.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
+        .expect("mil5-plates must lay out");
+    assert!(l.warnings.iter().any(|w| w.starts_with("cell-composed:")),
+        "the clean composed candidate must win over the validation-broken native");
+    let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).unwrap();
+    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    assert!(errors.is_empty(), "winner must validate clean: {errors:?}");
+}
+
 #[test]
 #[ignore = "debug probe"]
 fn probe_mil5_errors() {

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -223,6 +223,24 @@ follow-ups.
 
 ## Decision log
 
+- *2026-07-23 — Validation-tiered selection (#392; SHARED SCORING
+  MACHINERY — logged per the kill-3(b) rule). `accepted` never ran the
+  full validator, so an error-laden native could outscore a clean
+  sibling on density and reach callers as a broken Ok. The fix is a
+  selection TIER, deliberately not accepted-gating: among accepted
+  candidates, the best-scoring one whose layout validates with zero
+  errors wins; if none is clean, today's pick stands (callers still
+  see the errors — no new refusals), and candidate GATING is untouched
+  (no extra k1/size-split runs, no solve-time change). The
+  single-layout common case skips validation entirely. mil5-from-
+  plates flips to the composed 0/0 layout (gate:
+  `cell_candidate_wins_mil5_plates_over_broken_native`); goldens 9
+  ran / 0 drift — no stress fixture has a clean sibling, so bus-land
+  outcomes are unchanged. Not taken: gating `accepted` itself on
+  validation (would re-trigger the heavy fallback candidates on every
+  errored native and shift stress outcomes — a bigger, separate
+  decision if ever wanted).*
+
 - *2026-07-23 — mil5-ore COMPOSES (the Router overlap classes fixed;
   gate flipped to positive). Diagnosis: all 26 overlapping tiles were
   BOUNDARY BLINDNESS — the two-registry Router hops strict interiors


### PR DESCRIPTION
## Intent

Close #392: the decomposition search could return a validation-broken native layout as Ok while a clean sibling candidate existed (mil5-from-plates). User-approved unit ("good to merge if there's no outstanding review feedback").

## What's here

- A validation TIER in winner selection: among accepted candidates, the best-scoring layout that validates with **zero errors** wins; if none is clean, today's pick stands — callers still see the errors, no new refusals. Candidate gating and scoring are untouched (no extra fallback-candidate runs; the single-layout common case skips validation entirely, so the fast path costs nothing). Deliberately NOT the accepted-gating variant: that would re-trigger the heavy fallback candidates on every errored native and shift stress outcomes — a bigger, separate decision, recorded in the RFC log.
- Gate `cell_candidate_wins_mil5_plates_over_broken_native`: mil5-from-plates now resolves to the composed 0 errors / 0 warnings layout (225×22).

## Models / contracts touched

Winner-selection semantics only (`build_bus_layout` output can change ONLY where the previous winner had validation errors and a clean accepted sibling existed). No API/geometry/manifest changes.

## Verification

- Suite **896/0/50** (single clean run, +1 gate); cell gates 9/9.
- Stress goldens: canonical check-mode run, **9 ran, 0 drift** — no stress fixture has a clean sibling candidate, so bus-land outcomes are unchanged.
- clippy clean on touched files; WASM-target check green.
- Local adversarial review to follow before merge (bot has been silent on substantive PRs; merge is gated on that review coming back clean per the user's condition).

## Deviations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55