### PR TITLE
RFC-051 declaration package: world-keyed registry (#391), honest-world measurements, EC residual isolated

### DIFF
--- a/crates/core/data/cell-sim-registry.json
+++ b/crates/core/data/cell-sim-registry.json
@@ -3,9 +3,24 @@
     "target": "advanced-circuit",
     "rate": 1.0,
     "geometry_hash": "d7f2ea7165028274",
+    "declared_inserter_capacity": 0,
+    "declared_stacking": 1,
+    "harness_world": "nb=0 bulk=1, S=1 (post-#390 stacking parity)",
     "verdict": "PASS",
     "produced_per_s": 1.0,
-    "scenario": "spaghettio-sim chain-ac1 v3 (Factorio 2.0.76, 8/8 working, converged, +0.33%); hash re-encoded 2026-07-23 (recipe+modules added to geometry_hash, geometry unchanged)",
-    "date": "2026-07-22"
+    "scenario": "spaghettio-sim chain-ac1-d0 (Factorio 2.0.76, 7/8 working +1 transient shortage, converged, -0.3%; declaration-package re-measure in the honest world)",
+    "date": "2026-07-23"
+  },
+  {
+    "target": "military-science-pack",
+    "rate": 5.0,
+    "geometry_hash": "1b49c80c03e04947",
+    "declared_inserter_capacity": 0,
+    "declared_stacking": 1,
+    "harness_world": "nb=0 bulk=1, S=1 (post-#390 stacking parity)",
+    "verdict": "PASS",
+    "produced_per_s": 4.83,
+    "scenario": "spaghettio-sim chain-mil5plates-d0 (Factorio 2.0.76, 46/46 working, converged, delivered 5.00/s exact, produced -3.3% within pass band; first measurement of westward bypasses + feed retrofits)",
+    "date": "2026-07-23"
   }
 ]

--- a/crates/core/src/bus/cells/registry.rs
+++ b/crates/core/src/bus/cells/registry.rs
@@ -35,12 +35,14 @@ pub struct RegistryEntry {
     pub geometry_hash: String,
     /// The `inserter_capacity` the measured layout DECLARED — the sim
     /// forces research bonuses to this level (#378), so the verdict is
-    /// scoped to it.
-    #[serde(default)]
+    /// scoped to it. REQUIRED, no serde default: a default would equal
+    /// production's declared values exactly, so an entry omitting the
+    /// field would fail OPEN (silent full-match) instead of failing
+    /// loudly at parse (#397 review note).
     pub declared_inserter_capacity: u8,
     /// The `stacking` the measured layout declared (#390: the sim
-    /// world matches declared stacking).
-    #[serde(default = "default_stacking")]
+    /// world matches declared stacking). REQUIRED — same fail-closed
+    /// reasoning as above.
     pub declared_stacking: u8,
     /// The harness's realized-world line from the measurement report
     /// (provenance prose, e.g. "nb=0 bulk=1, S=1" — not matched on;
@@ -51,10 +53,6 @@ pub struct RegistryEntry {
     pub produced_per_s: f64,
     pub scenario: String,
     pub date: String,
-}
-
-fn default_stacking() -> u8 {
-    1
 }
 
 fn registry() -> &'static [RegistryEntry] {

--- a/crates/core/src/bus/cells/registry.rs
+++ b/crates/core/src/bus/cells/registry.rs
@@ -1,35 +1,60 @@
 //! RFC-051: the sim-verified registry (Tier-1 verification cache).
 //!
 //! Key = chain config + a GEOMETRY HASH of the composed layout's
-//! entities (#375 review, finding 1): cells regenerate from the live
-//! engine, so a config-only key would let row-template/placer/inserter
-//! changes silently decay "sim-verified" into "unverified with a stale
-//! verdict". The hash is self-maintaining: any engine change that
-//! alters the composed geometry changes the hash, the lookup misses,
-//! and the layout is annotated NOT-verified until someone re-runs the
-//! sim and re-registers. `cell_registry_hashes_current` (tests) turns a
-//! silent miss into a loud one for the seeded entries.
+//! entities (#375 review, finding 1) + the DECLARED WORLD the
+//! measurement ran in (#391): cells regenerate from the live engine,
+//! so a config-only key would let row-template/placer/inserter changes
+//! silently decay "sim-verified" into "unverified with a stale
+//! verdict" — and #390 proved the same decay exists on the WORLD axis
+//! (the stacking-parity change retired every pre-#390 measurement
+//! without tripping a single geometry hash). The hash is
+//! self-maintaining for geometry; the declared-world fields make the
+//! instrument part of the claim: an entry only reads as fully verified
+//! for a layout declaring the same `inserter_capacity` and `stacking`
+//! it was measured under. A hash-matching entry from a DIFFERENT
+//! declared world is reported as a scoped claim, not silently reused
+//! (#383: EC rows measure at plan only above declared capacity 0
+//! until RFC-049 Phase 3 sizing lands).
 //!
 //! Data: `crates/core/data/cell-sim-registry.json`, embedded via
 //! `include_str!` like the recipe DB. Grown deliberately — an entry is
-//! added only with a real sim PASS behind it (scenario + date recorded).
+//! added only with a real sim PASS behind it (scenario + date + the
+//! harness's realized-world line recorded).
 
 use std::sync::OnceLock;
 
 use crate::models::LayoutResult;
 use serde::Deserialize;
 
-/// One sim-verified composed geometry.
+/// One sim-verified composed geometry, in one declared world.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RegistryEntry {
     pub target: String,
     pub rate: f64,
     /// Hex FNV-1a-64 of the composed layout's entity list.
     pub geometry_hash: String,
+    /// The `inserter_capacity` the measured layout DECLARED — the sim
+    /// forces research bonuses to this level (#378), so the verdict is
+    /// scoped to it.
+    #[serde(default)]
+    pub declared_inserter_capacity: u8,
+    /// The `stacking` the measured layout declared (#390: the sim
+    /// world matches declared stacking).
+    #[serde(default = "default_stacking")]
+    pub declared_stacking: u8,
+    /// The harness's realized-world line from the measurement report
+    /// (provenance prose, e.g. "nb=0 bulk=1, S=1" — not matched on;
+    /// the declared fields above are the checked key).
+    #[serde(default)]
+    pub harness_world: String,
     pub verdict: String,
     pub produced_per_s: f64,
     pub scenario: String,
     pub date: String,
+}
+
+fn default_stacking() -> u8 {
+    1
 }
 
 fn registry() -> &'static [RegistryEntry] {
@@ -38,6 +63,12 @@ fn registry() -> &'static [RegistryEntry] {
         serde_json::from_str(include_str!("../../../data/cell-sim-registry.json"))
             .expect("cell-sim-registry.json must parse")
     })
+}
+
+/// All registry entries — the gate iterates these so every seeded
+/// claim is re-derived, not just a hardcoded list.
+pub fn entries() -> &'static [RegistryEntry] {
+    registry()
 }
 
 /// Stable FNV-1a-64 over the sorted entity list. Deliberately NOT the
@@ -89,21 +120,42 @@ pub fn geometry_hash(l: &LayoutResult) -> u64 {
     h
 }
 
-/// Look up a composed layout's verification status.
+/// Look up a composed layout's verification status by geometry. May
+/// return an entry measured under a DIFFERENT declared world than the
+/// caller's layout — `verification_note` surfaces that distinction;
+/// callers doing their own matching must compare the declared fields.
 pub fn lookup(target: &str, rate: f64, hash: u64) -> Option<&'static RegistryEntry> {
     let hex = format!("{hash:016x}");
-    registry().iter().find(|e| {
-        e.target == target && (e.rate - rate).abs() < 1e-9 && e.geometry_hash == hex
-    })
+    registry()
+        .iter()
+        .find(|e| e.target == target && (e.rate - rate).abs() < 1e-9 && e.geometry_hash == hex)
 }
 
 /// The annotation `CellComposedCandidate` attaches to its layouts.
+/// Three tiers: full match (geometry + declared world), scoped match
+/// (geometry verified, but in a different declared world than this
+/// layout's), and no match.
 pub fn verification_note(target: &str, rate: f64, l: &LayoutResult) -> String {
     let hash = geometry_hash(l);
     match lookup(target, rate, hash) {
+        Some(e)
+            if e.declared_inserter_capacity == l.inserter_capacity
+                && e.declared_stacking == l.stacking =>
+        {
+            format!(
+                "cell-composed: geometry SIM-VERIFIED at plan ({} — {} produced {:.2}/s at declared capacity {}, {})",
+                e.scenario, e.verdict, e.produced_per_s, e.declared_inserter_capacity, e.date
+            )
+        }
         Some(e) => format!(
-            "cell-composed: geometry SIM-VERIFIED at plan ({} — {} produced {:.2}/s, {})",
-            e.scenario, e.verdict, e.produced_per_s, e.date
+            "cell-composed: geometry sim-verified at plan ONLY under declared capacity {} / stacking {} ({} produced {:.2}/s, {}); this layout declares capacity {} / stacking {} — measured-at-plan does NOT transfer (#383)",
+            e.declared_inserter_capacity,
+            e.declared_stacking,
+            e.verdict,
+            e.produced_per_s,
+            e.date,
+            l.inserter_capacity,
+            l.stacking
         ),
         None => format!(
             "cell-composed: geometry NOT sim-verified (hash {hash:016x}) — run spaghettio-sim and add the entry to cell-sim-registry.json"

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -265,28 +265,44 @@ fn probe_chain_autoplace() {
     }
 }
 
-/// Artifact producers for the chain auto-placer's sim runs (Phase B/C).
+/// Artifact producers for the chain auto-placer's sim runs. Each
+/// fixture exports at one or more DECLARED inserter-capacity levels
+/// (the `-dN` suffix): the declaration changes zero geometry pre-#381,
+/// only the world the parity harness builds — the declaration package
+/// registers each geometry at the lowest level that measures at plan.
 #[test]
 #[ignore = "artifact producer"]
 fn export_chain_fixtures_for_sim() {
     use spaghettio_core::bus::cells::chain::compose_chain;
-    for (label, item, rate, inputs) in [
-        ("chain-ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
-        ("chain-ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
-        ("chain-ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..]),
+    for (label, item, rate, inputs, levels) in [
+        ("chain-ac1", "advanced-circuit", 1.0,
+         &["iron-plate", "copper-plate", "plastic-bar"][..], &[0u8][..]),
+        ("chain-ec15", "electronic-circuit", 15.0,
+         &["iron-plate", "copper-plate"][..], &[1, 2, 3, 5, 7][..]),
+        ("chain-ec30", "electronic-circuit", 30.0,
+         &["iron-plate", "copper-plate"][..], &[1, 2, 3, 5, 7][..]),
+        ("chain-mil5ore", "military-science-pack", 5.0,
+         &["iron-ore", "copper-ore", "stone", "coal"][..], &[0, 2, 3, 7][..]),
+        ("chain-mil5plates", "military-science-pack", 5.0,
+         &["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"][..], &[0, 2][..]),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
             item, rate, &inputs_set, &MachinePalette::default(),
             "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
         ).unwrap();
-        let l = compose_chain(&sr).unwrap();
-        let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, label);
-        std::fs::create_dir_all("target/tmp").unwrap();
-        std::fs::write(format!("target/tmp/{label}.bp"), &bp).unwrap();
-        std::fs::write(format!("target/tmp/{label}.manifest.json"),
-            serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-        println!("wrote target/tmp/{label}.bp ({} boundary in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
+        for &lvl in levels {
+            let mut l = compose_chain(&sr).unwrap();
+            l.inserter_capacity = lvl;
+            let tag = format!("{label}-d{lvl}");
+            let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, &tag);
+            std::fs::create_dir_all("target/tmp").unwrap();
+            std::fs::write(format!("target/tmp/{tag}.bp"), &bp).unwrap();
+            std::fs::write(format!("target/tmp/{tag}.manifest.json"),
+                serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+            println!("wrote target/tmp/{tag}.bp ({} boundary in / {} out)",
+                l.boundary_inputs.len(), l.boundary_outputs.len());
+        }
     }
 }
 
@@ -399,6 +415,8 @@ fn probe_registry_hashes() {
         ("chain-ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
         ("chain-ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
         ("chain-ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..]),
+        ("chain-mil5ore", "military-science-pack", 5.0, &["iron-ore", "copper-ore", "stone", "coal"][..]),
+        ("chain-mil5plates", "military-science-pack", 5.0, &["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"][..]),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
@@ -410,38 +428,50 @@ fn probe_registry_hashes() {
     }
 }
 
-/// PERMANENT GATE (RFC-051 registry): the seeded sim-verified entries
-/// still match freshly composed geometry. An engine change that alters
-/// these cells fails HERE — loudly — instead of silently decaying
-/// "sim-verified" into a stale verdict (#375 review finding 1). The
-/// fix when it fires: re-run the sim on the new geometry, then update
-/// the hash + measurement in cell-sim-registry.json.
+/// PERMANENT GATE (RFC-051 registry): every seeded sim-verified entry
+/// still matches freshly composed geometry — iterated from the
+/// registry itself, so adding an entry without a re-derivable fixture
+/// config fails loudly here, and an engine change that alters any
+/// registered cell fails here instead of silently decaying
+/// "sim-verified" into a stale verdict (#375 review finding 1; world
+/// axes added per #391 — declared fields are checked data, recorded at
+/// measurement time). The fix when it fires: re-run the sim on the new
+/// geometry, then update the hash + measurement in
+/// cell-sim-registry.json.
 #[test]
-// The registry currently carries one entry; the loop shape stays for
-// the ec15/ec30 entries that re-register after #381 (see below).
-#[allow(clippy::single_element_loop)]
 fn cell_registry_hashes_current() {
     use spaghettio_core::bus::cells::chain::compose_chain;
-    use spaghettio_core::bus::cells::registry::{geometry_hash, lookup};
-    // chain-ec15 is deliberately absent: under tech-state parity
-    // (declared inserter_capacity 0, #378) its long-handed input
-    // inserters genuinely under-deliver iron (#383, -8%) — the registry
-    // only carries measured-at-plan geometries. Re-measure and register
-    // once RFC-049 Phase 3 inserter sizing (#381) lands; chain-ac1's
-    // tiny rates never hit the bound, so its entry stands (re-verified
-    // PASS under the parity harness).
-    for (item, rate, inputs) in [
-        ("advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
-    ] {
-        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
-        let sr = solver::solve_with_palette_exclusions_and_quality(
-            item, rate, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
-        let l = compose_chain(&sr).unwrap();
-        let h = geometry_hash(&l);
-        assert!(lookup(item, rate, h).is_some(),
-            "{item}@{rate}: composed geometry (hash {h:016x}) no longer matches the sim-verified registry entry — re-verify in the sim and update cell-sim-registry.json");
+    use spaghettio_core::bus::cells::registry::{entries, geometry_hash};
+    // Fixture configs the registry may reference, keyed by (target,
+    // rate); same-key configs (mil5 ore vs plates) disambiguate by
+    // hash.
+    let configs: &[(&str, f64, &[&str])] = &[
+        ("advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"]),
+        ("electronic-circuit", 15.0, &["iron-plate", "copper-plate"]),
+        ("electronic-circuit", 30.0, &["iron-plate", "copper-plate"]),
+        ("military-science-pack", 5.0, &["iron-ore", "copper-ore", "stone", "coal"]),
+        ("military-science-pack", 5.0, &["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"]),
+    ];
+    assert!(!entries().is_empty(), "registry must not be empty");
+    for e in entries() {
+        let candidates: Vec<String> = configs
+            .iter()
+            .filter(|(t, r, _)| *t == e.target && (r - e.rate).abs() < 1e-9)
+            .map(|(t, r, inputs)| {
+                let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+                let sr = solver::solve_with_palette_exclusions_and_quality(
+                    t, *r, &inputs_set, &MachinePalette::default(),
+                    "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+                ).unwrap();
+                format!("{:016x}", geometry_hash(&compose_chain(&sr).unwrap()))
+            })
+            .collect();
+        assert!(!candidates.is_empty(),
+            "{}@{}: registry entry has no re-derivable fixture config in this gate — add it",
+            e.target, e.rate);
+        assert!(candidates.contains(&e.geometry_hash),
+            "{}@{} (declared capacity {}): composed geometry no longer matches the registered hash {} (fresh: {:?}) — re-verify in the sim and update cell-sim-registry.json",
+            e.target, e.rate, e.declared_inserter_capacity, e.geometry_hash, candidates);
     }
 }
 

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -223,6 +223,38 @@ follow-ups.
 
 ## Decision log
 
+- *2026-07-23 — Declaration package (post-#390 honest world; #391
+  world-axis hardening landed with it). Method: `inserter_capacity`
+  declarations change zero geometry pre-#381, only the world the
+  parity harness builds — so each composed geometry was swept across
+  declared levels and registered at the lowest level measuring at
+  plan. Registry entries now carry CHECKED world fields
+  (declared_inserter_capacity, declared_stacking, harness_world
+  provenance); `verification_note` distinguishes full matches from
+  scoped ones ("verified only under declared capacity N"); the gate
+  iterates the registry and re-derives every entry. **Registered
+  (both at declared 0, honest world)**: chain-ac1 (PASS −0.3%) and —
+  first measurement ever — chain-mil5plates (PASS, delivered 5.00/s
+  exact, 46/46 working: the westward bypasses and feed UG retrofits
+  physically work). **The declaration hypothesis HALF-FALSIFIED, and
+  the falsified half is the finding**: ec15/ec30 deficits shrink
+  −8.0% → −5.3% as declared capacity rises, then go LEVEL-INVARIANT
+  (d2..d7 identical at −5.3% produced; d7 realizes nb=3, hand 4 ≈
+  4.8/s — the input-inserter bound is definitively cleared). The
+  residual is a SECOND bound: the #385 output-side belt-drop class
+  (cable rows' output stacks at measured-not-credited rates) and/or
+  corridor saturation at 45/45 — Lane B's #394 constants are the fix
+  vehicle, and this sweep hands #385 input-side-excluded
+  corroboration. ec30's intermittent PASSes (d2, d5) are
+  delivered-window artifacts (produced −3..−6% every run): verdicts
+  that flicker with the measurement window do not register —
+  measured-at-plan means PRODUCED at plan. mil5-ore FAILs flat
+  (−28.7%) at every level: firearm-magazine rows need ~5 iron/s per
+  machine and the inserter COUNT is the bound — RFC-049 Phase 3
+  ladder territory (#381), not declarable-around. No EC or mil5-ore
+  entries; re-measure when #394/#381 land (every hash trips then by
+  design).*
+
 - *2026-07-23 — Validation-tiered selection (#392; SHARED SCORING
   MACHINERY — logged per the kill-3(b) rule). `accepted` never ran the
   full validator, so an error-laden native could outscore a clean

--- a/docs/status.md
+++ b/docs/status.md
@@ -218,16 +218,23 @@ PR #393 fixed the Router's boundary-blind hops and added westward
 bypass support after the placement order proved consumers can sit
 west of producers). mil5-from-plates' composed candidate is 0/0 but
 the search still returns the broken native layout there
-([#392](https://github.com/storkme/spaghettio/issues/392) — accepted
-never runs full validation). Measured-at-plan claims live in
-the sim-verified registry (geometry-hashed, checked-in): currently
-AC-from-plates (1.00/s, 8/8 working). EC-row geometries measure −8%
-under tech-state parity — the validator's inserter-item-throughput
-warnings turned out RIGHT under declared capacity (the Phase-1 "15.0/s
-exact" was a pre-#378 researched-bonus artifact;
-[#383](https://github.com/storkme/spaghettio/issues/383) has the
-forensics) — re-measure after RFC-049 Phase 3 inserter sizing
-([#381](https://github.com/storkme/spaghettio/issues/381)). Full
+([#392](https://github.com/storkme/spaghettio/issues/392) — resolved:
+validation-tiered selection). Measured-at-plan claims live in the
+sim-verified registry (geometry-hashed AND world-keyed per #391 —
+declared capacity/stacking are checked fields): currently
+AC-from-plates (PASS −0.3%) and mil5-from-plates (PASS, delivered
+5.00/s exact — first physical validation of the westward bypasses),
+both at declared capacity 0 in the post-#390 honest world. EC-row
+geometries stay unregistered: a declared-capacity sweep (1→7) shrank
+the deficit −8.0%→−5.3% then went level-invariant with the input
+bound cleared at nb=3 — the residual is the
+[#385](https://github.com/storkme/spaghettio/issues/385) output-side
+belt-drop class and/or 45/45 corridor saturation
+([#383](https://github.com/storkme/spaghettio/issues/383) has the
+sweep table); mil5-from-ore FAILs flat at −28.7% (firearm rows'
+inserter COUNT). Re-measure after
+[#394](https://github.com/storkme/spaghettio/pull/394) →
+[#381](https://github.com/storkme/spaghettio/issues/381) land. Full
 trail:
 [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md).
 


### PR DESCRIPTION
## Intent

The post-#390 declaration package (user-approved): re-measure the composed geometries in the honest world at declared inserter-capacity levels, register what produces at plan, and land #391's world-axis registry hardening in the same pass.

## What's here

- **#391**: `RegistryEntry` gains checked world fields (declared capacity, declared stacking, harness-world provenance). A geometry-hash match from a different declared world now reports a *scoped* claim ("verified only under declared capacity N") instead of silently reusing the verdict — the #390-class gap (instrument retired, zero entries tripped) is closed. The gate iterates the registry and re-derives every entry.
- **Registered** (both declared 0, honest world): chain-ac1 (PASS −0.3%) and chain-mil5plates (PASS, **delivered 5.00/s exact, 46/46 working** — the first physical validation of the westward bypasses and feed retrofits from #393).
- **Deliberately NOT registered, with the sweep as evidence**: ec15/ec30 shrink −8.0%→−5.3% with declared capacity, then go level-invariant with the input bound definitively cleared at nb=3 — isolating the residual to the #385 output-side belt-drop class and/or 45/45 corridor saturation (input-side-excluded corroboration posted to #383). ec30's occasional delivered-basis PASSes are window artifacts; the registry means *produced* at plan. mil5-ore FAILs flat (firearm rows' inserter count — #381 territory).

## Models / contracts touched

`RegistryEntry` schema (serde-defaulted — old entries parse), `verification_note` output strings (three tiers), registry gate shape. No geometry, no export/manifest changes (fixtures set `inserter_capacity` per declared level, which pre-#381 affects only the sim world).

## Verification

Suite 897/0/50 (single clean run); cell gates 10/10 (registry gate now re-derives both entries); goldens 9 ran / 0 drift; clippy clean on touched files; WASM check green. 16 sim runs across three batches (concurrent-safe alongside Lane B's).

## Deviations

The package's optimistic half ("EC rows clear around declared 2–3") was falsified by the sweep — documented as the finding rather than worked around. Re-measurement of EC rows and mil5-ore waits on #394 → #381 as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55