### PR TITLE
RFC-052: oil mega-cells — fluid subgraphs as uncropped composed units (design for review)

### DIFF
--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -1,0 +1,158 @@
+# RFC-052: Oil mega-cells — fluid subgraphs as uncropped composed units
+
+**Status**: Design (circulated for review)
+
+## Summary
+
+Extend chain composition (RFC-051) past its solid-only boundary by
+collapsing a chain's fluid-touching specs into ONE **mega-cell**: the
+engine's own layout for the fluid subgraph, used **uncropped** as a
+single composable unit. Fluids never cross cell boundaries — they live
+inside the mega-cell and at the layout's outer boundary records (crude,
+water), both of which the sim can already calibrate (#364; the plastic
+cell PASSED at 2.20/s). Between cells, everything stays solid belts and
+the existing corridor machinery. Flagship target: **advanced-circuit
+from fully raw inputs** (iron ore, copper ore, crude oil, water, coal)
+— smelting cells + an oil mega-cell + cable/EC/AC cells, composable at
+rates where the bus refuses.
+
+## Motivation
+
+- `chain_eligible` refuses any fluid ("solid-only Phase B"), so every
+  oil-touching chain falls back to the bus alone. The bus handles the
+  oil ladder cleanly at LOW rates (tier 3–7 all SOLVED) — the refusal
+  frontier is HIGH-rate configs, exactly where solid composition
+  already earns its keep (ec15/ec30/ec60, mil5).
+- The generator half of the work is already done and measured: the
+  engine lays out plastic-from-crude at 0 errors / 0 warnings (20×19,
+  probe 2026-07-23), and the hand-composed single plastic cell measured
+  at plan in the sim (RFC-048 gate (a), post-#364).
+- RFC-048 explicitly deferred fluid interiors to a Phase-3-shaped arc;
+  this is that arc, scoped to what the evidence supports.
+
+## Design
+
+### The mega-cell is UNCROPPED — decided by measurement, not taste
+
+`extract_cell`'s segment crop (keep `row:*` + poles + machines) is
+load-bearing for solid cells and **fatal for fluid complexes**: on
+plastic-from-crude it sheds the petroleum trunk between the refinery
+row and the chem row (22 trunk entities, 10 of them pipes), leaving a
+"cell" with orphaned petroleum-IN ports, a severed petroleum-OUT, and
+spurious W-edge "crude ports" derived from per-refinery pipe stubs
+(probe 2026-07-23, decision log). The internal plumbing IS the cell.
+So a mega-cell is the **whole engine layout** for the fluid subgraph:
+
+- Generated via `generate_cell_layout`-style bootstrap (bus pipeline,
+  composition forced Off) on the subgraph's terminal solid target(s).
+- Attached via the layout's own `boundary_inputs`/`boundary_outputs`
+  (probe: exactly `coal` + `crude-oil` for plastic; `water` +
+  `crude-oil` for sulfur) — fluid feeds as pipe columns (the
+  `compose_plastic_calibrated` idiom: column derived from the terminal
+  pipe, adjacency-asserted), solid feeds as belt feed columns exactly
+  as today.
+- Its solid outputs are ordinary out-ports for the chain corridor
+  machinery; no new corridor kinds.
+
+### Chain integration: the fluid-subgraph partition
+
+Eligibility extends instead of refusing outright: a chain is
+mega-eligible when its fluid-touching specs form **one connected
+subgraph** whose edges to the rest of the chain are all SOLID items.
+The subgraph collapses into a single super-spec (inputs: the subgraph's
+external inputs; outputs: its terminal solids) and the chain placer
+treats it as one slot — sized by a sub-solve of the subgraph at the
+chain's rate share. Multiple disconnected fluid subgraphs refuse in v1
+(named reason; N-mega-cells is future work). Quantization applies to
+the super-spec's SOLID outputs exactly as to any spec (fluids ride
+pipes, which in Factorio 2.0's segment model have no per-pipe
+throughput falloff — connectivity and isolation are the constraints,
+not rate).
+
+### Fluid isolation
+
+Pipes merge with ANY adjacent pipe, so cross-network adjacency is the
+hazard class. The mega-cell is internally self-consistent (the engine's
+own pipe-isolation validation passes), neighboring cells are belt/
+machine-only, and the only new pipes are the boundary feed columns.
+Design rule: fluid feed columns keep the same ≥4-tile pitch as belt
+feeds and the composed layout must pass the pipe-isolation validators
+— gated, not assumed.
+
+### Two rungs, deliberately
+
+1. **Basic complex** (this RFC's deliverable): refinery →
+   chem-plant chains via basic-oil-processing (the solver's own pick
+   for plastic/sulfur — single fluid intermediate, no cracking).
+2. **Advanced complex** (Phase C, deferred): advanced-oil-processing
+   with heavy/light/petroleum + cracking + lubricant (FRF/USP
+   territory). Byproduct balance is solver-side and already done
+   (net-flow); the layout question is whether the uncropped approach
+   scales to the 3-fluid-output row geometry. Not started until the
+   basic rung's gates pass.
+
+## Kill criteria
+
+1. **Generic-attachment or bust**: the mega-cell must attach through
+   the generic boundary machinery (feed columns + drains + the
+   existing Router). If plastic-from-crude needs per-recipe
+   hand-composition beyond what `compose_plastic_calibrated` already
+   established as reusable idiom, kill — the point is the generic
+   path.
+2. **Value-existence**: there must be at least one reachable config
+   where the composed chain resolves a BUS refusal at 0 validation
+   errors (the ec15-of-oil). If the bus already covers the whole
+   reachable oil frontier at every rate the sub-solve supports, record
+   the scoreboard and kill — a capability no-op is not worth the
+   machinery.
+3. **Sim gate**: the flagship fixture measures at plan in the honest
+   world (declared 0), or its deficit is attributed to a named
+   engine-wide bound (#385/#381-class) that solid chains share — a
+   NEW fluid-specific deficit class kills until diagnosed.
+4. **Isolation**: pipe-isolation and fluid-port validators clean on
+   every composed fixture. One cross-network merge = stop.
+
+## Verification plan
+
+- **Gate (a)** — standalone mega-cell: plastic-from-crude composed via
+  the generic path at 0 errors / 0 warnings, sim-measured at plan
+  (declared 0, honest world), registered in cell-sim-registry with
+  world fields.
+- **Gate (b)** — chain integration: AC-from-raw (iron ore, copper ore,
+  crude, water, coal) composes at 0 errors where the bus refuses
+  (rate chosen by scoreboard sweep); sim-measured; the mega-cell's
+  registry entry covers the composed-in-chain geometry.
+- Differential scoreboard rows for plastic/sulfur/AC-from-raw at a
+  rate ladder (bus vs composed), single-run quoted.
+- Full suite + canonical goldens + clippy + WASM as always; K=1
+  bit-identity of existing solid chains enforced by the registry gate
+  (mega-cells are additive machinery — solid-only chains must compose
+  byte-identically).
+
+## Phasing
+
+- **Phase A** — mega-cell generation + generic boundary attachment;
+  gate (a).
+- **Phase B** — fluid-subgraph partition in eligibility + placer;
+  flagship AC-from-raw; gate (b); scoreboard sweep for kill 2.
+- **Phase C** (deferred) — advanced-oil complex (cracking, lubricant).
+  Own go/no-go on Phase A/B evidence.
+
+## Decision log
+
+- *2026-07-23 — RFC authored (number claimed after fresh origin/main
+  registry + open-PR collision check). Scoping probe
+  (`debug_oil_cell_probe`, local example): (1) the solver picks
+  basic-oil-processing for plastic/sulfur-from-crude — the basic rung
+  has NO cracking complexity, so it is genuinely reachable now;
+  (2) engine layouts for it are small and clean (plastic 20×19 and
+  35×19 at 2/s and 5/s, sulfur 25×20 — all 0 errors / 0 warnings);
+  (3) `extract_cell`'s crop sheds the petroleum trunk (22 entities, 10
+  pipes) and derives nonsense ports from refinery pipe stubs — hence
+  the UNCROPPED mega-cell decision, made on measurement; (4) raw
+  boundary records are clean and small (coal+crude / water+crude),
+  matching the calibrated fluid-feed idiom the sim already PASSED
+  (plastic 2.20/s, post-#364). Deferred by decision: advanced-oil
+  complex (Phase C), multiple disconnected fluid subgraphs, fluid
+  corridors between cells (explicitly rejected — isolation risk with
+  no rate payoff under 2.0's segment model).*

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -63,5 +63,6 @@ backfill the status next time the doc is touched.
 | RFC-049 | 2026-07-22 | [`rfc-049-inserter-capacity-research.md`](rfc-049-inserter-capacity-research.md) | Complete (in-game anchor open; input-side data gap #343) |
 | RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Complete (fluid feed CALIBRATED via #364 — first fluid factory PASS; fluid-pack sweep + #345 re-measure open) |
 | RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Complete — default Candidate; sim registry; K-quantization (corridor-cap); EC-row re-measure waits on #381 |
+| RFC-052 | 2026-07-23 | [`rfc-052-oil-mega-cell.md`](rfc-052-oil-mega-cell.md) | Design (circulated for review) |
 
-Next number: **RFC-052**.
+Next number: **RFC-053**.


### PR DESCRIPTION
## Intent

Author the oil mega-cell RFC (the direction approved earlier in the RFC-051 arc). Docs-only: design + kill criteria + verification plan + the scoping-probe evidence in the decision log. Circulated for review — implementation starts as Phase A after the design survives.

## Scope

Two files: `docs/rfc-052-oil-mega-cell.md` (new) and `docs/rfcs.md` (registry row + next-number bump). No code, tests, or data touched. The scoping probe that produced the decision-log evidence lives in `crates/core/examples/` (gitignored, local-only per convention).

## Key design calls (details and evidence in the RFC)

- **Uncropped mega-cell**, decided by measurement: `extract_cell`'s crop sheds the petroleum trunk between refinery and chem rows (22 entities, 10 pipes) and derives nonsense ports from pipe stubs — the internal plumbing IS the cell, so the unit is the whole engine layout attached via its own boundary records (which are clean: coal+crude / water+crude).
- **Fluids never cross cell boundaries** — inside the mega-cell and at the outer boundary only (the sim-calibrated pipe-feed idiom, PASSED at 2.20/s post-#364). Solid corridors unchanged; no fluid corridors (explicitly rejected: isolation risk, no rate payoff under 2.0's segment fluid model).
- **Two rungs**: basic complex now (the solver itself picks basic-oil-processing for plastic/sulfur — no cracking; engine layouts measure 0/0 at 20×19), advanced complex with cracking/lubricant deferred to Phase C.
- **Kill 2 is value-existence**: a config must exist where the composed chain resolves a bus refusal — the bus already handles the oil ladder cleanly at low rates, so if the refusal frontier is unreachable the arc kills honestly.

## Models / contracts touched

None — design document only. The RFC *proposes* future contract changes (chain eligibility gains a fluid-subgraph partition; a mega-cell placed-unit kind in the chain placer) which land, if approved, in Phase A/B implementation PRs with their own review.

## Verification

Docs-only; no code or tests affected. Registry row added after a fresh origin/main + open-PR collision check; next number bumped to RFC-053.

## Deviations from intent

None. The RFC's scope is narrower than the original "oil mega-cell" ambition in one deliberate way, recorded in its decision log: the advanced-oil complex (cracking, lubricant) is deferred to Phase C with its own go/no-go rather than designed now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55