### PR TITLE
#400: refineries work — port-connected strips, reactive substation coverage, mirror-as-rotation export (RFC-052 gate (a) MET)

### DIFF
--- a/crates/core/data/cell-sim-registry.json
+++ b/crates/core/data/cell-sim-registry.json
@@ -22,5 +22,29 @@
     "produced_per_s": 4.83,
     "scenario": "spaghettio-sim chain-mil5plates-d0 (Factorio 2.0.76, 46/46 working, converged, delivered 5.00/s exact, produced -3.3% within pass band; first measurement of westward bypasses + feed retrofits)",
     "date": "2026-07-23"
+  },
+  {
+    "target": "plastic-bar",
+    "rate": 2.0,
+    "geometry_hash": "163148334829655d",
+    "declared_inserter_capacity": 0,
+    "declared_stacking": 1,
+    "harness_world": "nb=0 bulk=1, S=1 (post-#390 stacking parity)",
+    "verdict": "PASS",
+    "produced_per_s": 2.2,
+    "scenario": "spaghettio-sim mega-plastic2 (Factorio 2.0.76, 4/4 working, converged, delivered 2.20/s vs 2.00 planned; FIRST working refineries \u2014 #400 fixed: port-connected strip + reactive substation + mirror-as-rotation export)",
+    "date": "2026-07-23"
+  },
+  {
+    "target": "sulfur",
+    "rate": 2.0,
+    "geometry_hash": "21e4634c9a86cd4f",
+    "declared_inserter_capacity": 0,
+    "declared_stacking": 1,
+    "harness_world": "nb=0 bulk=1, S=1 (post-#390 stacking parity)",
+    "verdict": "PASS",
+    "produced_per_s": 2.0,
+    "scenario": "spaghettio-sim mega-sulfur2 (Factorio 2.0.76, 5/5 working, converged, produced 2.00/s EXACT; two-fluid mega-cell with adjacency-planned feeds)",
+    "date": "2026-07-23"
   }
 ]

--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -28,6 +28,14 @@ struct BlueprintFilter<'a> {
     name: &'a str,
 }
 
+/// Machines whose engine-side "mirror" is a front-back port flip that the
+/// GAME cannot express as `mirror` (game mirror = left-right). Their port
+/// layouts are x-symmetric, so the flip is tile-identical to a 180°
+/// rotation — the artifact boundary encodes it that way (#400).
+fn mirror_is_rotation(name: &str) -> bool {
+    matches!(name, "oil-refinery" | "foundry" | "cryogenic-plant")
+}
+
 #[derive(Serialize)]
 struct BlueprintEntity<'a> {
     entity_number: usize,
@@ -235,12 +243,26 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
                 // fluid feed in-game while validating clean.
                 direction: if ent.name.contains("inserter") || ent.name == "pipe-to-ground" {
                     (ent.direction as u8 + 8) % 16
+                } else if mirror_is_rotation(&ent.name) && ent.mirror {
+                    // MIRRORED FLUID MACHINES are the same artifact-boundary
+                    // class (#400, sim-measured 2026-07-23): the engine's
+                    // "mirror" models a FRONT-BACK (y) port flip, but the
+                    // game's `mirror` flag flips LEFT-RIGHT across the facing
+                    // axis — an exported (North, mirror) refinery still has
+                    // its inputs on the south in-game, so crude sat ON the
+                    // engine's intended port tiles and never entered (total
+                    // stall, first refinery measurement). For x-symmetric
+                    // port layouts (refinery/foundry/cryo — asserted by the
+                    // fluid_ports provenance script) the engine's y-flip is
+                    // TILE-IDENTICAL to a 180° rotation, so export encodes it
+                    // as (direction+8, mirror:false); the parser reverses it.
+                    (ent.direction as u8 + 8) % 16
                 } else {
                     ent.direction as u8
                 },
                 recipe: ent.recipe.as_deref(),
                 io_type: ent.io_type.as_deref(),
-                mirror: ent.mirror,
+                mirror: ent.mirror && !mirror_is_rotation(&ent.name),
                 input_priority: ent.input_priority.as_deref(),
                 output_priority: ent.output_priority.as_deref(),
                 use_filters: filters.is_some().then_some(true),

--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -251,11 +251,20 @@ pub fn export(layout: &LayoutResult, label: &str) -> String {
                     // axis — an exported (North, mirror) refinery still has
                     // its inputs on the south in-game, so crude sat ON the
                     // engine's intended port tiles and never entered (total
-                    // stall, first refinery measurement). For x-symmetric
-                    // port layouts (refinery/foundry/cryo — asserted by the
-                    // fluid_ports provenance script) the engine's y-flip is
-                    // TILE-IDENTICAL to a 180° rotation, so export encodes it
-                    // as (direction+8, mirror:false); the parser reverses it.
+                    // stall, first refinery measurement). For the engine's
+                    // own (North, mirror) placements the y-flip is
+                    // tile-identical to a 180° rotation — port POSITIONS
+                    // coincide because the layouts are x-symmetric — so
+                    // export encodes (direction+8, mirror:false) and the
+                    // parser reverses it. Two recorded caveats (#403
+                    // review): the wire form collides with genuinely
+                    // rotated-unmirrored placements (parser trade-off,
+                    // pinned there), and per-fluidbox IDENTITY (crude vs
+                    // water) swaps sides under rotation-vs-mirror — inert
+                    // for single-fluid basic processing, a Phase-C
+                    // precondition for advanced-oil (RFC-052 decision
+                    // log; the game itself warns about this exact
+                    // confusion in FFF #394).
                     (ent.direction as u8 + 8) % 16
                 } else {
                     ent.direction as u8

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -359,8 +359,14 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
         // "mirror" is a front-back port flip the game cannot express as
         // its (left-right) `mirror` flag; export encodes it as a 180°
         // rotation with mirror:false, so a rotated import maps back to
-        // the engine's (unrotated, mirror:true) placement. Tile-identical
-        // either way (x-symmetric ports).
+        // the engine's (unrotated, mirror:true) placement. KNOWN
+        // TRADE-OFF (#403 review): the wire forms (South, unmirrored)
+        // and (North, mirrored) COLLIDE — this reverse map is exact for
+        // everything spaghettio exports, but a community blueprint with
+        // a genuinely South/West-unmirrored refinery/foundry/cryo
+        // imports as the engine's mirrored form, whose INPUT face is
+        // 180° away. Pinned by
+        // `south_unmirrored_refinery_import_maps_to_mirrored_north`.
         let mirror_rot = matches!(
             raw.name.as_str(),
             "oil-refinery" | "foundry" | "cryogenic-plant"
@@ -648,6 +654,29 @@ mod tests {
         assert_eq!(parsed.entities[0].direction, EntityDirection::West);
         assert_eq!(parsed.entities[1].direction, EntityDirection::East);
         assert_eq!(parsed.entities[2].direction, EntityDirection::East);
+    }
+
+    /// #400/#403: the mirror-as-rotation wire encoding COLLIDES with a
+    /// genuinely South-unmirrored refinery — the parser maps both wire
+    /// forms to the engine's (North, mirror:true) placement. Exact for
+    /// spaghettio's own round-trips; a deliberate, PINNED trade-off for
+    /// community imports (the input face lands 180° from the original
+    /// there — #403 review enumeration).
+    #[test]
+    fn south_unmirrored_refinery_import_maps_to_mirrored_north() {
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "entities": [
+                    {"entity_number": 1, "name": "oil-refinery",
+                     "position": {"x": 2.5, "y": 2.5}, "direction": 8}
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.entities[0].direction, EntityDirection::North);
+        assert!(parsed.entities[0].mirror,
+            "South-unmirrored wire form maps to the engine's mirrored-North placement");
     }
 
     /// Pipe-to-ground un-flips on import (#364): a game pair faces AWAY

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -365,9 +365,7 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
             raw.name.as_str(),
             "oil-refinery" | "foundry" | "cryogenic-plant"
         ) && matches!(parsed, EntityDirection::South | EntityDirection::West);
-        let dir = if raw.name.contains("inserter") || raw.name == "pipe-to-ground" {
-            flip180(parsed)
-        } else if mirror_rot {
+        let dir = if raw.name.contains("inserter") || raw.name == "pipe-to-ground" || mirror_rot {
             flip180(parsed)
         } else {
             parsed

--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -355,7 +355,19 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
         let parsed = parse_direction(raw.direction);
         // Pipe-to-ground shares the flip (#364): game direction is the
         // surface-opening side, engine convention is the underground side.
+        // Mirrored fluid machines share it too (#400): the engine's
+        // "mirror" is a front-back port flip the game cannot express as
+        // its (left-right) `mirror` flag; export encodes it as a 180°
+        // rotation with mirror:false, so a rotated import maps back to
+        // the engine's (unrotated, mirror:true) placement. Tile-identical
+        // either way (x-symmetric ports).
+        let mirror_rot = matches!(
+            raw.name.as_str(),
+            "oil-refinery" | "foundry" | "cryogenic-plant"
+        ) && matches!(parsed, EntityDirection::South | EntityDirection::West);
         let dir = if raw.name.contains("inserter") || raw.name == "pipe-to-ground" {
+            flip180(parsed)
+        } else if mirror_rot {
             flip180(parsed)
         } else {
             parsed
@@ -395,7 +407,7 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
             recipe: raw.recipe,
             io_type: raw.io_type,
             carries: None,
-            mirror: false,
+            mirror: mirror_rot,
             segment_id: None,
             rate: None,
             items,

--- a/crates/core/src/bus/cells/mega.rs
+++ b/crates/core/src/bus/cells/mega.rs
@@ -131,12 +131,16 @@ pub fn adapt_boundaries(l: LayoutResult) -> Result<LayoutResult, String> {
     // SAME-fluid pipe (the join). Planned paths also register here so
     // records check against each other.
     let mut fluid_at: rustc_hash::FxHashMap<(i32, i32), String> = rustc_hash::FxHashMap::default();
+    let mut plain_pipe_at: FxHashSet<(i32, i32)> = FxHashSet::default();
     let mut solid_at: FxHashSet<(i32, i32)> = FxHashSet::default();
     for e in &entities {
         let is_pipe = e.name == "pipe" || e.name == "pipe-to-ground";
         if is_pipe {
             if let Some(f) = e.carries.as_deref() {
                 fluid_at.insert((e.x, e.y), f.to_string());
+                if e.name == "pipe" {
+                    plain_pipe_at.insert((e.x, e.y));
+                }
             }
         } else {
             solid_at.insert((e.x, e.y));
@@ -156,60 +160,97 @@ pub fn adapt_boundaries(l: LayoutResult) -> Result<LayoutResult, String> {
             // orthogonal neighbor carries a different fluid, and the
             // path ends adjacent to a same-fluid pipe.
             let mut chosen: Option<Vec<(i32, i32)>> = None;
+            // A join partner must genuinely CONNECT (#400's own lesson,
+            // recursively applied to the adapter): a plain pipe joins on
+            // any side; a pipe-to-ground only at its axis opening — we
+            // accept one directly BELOW the terminus (the trunk-head
+            // mouth pattern), never sideways.
             'cand: for dx in [0i32, 1, -1, 2, -2] {
                 let tail_x = p.orig_x + dx;
-                let mut tiles: Vec<(i32, i32)> = Vec::new();
-                for y in 0..=p.lane_row {
-                    tiles.push((p.head_x, y));
-                }
-                let (lo, hi) = (p.head_x.min(tail_x), p.head_x.max(tail_x));
-                for x in lo..=hi {
-                    if x != p.head_x {
-                        tiles.push((x, p.lane_row));
+                // The tail may descend past the band boundary into free
+                // layout space until a join materializes — post-#400 raw
+                // trunk heads are PTG mouths whose sides don't connect,
+                // so the band-boundary join can be unreachable while the
+                // strip a few tiles deeper is an honest plain-pipe join.
+                for tail_depth in 0..=8i32 {
+                    let mut tiles: Vec<(i32, i32)> = Vec::new();
+                    for y in 0..=p.lane_row {
+                        tiles.push((p.head_x, y));
                     }
-                }
-                for y in (p.lane_row + 1)..margin {
-                    tiles.push((tail_x, y));
-                }
-                if dx != 0 {
-                    tiles.push((tail_x, margin));
-                }
-                let tile_set: FxHashSet<(i32, i32)> = tiles.iter().copied().collect();
-                for &(x, y) in &tiles {
-                    if solid_at.contains(&(x, y)) || fluid_at.contains_key(&(x, y)) {
-                        continue 'cand;
-                    }
-                    for n in neighbors(x, y) {
-                        if tile_set.contains(&n) {
-                            continue;
+                    let (lo, hi) = (p.head_x.min(tail_x), p.head_x.max(tail_x));
+                    for x in lo..=hi {
+                        if x != p.head_x {
+                            tiles.push((x, p.lane_row));
                         }
-                        if let Some(f) = fluid_at.get(&n) {
-                            if f != &r.item {
-                                continue 'cand;
+                    }
+                    let tail_end = if dx != 0 || tail_depth > 0 {
+                        margin + tail_depth
+                    } else {
+                        margin - 1
+                    };
+                    for y in (p.lane_row + 1)..=tail_end.min(margin - 1 + tail_depth + 1) {
+                        if y >= margin && dx == 0 && tail_depth == 0 {
+                            break;
+                        }
+                        tiles.push((tail_x, y));
+                    }
+                    let tile_set: FxHashSet<(i32, i32)> = tiles.iter().copied().collect();
+                    let mut valid = true;
+                    'check: for &(x, y) in &tiles {
+                        if solid_at.contains(&(x, y)) || fluid_at.contains_key(&(x, y)) {
+                            valid = false;
+                            break 'check;
+                        }
+                        for n in neighbors(x, y) {
+                            if tile_set.contains(&n) {
+                                continue;
+                            }
+                            if let Some(f) = fluid_at.get(&n) {
+                                if f != &r.item {
+                                    valid = false;
+                                    break 'check;
+                                }
                             }
                         }
                     }
+                    if !valid {
+                        // A blocked deeper tail cannot unblock by going
+                        // deeper still through the same tile — but a
+                        // DIFFERENT depth may stop before the blocker;
+                        // simplest sound policy: abandon this dx.
+                        continue 'cand;
+                    }
+                    // The join candidate is the path's geometric
+                    // TERMINUS (deepest tail tile), NOT tiles.last() —
+                    // push order puts a lateral tile last whenever a
+                    // bend exists (#401 review finding 1). Join
+                    // partners: same-fluid PLAIN pipe on any side, or a
+                    // same-fluid pipe-to-ground DIRECTLY BELOW (its
+                    // axis opening) — a PTG side never connects.
+                    let terminus = *tiles.last().unwrap_or(&(tail_x, p.lane_row));
+                    let terminus = if tiles.iter().any(|&t| t.0 == tail_x && t.1 > p.lane_row) {
+                        (tail_x, tiles.iter().filter(|t| t.0 == tail_x).map(|t| t.1).max().unwrap())
+                    } else {
+                        terminus
+                    };
+                    let joins = neighbors(terminus.0, terminus.1).iter().any(|n| {
+                        if tile_set.contains(n) {
+                            return false;
+                        }
+                        let Some(f) = fluid_at.get(n) else { return false };
+                        if f != &r.item {
+                            return false;
+                        }
+                        let is_plain = plain_pipe_at.contains(n);
+                        let directly_below = *n == (terminus.0, terminus.1 + 1);
+                        is_plain || directly_below
+                    });
+                    if !joins {
+                        continue;
+                    }
+                    chosen = Some(tiles);
+                    break 'cand;
                 }
-                // The join candidate is the path's geometric TERMINUS
-                // (deepest tile on the tail column), NOT tiles.last() —
-                // push order puts a lateral tile last whenever a bend
-                // exists, which spuriously rejected the dx=0 candidate
-                // for the final record (#401 review finding 1).
-                let terminus = if p.lane_row + 1 < margin {
-                    (tail_x, margin - 1)
-                } else if dx != 0 {
-                    (tail_x, margin)
-                } else {
-                    (tail_x, p.lane_row)
-                };
-                let joins = neighbors(terminus.0, terminus.1).iter().any(|n| {
-                    !tile_set.contains(n) && fluid_at.get(n).map(|f| f == &r.item).unwrap_or(false)
-                });
-                if !joins {
-                    continue 'cand;
-                }
-                chosen = Some(tiles);
-                break;
             }
             let tiles = chosen.ok_or_else(|| {
                 format!(
@@ -219,6 +260,7 @@ pub fn adapt_boundaries(l: LayoutResult) -> Result<LayoutResult, String> {
             })?;
             for &(x, y) in &tiles {
                 fluid_at.insert((x, y), r.item.clone());
+                plain_pipe_at.insert((x, y));
                 entities.push(PlacedEntity {
                     name: "pipe".into(),
                     x,
@@ -314,6 +356,9 @@ pub fn adapt_boundaries(l: LayoutResult) -> Result<LayoutResult, String> {
         inserter_capacity: l.inserter_capacity,
         boundary_inputs: b_in,
         boundary_outputs: b_out,
+        // The engine's warnings survive the adaptation — dropping them
+        // hid the ships-uncovered power note during #400's diagnosis.
+        warnings: l.warnings.clone(),
         ..Default::default()
     })
 }

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -973,10 +973,31 @@ fn layout_pass(
                             .filter(|&(_x, y)| y >= row.y_start && y < machine_top)
                             .filter(|&(ix, iy)| is_packed(ix, iy))
                             .collect();
-                        if inserters.is_empty() {
+                        // #400: machine CENTERS become substation subjects
+                        // ONLY for rows with no inserters at all (fluid-only
+                        // rows, e.g. refineries) — their centers are
+                        // unreachable by any medium band when both pipe
+                        // strips are full. Mixed rows keep the old
+                        // medium-first behavior: their centers get covered
+                        // by the widened bands (EC@20-from-ore regression
+                        // guard — eager substations there changed a layout
+                        // mediums handle fine).
+                        let row_has_inserters = inserters_for_poles
+                            .iter()
+                            .any(|&(_x, y)| y >= row.y_start && y < row.y_end);
+                        let mut subjects = inserters;
+                        if !row_has_inserters {
+                            subjects.extend(
+                                machines_for_poles
+                                    .iter()
+                                    .filter(|&&(_, ty, _)| ty >= row.y_start && ty < row.y_end)
+                                    .map(|&(cx, ty, mh)| (cx, ty + mh / 2)),
+                            );
+                        }
+                        if subjects.is_empty() {
                             return None;
                         }
-                        Some(SubstationTarget { band_y0, band_y1, inserters })
+                        Some(SubstationTarget { band_y0, band_y1, inserters: subjects })
                     } else {
                         // Interior band (RFC Phase 3a-ii): the freed gap between
                         // row `row_after` and its successor; the target inserters
@@ -1002,10 +1023,24 @@ fn layout_pass(
                             .filter(|&(_x, y)| y >= below.y_start && y < below.y_start + 4)
                             .filter(|&(ix, iy)| is_packed(ix, iy))
                             .collect();
-                        if inserters.is_empty() {
+                        // #400: same fluid-only-row machine-center
+                        // extension as the top-edge branch.
+                        let row_has_inserters = inserters_for_poles
+                            .iter()
+                            .any(|&(_x, y)| y >= below.y_start && y < below.y_end);
+                        let mut subjects = inserters;
+                        if !row_has_inserters {
+                            subjects.extend(
+                                machines_for_poles
+                                    .iter()
+                                    .filter(|&&(_, ty, _)| ty >= below.y_start && ty < below.y_end)
+                                    .map(|&(cx, ty, mh)| (cx, ty + mh / 2)),
+                            );
+                        }
+                        if subjects.is_empty() {
                             return None;
                         }
-                        Some(SubstationTarget { band_y0, band_y1, inserters })
+                        Some(SubstationTarget { band_y0, band_y1, inserters: subjects })
                     }
                 })
                 .collect(),
@@ -1564,10 +1599,11 @@ fn place_unified_band_line(
 /// row-based structure of the bus layout.
 /// `machines` entries are `(center_x, top_y, height)` — height (not width)
 /// because every use below (row grouping, below-row fallback y) is a vertical
-/// offset from the machine row. Returns `(poles, uncovered_inserters)` — the
-/// second element is the set of electric inserters NEITHER a substation NOR a
-/// medium pole could reach (the `give_up` set), the reactive substation pass's
-/// trigger; a final `repair_pole_connectivity` bridges any disconnected pole
+/// offset from the machine row. Returns `(poles, uncovered_subjects)` — the
+/// second element is the set of electric inserters AND machine centers (#400:
+/// fluid-only rows have no inserters, so centers must report themselves)
+/// NEITHER a substation NOR a medium pole could reach (the `give_up` set),
+/// the reactive substation pass's trigger; a final `repair_pole_connectivity` bridges any disconnected pole
 /// clusters.
 fn place_poles(
     machines: &[(i32, i32, i32)],
@@ -1780,6 +1816,41 @@ fn place_poles(
             None => {
                 give_up.insert((ix, iy));
             }
+        }
+    }
+
+    // #400: machine CENTERS are coverage subjects too. Fluid-only 5×5
+    // rows have no inserters and (post-#400) a fully continuous input
+    // pipe strip — the strip's former pole gap put UG mouths on the
+    // input-port tiles, which is why it was removed — so nothing above
+    // places a pole that reaches those centers. Report uncoverable
+    // centers into the same reactive channel the substation bands
+    // consume (Phase 3a-ii) instead of shipping a silently unpowered
+    // machine row.
+    let subs: Vec<(i32, i32)> = entities
+        .iter()
+        .filter(|e| e.name == "substation")
+        .map(|e| (e.x, e.y))
+        .collect();
+    for &(cx, top_y, mh) in machines {
+        // FLUID-ONLY rows only (#400): a row with inserters keeps the
+        // pre-#400 behavior bit-identically — its center was never a
+        // reported subject, its coverage rides the inserter-driven
+        // bands, and the validator still warns if it ends uncovered
+        // (two stress goldens drifted when mixed-row centers added
+        // bands of their own). Rows are vertical partitions, so "no
+        // inserter in this row's y-range" identifies fluid-only rows.
+        let row_has_inserters = inserters
+            .iter()
+            .any(|&(_ix, iy)| iy >= top_y - 2 && iy <= top_y + mh + 1);
+        if row_has_inserters {
+            continue;
+        }
+        let cy = top_y + mh / 2;
+        let ok = covered(cx, cy, &placed)
+            || subs.iter().any(|&(sx, sy)| sub_covers(sx, sy, cx, cy));
+        if !ok {
+            give_up.insert((cx, cy));
         }
     }
 

--- a/crates/core/src/bus/templates.rs
+++ b/crates/core/src/bus/templates.rs
@@ -45,33 +45,6 @@ fn output_dir(output_east: bool) -> EntityDirection {
     if output_east { EntityDirection::East } else { EntityDirection::West }
 }
 
-/// The column (relative to the machine's left edge) to leave free for a power
-/// pole in a fluid-only row's continuous input pipe strip — or `None` when the
-/// row needs no reservation (RFC `docs/rfc-power-supply.md` Phase 1).
-///
-/// The continuous pipe strip sits on `pole_candidate_ys`' north band
-/// (`input_y == top_y - 1`), so it fills the one row a pole most wants. Whether
-/// the pole can instead sit in a row *beyond* the strip depends on the machine
-/// footprint: a medium-electric-pole supplies its tile ±3, so for a 5×5 machine
-/// the rows above the strip are occupied by the bus trunk and the strip itself
-/// is full — the pole has nowhere to go unless a strip tile is freed. Smaller
-/// (≤4-wide) fluid machines can be reached from the row above the strip, so
-/// they don't force a reservation. Replaces the former `oil-refinery`-only
-/// special case; now covers any 5×5 fluid-only machine (oil-refinery today, a
-/// fluid-only cryogenic-plant/foundry if one ever appears), and is byte-
-/// identical for the corpus (oil-refinery is its only 5×5 fluid-only row).
-///
-/// The gap goes at the machine's centre column (`msz / 2`), where the freed
-/// pole covers the whole footprint; the caller bridges the two pipe halves with
-/// a 1-tile underground pair so the fluid network stays connected across it.
-fn fluid_row_pole_gap_dx(msz: i32) -> Option<i32> {
-    if msz >= 5 {
-        Some(msz / 2)
-    } else {
-        None
-    }
-}
-
 /// Emit a continuous south-face fluid-output pipe row for a solid-in/fluid-out
 /// machine and register the machine's real south output-port columns (from the
 /// shared table) as bus tap points.
@@ -3447,64 +3420,32 @@ pub fn fluid_only_row(
             // basic-oil-processing's crude-oil), the extra pipe tiles touch
             // inactive fluid boxes which Factorio simply ignores.
             //
-            // For 5×5 oil-refinery rows the continuous strip leaves no free
-            // tile at `input_y` for power poles — the only y where a
-            // medium-electric-pole reaches the machine center. Bridge the
-            // strip with a 1-tile UG pair at dx=1 and dx=3 (the two
-            // physical fluid input port positions per `fluid_ports`),
-            // leaving dx=2 free for `place_poles` to drop a pole that
-            // covers each refinery's center. dx=0 and dx=4 stay as regular
-            // pipes so adjacent machines' strips connect on the surface.
+            // The strip is CONTINUOUS SURFACE PIPE for every dx (#400): the
+            // former 5×5 pole reservation bridged the mid-machine column
+            // with a UG pair whose mouths sat exactly ON the two input-port
+            // tiles (dx=1/dx=3 per `fluid_ports`) — and a pipe-to-ground
+            // connects only along its axis, never down into the machine, so
+            // crude physically never entered the refineries (first refinery
+            // sim ground truth; the validator shared the belief and passed
+            // it). The pole that used to live in the freed tile is now the
+            // reactive substation pass's job: `place_poles` reports the
+            // uncoverable machine center and the Phase-3a-ii band machinery
+            // powers the row with a substation.
             if let Some(&(_, item)) = fluid_inputs.first() {
                 let seg = Some(format!("row:{recipe}:belt-in:{item}"));
-                // RFC `docs/rfc-power-supply.md` Phase 1: reserve a pole gap in
-                // the continuous input pipe row (a `pole_candidate_ys` band)
-                // whenever the machine footprint forces the covering pole INTO
-                // that band. A medium-electric-pole supplies its footprint ±3;
-                // for a 5×5 machine every tile of the rows above the input pipe
-                // row (the bus trunk) is >3 from the machine and the pipe row
-                // itself is full, so the pole has nowhere to sit unless a tile
-                // is freed here. Smaller (3×3) fluid rows can be covered from
-                // the row above the pipe strip (within ±3), so they don't force
-                // a reservation. Principled + footprint-derived, replacing the
-                // former `oil-refinery`-only special case — now also covers a
-                // fluid-only cryogenic-plant/foundry (both 5×5).
-                let gap_dx: Option<i32> = fluid_row_pole_gap_dx(msz);
                 for dx in 0..msz {
-                    if Some(dx) == gap_dx {
-                        continue;
-                    }
-                    let (name, direction, io_type) = if Some(dx + 1) == gap_dx {
-                        ("pipe-to-ground", EntityDirection::East, Some("input".to_string()))
-                    } else if Some(dx - 1) == gap_dx {
-                        ("pipe-to-ground", EntityDirection::West, Some("output".to_string()))
-                    } else {
-                        ("pipe", EntityDirection::North, None)
-                    };
                     entities.push(PlacedEntity {
-                        name: name.to_string(),
+                        name: "pipe".to_string(),
                         x: mx + dx,
                         y: input_y,
-                        direction,
-                        io_type,
+                        direction: EntityDirection::North,
                         carries: Some(item.to_string()),
                         segment_id: seg.clone(),
                         ..Default::default()
                     });
                 }
-                if let Some(g) = gap_dx {
-                    // Report only the leftmost UG-bridge port (dx = g-1) so the
-                    // pole-tap reservation around the lane→port path
-                    // (`hi - 1` in `layout.rs`) doesn't claim the gap tile
-                    // before `place_poles` runs. The dx=g+1 port is still a
-                    // `pipe-to-ground` so the validator sees an adjacent pipe at
-                    // both physical input ports, and fluid reaches it via the
-                    // underground tunnel. (g=2 for a 5×5 → reports dx=1.)
-                    fluid_input_port_pipes.push((item.to_string(), mx + g - 1, input_y));
-                } else {
-                    for &(dx, port_item) in fluid_inputs {
-                        fluid_input_port_pipes.push((port_item.to_string(), mx + dx, input_y));
-                    }
+                for &(dx, port_item) in fluid_inputs {
+                    fluid_input_port_pipes.push((port_item.to_string(), mx + dx, input_y));
                 }
             }
         } else {
@@ -5573,17 +5514,7 @@ pub fn scrap_recycling_row(
 mod tests {
     use super::*;
 
-    #[test]
-    fn fluid_row_pole_gap_only_for_5x5() {
-        // RFC Phase 1: 5×5 fluid-only machines (oil-refinery, and a fluid-only
-        // cryogenic-plant/foundry if one appears) force the pole into the pipe
-        // strip → reserve the centre column. Smaller machines are covered from
-        // the row above → no reservation.
-        assert_eq!(fluid_row_pole_gap_dx(5), Some(2)); // byte-identical to the old oil-refinery gap
-        assert_eq!(fluid_row_pole_gap_dx(3), None);
-        assert_eq!(fluid_row_pole_gap_dx(4), None);
-    }
-
+    
     // Helper: assert at least one entity at (x, y) with given name; returns the first match.
     fn assert_entity<'a>(entities: &'a [PlacedEntity], x: i32, y: i32, name: &str) -> &'a PlacedEntity {
         let found: Vec<_> = entities.iter().filter(|e| e.x == x && e.y == y).collect();
@@ -7423,25 +7354,26 @@ mod tests {
             &[(0, "petroleum-gas")],
         );
         assert_eq!(height, 7);
-        // 1 reported input port (the dx=1 UG-bridge entry) + 1 output pipe
+        // 1 reported input port + 1 output pipe
         assert_eq!(fluid_in.len(), 1);
         assert_eq!(fluid_out.len(), 1);
-        // Input port reported at dx=1 (the leftmost UG-bridge entry).
-        assert_eq!(fluid_in[0], ("crude-oil".to_string(), 1, 0));
+        // Input port reported at the REAL crude port dx=3 (#400: the
+        // former dx=1 report was the UG-bridge hack that never
+        // physically connected in-game).
+        assert_eq!(fluid_in[0], ("crude-oil".to_string(), 3, 0));
         // Output pipe at dx=0 → (0, 6)
         assert_eq!(fluid_out[0], ("petroleum-gas".to_string(), 0, 6));
 
-        // Input row uses the pole-gap UG bridge: pipe, UG-in, GAP, UG-out, pipe.
-        let in_pipe_left = assert_entity(&entities, 0, 0, "pipe");
-        assert_eq!(in_pipe_left.carries.as_deref(), Some("crude-oil"));
-        let in_ug_left = assert_entity(&entities, 1, 0, "pipe-to-ground");
-        assert_eq!(in_ug_left.direction, EntityDirection::East);
-        assert_eq!(in_ug_left.io_type.as_deref(), Some("input"));
-        let in_ug_right = assert_entity(&entities, 3, 0, "pipe-to-ground");
-        assert_eq!(in_ug_right.direction, EntityDirection::West);
-        assert_eq!(in_ug_right.io_type.as_deref(), Some("output"));
-        // dx=2 left empty for `place_poles` to drop a medium-electric-pole.
-        assert!(!entities.iter().any(|e| e.x == 2 && e.y == 0));
+        // Input row is a CONTINUOUS surface pipe strip (#400): the former
+        // UG bridge parked its mouths ON the two input-port tiles (dx=1/3)
+        // where a pipe-to-ground never connects downward — the first
+        // refinery sim measurement caught crude never entering. All five
+        // dx are plain pipes; power comes from the reactive substation
+        // pass instead of a mid-strip pole.
+        for dx in 0..5 {
+            let p = assert_entity(&entities, dx, 0, "pipe");
+            assert_eq!(p.carries.as_deref(), Some("crude-oil"));
+        }
 
         // Refinery at (0, 1) NORTH mirrored
         let refinery = assert_entity(&entities, 0, 1, "oil-refinery");
@@ -7467,14 +7399,14 @@ mod tests {
             &[(3, "crude-oil")],
             &[(0, "petroleum-gas")],
         );
-        // 2 machines × 1 reported input port (dx=1) + 2 machines × 1 output pipe
+        // 2 machines × 1 reported input port (real crude port dx=3, #400)
         assert_eq!(fluid_in.len(), 2);
         assert_eq!(fluid_out.len(), 2);
 
         // Second refinery at x=5 (pitch=5)
         assert_entity(&entities, 5, 1, "oil-refinery");
-        // Second machine: input port reported at mx=5, dx=1 → (6, 0)
-        assert_eq!(fluid_in[1], ("crude-oil".to_string(), 6, 0));
+        // Second machine: input port reported at mx=5, dx=3 → (8, 0)
+        assert_eq!(fluid_in[1], ("crude-oil".to_string(), 8, 0));
         // Second machine: output pipe at mx=5, dx=0 → (5, 6)
         assert_eq!(fluid_out[1], ("petroleum-gas".to_string(), 5, 6));
     }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -426,6 +426,13 @@ fn probe_registry_hashes() {
         let l = compose_chain(&sr).unwrap();
         println!("{label}: {:016x}", geometry_hash(&l));
     }
+    for (label, item, rate, inputs) in [
+        ("mega-plastic2", "plastic-bar", 2.0, &["crude-oil", "water", "coal"][..]),
+        ("mega-sulfur2", "sulfur", 2.0, &["crude-oil", "water"][..]),
+    ] {
+        let (_sr, l) = spaghettio_core::bus::cells::mega::compose_mega_calibrated(item, rate, inputs).unwrap();
+        println!("{label}: {:016x}", geometry_hash(&l));
+    }
 }
 
 /// PERMANENT GATE (RFC-051 registry): every seeded sim-verified entry

--- a/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_4s_from_plates.txt
+++ b/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_4s_from_plates.txt
@@ -1,5 +1,5 @@
 === stress_advanced_circuit_partitioned_4s_from_plates scoreboard ===
-entities:         1159
+entities:         1178
 total warnings:   0
 zones solved:     0
 zones skipped:    0
@@ -9,11 +9,11 @@ total gap tiles:  8
 mean gap:         2.00
 max gap:          2
 max trunks/band:  4
-total poles:      75
-zero-slack poles: 9
-median slack:     2.0
+total poles:      78
+zero-slack poles: 1
+median slack:     3.0
 warnings by category:
   (none)
 errors by category:
   (none)
-layout hash: 3d94fd0dbc344e2a2e4aa3529a5bdc14717d07f8c437a1f6e17292c247493bfd
+layout hash: e1233415fbd7b518e456b35cfb4eda85cdf71a25801d8d777de13a232237b301

--- a/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_5s_from_plates.txt
+++ b/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_5s_from_plates.txt
@@ -1,5 +1,5 @@
 === stress_advanced_circuit_partitioned_5s_from_plates scoreboard ===
-entities:         1476
+entities:         1496
 total warnings:   0
 zones solved:     0
 zones skipped:    0
@@ -9,11 +9,11 @@ total gap tiles:  9
 mean gap:         2.25
 max gap:          3
 max trunks/band:  5
-total poles:      92
-zero-slack poles: 12
+total poles:      91
+zero-slack poles: 1
 median slack:     2.0
 warnings by category:
   (none)
 errors by category:
   (none)
-layout hash: 4405ac9905a4fa97950bf226f0efef3588c2bffd32b811100349af1186d3fed0
+layout hash: cb24dca4abb90c9441959e59e8114744a223f9a83cc1c939f0e07d8afc7626a6

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,47 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-23 — #400 FIXED, gate (a) fully MET: the first working
+  refineries in the project's history. Three stacked defects, each
+  found by the sim and fixed at its proper layer: (1) TEMPLATE — the
+  fluid-only row's pole reservation bridged the strip with a UG pair
+  whose mouths sat exactly ON the two input-port tiles; the strip is
+  now continuous surface pipe (ports connected) and the two template
+  tests re-pinned to the real port columns. (2) POWER — with a full
+  strip no medium pole can reach a 5×5 center, so `place_poles` now
+  reports uncoverable machine centers of FLUID-ONLY rows into the
+  Phase-3a-ii reactive channel, and the substation-band targets accept
+  machine centers for rows with no inserters; scoped twice by
+  regression evidence (EC@20-from-ore golden caught eager substations
+  on mixed rows; two AC-partitioned stress goldens caught center-driven
+  bands on inserter-covered rows — mixed rows keep pre-#400 behavior
+  bit-identically). The two AC-partitioned stress goldens re-blessed
+  deliberately: they are the only golden-pinned refinery-bearing
+  fixtures, and the new geometry improves pole slack (zero-slack 9→1).
+  (3) ARTIFACT BOUNDARY (the #348/#364 class, third instance) — the
+  engine's "mirror" models a front-back port flip, but the game's
+  mirror flag flips LEFT-RIGHT: an exported (North, mirror) refinery
+  still has inputs on the south in-game, so crude sat ON the intended
+  port tiles and never entered. For the x-symmetric port layouts
+  (refinery/foundry/cryo) the y-flip is tile-identical to a 180°
+  rotation, so export encodes (direction+8, mirror:false) and the
+  parser reverses it — engine geometry and all registry hashes
+  untouched. The earlier direction-8 patch experiment failed because
+  it KEPT mirror:true, which misdirected the first diagnosis toward
+  the strip alone (recorded so the next reader distrusts single-factor
+  experiments on compound defects). Sim: mega-plastic2 PASS (delivered
+  2.20/s vs 2.00 planned, 4/4 working — the +10% matches RFC-048's
+  known chem-plant planning conservatism), mega-sulfur2 PASS (produced
+  2.00/s EXACT, 5/5 working, two-fluid adjacency-planned feeds). Both
+  registered with world fields. The adapter also gained
+  descending-tail joins en route (post-#400 raw trunk heads are PTG
+  mouths whose sides don't connect — the adapter now descends past the
+  band boundary until an honest plain-pipe join materializes, and its
+  join predicate applies #400's own lesson recursively: plain pipes
+  join on any side, PTGs only at their axis opening). Suite 906/0/52;
+  goldens 9 ran / 0 drift post-re-bless; harness 44/44; WASM clean.
+  Phase B (fluid-subgraph partition + AC-from-raw flagship) is GO.*
+
 - *2026-07-23 — Phase A: validator half of gate (a) MET; sim half
   BLOCKED by a discovery bigger than the phase. Delivered:
   `cells/mega.rs` (`compose_mega_calibrated` — uncropped engine

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,22 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-23 — #403 review folds (no blockers; both findings are
+  verification-rigor gaps, not live bugs): (1) the mirror-as-rotation
+  wire encoding COLLIDES with genuinely South/West-unmirrored
+  placements — the parser maps both to the engine's mirrored-North
+  form, exact for our own round-trips but input-face-180°-wrong for
+  such community imports (12/24 enumeration cases; overclaiming
+  comments corrected, trade-off pinned by a parser unit test).
+  (2) KNOWN GAP, Phase-C precondition: per-fluidbox IDENTITY (crude vs
+  water) swaps sides under rotation-vs-mirror — the game itself warns
+  about this exact confusion (FFF #394). Inert for basic processing
+  (single fluid; both sim PASSes confirmed unexercised by decoding the
+  fixtures' entity lists), but advanced-oil-processing on a mirrored
+  refinery is UNVERIFIED for fluid identity until Phase C measures it;
+  `verify_fluid_ports_transforms.py` checks positional SET equality
+  only and cannot catch identity swaps.*
+
 - *2026-07-23 — #400 FIXED, gate (a) fully MET: the first working
   refineries in the project's history. Three stacked defects, each
   found by the sim and fixed at its proper layer: (1) TEMPLATE — the


### PR DESCRIPTION
## Intent

Fix #400 (refinery crude delivery game-broken — oil-ladder-wide) and complete RFC-052 Phase A's sim gate. User pre-authorized moving on this once reviews cleared #401.

## Scope

`bus/templates.rs` (fluid-only row strip), `bus/layout.rs` (reactive power channel + substation targets), `blueprint.rs`/`blueprint_parser.rs` (artifact-boundary encoding), `cells/mega.rs` (descending-tail joins), tests, registry data, RFC-052 decision log. Two stress goldens deliberately re-blessed.

## What's here

Three stacked defects, each found by sim measurement and fixed at its proper layer — the full narrative with the diagnostic dead-end recorded is in the RFC-052 decision log:

1. **Template**: the pole-reservation UG pair sat its mouths exactly ON the input-port tiles (the comment believed fluid connects "via the underground tunnel" — PTGs never connect downward). Strip is now continuous surface pipe.
2. **Power**: fluid-only rows (no inserters) now report uncoverable machine centers into the existing Phase-3a-ii reactive substation channel. Scoped precisely by two regression signals: mixed rows keep pre-#400 behavior **bit-identically** (EC@20-from-ore golden unchanged; AC-partitioned stress goldens guarded the band scoping). The only two golden-pinned refinery fixtures re-blessed deliberately — errors stay none, pole slack improves (zero-slack 9→1).
3. **Artifact boundary** (#348/#364 class, third instance): the engine's "mirror" is a front-back port flip; the game's `mirror` flips left-right. Mirrored refinery/foundry/cryo export as `(direction+8, mirror:false)` — tile-identical for x-symmetric ports — and the parser reverses it. Engine geometry and every registry hash untouched.

**Result**: mega-plastic2 **PASS** (delivered 2.20/s vs 2.00 planned, 4/4 working) and mega-sulfur2 **PASS** (produced **2.00/s exact**, 5/5 working) — the first working refineries ever measured. Both registered (registry now 4 entries). RFC-052 gate (a) fully met; Phase B is GO.

## Models / contracts touched

Blueprint export/import encoding for mirrored refinery/foundry/cryo (round-trip preserving; a genuinely south-unmirrored import maps to the engine's tile-identical (North, mirror) form — noted in code). `place_poles` return semantics widened to uncovered *subjects* (inserters + fluid-only-row machine centers).

## Verification

Suite 906/0/52 (single clean run); stress goldens 9 ran / 0 drift after the deliberate 2-fixture re-bless (diff in this PR); cell gates 11/11; harness 44/44; clippy silent on touched files (pre-existing workspace noise unchanged); WASM check green; sim runs recorded in the registry provenance.

## Deviations from intent

The first diagnosis (strip-only) was insufficient — a direction-flip experiment that kept `mirror:true` masked the encoding defect; recorded in the decision log as a compound-defect lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55