### PR TITLE
fix(ci): review-bot silent no-op fails loudly; bot saga moves out of CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
           f=.github/workflows/claude-code-review.yml
           grep -q 'pull-requests: write' "$f" || { echo "::error file=$f::missing 'pull-requests: write' — review posting silently discarded (#327)"; fail=1; }
           grep -q 'issues: write' "$f" || { echo "::error file=$f::missing 'issues: write' — review posting silently discarded (#327)"; fail=1; }
-          grep -q -- "--comment'" "$f" || { echo "::error file=$f::prompt missing --comment — plugin contract is 'do not post' without it (#329)"; fail=1; }
+          # Matches the flag on the slash-command invocation regardless of
+          # prompt quoting style (single-quoted line pre-#410, folded
+          # block scalar since).
+          grep -q -- 'number }} --comment' "$f" || { echo "::error file=$f::prompt missing --comment — plugin contract is 'do not post' without it (#329)"; fail=1; }
           grep -q -- '--allowedTools' "$f" || { echo "::error file=$f::claude_args missing --allowedTools — every posting/diff call denied (#331)"; fail=1; }
           g=.github/workflows/claude.yml
           grep -q 'github.event.sender.login == github.repository_owner' "$g" || { echo "::error file=$g::missing owner-only sender gate — public repo, outsiders can burn tokens via @claude"; fail=1; }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,7 +83,8 @@ jobs:
             echo "Draft PR — plugin gate skips these by design; guard not applicable."
             exit 0
           fi
-          if gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' | grep -q '^\.github/workflows/'; then
+          wf_files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '[.[] | select(.filename | startswith(".github/workflows/"))] | length' | awk '{s+=$1} END {print s+0}')
+          if [ "$wf_files" -gt 0 ]; then
             echo "PR touches workflow files — action self-skips these (anti-hijack); guard not applicable."
             exit 0
           fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,28 +3,14 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     # `pull-requests`/`issues` must be WRITE: the review agent posts its
-    # findings as a PR review + inline/summary comments. The stock
-    # template ships read-only, which silently discarded every review
-    # from #305 through #324 — the job green-checked after a single
-    # permission denial (~20s, "No buffered inline comments") and no
-    # review was ever posted. Diagnosed 2026-07-21 on PR #324.
+    # findings as a PR review + inline/summary comments. The stock template
+    # ships read-only, which silently discarded every review (failure
+    # class 1 in docs/review-bot.md).
     permissions:
       contents: read
       pull-requests: write
@@ -37,6 +23,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Three load-bearing pieces below, each individually sufficient to
+      # silently disable the bot when lost (classes 1-4 in
+      # docs/review-bot.md — the installer overwrite wiped all of them at
+      # once): write perms above, the `--comment` flag in the prompt, and
+      # the harness allowlist in claude_args. The prompt's harness note
+      # addresses class 5 (shape-sensitive denial starvation): denials of
+      # improvised command shapes (env prefixes, $(...), cd-chains, gh api)
+      # made runs abandon mid-review without posting.
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -44,20 +38,72 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          # `--comment` is LOAD-BEARING: the code-review plugin's own
-          # contract is "if --comment was NOT provided, stop here. Do not
-          # post any GitHub comments." Without it the review runs, prints
-          # to the action log, and posts nothing — which (together with
-          # the read-only perms fixed in #327) is why no PR ever received
-          # a bot review from #305 to #328.
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
-          # Third load-bearing piece (with write perms #327 and --comment
-          # #329): the harness-level tool allowlist. Without it the agent
-          # runs the review but every posting/diff tool call is denied
-          # (11 denials on the #330 canary run). Mirrors the plugin's
-          # frontmatter allowed-tools + the action's own examples.
+          prompt: >-
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+            — Harness note for you and EVERY subagent you launch: tool
+            permissions here match command SHAPES, not intent. Run gh
+            commands as plain single invocations — no env-var prefixes
+            (`GH_PAGER= gh ...`), no command substitution `$(...)`, no
+            `cd ... &&` chaining, no `gh api` — only plain `gh pr
+            view/diff/comment`, `gh issue view/list`, `gh search`. A
+            permission denial means your command shape missed the
+            allowlist, NOT that tools are broken: re-issue the same
+            command in plain allowed form and continue the review. Never
+            abandon the review because of denials; if you have findings
+            or a no-issues verdict, exhaust plain `gh pr comment` before
+            giving up on posting.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
 
+      # Full session transcript (includes every permission denial) — the
+      # difference between forensics and guesswork when a run misbehaves.
+      - name: Upload execution transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: ${{ runner.temp }}/claude-execution-output.json
+          if-no-files-found: warn
+          retention-days: 14
+
+      # Historically a green check only meant "the session exited cleanly"
+      # — five separate failure classes ended with nothing posted and a
+      # green check (docs/review-bot.md). This step makes silence loud: a
+      # non-trivial PR with zero review activity fails the check. Carve-outs
+      # mirror the plugin's designed skips (drafts, workflow-file PRs via
+      # the action's anti-hijack self-skip, tiny diffs, already-reviewed).
+      - name: Guard — silent no-op must not green-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "$(gh pr view "$PR" -R "$REPO" --json isDraft --jq .isDraft)" = "true" ]; then
+            echo "Draft PR — plugin gate skips these by design; guard not applicable."
+            exit 0
+          fi
+          if gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' | grep -q '^\.github/workflows/'; then
+            echo "PR touches workflow files — action self-skips these (anti-hijack); guard not applicable."
+            exit 0
+          fi
+          changed=$(gh pr view "$PR" -R "$REPO" --json additions,deletions --jq '.additions + .deletions')
+          if [ "$changed" -lt 20 ]; then
+            echo "Diff is $changed changed lines (<20) — triviality-gate territory; guard not applicable."
+            exit 0
+          fi
+          # Coverage = any PR review (bot or session-side), any inline review
+          # comment, or a bot summary comment. Session-side reviews count:
+          # the guard guarantees the PR was reviewed, not who reviewed it —
+          # the plugin's own gate skips already-reviewed PRs, and that skip
+          # is legitimate.
+          reviews=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate --jq 'length' | awk '{s+=$1} END {print s+0}')
+          inline=$(gh api "repos/$REPO/pulls/$PR/comments" --paginate --jq 'length' | awk '{s+=$1} END {print s+0}')
+          bot_summaries=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '[.[] | select(.user.login | test("claude"; "i"))] | length' | awk '{s+=$1} END {print s+0}')
+          echo "coverage: reviews=$reviews inline=$inline bot_summaries=$bot_summaries"
+          if [ "$reviews" -gt 0 ] || [ "$inline" -gt 0 ] || [ "$bot_summaries" -gt 0 ]; then
+            echo "Review coverage exists — OK."
+            exit 0
+          fi
+          echo "::error title=Silent review no-op::claude-review exited green but PR #$PR ($changed changed lines) has zero reviews, zero inline comments, and no bot summary. This is the silent no-op failure class — download the claude-execution-output artifact for the transcript and see docs/review-bot.md."
+          exit 1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -78,33 +78,65 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
-          if [ "$(gh pr view "$PR" -R "$REPO" --json isDraft --jq .isDraft)" = "true" ]; then
+          set -uo pipefail
+          # Fail-open on API errors: the guard is a safety net, and its own
+          # flakiness must never block a merge. It fails ONLY on confirmed
+          # zero-coverage abandonment.
+          if ! draft=$(gh pr view "$PR" -R "$REPO" --json isDraft --jq .isDraft); then
+            echo "::warning::guard: gh pr view failed (transient?) — failing open."; exit 0
+          fi
+          if [ "$draft" = "true" ]; then
             echo "Draft PR — plugin gate skips these by design; guard not applicable."
             exit 0
           fi
-          wf_files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '[.[] | select(.filename | startswith(".github/workflows/"))] | length' | awk '{s+=$1} END {print s+0}')
+          # Deliberately broader than the action's actual self-skip (which
+          # keys on the executing workflow file): over-carving fails safe,
+          # because workflow-file PRs get session-side review by repo rule.
+          if ! wf_files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '[.[] | select(.filename | startswith(".github/workflows/"))] | length' | awk '{s+=$1} END {print s+0}'); then
+            echo "::warning::guard: files query failed — failing open."; exit 0
+          fi
           if [ "$wf_files" -gt 0 ]; then
             echo "PR touches workflow files — action self-skips these (anti-hijack); guard not applicable."
             exit 0
           fi
-          changed=$(gh pr view "$PR" -R "$REPO" --json additions,deletions --jq '.additions + .deletions')
+          changed=$(gh pr view "$PR" -R "$REPO" --json additions,deletions --jq '.additions + .deletions') || changed=""
+          case "$changed" in ''|*[!0-9]*)
+            echo "::warning::guard: could not determine diff size — failing open."; exit 0;;
+          esac
           if [ "$changed" -lt 20 ]; then
             echo "Diff is $changed changed lines (<20) — triviality-gate territory; guard not applicable."
             exit 0
           fi
           # Coverage = any PR review (bot or session-side), any inline review
           # comment, or a bot summary comment. Session-side reviews count:
-          # the guard guarantees the PR was reviewed, not who reviewed it —
-          # the plugin's own gate skips already-reviewed PRs, and that skip
-          # is legitimate.
-          reviews=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate --jq 'length' | awk '{s+=$1} END {print s+0}')
-          inline=$(gh api "repos/$REPO/pulls/$PR/comments" --paginate --jq 'length' | awk '{s+=$1} END {print s+0}')
-          bot_summaries=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '[.[] | select(.user.login | test("claude"; "i"))] | length' | awk '{s+=$1} END {print s+0}')
+          # the guard guarantees the PR was reviewed, not who reviewed it.
+          # Coverage is PR-lifetime, not per-SHA — deliberate: the plugin's
+          # own gate declines to re-review a PR Claude already commented on,
+          # so per-SHA enforcement would permanently red every follow-up
+          # push. Per-SHA freshness is the agent-reviewed label's job
+          # (clear-agent-reviewed.yml). See docs/review-bot.md.
+          if ! reviews=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate --jq 'length' | awk '{s+=$1} END {print s+0}'); then
+            echo "::warning::guard: reviews query failed — failing open."; exit 0
+          fi
+          if ! inline=$(gh api "repos/$REPO/pulls/$PR/comments" --paginate --jq 'length' | awk '{s+=$1} END {print s+0}'); then
+            echo "::warning::guard: inline-comments query failed — failing open."; exit 0
+          fi
+          if ! bot_summaries=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '[.[] | select(.user.login == "claude[bot]" or .user.login == "claude")] | length' | awk '{s+=$1} END {print s+0}'); then
+            echo "::warning::guard: issue-comments query failed — failing open."; exit 0
+          fi
           echo "coverage: reviews=$reviews inline=$inline bot_summaries=$bot_summaries"
           if [ "$reviews" -gt 0 ] || [ "$inline" -gt 0 ] || [ "$bot_summaries" -gt 0 ]; then
             echo "Review coverage exists — OK."
             exit 0
           fi
-          echo "::error title=Silent review no-op::claude-review exited green but PR #$PR ($changed changed lines) has zero reviews, zero inline comments, and no bot summary. This is the silent no-op failure class — download the claude-execution-output artifact for the transcript and see docs/review-bot.md."
+          # Zero coverage. Distinguish a conscious plugin gate-skip (cheap,
+          # few turns: ~2-6 observed) from mid-review abandonment (the
+          # class-5 signature: 16-20 turns, then nothing). Threshold 8 sits
+          # between the observed clusters; see docs/review-bot.md.
+          turns=$(grep -o '"num_turns"[[:space:]]*:[[:space:]]*[0-9]*' "${RUNNER_TEMP}/claude-execution-output.json" 2>/dev/null | tail -1 | grep -o '[0-9]*$' || true)
+          if [ -n "$turns" ] && [ "$turns" -le 8 ]; then
+            echo "No coverage, but the transcript shows a cheap conscious run (num_turns=$turns <= 8) — plugin gate-skip signature, not abandonment. Passing."
+            exit 0
+          fi
+          echo "::error title=Silent review no-op::claude-review exited green but PR #$PR ($changed changed lines) has zero reviews, zero inline comments, and no bot summary (transcript turns: ${turns:-unknown}). This is the silent no-op failure class — see docs/review-bot.md. Escape hatch if the skip was legitimate: re-run this job (runs are stochastic), or post a review and re-run the check."
           exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,8 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   reviews every PR; expect inline comments on findings or a "no issues"
   summary comment. Its historical silent-failure mode is now loud: the
   `claude-review` check FAILS when a non-trivial PR ends with zero review
-  activity (benign skips: drafts, workflow-file PRs, <20-line diffs).
+  activity (benign skips: drafts, workflow-file PRs, small diffs, and
+  cheap runs bearing the plugin's conscious gate-skip signature).
   Live trap: re-running `/install-github-app` overwrites the repaired
   workflow files with the stock template — diff them against main before
   merging its PR. Failure-class history and forensics playbook:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,31 +60,14 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
 - **Adversarial review before anything is commit-ready** — code *and*
   documentation. Preferred: the CI review bot —
   [`.github/workflows/claude-code-review.yml`](.github/workflows/claude-code-review.yml)
-  runs a Claude code review on every PR (opened/synchronized/reopened), and
-  `clear-agent-reviewed.yml` drops the `agent-reviewed` label when new
-  commits land so the new SHA gets re-reviewed. **A green `claude-review`
-  check is NOT evidence a review happened — confirm the bot actually
-  posted.** From #305 through #330 the bot posted *nothing*: three
-  stacked, each-sufficient causes — template read-only permissions
-  (fixed #327), the plugin's `--comment` flag never passed (its own
-  contract is "do not post" without it; fixed #329), and no
-  harness-level tool allowlist (`claude_args --allowedTools`), which
-  denied every posting/diff call (fixed #331). Validated 2026-07-21 via
-  a planted-bug canary (#330): the bot's first-ever comment correctly
-  flagged the bug inline with a committable fix. All substantive PR
-  review feedback before then was session-side. **A fourth cause class
-  surfaced 2026-07-22: re-running `/install-github-app` overwrote both
-  workflow files with the stock template, silently wiping all three
-  fixes at once (plus `claude.yml`'s owner-only sender gate). Restored
-  in #369, re-validated via canary #368. If anyone reruns the installer,
-  diff the workflow files against main before merging its PR.**
-  Expected behavior now:
-  inline comments on findings, or a "no issues" summary comment on
-  clean substantive PRs — a green check with *neither* on a
-  non-trivial PR means it's broken again. Known benign no-comment
-  cases: PRs that modify the workflow file itself (the action's
-  anti-hijack self-skip) and changes its triviality gate deems
-  obviously correct. Local adversarial review (an
+  reviews every PR; expect inline comments on findings or a "no issues"
+  summary comment. Its historical silent-failure mode is now loud: the
+  `claude-review` check FAILS when a non-trivial PR ends with zero review
+  activity (benign skips: drafts, workflow-file PRs, <20-line diffs).
+  Live trap: re-running `/install-github-app` overwrites the repaired
+  workflow files with the stock template — diff them against main before
+  merging its PR. Failure-class history and forensics playbook:
+  [`docs/review-bot.md`](docs/review-bot.md). Local adversarial review (an
   independent agent that re-runs gates and probes the claims) is the
   fallback when a PR isn't in play — and it remains **required in addition
   to the bot** for layout-engine or validator-semantics changes: the bot

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -40,7 +40,9 @@ summary comment**. Designed silences (no post, and that's correct):
 
 Any other green check with nothing posted is a failure. Since the guard
 step landed (2026-07-24), that combination fails the check outright on
-non-draft PRs with ≥20 changed lines and zero review activity.
+non-draft PRs with ≥20 changed lines, zero review activity, and a
+transcript that doesn't bear the cheap gate-skip signature (see Guard
+semantics below).
 
 ## Failure-class history
 
@@ -100,12 +102,38 @@ nothing posted).
 ## Guard semantics
 
 The final workflow step fails the check when a PR has **zero** review
-activity (no PR reviews from anyone, no inline comments, no bot summary
-comment) despite being non-trivial. Carve-outs, in order: draft PRs;
-PRs touching `.github/workflows/**`; diffs under 20 changed lines.
-Session-side reviews count as coverage — the guard guarantees *a* review
-happened, not that the bot did it. The 20-line threshold is a judgment
-call: below it the plugin's triviality gate is plausibly right; above it,
-silence on a PR nobody reviewed is exactly what we want to catch. Doc-only
-PRs are deliberately NOT carved out — documentation gets adversarial
-review in this repo.
+activity (no PR reviews from anyone, no inline comments, no
+`claude[bot]`/`claude` summary comment — exact login match) despite being
+non-trivial. Carve-outs, in order: draft PRs; PRs touching
+`.github/workflows/**` (deliberately broader than the action's actual
+self-skip — over-carving fails safe because workflow PRs get session-side
+review by repo rule); diffs under 20 changed lines; and, when coverage is
+zero, a transcript whose `num_turns ≤ 8` — the conscious gate-skip
+signature (observed skips run 2–6 turns; observed abandonments 16–20), so
+a plugin that *looked and declined* passes while a run that *died
+mid-review* fails.
+
+Design decisions worth knowing:
+
+- **Coverage is PR-lifetime, not per-SHA.** Deliberate: the plugin's gate
+  declines to re-review a PR Claude already commented on, so per-SHA
+  enforcement would permanently red every follow-up push. Per-SHA
+  freshness is owned by the `agent-reviewed` label flow
+  (`clear-agent-reviewed.yml`), not the guard. Consequence: a bot no-op on
+  push N of an already-reviewed PR does not fail the check — the guard
+  catches never-reviewed PRs, not staleness.
+- **Fail-open on API errors.** Any transient GitHub API failure warns and
+  passes; the guard reds only on *confirmed* zero coverage. A safety net
+  must not be a new flake surface.
+- **Session-side reviews count** — the guard guarantees *a* review
+  happened, not that the bot did it.
+- **Doc-only PRs are NOT carved out** — documentation gets adversarial
+  review in this repo.
+- **Escape hatch** for a false red (e.g. the gate judged a ≥20-line PR
+  trivial but the transcript heuristic disagreed): re-run the job (runs
+  are stochastic), or post a review and re-run the check.
+
+Related tripwire: `ci.yml`'s `workflow-guard` job asserts the
+claude-code-review workflow keeps its load-bearing pieces (write perms,
+`--comment` on the invocation line, `--allowedTools`, claude.yml's sender
+gate) — the anti-regression net for classes 1–4.

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -118,10 +118,16 @@ Design decisions worth knowing:
 - **Coverage is PR-lifetime, not per-SHA.** Deliberate: the plugin's gate
   declines to re-review a PR Claude already commented on, so per-SHA
   enforcement would permanently red every follow-up push. Per-SHA
-  freshness is owned by the `agent-reviewed` label flow
-  (`clear-agent-reviewed.yml`), not the guard. Consequence: a bot no-op on
-  push N of an already-reviewed PR does not fail the check — the guard
-  catches never-reviewed PRs, not staleness.
+  freshness is owned by the `agent-reviewed` label flow, not the guard:
+  `clear-agent-reviewed.yml` drops the label on new commits, and the
+  containerised watcher agent re-reviews PRs missing it
+  (`scripts/agent-reviewer.sh`; see
+  [`docs/agent-container.md`](agent-container.md#pr-review-queue)) — a
+  separate reviewer from this workflow's plugin. Caveat: the watcher is
+  an on-demand container, so while it isn't running, per-SHA staleness on
+  already-reviewed PRs is an accepted gap. Consequence either way: a bot
+  no-op on push N of an already-reviewed PR does not fail the check — the
+  guard catches never-reviewed PRs, not staleness.
 - **Fail-open on API errors.** Any transient GitHub API failure warns and
   passes; the guard reds only on *confirmed* zero coverage. A safety net
   must not be a new flake surface.

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -1,0 +1,111 @@
+# CI review bot — how it works, how it fails, how to diagnose it
+
+Reference doc for the automated PR review pipeline. `CLAUDE.md` carries only
+the operating rules; this file is the canonical home for the failure-class
+history and the forensics playbook. Keep it current when the workflow
+changes.
+
+## Moving parts
+
+- [`.github/workflows/claude-code-review.yml`](../.github/workflows/claude-code-review.yml)
+  — runs on every PR event (opened / synchronize / ready_for_review /
+  reopened): checkout → `anthropics/claude-code-action@v1` running the
+  `code-review` plugin → transcript artifact upload → silent-no-op guard.
+- **The plugin** (`code-review@claude-code-plugins`, from the
+  anthropics/claude-code marketplace) is a multi-subagent orchestration:
+  a haiku gate (skip closed / draft / trivial / already-reviewed PRs) → a
+  CLAUDE.md-paths agent → a sonnet diff-summary agent → 4 parallel reviewer
+  agents (2× CLAUDE.md compliance, 2× opus bug-hunting) → per-finding
+  validation subagents → post. With `--comment` (which we pass —
+  load-bearing) it posts inline comments on findings or a
+  "No issues found" summary comment when clean.
+- [`clear-agent-reviewed.yml`](../.github/workflows/clear-agent-reviewed.yml)
+  — drops the `agent-reviewed` label when new commits land, so a new head
+  SHA gets re-reviewed.
+
+## Expected behavior
+
+On a substantive PR: **inline comments on findings, or a "no issues"
+summary comment**. Designed silences (no post, and that's correct):
+
+- Draft PRs, closed PRs (plugin gate).
+- PRs the gate deems trivially correct.
+- PRs where Claude already commented (gate) — includes session-side reviews
+  that read as Claude output; re-review after new commits is still expected
+  via the label-clear workflow, but the gate may legitimately decline when
+  coverage already exists.
+- PRs touching `.github/workflows/**` (the action's anti-hijack self-skip).
+  These need session-side review instead — the bot cannot review changes to
+  itself.
+
+Any other green check with nothing posted is a failure. Since the guard
+step landed (2026-07-24), that combination fails the check outright on
+non-draft PRs with ≥20 changed lines and zero review activity.
+
+## Failure-class history
+
+Five classes, each individually sufficient to produce the same symptom —
+green check, nothing posted:
+
+| # | Cause | Symptom signature | Fixed |
+|---|-------|-------------------|-------|
+| 1 | Stock template ships `pull-requests: read` — every post discarded | ~20s run, 1 denial, "No buffered inline comments" | #327 |
+| 2 | Plugin's `--comment` flag not passed — its own contract is "do not post" without it | review runs fully, prints to action log, posts nothing | #329 |
+| 3 | No harness `--allowedTools` — every posting/diff call denied | 11 denials on the #330 canary | #331 |
+| 4 | Re-running `/install-github-app` overwrote both workflow files with the stock template — wiped fixes 1–3 at once (plus `claude.yml`'s owner-only sender gate) | all of the above, after a period of working fine | #369 (canary #368) |
+| 5 | Shape-sensitive denial starvation — the allowlist admits plain `gh pr/issue` commands but denies improvised *shapes* (env prefixes `GH_PAGER= gh …`, command substitution `$(…)`, `cd … &&` chains, `gh api`); enough denials and the orchestrator abandons mid-review without posting. Stochastic per run, worse on large PRs (more context wanted → more improvised commands). Diagnosed 2026-07-24 on PR #389 (two consecutive silent no-ops; PR #405 succeeded through 31 denials the same day) | mid-cost, mid-duration run: more than a gate-skip, far less than a full review; see signature table below | prompt hardening + guard step (introduced with this doc) |
+
+Validation history: planted-bug canary #330 (2026-07-21) — first-ever bot
+comment correctly flagged the bug inline with a committable fix; canary
+#368 re-validated after the installer overwrite was restored in #369.
+
+## Forensics playbook
+
+**Run signatures** (from the action's result JSON in the job log — grep the
+log for `total_cost_usd|num_turns|permission_denials_count|duration_ms`):
+
+| Outcome | Duration | Turns | Cost | Reading |
+|---------|----------|-------|------|---------|
+| Designed gate-skip | ~20s | 2–6 | ~$0.2 | fine if a skip condition genuinely holds |
+| Mid-review abandonment (class 5) | 1–2 min | 15–20 | $0.6–1.5 | got past the gate, died before/at the fan-out; check denial count |
+| Completed full review | ~8 min | ~10 | ~$4 | the 4-agent fan-out + validators ran; post should exist |
+
+Reference points, all 2026-07-23/24: PR 405 full review 500s/10 turns/31
+denials/$4.16 (posted); PR 405 incremental pushes ~20s/$0.17–0.25
+(gate-skip, comment already existed); PR 389 run 1 66s/16 turns/6
+denials/$0.62 and run 2 108s/20 turns/13 denials/$1.45 (both abandoned,
+nothing posted).
+
+**Steps:**
+
+1. Confirm what was actually posted: `gh api repos/<repo>/pulls/<n>/reviews`,
+   `.../pulls/<n>/comments` (inline), and `gh pr view <n> --json comments`
+   (summary comments; the bot posts as a `claude`-ish login).
+2. Pull the run stats:
+   `gh run list --workflow=claude-code-review.yml --branch <branch>` then
+   `gh run view <id> --log | grep -E 'total_cost_usd|num_turns|permission_denials'`.
+   Classify against the signature table.
+3. Download the `claude-execution-output` artifact (uploaded on every run
+   since 2026-07-24, 14-day retention) — the full transcript, including
+   exactly which tool calls were denied. This turns class-5 diagnosis from
+   inference into reading.
+4. To probe permission semantics locally, replicate the environment:
+   `claude -p --setting-sources "" --allowedTools "<the workflow's exact list>"`
+   with a battery of read-only commands, and ask for an allowed/denied
+   table. Measured 2026-07-24: plain `gh pr/issue` subcommands, pipes,
+   read-only `git`, and `Task` (subagent fan-out) are ALLOWED; env-prefixed
+   forms, `$(…)` substitution, `cd`-chains, and everything else
+   non-read-only (`gh api`, `cargo`, …) are DENIED.
+
+## Guard semantics
+
+The final workflow step fails the check when a PR has **zero** review
+activity (no PR reviews from anyone, no inline comments, no bot summary
+comment) despite being non-trivial. Carve-outs, in order: draft PRs;
+PRs touching `.github/workflows/**`; diffs under 20 changed lines.
+Session-side reviews count as coverage — the guard guarantees *a* review
+happened, not that the bot did it. The 20-line threshold is a judgment
+call: below it the plugin's triviality gate is plausibly right; above it,
+silence on a PR nobody reviewed is exactly what we want to catch. Doc-only
+PRs are deliberately NOT carved out — documentation gets adversarial
+review in this repo.


### PR DESCRIPTION
## Intent

A fifth review-bot silent-failure class surfaced on #389: shape-sensitive denial starvation — the harness allowlist admits plain `gh pr/issue` commands but denies improvised *shapes* (env prefixes, `$(...)`, `cd`-chains, `gh api`), and enough denials make the orchestrator abandon mid-review without posting, leaving a green check. Stochastic per run: #389 no-op'd twice ($0.62/66s, $1.45/108s — past the gate, short of the fan-out) then succeeded on the third; #405 survived 31 denials to post. This PR makes that class (and every future one) loud, and moves the accumulated bot saga out of `CLAUDE.md`, which was spending 33 lines (16% of the file) on incident history in every session's context.

## Scope

- **In:**
  - Workflow guard step: non-draft, non-workflow-file PR with ≥20 changed lines and zero review activity (no PR reviews from anyone, no inline comments, no claude-login summary) → red `claude-review` check. Session-side reviews count as coverage; the guard guarantees *a* review, not who did it.
  - Prompt hardening: the plugin and its subagents are told permissions match command shapes, a denial means re-issue plainly, and never to abandon the review over denials (the plugin's own "all tools are functional" assumption gave it no recovery script when denials contradicted it).
  - Transcript artifact: `claude-execution-output.json` uploaded `if: always()`, 14-day retention — includes the exact denied calls, turning the next diagnosis from inference into reading.
  - New reference doc `docs/review-bot.md`: five failure classes with fix PRs, run-signature forensics table (gate-skip ≈ $0.2/20s vs abandonment ≈ $0.6–1.5/1–2min vs full review ≈ $4/8min), diagnosis playbook, local probe methodology, guard semantics.
  - `CLAUDE.md` review bullet slimmed 33→17 lines: operating rules, installer trap, doc pointer.
- **Out:**
  - Allowlist unchanged — deliberately. Widening (e.g. `gh api`) trades a diagnosed starvation problem for an undiagnosed write-surface; the prompt note targets the observed deny shapes directly.
  - `docs/status.md` row — its open-issue sections are layout-quality-scoped, and this PR closes the issue such a row would track.

## Verification

- [x] YAML parses; the folded `prompt:` scalar collapses to a single line starting with the slash command (verified via PyYAML — multiline would break slash-command detection).
- [x] Guard logic dry-run against live GitHub data for #389: carve-outs evaluated in order, coverage counters (`reviews=12 inline=15 bot_summaries=1`) → pass path taken. Pagination summing via awk verified against `--paginate` per-page output.
- [x] Permission-shape findings backing the prompt note measured empirically: local `claude -p --setting-sources "" --allowedTools "<exact CI list>"` probe — plain gh subcommands/pipes/read-only git/Task allowed; env-prefix, `$(...)`, `cd`-chains denied.
- [ ] Guard fail path (exit 1) not integration-tested — needs a real or canary silent no-op; the branch logic is a plain if/else over the tested counters.
- Not applicable (no Rust/TS touched): cargo test, clippy, WASM rebuild, snapshots.

## Deviations from intent

Told the session lead status.md would get an open-issue row; dropped for the reason above.

## Models / contracts touched

No code contracts. Process docs: `CLAUDE.md` (review workflow section), new `docs/review-bot.md` reference doc. Note this PR self-triggers the action's anti-hijack skip AND the guard's workflow-file carve-out — bot review is structurally unavailable, so local adversarial review is being run session-side (report will be added as a PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)