### PR TITLE
Chain-fed mega inputs (RFC-052 increment 2) — the PU class composes and runs

### DIFF
--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -204,8 +204,8 @@ struct Placed {
     ext_inputs: Vec<String>,
 }
 
-fn port_abs(p: &Port, cell_x: i32) -> (i32, i32) {
-    (cell_x + p.x, CELL_Y + p.y)
+fn port_abs(p: &Port, cell_x: i32, cell_y: i32) -> (i32, i32) {
+    (cell_x + p.x, cell_y + p.y)
 }
 
 /// Crossing-aware corridor stamper. Horizontal runs hop under
@@ -638,13 +638,25 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 .cloned()
                 .collect();
             // Synthetic super-spec: one "machine" producing the
-            // subgraph's terminal solid at the full chain rate; no
-            // chain-side inputs (v1: external-only, self-fed block).
+            // subgraph's terminal solid at the full chain rate.
+            // Chain-fed inputs (increment 2) are DECLARED so the
+            // generic consumer/corridor machinery routes their
+            // producers here; true externals stay off the spec (they
+            // arrive via the block's own boundary heads).
             v.push(crate::models::MachineSpec {
                 entity: "mega-cell".into(),
                 recipe: format!("{MEGA_PREFIX}{}", plan.target),
                 count: 1.0,
-                inputs: Vec::new(),
+                inputs: plan
+                    .chain_fed
+                    .iter()
+                    .map(|(item, rate)| crate::models::ItemFlow {
+                        item: item.clone(),
+                        rate: *rate,
+                        is_fluid: false,
+                        module_id: 0,
+                    })
+                    .collect(),
                 outputs: plan
                     .outputs
                     .iter()
@@ -667,15 +679,19 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         .map(|(i, r)| (r.clone(), i))
         .collect();
     if let Some(plan) = &mega_plan {
-        // The super-spec inherits its DEEPEST member's dependency
-        // position, so it places before its consumer like the member
-        // rows would have.
-        let best = plan
-            .members
-            .iter()
-            .filter_map(|r| pos.get(r).copied())
-            .max();
-        if let Some(i) = best {
+        // Source-only subgraph (no chain-fed inputs): inherit the
+        // DEEPEST member's dependency position, so it places before
+        // its consumer like the member rows would have. Chain-fed
+        // subgraph (increment 2): inherit the MOST-DOWNSTREAM
+        // member's position — the member that consumes the chain-fed
+        // items governs, so the mega places AFTER its producers (for
+        // the PU class that member is the chain target itself).
+        let picked = if plan.chain_fed.is_empty() {
+            plan.members.iter().filter_map(|r| pos.get(r).copied()).max()
+        } else {
+            plan.members.iter().filter_map(|r| pos.get(r).copied()).min()
+        };
+        if let Some(i) = picked {
             pos.insert(format!("{MEGA_PREFIX}{}", plan.target), i);
         }
     }
@@ -737,10 +753,45 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                     let plan = mega_plan.as_ref().expect("mega spec implies plan");
                     let (_msr, block) = super::mega::compose_mega_block(sr, plan, scale)?;
                     mega_block_cache = Some(block.clone());
+                    // Chain-fed inputs (increment 2): each adapter
+                    // west-edge entry becomes an inbound PORT — an
+                    // east-facing belt at (0, lane_row), so the
+                    // corridor's eastbound approach is a straight
+                    // merge (both lanes). v1: one entry per chain-fed
+                    // item (multi-entry re-pitches would need a fan-in
+                    // the corridor can't provide).
+                    let mut ports: Vec<Port> = Vec::new();
+                    for (item, _) in &plan.chain_fed {
+                        let heads: Vec<_> = block
+                            .boundary_inputs
+                            .iter()
+                            .filter(|r| &r.item == item)
+                            .collect();
+                        match heads.as_slice() {
+                            [h] => ports.push(Port {
+                                edge: "W",
+                                x: h.x,
+                                y: h.y,
+                                item: item.clone(),
+                                inbound: true,
+                            }),
+                            [] => {
+                                return Err(format!(
+                                    "mega: chain-fed {item} has no block feed head"
+                                ))
+                            }
+                            _ => {
+                                return Err(format!(
+                                    "mega: chain-fed {item} has {} feed heads (v1 routes one corridor)",
+                                    heads.len()
+                                ))
+                            }
+                        }
+                    }
                     cell_cache.push(Cell {
                         width: block.width,
                         height: block.height,
-                        ports: Vec::new(),
+                        ports,
                         entities: block.entities,
                     });
                 } else {
@@ -794,6 +845,13 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 // records at the placed offset; each drain head anchors
                 // one outgoing corridor.
                 for r in &block.boundary_inputs {
+                    // Chain-fed heads are supplied by chain corridors,
+                    // not the outside world — they are ports, not
+                    // chain boundary records (increment 2).
+                    let cf = &mega_plan.as_ref().expect("mega spec implies plan").chain_fed;
+                    if cf.iter().any(|(i, _)| i == &r.item) {
+                        continue;
+                    }
                     b_in.push(BoundaryRecord { x: r.x + x, ..r.clone() });
                 }
                 if block.boundary_outputs.is_empty() {
@@ -845,7 +903,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         for item in &p.ext_inputs {
             let mut found = false;
             for port in p.cell.ports.iter().filter(|q| q.inbound && q.item == *item) {
-                let (tx, ty) = port_abs(port, p.x);
+                let (tx, ty) = port_abs(port, p.x, p.y_off);
                 targets.push((item.clone(), tx, ty));
                 found = true;
             }
@@ -967,10 +1025,18 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                         && c.cell.ports.iter().any(|q| q.inbound && q.item == d_item)
                 });
                 let Some((ci, c)) = consumer else {
+                    // Consumer-less export: extend the drain to the
+                    // chain's drain row like the solid final-product
+                    // path — a b_out mid-layout leaves a dead-end belt
+                    // (the exemption is bounds-based) and puts the sim
+                    // rig at a nonuniform depth (#363).
+                    let seg = format!("out:{}", p.seg);
+                    router.vcol(&mut entities, dx0, dy0 + 1, drain_row, &d_item,
+                        "transport-belt", "underground-belt", &seg);
                     b_out.push(BoundaryRecord {
                         item: d_item.clone(),
                         x: dx0,
-                        y: dy0,
+                        y: drain_row,
                         direction: EntityDirection::South,
                         is_fluid: false,
                         entity: "transport-belt".into(),
@@ -983,7 +1049,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                     .iter()
                     .find(|q| q.inbound && q.item == d_item)
                     .expect("consumer port checked in eligibility");
-                let (tx, ty) = port_abs(port, c.x);
+                let (tx, ty) = port_abs(port, c.x, c.y_off);
                 let seg = format!("corr:{}:{}", p.seg, c.seg);
                 let up_demand = lane_demand[ci % n];
                 let lane_up = alloc_lane(&mut lane_next, ci, c.vlane_base, lane_step(up_demand));
@@ -1031,7 +1097,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         if consumers.is_empty() {
             // Final product: corner south past the band, drain record.
             let o1 = outs.first().ok_or_else(|| format!("cells: {} has no out port", p.recipe))?;
-            let (ox, oy) = port_abs(o1, p.x);
+            let (ox, oy) = port_abs(o1, p.x, p.y_off);
             let drain_x = ox + 2;
             let seg = format!("out:{}", p.seg);
             router.hrow(&mut entities, oy, ox + 1, drain_x - 1, &out_item,
@@ -1062,13 +1128,13 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         // topmost is the accumulator row.
         let mut outs_sorted = outs.clone();
         outs_sorted.sort_by_key(|q| q.y);
-        let (acc_x0, acc_y) = port_abs(outs_sorted[0], p.x);
+        let (acc_x0, acc_y) = port_abs(outs_sorted[0], p.x, p.y_off);
         let base_sx = p.x + p.cell.width + 2;
         router.hrow(&mut entities, acc_y, acc_x0 + 1, base_sx - 1, &out_item,
             "express-transport-belt", "express-underground-belt", &format!("cc:a:{}", p.seg));
         let mut run_x = base_sx;
         for (k, o) in outs_sorted.iter().enumerate().skip(1) {
-            let (ox, oy) = port_abs(o, p.x);
+            let (ox, oy) = port_abs(o, p.x, p.y_off);
             assert!(oy > acc_y + 1, "cells: merge assumes below-approach ({oy} vs {acc_y})");
             let seg = format!("cc:b{k}:{}", p.seg);
             router.hrow(&mut entities, oy, ox + 1, run_x - 2, &out_item,
@@ -1131,7 +1197,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
             let port = c.cell.ports.iter()
                 .find(|q| q.inbound && q.item == out_item)
                 .expect("consumer port checked in eligibility");
-            let (tx, ty) = port_abs(port, c.x);
+            let (tx, ty) = port_abs(port, c.x, c.y_off);
             let (bx, by) = branch_origins[bi];
             let seg = format!("corr:{}:{}", p.seg, c.seg);
             if *ci == pi + 1 {

--- a/crates/core/src/bus/cells/mega.rs
+++ b/crates/core/src/bus/cells/mega.rs
@@ -64,20 +64,35 @@ pub fn compose_mega_calibrated(
 /// fixtures; the Router's hop machinery is the Phase-B answer if a
 /// real subgraph ever needs it).
 pub fn adapt_boundaries(l: LayoutResult) -> Result<LayoutResult, String> {
+    adapt_boundaries_chain_fed(l, &FxHashSet::default())
+}
+
+/// `chain_fed` (increment 2): items supplied by chain corridors, not
+/// the outside world. Their records get NO head column — instead a
+/// west-edge entry at (0, lane_row), each on its own lane row, so the
+/// chain's delivery corridors approach on distinct rows.
+pub fn adapt_boundaries_chain_fed(
+    l: LayoutResult,
+    chain_fed: &FxHashSet<String>,
+) -> Result<LayoutResult, String> {
     // Lane spacing 1 first — bit-identical to the original adapter for
     // every fixture it could route (the registered hashes depend on
     // it). Spacing 2 unlocks 3+-fluid-feed blocks (the chem-pack
     // class), where a lateral otherwise passes directly under an
     // earlier head column with no clearance row.
-    match adapt_with_spacing(&l, 1) {
+    match adapt_with_spacing(&l, 1, chain_fed) {
         Ok(adapted) => Ok(adapted),
-        Err(e1) => adapt_with_spacing(&l, 2).map_err(|e2| {
+        Err(e1) => adapt_with_spacing(&l, 2, chain_fed).map_err(|e2| {
             format!("{e1}; at spacing 2: {e2}")
         }),
     }
 }
 
-fn adapt_with_spacing(l: &LayoutResult, spacing: i32) -> Result<LayoutResult, String> {
+fn adapt_with_spacing(
+    l: &LayoutResult,
+    spacing: i32,
+    chain_fed: &FxHashSet<String>,
+) -> Result<LayoutResult, String> {
     let n_in = l.boundary_inputs.len() as i32;
     if n_in == 0 {
         return Err("mega: layout has no boundary inputs".into());
@@ -93,8 +108,18 @@ fn adapt_with_spacing(l: &LayoutResult, spacing: i32) -> Result<LayoutResult, St
 
     // Records sorted west→east (#363 rig-depth rule); heads assigned
     // at 4-pitch starting from the westmost original head.
+    // Chain-fed records (increment 2) sort LAST, eastmost-orig first:
+    // they take the DEEPEST lanes, so no external head or tail column
+    // (all of which bottom out at shallower external lane rows) ever
+    // descends into a chain-fed lateral's row, and no chain-fed tail
+    // (short: deep row to margin) reaches an external lateral. Every
+    // residual crossing is a chain-fed LATERAL (always a solid belt)
+    // over some column — resolved by UG hops at stamp time. Among
+    // chain-fed records, east→west = shallow→deep keeps their own
+    // (short) tails east of every deeper chain-fed lateral's span.
     let mut records = l.boundary_inputs.clone();
-    records.sort_by_key(|r| r.x);
+    let is_cf = |r: &BoundaryRecord| chain_fed.contains(&r.item);
+    records.sort_by_key(|r| if is_cf(r) { (1, -r.x) } else { (0, r.x) });
     let head0 = records.first().map(|r| r.x).unwrap_or(1);
 
     // Plan first, stamp second: refuse crossings before emitting
@@ -107,18 +132,36 @@ fn adapt_with_spacing(l: &LayoutResult, spacing: i32) -> Result<LayoutResult, St
         orig_x: i32,
         lane_row: i32,
         is_fluid: bool,
+        west_entry: bool,
     }
+    let mut n_heads = 0i32;
     let plans: Vec<Plan> = records
         .iter()
         .enumerate()
-        .map(|(i, r)| Plan {
-            head_x: head0 + FEED_PITCH * i as i32,
-            orig_x: r.x,
-            lane_row: 1 + spacing * i as i32,
-            is_fluid: r.is_fluid,
+        .map(|(i, r)| {
+            let west_entry = is_cf(r);
+            let head_x = if west_entry {
+                0
+            } else {
+                let h = head0 + FEED_PITCH * n_heads;
+                n_heads += 1;
+                h
+            };
+            Plan {
+                head_x,
+                orig_x: r.x,
+                lane_row: 1 + spacing * i as i32,
+                is_fluid: r.is_fluid,
+                west_entry,
+            }
         })
         .collect();
     for (i, p) in plans.iter().enumerate() {
+        if p.west_entry {
+            // Chain-fed laterals resolve crossings with UG hops at
+            // stamp time instead of refusing here.
+            continue;
+        }
         let (lo, hi) = (p.head_x.min(p.orig_x), p.head_x.max(p.orig_x));
         for (j, q) in plans.iter().enumerate() {
             if i == j {
@@ -315,7 +358,107 @@ fn adapt_with_spacing(l: &LayoutResult, spacing: i32) -> Result<LayoutResult, St
             // dx-shifted tails, so belts verify their tiles too and
             // refuse loudly on conflict (#401 review finding 2).
             let mut path: Vec<(i32, i32, EntityDirection)> = Vec::new();
-            if p.head_x == p.orig_x {
+            let mut ug_mouths: Vec<(i32, i32, &str)> = Vec::new();
+            if p.west_entry {
+                // Chain-fed (increment 2): no head column. West-edge
+                // entry at (0, lane_row) running east to the original
+                // column, corner south, tail into the original head.
+                // The chain corridor's eastbound approach into the
+                // entry tile is a straight merge — both lanes. The
+                // lateral UG-hops under every occupied column it
+                // crosses (external tails, fluid tails, earlier
+                // chain-fed tails — a solid belt hops under any of
+                // them), same clustering as the chain Router.
+                let occupied = |x: i32| {
+                    solid_at.contains(&(x, p.lane_row))
+                        || fluid_at.contains_key(&(x, p.lane_row))
+                };
+                let mut cols: Vec<i32> = (1..p.orig_x).filter(|&x| occupied(x)).collect();
+                // A crossing at orig_x-1 leaves no room for the hop's
+                // exit mouth (it would land ON our tail corner).
+                // Retrofit that column VERTICALLY instead: convert its
+                // south belts at our-row±1 into a South UG pair and
+                // free our row — the retrofit_feed_hop idiom. Solid
+                // columns only; interior rows only (never a corner or
+                // the engine head tile).
+                if cols.last() == Some(&(p.orig_x - 1)) {
+                    let c = p.orig_x - 1;
+                    let row = p.lane_row;
+                    let owner = plans.iter().find(|q| q.orig_x == c && q.lane_row < row);
+                    let interior = owner.is_some_and(|q| row - 1 > q.lane_row) && row + 1 < margin;
+                    let is_solid_col = solid_at.contains(&(c, row));
+                    if !(interior && is_solid_col) {
+                        return Err(format!(
+                            "mega: chain-fed {} crossing at x={c} abuts its tail and cannot be retrofitted",
+                            r.item
+                        ));
+                    }
+                    let mut converted = 0;
+                    let mut removed = None;
+                    for (idx, e) in entities.iter_mut().enumerate() {
+                        if e.x != c || !e.name.contains("transport-belt") {
+                            continue;
+                        }
+                        if e.y == row && e.direction == EntityDirection::South {
+                            removed = Some(idx);
+                        } else if (e.y == row - 1 || e.y == row + 1)
+                            && e.direction == EntityDirection::South
+                        {
+                            e.name = e.name.replace("transport-belt", "underground-belt");
+                            e.io_type =
+                                Some(if e.y == row - 1 { "input" } else { "output" }.into());
+                            converted += 1;
+                        }
+                    }
+                    match (converted, removed) {
+                        (2, Some(idx)) => {
+                            entities.remove(idx);
+                            solid_at.remove(&(c, row));
+                            cols.pop();
+                        }
+                        _ => {
+                            return Err(format!(
+                                "mega: chain-fed {} vertical retrofit at x={c} found {converted} belts (need 2) — adapter refuses",
+                                r.item
+                            ));
+                        }
+                    }
+                }
+                let mut clusters: Vec<(i32, i32)> = Vec::new();
+                for c in cols {
+                    match clusters.last_mut() {
+                        Some((_, hi)) if c - *hi < 3 => *hi = c,
+                        _ => clusters.push((c, c)),
+                    }
+                }
+                let mut x = 0;
+                for (lo2, hi2) in clusters {
+                    if hi2 - lo2 + 2 > 9 {
+                        return Err(format!(
+                            "mega: chain-fed {} lateral hop cluster {}..{} exceeds express reach",
+                            r.item, lo2, hi2
+                        ));
+                    }
+                    if lo2 - 1 < 1 {
+                        return Err(format!(
+                            "mega: chain-fed {} lateral crossing at x={} leaves no entry tile",
+                            r.item, lo2
+                        ));
+                    }
+                    for xx in x..=(lo2 - 2) {
+                        path.push((xx, p.lane_row, EntityDirection::East));
+                    }
+                    ug_mouths.push((lo2 - 1, p.lane_row, "input"));
+                    ug_mouths.push((hi2 + 1, p.lane_row, "output"));
+                    x = hi2 + 2;
+                }
+                for xx in x..p.orig_x {
+                    path.push((xx, p.lane_row, EntityDirection::East));
+                }
+                for y in p.lane_row..margin {
+                    path.push((p.orig_x, y, EntityDirection::South));
+                }
+            } else if p.head_x == p.orig_x {
                 for y in 0..margin {
                     path.push((p.head_x, y, EntityDirection::South));
                 }
@@ -347,6 +490,14 @@ fn adapt_with_spacing(l: &LayoutResult, spacing: i32) -> Result<LayoutResult, St
                     ));
                 }
             }
+            for &(x, y, _) in &ug_mouths {
+                if solid_at.contains(&(x, y)) || fluid_at.contains_key(&(x, y)) {
+                    return Err(format!(
+                        "mega: chain-fed {} hop mouth collides at ({x},{y}) — adapter refuses",
+                        r.item
+                    ));
+                }
+            }
             for (x, y, dir) in path {
                 solid_at.insert((x, y));
                 entities.push(PlacedEntity {
@@ -359,12 +510,29 @@ fn adapt_with_spacing(l: &LayoutResult, spacing: i32) -> Result<LayoutResult, St
                     ..Default::default()
                 });
             }
+            for (x, y, io) in ug_mouths {
+                solid_at.insert((x, y));
+                entities.push(PlacedEntity {
+                    name: r.entity.replace("transport-belt", "underground-belt"),
+                    x,
+                    y,
+                    direction: EntityDirection::East,
+                    io_type: Some(io.into()),
+                    carries: Some(r.item.clone()),
+                    segment_id: Some(seg.clone()),
+                    ..Default::default()
+                });
+            }
         }
         b_in.push(BoundaryRecord {
             item: r.item.clone(),
             x: p.head_x,
-            y: 0,
-            direction: EntityDirection::South,
+            y: if p.west_entry { p.lane_row } else { 0 },
+            direction: if p.west_entry {
+                EntityDirection::East
+            } else {
+                EntityDirection::South
+            },
             is_fluid: r.is_fluid,
             entity: if p.is_fluid { "pipe".into() } else { r.entity.clone() },
         });
@@ -574,6 +742,12 @@ pub struct MegaPlan {
     pub outputs: Vec<(String, f64)>,
     /// External inputs the subgraph consumes (fluids + solids).
     pub inputs: Vec<String>,
+    /// Solid inputs produced elsewhere in the CHAIN, with their total
+    /// subgraph consumption rates (increment 2: the PU class — the
+    /// subgraph swallows a spec that consumes chain-produced
+    /// EC/AC/plates). Each becomes a chain corridor into the block's
+    /// adapter feed head instead of an external.
+    pub chain_fed: Vec<(String, f64)>,
     /// Recipes collapsed into the mega-cell.
     pub members: rustc_hash::FxHashSet<String>,
 }
@@ -636,16 +810,26 @@ pub fn mega_subgraph(sr: &crate::models::SolverResult) -> Result<Option<MegaPlan
     // Edges out must be solid; inputs from inside the chain refuse
     // (v1: the sub-solve must be self-contained on externals).
     let mut inputs: Vec<String> = Vec::new();
+    let mut chain_fed: Vec<(String, f64)> = Vec::new();
     let mut solid_outputs: Vec<(&str, f64)> = Vec::new();
     for m in &fluid_specs {
         for i in &m.inputs {
             match produced_anywhere.get(i.item.as_str()) {
                 Some(producer) if in_subgraph(producer) => {} // internal
-                Some(producer) => {
-                    return Err(format!(
-                        "mega: subgraph input {} is produced by non-member {} (v1 requires external-only inputs)",
-                        i.item, producer
-                    ));
+                Some(_) => {
+                    // Produced by a non-member chain spec (increment 2):
+                    // fed by a chain corridor into the block's adapter
+                    // head. Fluids never cross the boundary.
+                    if i.is_fluid {
+                        return Err(format!(
+                            "mega: chain-fed input {} is a fluid (fluids never cross cell boundaries)",
+                            i.item
+                        ));
+                    }
+                    match chain_fed.iter_mut().find(|(x, _)| x == &i.item) {
+                        Some((_, r)) => *r += i.rate * m.count,
+                        None => chain_fed.push((i.item.clone(), i.rate * m.count)),
+                    }
                 }
                 None => {
                     if !inputs.iter().any(|x| x == &i.item) {
@@ -682,6 +866,7 @@ pub fn mega_subgraph(sr: &crate::models::SolverResult) -> Result<Option<MegaPlan
             .map(|(i, r)| (i.to_string(), *r))
             .collect(),
         inputs,
+        chain_fed,
         members,
     }))
 }
@@ -758,6 +943,7 @@ pub fn compose_mega_block(
     };
     let l = crate::bus::layout::build_bus_layout(&sub, opts)
         .map_err(|e| format!("mega: block layout: {}", e.lines().next().unwrap_or("")))?;
-    let adapted = adapt_boundaries(l)?;
+    let cf: FxHashSet<String> = plan.chain_fed.iter().map(|(i, _)| i.clone()).collect();
+    let adapted = adapt_boundaries_chain_fed(l, &cf)?;
     Ok((sub, adapted))
 }

--- a/crates/core/src/bus/cells/mega.rs
+++ b/crates/core/src/bus/cells/mega.rs
@@ -432,11 +432,17 @@ fn adapt_with_spacing(
                     }
                 }
                 let mut x = 0;
+                let ug_gap = crate::common::ug_max_reach(&r.entity) as i32;
                 for (lo2, hi2) in clusters {
-                    if hi2 - lo2 + 2 > 9 {
+                    // Mouths at lo2-1 / hi2+1 → underground gap =
+                    // hi2-lo2+1, capped by the RECORD's belt tier (the
+                    // mouths stamp that tier — a hardcoded express cap
+                    // would let a yellow record plan a pair the game
+                    // never connects; #411 review).
+                    if hi2 - lo2 + 1 > ug_gap {
                         return Err(format!(
-                            "mega: chain-fed {} lateral hop cluster {}..{} exceeds express reach",
-                            r.item, lo2, hi2
+                            "mega: chain-fed {} lateral hop cluster {}..{} exceeds {} reach",
+                            r.item, lo2, hi2, r.entity
                         ));
                     }
                     if lo2 - 1 < 1 {

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -853,6 +853,69 @@ fn mega_chain_chem5_resolves_bus_failure() {
     );
 }
 
+/// RFC-052 increment 2 (chain-fed mega inputs): processing-unit@4
+/// from raw — the fluid subgraph swallows the PU spec, which consumes
+/// chain-produced EC/AC/iron-plate. The BUS path hard-fails here
+/// (unresolved junctions); the chain must compose with zero errors,
+/// tolerating only the adjudicated categories. (@2 is both-paths-clean
+/// since #408's reach fix shifted junction geometry — the bus-refusal
+/// win for this class lives at 4/s.)
+#[test]
+fn mega_chain_pu4_resolves_bus_failure() {
+    use spaghettio_core::bus::cells::chain::compose_chain;
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+            .iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "processing-unit", 4.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let plan = spaghettio_core::bus::cells::mega::mega_subgraph(&sr)
+        .expect("subgraph")
+        .expect("PU chain has a fluid subgraph");
+    assert!(
+        !plan.chain_fed.is_empty(),
+        "PU class must exercise chain-fed inputs, got {:?}",
+        plan.chain_fed
+    );
+    let l = compose_chain(&sr).expect("PU@4 from raw must compose");
+    let issues = match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
+        Ok(v) => v,
+        Err(e) => e.issues,
+    };
+    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    assert!(errors.is_empty(), "PU@4 errors: {errors:?}");
+    assert!(
+        issues.iter().all(|i| matches!(
+            i.category.as_str(),
+            "inserter-item-throughput" | "inserter-throughput" | "power" | "row-output-lane-budget"
+        )),
+        "only adjudicated categories tolerated: {issues:?}"
+    );
+}
+
+/// Artifact producer for the increment-2 sim run.
+#[test]
+#[ignore = "artifact producer"]
+fn export_mega_pu_for_sim() {
+    use spaghettio_core::bus::cells::chain::compose_chain;
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+            .iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "processing-unit", 4.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let l = compose_chain(&sr).unwrap();
+    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-pu4raw");
+    std::fs::create_dir_all("target/tmp").unwrap();
+    std::fs::write("target/tmp/mega-chain-pu4raw.bp", &bp).unwrap();
+    std::fs::write("target/tmp/mega-chain-pu4raw.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+    println!("wrote mega-chain-pu4raw.bp ({} in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
+}
+
 /// Artifact producer for the kill-2 sim run.
 #[test]
 #[ignore = "artifact producer"]

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -479,8 +479,15 @@ script.on_init(function()
   end
   local s = game.create_surface("lab")
   s.generate_with_lab_tiles = true
-  s.request_to_generate_chunks({0, 0}, 12)
-  s.request_to_generate_chunks({DIMS_X, DIMS_Y}, 12)
+  -- The paste is CENTERED on {0,0}, so generated chunks must cover
+  -- the layout's HALF-span plus rig margin in every direction. The
+  -- old fixed radius (12 chunks = 384 tiles) silently truncated any
+  -- fixture wider than ~768 tiles: build_blueprint creates no ghosts
+  -- on ungenerated chunks, and the PU@4 chain (2704 tiles wide) lost
+  -- 2/3 of its entities that way — dead feed rigs, NO DATA (#345
+  -- adjacent, RFC-052 increment 2 forensics).
+  local gen_radius = math.max(12, math.ceil((math.max(DIMS_X, DIMS_Y) / 2 + 64) / 32) + 1)
+  s.request_to_generate_chunks({0, 0}, gen_radius)
   s.force_generate_chunk_requests()
 
   local inv = game.create_inventory(1)

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,43 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-24 — Increment 2 DELIVERED (chain-fed mega inputs) and
+  KILL-2 RESOLVED: NOT INVOKED. `mega_subgraph` now collects inputs
+  produced by non-member chain specs as `plan.chain_fed` instead of
+  refusing; the super-spec DECLARES them, so the generic
+  consumer/fan-out/corridor machinery routes producers into the mega
+  like any consumer cell. Geometry: chain-fed records take the
+  adapter's DEEPEST lanes with west-edge entries at (0, lane_row) —
+  one east-facing port per record, distinct approach rows, straight
+  merges; residual crossings consolidate onto the (always-solid)
+  chain-fed lateral, resolved by UG hops under any occupied column,
+  with the orig-adjacent case retrofitting the crossing solid tail
+  into a vertical UG pair. Consumer-less mega drains extend to the
+  chain drain row (latent dead-end + rig-depth gap, exposed by PU
+  whose export has no chain consumer). Honesty note: the bus no
+  longer hard-fails PU@2 (junction geometry shifted under #408) — the
+  class's bus-refusal win lives at PU@4 (unresolved junctions), which
+  composes 0 errors (gate `mega_chain_pu4_resolves_bus_failure`).
+  **Sim (after a harness fix — the scenario's fixed radius-12 chunk
+  pregeneration truncated any fixture wider than ~768 tiles;
+  build_blueprint creates no ghosts on ungenerated chunks, so the
+  2704-wide PU@4 chain lost 2/3 of its entities and reported dead
+  feed rigs/NO DATA; radius now derives from manifest dims):
+  27498/27498 revived, CONVERGED, zero kit/fluid errors — the deepest
+  chain ever measured, raw ore → plates → cable/EC → AC + oil →
+  sulfur → acid → PU across 8 quantized copies. PU 3.17/s of 4.00
+  (−20%)**, and the chain-fed machinery is NOT the bottleneck: AC (a
+  chain-fed input) overproduces +4.1%, plastic +10%, PG −4.7%
+  demand-limited; the deficit originates at the plate/sulfur cells'
+  DECLARED inserter/lane bounds (#383 class — plates −21% at the
+  source, sulfur output inserter declared 0.84/1.00). Not registered
+  (registry records measured PASS baselines); registers when #383's
+  template sizing lifts the declared bounds. With both named
+  increments landed — chem (validator + fluid-proven sim) and PU
+  (validator + converged sim) — the deferred kill-2 criterion
+  resolves: the chain-integration machinery has real bus-refusal
+  wins; the architecture stands.*
+
 - *2026-07-24 — #408 adversarial review folds (APPROVE-WITH-NITS; the
   reviewer independently re-derived the reach semantics from game data
   and re-ran the full battery). The one MAJOR is SIGNED OFF as a

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,25 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-24 — #411 adversarial review folds (APPROVE-WITH-NITS; both
+  bus-refusal claims independently re-verified, retrofit guards probed
+  and held, full battery re-run clean). Folds: (1) the chain-fed hop
+  reach guard now derives from the RECORD's belt tier via
+  `ug_max_reach` instead of a hardcoded express cap — the mouths stamp
+  the record's tier, so a yellow record with a 6..9-tile span would
+  have planned a pair the game never connects (latent,
+  validator-backstopped, not triggered by any current fixture);
+  (2) origin/main merged into the branch — the review's one MAJOR was
+  merge hygiene, not code: the stale base made the two-dot diff show
+  #410's review-bot guard as phantom reverts (three-dot diff touches
+  only the 5 real files; 0 contested commits). Bot review's
+  CLAUDE.md-compliance finding (skipped browser step) resolved by
+  DOING the step: composed PU@4 verified in the web pipeline (0
+  errors / 81 warnings, candidate selected) and eyeballed at three
+  zoom levels; the "session convention" carve-out is memory-side, not
+  CLAUDE.md — future layout PRs do the step or cite sim coverage
+  explicitly.*
+
 - *2026-07-24 — Increment 2 DELIVERED (chain-fed mega inputs) and
   KILL-2 RESOLVED: NOT INVOKED. `mega_subgraph` now collects inputs
   produced by non-member chain specs as `plan.chain_fed` instead of


### PR DESCRIPTION
## Intent

RFC-052 increment 2: let the mega subgraph swallow specs that consume chain-produced solids (the PU class — PU eats chain-made EC/AC/iron-plate). With this, both named kill-2 increments have landed and the deferred kill-2 criterion resolves NOT INVOKED — the chain-integration machinery has real bus-refusal wins.

## Scope

- **In:**
  - `mega_subgraph` collects chain-produced inputs as `plan.chain_fed` (with rates) instead of refusing; fluids still refuse (never cross cell boundaries).
  - The super-spec declares chain-fed inputs → the existing generic consumer/fan-out/corridor machinery routes producers into the mega like any consumer cell. Placement position: most-downstream member when chain-fed exist (mega places after its producers); unchanged (deepest member) otherwise.
  - Adapter (`mega.rs`): chain-fed records take the DEEPEST lanes with a west-edge entry at (0, lane_row) — one east-facing port per record, so each delivery corridor approaches on a distinct row as a straight merge (both lanes, no sideload). Residual crossings all land on the chain-fed lateral (always a solid belt): UG hops under any occupied column, with the orig-adjacent case retrofitting the crossing solid tail into a vertical UG pair (`retrofit_feed_hop` idiom). Chain-fed records emit no chain `b_in` (the chain supplies them) and become mega Cell ports.
  - `port_abs` takes the placed `y_off` (mega sits at 0; solid cells bit-identical at `CELL_Y`).
  - Consumer-less mega drains extend to the chain drain row — the old mid-layout `b_out` left a dead-end belt and a nonuniform sim rig depth (latent until PU, whose export has no chain consumer).
  - **Sim-harness fix**: scenario chunk pregeneration radius now derives from manifest dims (floor 12 = old behavior). The fixed radius silently truncated any fixture wider than ~768 tiles — `build_blueprint` creates no ghosts on ungenerated chunks, so the 2704-wide PU@4 chain lost 2/3 of its entities and reported dead feed rigs / NO DATA.
  - Gate: `mega_chain_pu4_resolves_bus_failure` (bus hard-fails with unresolved junctions; chain composes 0 errors; only adjudicated warning categories tolerated) + `export_mega_pu_for_sim` artifact producer.
- **Out:** registry entry for PU@4 (measures −20%, at the declared #383-class bounds — registers when template sizing lifts them); multi-entry fan-in per chain-fed item (v1 refuses loudly); fluid chain-fed (refused by design); PTG-retrofit of fluid crossing columns (refused loudly).

## Verification

- [x] Full suite green (one clean invocation: lib 814/0, e2e 60/0, cell_composition 14/0 incl. the new gate, all others 0 failed)
- [x] `cargo clippy` clean (0 warnings lib)
- [x] Registry hash gate green — chain_fed-empty paths (all existing fixtures, solid chains, chem/AC megas) bit-identical
- [x] Stress goldens: drift is exactly the known #406 six (layout-hash-identical, warning-category-only per the #408 review)
- [x] Bus-failure claim verified honestly: PU@4 bus = 3 unresolved-junction errors; **PU@2 bus is now clean** (junction geometry shifted under #408's reach fix) — gate targets @4, @2 recorded as both-paths-clean
- [x] Tile-level audit of the export: west-entry ports on distinct rows with corridor arrivals as straight merges; vertical retrofit at the coal column (UG pair with freed surface row); Router ascent-lane hop under delivery rows
- [x] **Sim (headless Factorio)**: 27498/27498 revived, CONVERGED, zero kit/fluid errors — deepest chain ever measured (raw ore → plates → cable/EC → AC + oil → sulfur → acid → PU, 8 quantized copies). PU 3.17/4.00 (−20%); the chain-fed machinery is not the bottleneck (AC, a chain-fed input, overproduces +4.1%); deficit originates at plate/sulfur cells' declared inserter/lane bounds (#383 class, Lane B's thread)
- Browser eyeball deferred to the user per session convention.

## Deviations from intent

The sim initially returned NO DATA from a harness-scaling defect (fixed here, floor-12 preserves every prior fixture's behavior). The kill-2 sweep's "PU@2–4 bus hard-fails" claim narrowed to @4-only after #408 — recorded in the decision log rather than papered over.

## Models / contracts touched

`rfc-052-oil-mega-cell.md` decision log (increment 2 + kill-2 resolution). No mechanics-doc changes (no new game rules; the hop/retrofit idioms follow documented belt rules). Tier ladder untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55