### PR TITLE
chore(goldens): #406 re-bless — new #402 warning category, zero layout movement

### DIFF
--- a/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_4s_from_plates.txt
+++ b/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_4s_from_plates.txt
@@ -1,6 +1,6 @@
 === stress_advanced_circuit_partitioned_4s_from_plates scoreboard ===
 entities:         1178
-total warnings:   0
+total warnings:   1
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -13,7 +13,7 @@ total poles:      78
 zero-slack poles: 1
 median slack:     3.0
 warnings by category:
-  (none)
+  row-output-lane-budget: 1
 errors by category:
   (none)
 layout hash: e1233415fbd7b518e456b35cfb4eda85cdf71a25801d8d777de13a232237b301

--- a/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_5s_from_plates.txt
+++ b/crates/core/tests/goldens/stress/stress_advanced_circuit_partitioned_5s_from_plates.txt
@@ -1,6 +1,6 @@
 === stress_advanced_circuit_partitioned_5s_from_plates scoreboard ===
 entities:         1496
-total warnings:   0
+total warnings:   1
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -13,7 +13,7 @@ total poles:      91
 zero-slack poles: 1
 median slack:     2.0
 warnings by category:
-  (none)
+  row-output-lane-budget: 1
 errors by category:
   (none)
 layout hash: cb24dca4abb90c9441959e59e8114744a223f9a83cc1c939f0e07d8afc7626a6

--- a/crates/core/tests/goldens/stress/stress_electronic_circuit_30s_from_ore.txt
+++ b/crates/core/tests/goldens/stress/stress_electronic_circuit_30s_from_ore.txt
@@ -1,6 +1,6 @@
 === stress_electronic_circuit_30s_from_ore scoreboard ===
 entities:         4966
-total warnings:   0
+total warnings:   5
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -13,7 +13,7 @@ total poles:      196
 zero-slack poles: 0
 median slack:     4.0
 warnings by category:
-  (none)
+  row-output-lane-budget: 5
 errors by category:
   (none)
 layout hash: fcb254ed8d57dadf978ea4b2210da4349a3ceeb6e9a8c8a6cc6fca1ecd1641ce

--- a/crates/core/tests/goldens/stress/stress_electronic_circuit_35s_from_ore.txt
+++ b/crates/core/tests/goldens/stress/stress_electronic_circuit_35s_from_ore.txt
@@ -1,6 +1,6 @@
 === stress_electronic_circuit_35s_from_ore scoreboard ===
 entities:         6353
-total warnings:   123
+total warnings:   127
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -15,6 +15,7 @@ median slack:     4.0
 warnings by category:
   belt-flow-reachability: 88
   input-rate-delivery: 35
+  row-output-lane-budget: 4
 errors by category:
   belt-dead-end: 4
 layout hash: 18116e5daf58a7f01fba2a09dd293735378e4e0810a17243658c867df7d7688b

--- a/crates/core/tests/goldens/stress/stress_electronic_circuit_40s_from_ore.txt
+++ b/crates/core/tests/goldens/stress/stress_electronic_circuit_40s_from_ore.txt
@@ -1,6 +1,6 @@
 === stress_electronic_circuit_40s_from_ore scoreboard ===
 entities:         7201
-total warnings:   227
+total warnings:   234
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -16,6 +16,7 @@ warnings by category:
   belt-flow-path: 25
   belt-flow-reachability: 121
   input-rate-delivery: 81
+  row-output-lane-budget: 7
 errors by category:
   belt-dead-end: 13
 layout hash: cf1f51aaa09649c9cdf0690e2b934b2a80cbfc69b75430598bd0673d37ce06fa

--- a/crates/core/tests/goldens/stress/stress_electronic_circuit_60s_red_from_ore.txt
+++ b/crates/core/tests/goldens/stress/stress_electronic_circuit_60s_red_from_ore.txt
@@ -1,6 +1,6 @@
 === stress_electronic_circuit_60s_red_from_ore scoreboard ===
 entities:         5568
-total warnings:   0
+total warnings:   11
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -13,7 +13,7 @@ total poles:      361
 zero-slack poles: 0
 median slack:     4.0
 warnings by category:
-  (none)
+  row-output-lane-budget: 11
 errors by category:
   (none)
 layout hash: f12597061318762909146582a883a3622c6c484927100037259689bb2caa7f6d


### PR DESCRIPTION
## Intent

Clear #406: the six stress goldens drifted on main and every branch's opt-in golden check has been red on main's account since the #381/#402 merge day.

## Scope

- **In:** re-bless of the 6 drifted golden files, nothing else.
- **Out:** any layout or check change.

## Verification

- [x] `SPAGHETTIO_STRESS_GOLDEN=check` run captured before blessing: **all six diffs are warnings-only** — every layout hash byte-identical, every errors-by-category unchanged (35s/40s retain their pre-existing `belt-dead-end: 4/13` exactly). The drift is the `row-output-lane-budget` warning category (#402's sim-calibrated check) reporting on unchanged layouts — i.e. check-side visibility, **not** #381 layout movement as #406 hypothesized. This satisfies #406's own pass criterion (errors-by-category stays none/unchanged).
- [x] Post-bless `SPAGHETTIO_STRESS_GOLDEN=bless` run wrote exactly the 6 expected files (12+/10− lines, all warning-count/category lines).
- Not applicable: clippy/WASM/browser (goldens-only).

## Deviations from intent

None. Note goldens are host-cache-relative by design; this bless ran on the same host as the prior baselines.

## Models / contracts touched

None — committed test baselines only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)