### PR TITLE
fix(validate): #404 — lane walkers over-seeded multi-inserter machines; share rate across hands

### DIFF
--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -2314,6 +2314,11 @@ fn compute_lane_rates_impl(
     // Pass 2: each machine's per-item output rate is split evenly across
     // its qualifying output inserters (identical hands drain a shared
     // buffer — the even split is the steady state the planner sizes for).
+    // ASSUMPTION GUARD (#414 review): relies on the sizer emitting ONE
+    // uniform plan per side and output templates confining a machine's
+    // hands to one belt run; if the placer ever mixes hand tiers per
+    // (machine, item) or fans hands across separate runs, revisit —
+    // even-split would then under-state the faster hand's lane.
     for (drop_pos, lane, key, rate) in qualifying {
         let n = inserters_per_output[&key] as f64;
         let entry = lane_injections.entry(drop_pos).or_insert([0.0, 0.0]);

--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -2241,6 +2241,16 @@ fn compute_lane_rates_impl(
         }
     }
 
+    // Pass 1: qualifying output inserters, keyed by (machine origin, item).
+    // A machine's production is SHARED by all its output inserters — the
+    // sizing ladder adds a second hand when one can't keep up (common at
+    // low capacity research / high quality). Injecting the full per-machine
+    // rate once per inserter double-counts such machines: #404's "bridged
+    // row" false positives were really a 2-inserter machine seeding 2×6.5/s
+    // onto a 13/s row (the bridge model itself was and is correct). Collect
+    // first, then inject rate / n_inserters.
+    let mut qualifying: Vec<((i32, i32), &str, ((i32, i32), &str), f64)> = Vec::new();
+    let mut inserters_per_output: FxHashMap<((i32, i32), &str), u32> = FxHashMap::default();
     let mut lane_injections: FxHashMap<(i32, i32), [f64; 2]> = FxHashMap::default();
     for ins in &layout.entities {
         if !is_inserter(&ins.name) {
@@ -2297,11 +2307,20 @@ fn compute_lane_rates_impl(
         }
         let belt_d = belt_dir_map[&drop_pos];
         let lane = inserter_target_lane(ins.x, ins.y, drop_pos.0, drop_pos.1, belt_d);
+        let key = (mpos, carried_item);
+        *inserters_per_output.entry(key).or_insert(0) += 1;
+        qualifying.push((drop_pos, lane, key, rate));
+    }
+    // Pass 2: each machine's per-item output rate is split evenly across
+    // its qualifying output inserters (identical hands drain a shared
+    // buffer — the even split is the steady state the planner sizes for).
+    for (drop_pos, lane, key, rate) in qualifying {
+        let n = inserters_per_output[&key] as f64;
         let entry = lane_injections.entry(drop_pos).or_insert([0.0, 0.0]);
         if lane == LANE_LEFT {
-            entry[0] += rate;
+            entry[0] += rate / n;
         } else {
-            entry[1] += rate;
+            entry[1] += rate / n;
         }
     }
 

--- a/crates/core/src/validate/belt_structural.rs
+++ b/crates/core/src/validate/belt_structural.rs
@@ -1081,7 +1081,13 @@ pub fn compute_lane_rates(layout: &LayoutResult, solver_result: &SolverResult) -
     }
     // Each machine's per-item rate splits evenly across its qualifying
     // output inserters (identical hands drain a shared buffer — the even
-    // split is the steady state the planner sizes for).
+    // split is the steady state the planner sizes for). ASSUMPTION GUARD
+    // (#414 review): this relies on the sizer emitting ONE uniform plan
+    // per side (`size_belt_drop_side`/`size_side_output`) and the output
+    // templates confining a machine's hands to adjacent tiles of one
+    // belt run. If the placer ever mixes hand tiers per (machine, item)
+    // or fans one machine's hands across separate runs, revisit —
+    // even-split would then under-state the faster hand's lane.
     for (drop_pos, lane, key, rate) in qualifying {
         let n = inserters_per_output[&key] as f64;
         let entry = lane_injections.entry(drop_pos).or_insert((0.0, 0.0));
@@ -1956,6 +1962,82 @@ mod tests {
             split.is_empty(),
             "6.5/s over two hands must seed 3.25 each (6.5 on the lane, under 7.5 cap), got: {:?}",
             split.iter().map(|i| &i.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn lane_rates_midpoint_bridge_swaps_lane_and_conserves_flow() {
+        // #404 companion pin: the bridge/sideload lane model was CORRECT
+        // all along — the false positives came from per-hand seed
+        // duplication, not the bridge. This pins the bridge half
+        // independently: two single-hand machines around an engine-style
+        // midpoint bridge (jog up, two bridge tiles, sideload back onto a
+        // through-belt). Upstream flow must cross the bridge onto the
+        // OPPOSITE lane (sideload collapse), downstream's hand fills the
+        // near lane, and total flow is conserved — 6.5/6.5 on a 13/s run,
+        // no lane over 7.5, zero lane-throughput issues.
+        let sr = SolverResult {
+            machines: vec![MachineSpec {
+                entity: "assembling-machine-3".to_string(),
+                recipe: "electronic-circuit".to_string(),
+                self_loop: vec![], voider: false, game_modules: Vec::new(),
+                count: 2.0,
+                inputs: vec![],
+                outputs: vec![ItemFlow {
+                    item: "electronic-circuit".to_string(),
+                    rate: 6.5,
+                    is_fluid: false,
+                    module_id: 0,
+                }],
+            }],
+            external_inputs: vec![],
+            external_outputs: vec![],
+            surplus_outputs: vec![],
+            dependency_order: vec![],
+        };
+        let item = "electronic-circuit";
+        let entities = vec![
+            machine("assembling-machine-3", 0, 0, item),
+            machine("assembling-machine-3", 8, 0, item),
+            // One hand each: A picks (1,2), drops (1,4); B picks (9,2), drops (9,4).
+            inserter(1, 3, EntityDirection::South),
+            inserter(9, 3, EntityDirection::South),
+            // Upstream run, jog, bridge row, and the through-belt it
+            // sideloads back onto (engine sideload_bridge geometry).
+            belt_carrying(1, 4, EntityDirection::East, item),
+            belt_carrying(2, 4, EntityDirection::East, item),
+            belt_carrying(3, 4, EntityDirection::North, item), // jog up
+            belt_carrying(3, 3, EntityDirection::East, item),  // bridge
+            belt_carrying(4, 3, EntityDirection::East, item),  // bridge
+            belt_carrying(5, 3, EntityDirection::South, item), // drop back
+            belt_carrying(4, 4, EntityDirection::East, item),  // filler (fresh through-belt)
+            belt_carrying(5, 4, EntityDirection::East, item),  // sideload target
+            belt_carrying(6, 4, EntityDirection::East, item),
+            belt_carrying(7, 4, EntityDirection::East, item),
+            belt_carrying(8, 4, EntityDirection::East, item),
+            belt_carrying(9, 4, EntityDirection::East, item),  // B's drop
+            belt_carrying(10, 4, EntityDirection::East, item), // tail
+        ];
+        let lr = layout(entities);
+
+        let issues = check_lane_throughput(&lr, Some(&sr));
+        assert!(
+            issues.is_empty(),
+            "bridged 13/s run at 6.5/lane must not flag: {:?}",
+            issues.iter().map(|i| &i.message).collect::<Vec<_>>()
+        );
+
+        let rates = compute_lane_rates(&lr, &sr);
+        let (l, r) = rates[&(10, 4)];
+        let total = l + r;
+        assert!(
+            (total - 13.0).abs() < 1e-6,
+            "flow must be conserved through jog corners + sideload (got L={l} R={r})"
+        );
+        assert!(
+            (l - 6.5).abs() < 1e-6 && (r - 6.5).abs() < 1e-6,
+            "bridge must land upstream flow on the opposite lane from the \
+             downstream hand's drops (got L={l} R={r})"
         );
     }
 

--- a/crates/core/src/validate/belt_structural.rs
+++ b/crates/core/src/validate/belt_structural.rs
@@ -1016,6 +1016,8 @@ pub fn compute_lane_rates(layout: &LayoutResult, solver_result: &SolverResult) -
 
     // Seed lane injection rates from output inserters.
     let mut lane_injections: FxHashMap<(i32, i32), (f64, f64)> = FxHashMap::default();
+    let mut qualifying: Vec<((i32, i32), &str, ((i32, i32), &str), f64)> = Vec::new();
+    let mut inserters_per_output: FxHashMap<((i32, i32), &str), u32> = FxHashMap::default();
     for ins in &layout.entities {
         if !is_inserter(&ins.name) {
             continue;
@@ -1066,8 +1068,24 @@ pub fn compute_lane_rates(layout: &LayoutResult, solver_result: &SolverResult) -
         }
         let belt_d = belt_dir_map[&drop_pos];
         let lane = inserter_target_lane(ins.x, ins.y, drop_pos.0, drop_pos.1, belt_d);
+        // Collect only — a machine's per-item output is SHARED by all its
+        // qualifying output inserters (the sizing ladder adds a second hand
+        // when one can't keep up, common at low capacity research / high
+        // quality). Injecting the full per-machine rate once per inserter
+        // double-counts such machines: #404's "bridged row" lane-throughput
+        // false positives were a 2-inserter machine seeding 2×6.5/s onto a
+        // 13/s row — the bridge/sideload model was already correct.
+        let key = (mpos, carried_item);
+        *inserters_per_output.entry(key).or_insert(0) += 1;
+        qualifying.push((drop_pos, lane, key, rate));
+    }
+    // Each machine's per-item rate splits evenly across its qualifying
+    // output inserters (identical hands drain a shared buffer — the even
+    // split is the steady state the planner sizes for).
+    for (drop_pos, lane, key, rate) in qualifying {
+        let n = inserters_per_output[&key] as f64;
         let entry = lane_injections.entry(drop_pos).or_insert((0.0, 0.0));
-        if lane == "left" { entry.0 += rate; } else { entry.1 += rate; }
+        if lane == "left" { entry.0 += rate / n; } else { entry.1 += rate / n; }
     }
 
     let feeders = classify_belt_feeders(&belt_dir_map, &ug_output_tiles);
@@ -1875,6 +1893,69 @@ mod tests {
             fractional.is_empty(),
             "count=0.06 must seed utilization-scaled 0.96/s, got: {:?}",
             fractional.iter().map(|i| &i.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn lane_rates_multi_inserter_machine_splits_rate_across_hands() {
+        // #404: a machine whose output is served by TWO inserters (the
+        // sizing ladder adds a hand when one can't keep up — low capacity
+        // research / high quality worlds) must seed its per-machine rate
+        // ONCE, split across the hands, not once per hand. The field
+        // symptom was lane-throughput ERROR false positives on bridged
+        // rows (a 13/s row read as 13/s on one lane; the game runs it at
+        // plan — RFC-047 decision log, cable13u) but the defect is the
+        // per-inserter duplication, not the bridge model.
+        //
+        // Two legs, same geometry: per-machine 6.5/s over two hands is
+        // 3.25/s each → downstream lane carries 6.5 < 7.5, must NOT flag
+        // (pre-fix it read 13.0 and flagged). Per-machine 16/s over two
+        // hands is 8/s each → 16 total on the lane, MUST flag (proves the
+        // geometry seeds and the split doesn't silently under-count).
+        let run = |rate: f64| {
+            let sr = SolverResult {
+                machines: vec![MachineSpec {
+                    entity: "assembling-machine-3".to_string(),
+                    recipe: "copper-cable".to_string(),
+                    self_loop: vec![], voider: false, game_modules: Vec::new(),
+                    count: 1.0,
+                    inputs: vec![],
+                    outputs: vec![ItemFlow {
+                        item: "copper-cable".to_string(),
+                        rate,
+                        is_fluid: false,
+                        module_id: 0,
+                    }],
+                }],
+                external_inputs: vec![],
+                external_outputs: vec![],
+                surplus_outputs: vec![],
+                dependency_order: vec![],
+            };
+            let entities = vec![
+                machine("assembling-machine-3", 3, 0, "copper-cable"),
+                // Two hands off ONE machine: pickups (4,2)/(5,2) inside the
+                // machine, drops (4,4)/(5,4) on the same eastbound run.
+                inserter(4, 3, EntityDirection::South),
+                inserter(5, 3, EntityDirection::South),
+                belt_carrying(4, 4, EntityDirection::East, "copper-cable"),
+                belt_carrying(5, 4, EntityDirection::East, "copper-cable"),
+                belt_carrying(6, 4, EntityDirection::East, "copper-cable"),
+            ];
+            check_lane_throughput(&layout(entities), Some(&sr))
+        };
+
+        let over = run(16.0);
+        assert!(
+            over.iter().any(|i| i.category == "lane-throughput"),
+            "16/s over two hands is 16 on the lane and must flag (seed sanity), got: {:?}",
+            over.iter().map(|i| &i.message).collect::<Vec<_>>()
+        );
+        let split = run(6.5);
+        assert!(
+            split.is_empty(),
+            "6.5/s over two hands must seed 3.25 each (6.5 on the lane, under 7.5 cap), got: {:?}",
+            split.iter().map(|i| &i.message).collect::<Vec<_>>()
         );
     }
 

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -7166,6 +7166,54 @@ fn quality_differential_ec_normal_vs_legendary() {
     );
 }
 
+/// #404 regression: the sim-proven cable13u fixture — a single engine-
+/// midpoint-bridged row (2 uncommon AM3s à 6.5/s, yellow belts) — measured
+/// 13.00/13 at plan in-game (RFC-047 decision log, 2026-07-23) yet raised
+/// 3 lane-throughput ERRORs: the walker seeded the per-machine rate once
+/// per output inserter, and the two-hand machine injected 2×6.5/s. The
+/// bridge/sideload lane model itself was correct. Pins zero
+/// lane-throughput issues on the honest fixture.
+#[test]
+#[ntest::timeout(120000)]
+fn cable13u_bridged_row_lane_throughput_clean() {
+    use spaghettio_core::common::QualityTier;
+    use spaghettio_core::recipe_db::MachinePalette;
+
+    let inputs: FxHashSet<String> = ["copper-plate"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "copper-cable",
+        13.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Uncommon,
+    )
+    .unwrap_or_else(|e| panic!("solve: {e}"));
+
+    let layout_result = layout::build_bus_layout(
+        &sr,
+        layout::LayoutOptions {
+            max_belt_tier: Some("transport-belt".to_string()),
+            quality: QualityTier::Uncommon,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|e| panic!("layout: {e}"));
+
+    let issues = match validate::validate(&layout_result, Some(&sr), LayoutStyle::Bus) {
+        Ok(i) => i,
+        Err(e) => e.issues,
+    };
+    let lane_issues: Vec<_> =
+        issues.iter().filter(|i| i.category == "lane-throughput").collect();
+    assert!(
+        lane_issues.is_empty(),
+        "cable13u runs at plan in-game; lane-throughput must not flag it: {:?}",
+        lane_issues.iter().map(|i| &i.message).collect::<Vec<_>>()
+    );
+}
+
 /// Stress-scale legendary fixture (RFC kill criterion 5: capped at one
 /// blue belt, 45/s, until #311 closes — the 60/s headline re-lands
 /// after). EC from ore on express at Legendary: ~92 machines vs ~230 at

--- a/docs/rfc-047-lane-aware-tap-delivery.md
+++ b/docs/rfc-047-lane-aware-tap-delivery.md
@@ -740,3 +740,15 @@ generator remains future work.
   cable13u exposes lane-throughput ERROR false positives on bridged
   rows (walker attributes the full 13/s to one lane; the game runs it
   at plan) — filed separately.*
+
+- *2026-07-24 — #404 closed: the cable13u false positives were NOT a
+  bridge-model gap. Both lane-rate walkers (belt_structural's dispatched
+  `check_lane_throughput` and belt_flow's `compute_lane_rates`) seeded
+  the per-machine output rate once PER OUTPUT INSERTER — a two-hand
+  machine (ladder-sized at low capacity / high quality) injected 2×6.5/s
+  onto a 13/s row. The bridge/sideload lane transfer was verified correct
+  en route (east-bridge repro splits 6.5/6.5 pre-fix). Fix: per-(machine,
+  item) rate shared evenly across qualifying hands; pinned by
+  `lane_rates_multi_inserter_machine_splits_rate_across_hands` (unit) and
+  `cable13u_bridged_row_lane_throughput_clean` (e2e, the sim-proven
+  fixture).*


### PR DESCRIPTION
## Intent

Close #404: `lane-throughput` ERROR false positives on bridged rows the game runs at plan (cable13u: 3 errors on a sim-measured 13.00/13 PASS fixture). Error-severity false positives poison the honest-world signal the sim program leans on.

## Scope

- **In:** the root cause — which is *not* the issue's hypothesized bridge-model gap. Both duplicated lane-rate walkers (`belt_structural::check_lane_throughput`, the dispatched one; and `belt_flow::compute_lane_rates`, which feeds input-rate-delivery) injected the full per-machine output rate once **per output inserter**. A two-hand machine (sizing ladder at low capacity research / high quality — exactly the worlds that also bridge rows, hence the misleading correlation) seeded 2× its rate. Fix in both walkers: collect qualifying hands per (machine origin, item), inject `rate / n_hands`. Plus an RFC-047 decision-log close-the-loop entry.
- **Out:** unifying the two duplicated walkers (real debt, separate concern); `check_row_output_lane_budget` needs nothing — it dedups machines via a `counted` set (verified).

## Verification

- [x] Reproduced the exact issue fixture first (quality-aware solve: copper-cable@13/s, 2 uncommon AM3s à 6.5/s, yellow, single midpoint-bridged row) → the 3 errors, with a tile-by-tile lane dump showing the bridge splitting *correctly* (6.5/6.5) and the corruption arriving via the second hand's duplicate 6.5 injection. Post-fix: 0 errors, lane rates physically conserved (13 total, max 6.5/lane).
- [x] Bridge model independently verified en route: an east-bridge AM3 layout splits lanes correctly pre- and post-fix.
- [x] New tests: `lane_rates_multi_inserter_machine_splits_rate_across_hands` (unit — negative leg: 6.5/s over two hands must not flag; positive leg: 16/s over two hands must flag, proving the split doesn't under-count) and `cable13u_bridged_row_lane_throughput_clean` (e2e — the sim-proven fixture end to end).
- [x] Full suite with `SPAGHETTIO_ZONE_CACHE_PATH` pinned to `sat-zones-ci.bin` (pin restored after): **lib 833/0, e2e 61/0**, all targets green, **zero fixture drift** — no existing count assertion moved.
- [x] `cargo clippy` — 0 warnings.
- [x] Stress goldens: no golden carries a `lane-throughput` entry; no drift (fresh from the #413 re-bless).
- Not run: browser eyeball / snapshots — no layout-generation change; the diff is validator-side rate accounting only. Sim ground truth for the fixture already exists (RFC-047 decision log 2026-07-23: 13.00/13 PASS).

## Deviations from intent

The issue prescribed "bridge-aware lane attribution in the walker" — the investigation falsified that mechanism (bridge attribution was already correct) and the landed fix is the actual root cause. Issue comment will record the re-attribution on close.

## Models / contracts touched

Validator semantics (lane-rate model). No layout-engine change, no doc contracts beyond the RFC-047 decision-log entry included here. Per CLAUDE.md, a session-side adversarial review is being dispatched in addition to the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)