### PR TITLE
feat(registry): admit honestly-warned + sim-confirmed cells (#383 policy)

### DIFF
--- a/crates/core/data/cell-sim-registry.json
+++ b/crates/core/data/cell-sim-registry.json
@@ -32,7 +32,7 @@
     "harness_world": "nb=0 bulk=1, S=1 (post-#390 stacking parity)",
     "verdict": "PASS",
     "produced_per_s": 2.2,
-    "scenario": "spaghettio-sim mega-plastic2 (Factorio 2.0.76, 4/4 working, converged, delivered 2.20/s vs 2.00 planned; re-measured 2026-07-24 after the Phase-B joint fluid planner corrected the feed path \u2014 the prior geometry pinned a residual terminus bug)",
+    "scenario": "spaghettio-sim mega-plastic2 (Factorio 2.0.76, 4/4 working, converged, delivered 2.20/s vs 2.00 planned; re-measured 2026-07-24 after the Phase-B joint fluid planner corrected the feed path — the prior geometry pinned a residual terminus bug)",
     "date": "2026-07-24"
   },
   {
@@ -56,7 +56,46 @@
     "harness_world": "nb=0 bulk=1, S=1 (post-#390 stacking parity)",
     "verdict": "PASS",
     "produced_per_s": 2.01,
-    "scenario": "spaghettio-sim mega-chain-ac2raw (Factorio 2.0.76, 45/45 working, converged, delivered 2.00/s EXACT from fully raw inputs \u2014 the RFC-052 Phase B flagship: smelting cells + oil mega-cell + circuit cells in one composed chain)",
+    "scenario": "spaghettio-sim mega-chain-ac2raw (Factorio 2.0.76, 45/45 working, converged, delivered 2.00/s EXACT from fully raw inputs — the RFC-052 Phase B flagship: smelting cells + oil mega-cell + circuit cells in one composed chain)",
+    "date": "2026-07-24"
+  },
+  {
+    "target": "electronic-circuit",
+    "rate": 15.0,
+    "geometry_hash": "cde5f2fcb0f5ef21",
+    "declared_inserter_capacity": 1,
+    "declared_stacking": 1,
+    "harness_world": "nb=0 bulk=2, S=1",
+    "verdict": "WARN",
+    "produced_per_s": 13.8,
+    "known_residual": "produced -8.0% vs plan (13.80/15.00): EC-row yellow output-belt ceiling, priced at generation by row-output-lane-budget (13.0/s measured floor on yellow) + input-side inserter bound at declared L1 (capacity never reaches composed cells until #415) — #383 attribution, 2026-07-24",
+    "scenario": "spaghettio-sim chain-ec15-d1 (Factorio 2.0.76, 14/15 working +1 full-output, converged, produced 13.80/15.00; #383 re-measurement on post-#394/#381 main)",
+    "date": "2026-07-24"
+  },
+  {
+    "target": "electronic-circuit",
+    "rate": 15.0,
+    "geometry_hash": "cde5f2fcb0f5ef21",
+    "declared_inserter_capacity": 7,
+    "declared_stacking": 1,
+    "harness_world": "nb=3 bulk=11, S=1",
+    "verdict": "WARN",
+    "produced_per_s": 14.2,
+    "known_residual": "produced -5.3% vs plan (14.20/15.00): EC-row yellow output-belt ceiling only (input bound cleared at L7 bonuses), priced at generation by row-output-lane-budget (13.0/s measured floor on yellow) — #383 attribution, 2026-07-24",
+    "scenario": "spaghettio-sim chain-ec15-d7 (Factorio 2.0.76, converged, produced 14.20/15.00; #383 re-measurement on post-#394/#381 main)",
+    "date": "2026-07-24"
+  },
+  {
+    "target": "electronic-circuit",
+    "rate": 30.0,
+    "geometry_hash": "a39229702290b496",
+    "declared_inserter_capacity": 1,
+    "declared_stacking": 1,
+    "harness_world": "nb=0 bulk=2, S=1",
+    "verdict": "WARN",
+    "produced_per_s": 27.7,
+    "known_residual": "produced -7.7% vs plan (27.70/30.00): same EC-row output ceiling + declared-L1 input bound as chain-ec15 (K=2 copies of the same row class) — #383 attribution, 2026-07-24",
+    "scenario": "spaghettio-sim chain-ec30-d1 (Factorio 2.0.76, converged, produced 27.70/30.00; #383 re-measurement on post-#394/#381 main)",
     "date": "2026-07-24"
   }
 ]

--- a/crates/core/src/bus/cells/registry.rs
+++ b/crates/core/src/bus/cells/registry.rs
@@ -19,7 +19,13 @@
 //! Data: `crates/core/data/cell-sim-registry.json`, embedded via
 //! `include_str!` like the recipe DB. Grown deliberately — an entry is
 //! added only with a real sim PASS behind it (scenario + date + the
-//! harness's realized-world line recorded).
+//! harness's realized-world line recorded), OR — policy decision
+//! 2026-07-24 (#383, user-approved) — a WARN verdict whose deficit is
+//! BOTH priced by a generation-time validator warning on the exact
+//! geometry AND sim-measured at the warned magnitude. Such entries
+//! carry `known_residual` with the attribution and are rendered
+//! "SIM-VERIFIED AS WARNED", never "at plan": the registry's job is
+//! catching drift, and an unregistered cell catches nothing.
 
 use std::sync::OnceLock;
 
@@ -51,6 +57,12 @@ pub struct RegistryEntry {
     pub harness_world: String,
     pub verdict: String,
     pub produced_per_s: f64,
+    /// Present only on entries admitted under the "honestly warned +
+    /// sim-confirmed" bar (#383 policy, 2026-07-24): the attribution of
+    /// a known, generation-time-warned deficit that the sim measured at
+    /// the warned magnitude. `None` = measured at plan.
+    #[serde(default)]
+    pub known_residual: Option<String>,
     pub scenario: String,
     pub date: String,
 }
@@ -132,21 +144,38 @@ pub fn lookup(target: &str, rate: f64, hash: u64) -> Option<&'static RegistryEnt
 /// The annotation `CellComposedCandidate` attaches to its layouts.
 /// Three tiers: full match (geometry + declared world), scoped match
 /// (geometry verified, but in a different declared world than this
-/// layout's), and no match.
+/// layout's), and no match. Warned entries (`known_residual`) render
+/// "AS WARNED", never "at plan" — the claim is exactly as strong as
+/// the measurement.
 pub fn verification_note(target: &str, rate: f64, l: &LayoutResult) -> String {
     let hash = geometry_hash(l);
-    match lookup(target, rate, hash) {
-        Some(e)
-            if e.declared_inserter_capacity == l.inserter_capacity
-                && e.declared_stacking == l.stacking =>
-        {
-            format!(
+    let hex = format!("{hash:016x}");
+    let matches: Vec<&RegistryEntry> = registry()
+        .iter()
+        .filter(|e| e.target == target && (e.rate - rate).abs() < 1e-9 && e.geometry_hash == hex)
+        .collect();
+    // Prefer the entry measured under THIS layout's declared world. The
+    // same geometry can be registered under several declared worlds
+    // (#383: capacity never reaches composed cells until #415, so d1/d7
+    // share a hash) — first-in-file order must not decide which world
+    // the note reports.
+    let full = matches.iter().find(|e| {
+        e.declared_inserter_capacity == l.inserter_capacity && e.declared_stacking == l.stacking
+    });
+    match (full, matches.first()) {
+        (Some(e), _) => match &e.known_residual {
+            None => format!(
                 "cell-composed: geometry SIM-VERIFIED at plan ({} — {} produced {:.2}/s at declared capacity {}, {})",
                 e.scenario, e.verdict, e.produced_per_s, e.declared_inserter_capacity, e.date
-            )
-        }
-        Some(e) => format!(
-            "cell-composed: geometry sim-verified at plan ONLY under declared capacity {} / stacking {} ({} produced {:.2}/s, {}); this layout declares capacity {} / stacking {} — measured-at-plan does NOT transfer (#383)",
+            ),
+            Some(res) => format!(
+                "cell-composed: geometry SIM-VERIFIED AS WARNED, not at plan — {res} ({} — {} produced {:.2}/s at declared capacity {}, {})",
+                e.scenario, e.verdict, e.produced_per_s, e.declared_inserter_capacity, e.date
+            ),
+        },
+        (None, Some(e)) => format!(
+            "cell-composed: geometry sim-verified {} ONLY under declared capacity {} / stacking {} ({} produced {:.2}/s, {}); this layout declares capacity {} / stacking {} — measurements do NOT transfer across worlds (#383)",
+            if e.known_residual.is_some() { "as warned" } else { "at plan" },
             e.declared_inserter_capacity,
             e.declared_stacking,
             e.verdict,
@@ -155,8 +184,8 @@ pub fn verification_note(target: &str, rate: f64, l: &LayoutResult) -> String {
             l.inserter_capacity,
             l.stacking
         ),
-        None => format!(
-            "cell-composed: geometry NOT sim-verified (hash {hash:016x}) — run spaghettio-sim and add the entry to cell-sim-registry.json"
+        (None, None) => format!(
+            "cell-composed: geometry NOT sim-verified (hash {hex}) — run spaghettio-sim and add the entry to cell-sim-registry.json"
         ),
     }
 }

--- a/docs/rfc-051-cell-composition-integration.md
+++ b/docs/rfc-051-cell-composition-integration.md
@@ -223,6 +223,22 @@ follow-ups.
 
 ## Decision log
 
+- *2026-07-24 — registry policy widened (user-approved, #383): entries
+  may now record a WARN verdict when the deficit is BOTH priced by a
+  generation-time validator warning on the exact geometry AND
+  sim-measured at the warned magnitude. Rationale: the registry's job
+  is catching drift; an unregistered cell catches nothing, and the
+  "honest-or-at-plan" criterion is the same bar #381's merge gate used.
+  `RegistryEntry.known_residual` carries the attribution;
+  `verification_note` renders these "SIM-VERIFIED AS WARNED", never "at
+  plan", and now prefers the entry matching the layout's declared world
+  (multi-world same-hash entries exist precisely because capacity never
+  reaches composed cells until #415). First admissions: chain-ec15-d1
+  (13.80/15, -8.0%), chain-ec15-d7 (14.20/15, -5.3%), chain-ec30-d1
+  (27.70/30, -7.7%) — all attributed to the EC-row yellow output-belt
+  ceiling (row-output-lane-budget) plus, at L1, the #415 input bound.
+  They re-register at plan when the EC-row output template work lands.*
+
 - *2026-07-23 — Declaration package (post-#390 honest world; #391
   world-axis hardening landed with it). Method: `inserter_capacity`
   declarations change zero geometry pre-#381, only the world the

--- a/docs/status.md
+++ b/docs/status.md
@@ -225,17 +225,19 @@ declared capacity/stacking are checked fields): currently
 AC-from-plates (PASS −0.3%) and mil5-from-plates (PASS, delivered
 5.00/s exact — first physical validation of the westward bypasses),
 both at declared capacity 0 in the post-#390 honest world. EC-row
-geometries stay unregistered: a declared-capacity sweep (1→7) shrank
-the deficit −8.0%→−5.3% then went level-invariant with the input
-bound cleared at nb=3 — the residual is the
-[#385](https://github.com/storkme/spaghettio/issues/385) output-side
-belt-drop class and/or 45/45 corridor saturation
-([#383](https://github.com/storkme/spaghettio/issues/383) has the
-sweep table); mil5-from-ore FAILs flat at −28.7% (firearm rows'
-inserter COUNT). Re-measure after
-[#394](https://github.com/storkme/spaghettio/pull/394) →
-[#381](https://github.com/storkme/spaghettio/issues/381) land. Full
-trail:
+geometries are REGISTERED AS WARNED (policy 2026-07-24, user-approved
+on [#383](https://github.com/storkme/spaghettio/issues/383)): the
+post-#394/#381 re-measurement reproduced the sweep bit-identically
+(−8.0% d1 / −5.3% d7 / −7.7% ec30-d1) and fully attributed it — the
+level-invariant residual is the EC-row yellow output-belt ceiling
+(row-output-lane-budget warns on the exact geometry at generation),
+plus at L1 the input bound, which #381 cannot reach on the composed
+path until [#415](https://github.com/storkme/spaghettio/issues/415)
+threads `inserter_capacity` through `generate_cell_layout`. Entries
+carry `known_residual` and render "SIM-VERIFIED AS WARNED", never "at
+plan"; they graduate at plan when the EC-row output template work
+lands. mil5-from-ore FAILs flat at −28.7% (firearm rows' inserter
+COUNT) and stays unregistered. Full trail:
 [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md).
 
 **`rfc-048-cell-composition.md` Phase-1 close-out (2026-07-22, PR #365)**:


### PR DESCRIPTION
## Intent

Execute the #383 policy decision (user-approved): the cell-sim registry's job is catching drift, and an unregistered cell catches nothing — so cells whose deficit is honestly warned at generation time AND sim-confirmed at the warned magnitude may register, with the claim rendered exactly as strong as the measurement.

## Scope

- **In:** `RegistryEntry.known_residual` (optional, fail-safe absent = at-plan); `verification_note` renders warned entries "SIM-VERIFIED AS WARNED, never at plan" and now prefers the entry matching the layout's declared world (d1/d7 share a geometry hash until #415, so file order must not decide the reported world); three first admissions (chain-ec15-d1/-d7, chain-ec30-d1) with full attribution strings; RFC-051 decision-log entry.
- **Out:** the fixes that graduate these to at-plan (#415 capacity threading; the EC-row output template work).

## Verification

- [x] Registry gate (`cell_registry_hashes_current`) green — all three hashes re-derived from fresh composition on this branch (ec15: `cde5f2fcb0f5ef21`, ec30: `a39229702290b496`).
- [x] Full `cell_composition` 14/0 (pinned cache, pin restored), lib 834/0, clippy `-D warnings` clean.
- [x] Measured numbers taken verbatim from the 2026-07-24 #383 re-measurement reports (converged, kit-clean; harness verdict WARN matches the registered verdict).
- [x] Registry JSON diff is additive (41+/2−, bracket churn only).
- Not applicable: browser/snapshots (no layout change).

## Deviations from intent

None.

## Models / contracts touched

Registry semantics (what "registered" asserts) — the policy and rendering change is the point of the PR; recorded in the module doc and RFC-051's decision log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)