### PR TITLE
fix(ci): review-bot class 6 — forbid async parking in one-shot review runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,13 @@ jobs:
             command in plain allowed form and continue the review. Never
             abandon the review because of denials; if you have findings
             or a no-issues verdict, exhaust plain `gh pr comment` before
-            giving up on posting.
+            giving up on posting. You are running ONE-SHOT and headless:
+            never use ScheduleWakeup, background tasks, or any
+            wait-for-later mechanism — a parked session simply ends and
+            the review is lost (observed 2026-07-24, PR #416: the
+            orchestrator scheduled a wakeup to wait for its subagents
+            and ended mid-wait). Launch subagents and consume their
+            results synchronously within this run.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
 

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -46,7 +46,7 @@ semantics below).
 
 ## Failure-class history
 
-Five classes, each individually sufficient to produce the same symptom —
+Six classes, each individually sufficient to produce the same symptom —
 green check, nothing posted:
 
 | # | Cause | Symptom signature | Fixed |
@@ -56,6 +56,7 @@ green check, nothing posted:
 | 3 | No harness `--allowedTools` — every posting/diff call denied | 11 denials on the #330 canary | #331 |
 | 4 | Re-running `/install-github-app` overwrote both workflow files with the stock template — wiped fixes 1–3 at once (plus `claude.yml`'s owner-only sender gate) | all of the above, after a period of working fine | #369 (canary #368) |
 | 5 | Shape-sensitive denial starvation — the allowlist admits plain `gh pr/issue` commands but denies improvised *shapes* (env prefixes `GH_PAGER= gh …`, command substitution `$(…)`, `cd … &&` chains, `gh api`); enough denials and the orchestrator abandons mid-review without posting. Stochastic per run, worse on large PRs (more context wanted → more improvised commands). Diagnosed 2026-07-24 on PR #389 (two consecutive silent no-ops; PR #405 succeeded through 31 denials the same day) | mid-cost, mid-duration run: more than a gate-skip, far less than a full review; see signature table below | prompt hardening + guard step (introduced with this doc) |
+| 6 | Async-wait abandonment — the plugin orchestrator fans out its reviewer subagents, then parks via `ScheduleWakeup` to "wait" for them; in a one-shot headless run the wakeup never fires and the session ends mid-wait. First caught live by the guard 2026-07-24 on PR #416 — transcript artifact showed 26 tool calls, near-zero denials, 4 parallel reviewers spawned, `ScheduleWakeup(180s)` then end at 10 turns/$1.08 with nothing posted. NOT a denial problem: the class-5 prompt note was propagating into every subagent and reads worked fine | mid-cost short run like class 5, but transcript shows `ScheduleWakeup` + spawned agents with unconsumed results | prompt note extended: one-shot/headless, never park, consume subagent results synchronously |
 
 Validation history: planted-bug canary #330 (2026-07-21) — first-ever bot
 comment correctly flagged the bug inline with a committable fix; canary


### PR DESCRIPTION
## Intent

Fold the guard's first live catch back into the pipeline. PR #416's red `claude-review` check came with the first transcript artifact, which rewrote the diagnosis: the orchestrator spawned its 4 reviewer subagents, then parked via `ScheduleWakeup(180s)` to wait for them — and the one-shot headless session simply ended mid-wait. A sixth failure class, distinct from denial starvation (the class-5 prompt note was verifiably propagating into every subagent, and file reads worked fine).

## Scope

- **In:** one sentence block added to the workflow prompt (one-shot/headless — never park, consume subagent results synchronously, with the PR #416 citation); `docs/review-bot.md` failure-class table gains class 6 with the transcript evidence and its run signature.
- **Out:** any allowlist change (the transcript confirmed denials weren't the problem — 4 self-corrected `gh` URL-format stumbles, zero starvation).

## Verification

- [x] YAML parses; folded prompt still collapses to one line starting with the slash command; ci.yml's `number }} --comment` assertion still matches.
- [x] Diagnosis is transcript-grounded, not inferred: 26 tool calls, 4 spawned reviewers, `ScheduleWakeup(180s)` → `stop` → session end at 10 turns/$1.08, zero posts (artifact from run 30096604701, retained 14 days).
- Note: this PR self-triggers the anti-hijack skip + the guard's workflow-file carve-out, as designed; PR #416 itself was re-run per the guard's escape hatch.

## Deviations from intent

None.

## Models / contracts touched

None — CI prompt + reference doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)