### PR TITLE
chore(balancer): accept (7,3)/(7,4) lane skew + (5,8) MX1 limit as documented limitations

### DIFF
--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -1067,14 +1067,20 @@ mod tests {
         assert_eq!(r.class, BalancerClass::Balanced);
     }
 
-    /// Tripwire for #266: pin the library's known throughput-limited (MX1)
-    /// shapes, so a re-bake can't silently regress a template into MX1 or
-    /// silently "fix" a known one without the issue being consciously
-    /// closed. Mirrors `balancer_lane_audit`'s KNOWN_IMBALANCED pattern.
+    /// Tripwire for #266 (CLOSED — skew accepted 2026-07-24, user call):
+    /// pin the library's known throughput-limited (MX1) shapes, so a
+    /// re-bake can't silently regress a template into MX1 or silently
+    /// "fix" the accepted one without bookkeeping. Mirrors
+    /// `balancer_lane_audit`'s KNOWN_IMBALANCED pattern.
     ///
     /// History: #266 originally listed (5, 8) AND (8, 6); the 2026-07-24
     /// audit found (8, 6) already classifies MX3 balanced on main (fixed by
-    /// a later library re-bake), so only (5, 8) is pinned here.
+    /// a later library re-bake), so only (5, 8) is pinned. The (5, 8)
+    /// throughput limit (saturated inputs {1,2} realize 1 belt, not 2) is
+    /// an accepted, documented limitation — revocable: a re-bake that
+    /// fixes it should empty this list (the second assert forces that
+    /// bookkeeping), and a field failure implicating the shape reopens
+    /// the issue.
     #[test]
     fn known_throughput_limited_shapes_are_pinned() {
         const KNOWN_THROUGHPUT_LIMITED: [(u32, u32); 1] = [(5, 8)];
@@ -1105,7 +1111,7 @@ mod tests {
             KNOWN_THROUGHPUT_LIMITED.len(),
             "a KNOWN_THROUGHPUT_LIMITED shape no longer classifies MX1 (found only \
              {still_limited:?}). If a re-bake fixed it, remove it from the list and \
-             close #266 consciously."
+             note the fix on closed #266."
         );
     }
 }

--- a/crates/core/tests/balancer_lane_audit.rs
+++ b/crates/core/tests/balancer_lane_audit.rs
@@ -188,10 +188,15 @@ fn audit_lane_correctness() {
     // convergence walker exposed genuine internal lane imbalance in
     // shapes (7,3) and (7,4) under saturation (worst 8.112/s on a
     // 7.5/s per-lane cap; aggregate stays exactly at capacity — the
-    // old lane-mixing model structurally could not see this). Carried
-    // as an expected finding until the shapes are re-baked with a
-    // lane-balance constraint; any error OUTSIDE these shapes (or any
-    // new category inside them) still fails the audit.
+    // old lane-mixing model structurally could not see this). ACCEPTED
+    // 2026-07-24 (#334 closed, user call): months in production with no
+    // correlated field failure; the skew is a documented limitation of
+    // these two shapes, not pending work. Acceptance is revocable — a
+    // re-bake with a lane-balance constraint that fixes them should
+    // remove them from this list (the assert below fires to force that
+    // bookkeeping), and a field failure implicating either shape
+    // reopens #334. Any error OUTSIDE these shapes (or any new category
+    // inside them) still fails the audit.
     const KNOWN_IMBALANCED: [(u32, u32); 2] = [(7, 3), (7, 4)];
     if std::env::var("BALANCER_AUDIT_NO_FAIL").is_err() {
         let unexpected: Vec<&Row> = rows
@@ -213,8 +218,9 @@ fn audit_lane_correctness() {
             .any(|r| KNOWN_IMBALANCED.contains(&r.shape) && r.errors > 0);
         assert!(
             known_still_failing,
-            "known-imbalanced shapes (7,3)/(7,4) now pass — #334 is fixed; remove \
-             KNOWN_IMBALANCED and close the issue consciously."
+            "known-imbalanced shapes (7,3)/(7,4) now pass — a re-bake fixed the \
+             accepted #334 skew; remove KNOWN_IMBALANCED and note the fix on the \
+             closed issue."
         );
     }
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -319,12 +319,14 @@ golden re-blesses across the arc. Full trail:
 - [#135 balancer templates are oversized](https://github.com/storkme/spaghettio/issues/135) — main compaction lever
 - [#311 output merger over-commits a single final belt; lane-throughput check never visits merger tiles](https://github.com/storkme/spaghettio/issues/311) — gates >45/s headline claims
 - [#312 consumer-clamped fan-in refusal bites much earlier at high build quality](https://github.com/storkme/spaghettio/issues/312) — S=1; the wall now scales ×S with stacking (RFC-047 Leg C)
-- [#334 two lane-imbalanced balancer-library shapes](https://github.com/storkme/spaghettio/issues/334) — carved out of the RFC-047 convergence walker with a fix tripwire
 - [#335 one unreached furnace bank in the legendary-express@60 fixture](https://github.com/storkme/spaghettio/issues/335)
 - [#336 (n,1) merge-tap unwired; late sideload check refuses those shapes by name](https://github.com/storkme/spaghettio/issues/336)
 
 (Audited 2026-07-21: #65, #68, #136, #310 — previously cited here — are all
-closed.)
+closed. 2026-07-24: #334 closed — the (7,3)/(7,4) lane skew is ACCEPTED as a
+documented limitation (user call), guarded by `balancer_lane_audit`'s
+KNOWN_IMBALANCED tripwire; #266's (5,8) MX1 limit accepted the same way,
+guarded in `balancer_classify`. Both revocable on re-bake or field failure.)
 
 ## Deferred tooling tasks
 


### PR DESCRIPTION
## Intent

Execute the user's 2026-07-24 accept-the-skew call on the two tripwired balancer shapes (#334, #266): both become documented, guarded limitations instead of queued work.

## Scope

- **In:** comment/message updates in both tripwires (`balancer_lane_audit`'s KNOWN_IMBALANCED, `balancer_classify`'s known MX1 pin) recording the acceptance, its rationale, and the two revocation triggers (re-bake fix → bookkeeping assert fires; field failure → reopen); status.md open-tracking row for #334 removed with the acceptance noted.
- **Out:** any template/behavior change — the guards' assertions are semantically unchanged (new shapes still fail; silent fixes still fail).

## Verification

- [x] Both tripwire tests green (`known_throughput_limited_shapes_are_pinned`, `balancer_lane_audit` 3/3).
- Not applicable: full-suite/clippy churn (comments, strings, and docs only — no logic edits).

## Deviations from intent

None.

## Models / contracts touched

`docs/status.md` ledger (the point of the change). No code contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)