### PR TITLE
fix(ci): review bot announces conscious skips — closes the guard's false-positive mode

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,7 +57,11 @@ jobs:
             the review is lost (observed 2026-07-24, PR #416: the
             orchestrator scheduled a wakeup to wait for its subagents
             and ended mid-wait). Launch subagents and consume their
-            results synchronously within this run.
+            results synchronously within this run. If you consciously
+            decide NOT to review (triviality gate, out-of-scope diff,
+            already reviewed), do not end silently — post a one-line
+            `gh pr comment` stating the skip and the reason. A silent
+            end is indistinguishable from a crash and fails the check.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
 

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -139,6 +139,14 @@ Design decisions worth knowing:
 - **Escape hatch** for a false red (e.g. the gate judged a ≥20-line PR
   trivial but the transcript heuristic disagreed): re-run the job (runs
   are stochastic), or post a review and re-run the check.
+- **Known guard false-positive mode** (observed 2026-07-24, PR #419):
+  a conscious skip that reads the full diff first can take ~20 turns —
+  indistinguishable from class-5/6 abandonment by the turns heuristic.
+  Mitigated the same day: the prompt now requires a one-line skip
+  comment for every conscious no-review decision, so conscious skips
+  produce coverage signal and the turns heuristic is a fallback only.
+  A red on a silent ≥8-turn run after that prompt change is
+  presumptively real.
 
 Related tripwire: `ci.yml`'s `workflow-guard` job asserts the
 claude-code-review workflow keeps its load-bearing pieces (write perms,


### PR DESCRIPTION
## Intent

Close the guard false-positive mode PR #419 exposed: a conscious triviality skip that reads the diff first (~20 turns) is indistinguishable from abandonment by the turns heuristic. Instead of tuning thresholds over overlapping distributions, eliminate silent conscious skips: the bot must post a one-line `gh pr comment` stating any deliberate no-review decision. Conscious skips then produce coverage signal; the turns heuristic becomes fallback-only, and a silent ≥8-turn run is presumptively a real failure.

## Scope

- **In:** one prompt sentence in the review workflow; `docs/review-bot.md` guard-semantics note recording the observed mode and the mitigation.
- **Out:** guard script changes (none needed — coverage-based pass already handles announced skips).

## Verification

- [x] YAML parses; folded prompt still single-line; ci.yml `number }} --comment` assertion still matches.
- [x] Diagnosis transcript-grounded: run for #419 shows 20 turns, full diff read, explicit "No review posted — out of scope" conclusion in the final (unposted) text.
- Note: self-triggers the anti-hijack skip + workflow-file carve-out, as designed.

## Deviations from intent

Also for the record: I merged #419 while its check was red — the red turned out to be this false positive, but the process slip (chained merge without inspecting the red) is mine and noted.

## Models / contracts touched

None — CI prompt + reference doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)