### PR TITLE
RFC-052 Phase C: advanced-oil mega complex — USP@2-from-raw composes at zero errors

### DIFF
--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -153,7 +153,7 @@ pub fn export_with_manifest(
         "targets": solver
             .external_outputs
             .iter()
-            .map(|o| serde_json::json!({"item": o.item, "rate": o.rate}))
+            .map(|o| serde_json::json!({"item": o.item, "rate": o.rate, "is_fluid": o.is_fluid}))
             .collect::<Vec<_>>(),
         "external_inputs": solver
             .external_inputs

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -743,9 +743,24 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         for o in &m.outputs {
             for (ci, c) in specs.iter().enumerate() {
                 if pi_mega && ci != pi && c.inputs.iter().any(|i| i.item == o.item) {
-                    // Mega corridors always ride the bypass row (the
-                    // drain exits south) — ascent lane only.
+                    // Mega corridors ride the bypass row (the drain
+                    // exits south) — ascent lane always; fanned
+                    // outputs (>=2 consumers) ALSO drop each branch
+                    // through a lane in the next slot's strip, like
+                    // solid bypass descents (ad-hoc splitter-column
+                    // drops collided with consumer ascent lanes —
+                    // USP@2 head-on/loop cluster).
                     lane_demand[ci] += 1;
+                    let consumers_of_o = specs
+                        .iter()
+                        .enumerate()
+                        .filter(|(cj, cc)| {
+                            *cj != pi && cc.inputs.iter().any(|i| i.item == o.item)
+                        })
+                        .count();
+                    if consumers_of_o >= 2 && pi + 1 < n {
+                        lane_demand[pi + 1] += 1;
+                    }
                     continue;
                 }
                 if ci != pi && c.inputs.iter().any(|i| i.item == o.item) && ci != pi + 1 {
@@ -1154,20 +1169,45 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                         let by_y = band_bottom + 1 + 3 * *row;
                         *row += 1;
                         // Drop from the branch origin to this branch's
-                        // own row. Branch origins on fan_y+1 curve
-                        // south from the splitter's south output; the
-                        // pass-through origin on fan_y corners south.
-                        router.corner_south(&mut entities, bx, by, &d_item, "express-transport-belt", &seg);
-                        router.vcol(&mut entities, bx, by + 1, by_y - 1, &d_item,
+                        // own row THROUGH an allocated lane in the next
+                        // slot's strip (sized via lane_demand above) —
+                        // ad-hoc drops at splitter columns collided
+                        // with consumer ascent lanes. Falls back to an
+                        // in-place corner drop when the run east is not
+                        // stampable (the solid path's in-gap idiom).
+                        let (drop_x, drop_top) = if pi + 1 < placed.len() {
+                            let down_demand = lane_demand[(pi + 1) % n];
+                            let cand = placed[pi + 1].vlane_base
+                                + *lane_next.get(&(pi + 1)).unwrap_or(&0)
+                                    * lane_step(down_demand);
+                            if cand > bx && router.is_row_stampable(by, bx, cand - 1) {
+                                let lane_down = alloc_lane(
+                                    &mut lane_next,
+                                    pi + 1,
+                                    placed[pi + 1].vlane_base,
+                                    lane_step(down_demand),
+                                );
+                                router.hrow(&mut entities, by, bx, lane_down - 1, &d_item,
+                                    "express-transport-belt", "express-underground-belt", &seg);
+                                (lane_down, by)
+                            } else {
+                                router.corner_south(&mut entities, bx, by, &d_item, "express-transport-belt", &seg);
+                                (bx, by + 1)
+                            }
+                        } else {
+                            router.corner_south(&mut entities, bx, by, &d_item, "express-transport-belt", &seg);
+                            (bx, by + 1)
+                        };
+                        router.vcol(&mut entities, drop_x, drop_top, by_y - 1, &d_item,
                             "express-transport-belt", "express-underground-belt", &seg);
-                        if lane_up < bx {
-                            router.corner_west(&mut entities, bx, by_y, &d_item, "express-transport-belt", &seg);
-                            router.hrow_west(&mut entities, by_y, bx - 1, lane_up + 1, &d_item,
+                        if lane_up < drop_x {
+                            router.corner_west(&mut entities, drop_x, by_y, &d_item, "express-transport-belt", &seg);
+                            router.hrow_west(&mut entities, by_y, drop_x - 1, lane_up + 1, &d_item,
                                 "express-transport-belt", "express-underground-belt", &seg);
                             router.corner_north(&mut entities, lane_up, by_y, &d_item, "express-transport-belt", &seg);
                         } else {
-                            router.corner_east(&mut entities, bx, by_y, &d_item, "express-transport-belt", &seg);
-                            router.hrow(&mut entities, by_y, bx + 1, lane_up - 1, &d_item,
+                            router.corner_east(&mut entities, drop_x, by_y, &d_item, "express-transport-belt", &seg);
+                            router.hrow(&mut entities, by_y, drop_x + 1, lane_up - 1, &d_item,
                                 "express-transport-belt", "express-underground-belt", &seg);
                             router.occ.insert((lane_up, by_y));
                             entities.push(PlacedEntity {

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -144,20 +144,11 @@ pub fn chain_eligible(sr: &SolverResult) -> Result<(), String> {
     }
     if let Some(plan) = &mega {
         // Each mega output competes for corridor capacity like any
-        // produced item, and each routes ONE corridor (v1: a single
-        // consumer per exported item).
+        // produced item. Multi-consumer exports fan out on the drain's
+        // bypass row (Phase C) — same splitter-chain idiom as solid
+        // cells, so no consumer-count refusal remains.
         for (item, _rate) in &plan.outputs {
             *producers.entry(item.as_str()).or_default() += 1;
-            let consumers = sr
-                .machines
-                .iter()
-                .filter(|c| !is_member(&c.recipe) && c.inputs.iter().any(|i| i.item == *item))
-                .count();
-            if consumers > 1 {
-                return Err(format!(
-                    "mega: {item} feeds {consumers} consumers (v1 routes a single corridor per mega output)"
-                ));
-            }
         }
     }
     for (item, n) in &producers {

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -965,7 +965,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 if pi_mega { &m.outputs } else { &m.outputs[..1] };
             outs.iter()
                 .map(|o| {
-                    specs
+                    let edges = specs
                         .iter()
                         .enumerate()
                         .filter(|(ci, c)| {
@@ -977,7 +977,11 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                                     .iter()
                                     .any(|q| q.inbound && q.item == o.item)
                         })
-                        .count() as i32
+                        .count() as i32;
+                    // A fanned mega output (>=2 consumers, Phase C)
+                    // spends one extra row hosting the splitter chain
+                    // before the per-branch rows.
+                    if pi_mega && edges >= 2 { edges + 1 } else { edges }
                 })
                 .sum::<i32>()
         })
@@ -1032,12 +1036,108 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         // Outputs with no consumer stay chain exports at their drain.
         if !p.mega_drains.is_empty() {
             for (dx0, dy0, d_item) in p.mega_drains.clone() {
-                let consumer = placed.iter().enumerate().find(|(ci, c)| {
-                    *ci != pi
-                        && c.copy == p.copy
-                        && specs[*ci % n].inputs.iter().any(|i| i.item == d_item)
-                        && c.cell.ports.iter().any(|q| q.inbound && q.item == d_item)
-                });
+                let drain_consumers: Vec<usize> = placed
+                    .iter()
+                    .enumerate()
+                    .filter(|(ci, c)| {
+                        *ci != pi
+                            && c.copy == p.copy
+                            && specs[*ci % n].inputs.iter().any(|i| i.item == d_item)
+                            && c.cell.ports.iter().any(|q| q.inbound && q.item == d_item)
+                    })
+                    .map(|(ci, _)| ci)
+                    .collect();
+                // Fan path (Phase C): >=2 consumers split on the drain's
+                // own bypass row, then each branch drops to a fresh row
+                // and rides to its consumer via the shared delivery
+                // idiom. The single-consumer path below is byte-identical
+                // to Phase B (registry gate).
+                if drain_consumers.len() >= 2 {
+                    let row = bypass_idx.entry(p.copy).or_insert(0);
+                    let fan_y = band_bottom + 1 + 3 * *row;
+                    *row += 1;
+                    let seg0 = format!("fan:{}:{}", d_item, p.seg);
+                    router.vcol(&mut entities, dx0, dy0 + 1, fan_y - 1, &d_item,
+                        "express-transport-belt", "express-underground-belt", &seg0);
+                    router.corner_east(&mut entities, dx0, fan_y, &d_item, "express-transport-belt", &seg0);
+                    let mut ordered = drain_consumers.clone();
+                    ordered.sort_by_key(|ci| placed[*ci].x);
+                    // Splitter chain east of the corner; branch b exits
+                    // south at (sx+1, fan_y+1); the last branch is the
+                    // pass-through at (sx_last+1, fan_y).
+                    let n_br = ordered.len();
+                    let mut branch_origins: Vec<(i32, i32)> = Vec::new();
+                    let mut sx = dx0 + 1;
+                    for b in 1..n_br {
+                        router.occ.insert((sx, fan_y));
+                        router.occ.insert((sx, fan_y + 1));
+                        entities.push(PlacedEntity {
+                            name: "express-splitter".into(), x: sx, y: fan_y,
+                            direction: EntityDirection::East,
+                            carries: Some(d_item.clone()),
+                            segment_id: Some(format!("fan{b}:{}:{}", d_item, p.seg)),
+                            ..Default::default()
+                        });
+                        branch_origins.push((sx + 1, fan_y + 1));
+                        if b < n_br - 1 {
+                            router.corner_east(&mut entities, sx + 1, fan_y, &d_item,
+                                "express-transport-belt", &format!("fan:{}:{}", d_item, p.seg));
+                        }
+                        sx += 2;
+                    }
+                    branch_origins.push((sx - 1, fan_y));
+                    for (bi, ci) in ordered.iter().enumerate() {
+                        let c = &placed[*ci];
+                        let port = c
+                            .cell
+                            .ports
+                            .iter()
+                            .find(|q| q.inbound && q.item == d_item)
+                            .expect("consumer port checked in eligibility");
+                        let (tx, ty) = port_abs(port, c.x, c.y_off);
+                        let (bx, by) = branch_origins[bi];
+                        let seg = format!("corr:{}:{}", p.seg, c.seg);
+                        let up_demand = lane_demand[*ci % n];
+                        let lane_up = alloc_lane(&mut lane_next, *ci, c.vlane_base, lane_step(up_demand));
+                        let row = bypass_idx.entry(p.copy).or_insert(0);
+                        let by_y = band_bottom + 1 + 3 * *row;
+                        *row += 1;
+                        // Drop from the branch origin to this branch's
+                        // own row. Branch origins on fan_y+1 curve
+                        // south from the splitter's south output; the
+                        // pass-through origin on fan_y corners south.
+                        router.corner_south(&mut entities, bx, by, &d_item, "express-transport-belt", &seg);
+                        router.vcol(&mut entities, bx, by + 1, by_y - 1, &d_item,
+                            "express-transport-belt", "express-underground-belt", &seg);
+                        if lane_up < bx {
+                            router.corner_west(&mut entities, bx, by_y, &d_item, "express-transport-belt", &seg);
+                            router.hrow_west(&mut entities, by_y, bx - 1, lane_up + 1, &d_item,
+                                "express-transport-belt", "express-underground-belt", &seg);
+                            router.corner_north(&mut entities, lane_up, by_y, &d_item, "express-transport-belt", &seg);
+                        } else {
+                            router.corner_east(&mut entities, bx, by_y, &d_item, "express-transport-belt", &seg);
+                            router.hrow(&mut entities, by_y, bx + 1, lane_up - 1, &d_item,
+                                "express-transport-belt", "express-underground-belt", &seg);
+                            router.occ.insert((lane_up, by_y));
+                            entities.push(PlacedEntity {
+                                name: "express-transport-belt".into(), x: lane_up, y: by_y,
+                                direction: EntityDirection::North,
+                                carries: Some(d_item.clone()),
+                                segment_id: Some(seg.clone()), ..Default::default()
+                            });
+                        }
+                        if router.occ.contains(&(lane_up, ty + 1)) {
+                            retrofit_feed_hop(&mut entities, &mut router, lane_up, ty + 1)?;
+                        }
+                        router.vcol(&mut entities, lane_up, by_y - 1, ty + 1, &d_item,
+                            "express-transport-belt", "express-underground-belt", &seg);
+                        router.corner_east(&mut entities, lane_up, ty, &d_item, "express-transport-belt", &seg);
+                        router.hrow(&mut entities, ty, lane_up + 1, tx - 1, &d_item,
+                            "express-transport-belt", "express-underground-belt", &seg);
+                    }
+                    continue;
+                }
+                let consumer = drain_consumers.first().map(|&ci| (ci, &placed[ci]));
                 let Some((ci, c)) = consumer else {
                     // Consumer-less export: extend the drain to the
                     // chain's drain row like the solid final-product

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -582,7 +582,21 @@ fn retrofit_feed_hop(
                     && e.segment_id.as_deref().is_some_and(|s| s.starts_with("feed:"))
             })
             .ok_or_else(|| {
-                format!("cells: ascent terminal collision at ({x},{y}) is not a plain feed row (tile x={cx})")
+                let blocker = entities
+                    .iter()
+                    .find(|e| e.x == *cx && e.y == y)
+                    .map(|e| {
+                        format!(
+                            "{} dir={:?} seg={}",
+                            e.name,
+                            e.direction,
+                            e.segment_id.as_deref().unwrap_or("-")
+                        )
+                    })
+                    .unwrap_or_else(|| "empty".into());
+                format!(
+                    "cells: ascent terminal collision at ({x},{y}) is not a plain feed row (tile x={cx}: {blocker})"
+                )
             })?;
         idxs[k] = i;
     }

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -561,6 +561,21 @@ fn retrofit_feed_hop(
     x: i32,
     y: i32,
 ) -> Result<(), String> {
+    // Any horizontal surface-belt run may host the hop: feed rows
+    // (eastbound) and corridor/fan rows (either direction — Phase C:
+    // USP's ascent terminal landed on the mega's own fan branch). The
+    // three tiles must be same-direction plain belts of one row
+    // segment class; anything else refuses loudly.
+    let row_dir = entities
+        .iter()
+        .find(|e| e.x == x && e.y == y)
+        .map(|e| e.direction)
+        .unwrap_or(EntityDirection::East);
+    if row_dir != EntityDirection::East && row_dir != EntityDirection::West {
+        return Err(format!(
+            "cells: ascent terminal collision at ({x},{y}) is not a horizontal belt run"
+        ));
+    }
     let mut idxs = [usize::MAX; 3];
     for (k, cx) in [x - 1, x, x + 1].iter().enumerate() {
         let i = entities
@@ -568,9 +583,11 @@ fn retrofit_feed_hop(
             .position(|e| {
                 e.x == *cx
                     && e.y == y
-                    && e.direction == EntityDirection::East
+                    && e.direction == row_dir
                     && e.name.ends_with("transport-belt")
-                    && e.segment_id.as_deref().is_some_and(|s| s.starts_with("feed:"))
+                    && e.segment_id.as_deref().is_some_and(|s| {
+                        s.starts_with("feed:") || s.starts_with("corr:") || s.starts_with("fan")
+                    })
             })
             .ok_or_else(|| {
                 let blocker = entities
@@ -586,7 +603,7 @@ fn retrofit_feed_hop(
                     })
                     .unwrap_or_else(|| "empty".into());
                 format!(
-                    "cells: ascent terminal collision at ({x},{y}) is not a plain feed row (tile x={cx}: {blocker})"
+                    "cells: ascent terminal collision at ({x},{y}) is not a hoppable belt row (tile x={cx}: {blocker})"
                 )
             })?;
         idxs[k] = i;
@@ -597,13 +614,23 @@ fn retrofit_feed_hop(
         "transport-belt" => "underground-belt",
         other => return Err(format!("cells: unexpected feed belt tier {other}")),
     };
-    for (k, io) in [(0usize, "input"), (2usize, "output")] {
-        entities[idxs[k]].name = ug.into();
-        entities[idxs[k]].io_type = Some(io.into());
+    // Entrance = upstream side of the run's flow direction.
+    let (in_k, out_k) = if row_dir == EntityDirection::East {
+        (0usize, 2usize)
+    } else {
+        (2usize, 0usize)
+    };
+    for (k, io) in [(in_k, "input"), (out_k, "output")] {
+        entities[k_idx(&idxs, k)].name = ug.into();
+        entities[k_idx(&idxs, k)].io_type = Some(io.into());
     }
     entities.remove(idxs[1]);
     router.occ.remove(&(x, y));
     Ok(())
+}
+
+fn k_idx(idxs: &[usize; 3], k: usize) -> usize {
+    idxs[k]
 }
 
 /// Compose an eligible chain solve into one layout: K quantized copies
@@ -1057,9 +1084,30 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                     // south at (sx+1, fan_y+1); the last branch is the
                     // pass-through at (sx_last+1, fan_y).
                     let n_br = ordered.len();
+                    // Splitter/branch columns must dodge the OTHER
+                    // drains' head columns — each of those descends
+                    // from the block bottom through every bypass row,
+                    // and a branch drop on the same x overlaps it (the
+                    // USP@2 overlap cluster at x=272).
+                    let reserved: FxHashSet<i32> = p
+                        .mega_drains
+                        .iter()
+                        .filter(|(ox, _, oi)| *ox != dx0 || oi != &d_item)
+                        .map(|(ox, _, _)| *ox)
+                        .collect();
                     let mut branch_origins: Vec<(i32, i32)> = Vec::new();
-                    let mut sx = dx0 + 1;
+                    let mut cursor = dx0 + 1;
                     for b in 1..n_br {
+                        let mut sx = cursor;
+                        while reserved.contains(&sx) || reserved.contains(&(sx + 1)) {
+                            sx += 1;
+                        }
+                        // Bridge from the previous chain tile to the
+                        // splitter input with plain belts.
+                        for xx in cursor..sx {
+                            router.corner_east(&mut entities, xx, fan_y, &d_item,
+                                "express-transport-belt", &format!("fan:{}:{}", d_item, p.seg));
+                        }
                         router.occ.insert((sx, fan_y));
                         router.occ.insert((sx, fan_y + 1));
                         entities.push(PlacedEntity {
@@ -1074,9 +1122,21 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                             router.corner_east(&mut entities, sx + 1, fan_y, &d_item,
                                 "express-transport-belt", &format!("fan:{}:{}", d_item, p.seg));
                         }
-                        sx += 2;
+                        cursor = sx + 2;
                     }
-                    branch_origins.push((sx - 1, fan_y));
+                    // Pass-through: step EAST off the last splitter's
+                    // output column (branch n-1 drops at sx+1 from the
+                    // south output; sharing that column overlapped the
+                    // two descents) to its own reserved-dodged column.
+                    let mut pt_x = cursor;
+                    while reserved.contains(&pt_x) {
+                        pt_x += 1;
+                    }
+                    for xx in (cursor - 1)..pt_x {
+                        router.corner_east(&mut entities, xx, fan_y, &d_item,
+                            "express-transport-belt", &format!("fan:{}:{}", d_item, p.seg));
+                    }
+                    branch_origins.push((pt_x, fan_y));
                     for (bi, ci) in ordered.iter().enumerate() {
                         let c = &placed[*ci];
                         let port = c
@@ -1404,7 +1464,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
 
     // --- Poles: per-cell trio down the corridor gap + a spanning line
     // along the band bottom (nudge-not-skip — Phase-1 pole lesson).
-    let occupied: FxHashSet<(i32, i32)> = entities.iter().map(|e| (e.x, e.y)).collect();
+    let mut occupied: FxHashSet<(i32, i32)> = entities.iter().map(|e| (e.x, e.y)).collect();
     for p in &placed {
         let px = p.x + p.cell.width + CORRIDOR_GAP - 1;
         for y in [CELL_Y, CELL_Y + 7, CELL_Y + 14] {
@@ -1413,6 +1473,11 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                 while occupied.contains(&(px, yy)) {
                     yy += 1;
                 }
+                // The snapshot must learn each placement — two trio
+                // members sliding down one congested column otherwise
+                // land on the SAME first-free tile (USP@2 pole-pole
+                // overlaps).
+                occupied.insert((px, yy));
                 entities.push(PlacedEntity {
                     name: "medium-electric-pole".into(), x: px, y: yy,
                     direction: EntityDirection::North,

--- a/crates/core/src/bus/cells/mega.rs
+++ b/crates/core/src/bus/cells/mega.rs
@@ -450,7 +450,7 @@ fn adapt_with_spacing(
                 // (x=0): the delivery corridor then feeds the UG
                 // entrance head-on — a straight feed, both lanes.
                 let hoppable = |lo2: i32, hi2: i32| {
-                    lo2 - 1 >= 0 && hi2 + 1 < p.orig_x && hi2 - lo2 + 1 <= ug_gap
+                    lo2 >= 1 && hi2 + 1 < p.orig_x && hi2 - lo2 < ug_gap
                 };
                 let mut freed: FxHashSet<i32> = FxHashSet::default();
                 for &(lo2, hi2) in &clusters {
@@ -1048,6 +1048,11 @@ pub fn compose_mega_block(
     };
     let opts = crate::bus::layout::LayoutOptions {
         cell_composition: super::CellComposition::Off,
+        // Mega sub-solves pack every trunk span from y=0 (all inputs
+        // are boundary heads), so tap splitters land on live neighbor
+        // trunks and the zones don't bridge them — the spacer is the
+        // fix (Phase C; main-line default stays off).
+        splitter_tap_spacers: true,
         ..Default::default()
     };
     let l = crate::bus::layout::build_bus_layout(&sub, opts)

--- a/crates/core/src/bus/cells/mega.rs
+++ b/crates/core/src/bus/cells/mega.rs
@@ -80,26 +80,42 @@ pub fn adapt_boundaries_chain_fed(
     // it). Spacing 2 unlocks 3+-fluid-feed blocks (the chem-pack
     // class), where a lateral otherwise passes directly under an
     // earlier head column with no clearance row.
-    match adapt_with_spacing(&l, 1, chain_fed) {
-        Ok(adapted) => Ok(adapted),
-        Err(e1) => adapt_with_spacing(&l, 2, chain_fed).map_err(|e2| {
-            format!("{e1}; at spacing 2: {e2}")
-        }),
+    // Retry ladder: spacing 1 plain first (bit-identical for every
+    // registered fixture), then the fluid-head DODGE at spacing 1
+    // (relocates fluid head slots away from foreign fluid columns —
+    // needed by blocks whose trunk heads pack adjacent, the USP
+    // advanced complex), then spacing 2 in the same order.
+    let mut last = String::new();
+    for (spacing, dodge) in [(1, false), (1, true), (2, false), (2, true)] {
+        match adapt_with_spacing(&l, spacing, chain_fed, dodge) {
+            Ok(adapted) => return Ok(adapted),
+            Err(e) => {
+                if !last.is_empty() {
+                    last.push_str("; ");
+                }
+                last.push_str(&format!("s{spacing}{}: {e}", if dodge { "+dodge" } else { "" }));
+            }
+        }
     }
+    Err(last)
 }
 
 fn adapt_with_spacing(
     l: &LayoutResult,
     spacing: i32,
     chain_fed: &FxHashSet<String>,
+    dodge_fluid_heads: bool,
 ) -> Result<LayoutResult, String> {
     let n_in = l.boundary_inputs.len() as i32;
     if n_in == 0 {
         return Err("mega: layout has no boundary inputs".into());
     }
     // One lateral lane per input (pitch `spacing`) + a clearance row
-    // above the original north edge.
-    let margin = (n_in - 1) * spacing + 2;
+    // above the original north edge. Chain-fed records get ONE extra
+    // clearance row: the deepest cf lateral sits at the old margin-1,
+    // where a vertical retrofit's UG-out would land ON the engine head
+    // row (Phase C, the USP advanced complex).
+    let margin = (n_in - 1) * spacing + 2 + i32::from(!chain_fed.is_empty());
 
     let mut entities: Vec<PlacedEntity> = l.entities.clone();
     for e in &mut entities {
@@ -135,6 +151,16 @@ fn adapt_with_spacing(
         west_entry: bool,
     }
     let mut n_heads = 0i32;
+    // A FLUID head column descends through every shallower lateral row;
+    // standing x-adjacent to a DIFFERENT fluid's orig or head column
+    // makes a plain-plain side contact somewhere on the way down (the
+    // USP advanced complex: the 4-pitch slot put water's head at
+    // exactly its orig column 9, beside crude's orig 8 — every
+    // candidate died on that adjacency). Fluid heads skip slots that
+    // land within 1 of a foreign fluid column; solid heads don't care
+    // (belts don't merge with pipes).
+    let fluid_cols: Vec<i32> = records.iter().filter(|r| r.is_fluid).map(|r| r.x).collect();
+    let mut fluid_heads: Vec<i32> = Vec::new();
     let plans: Vec<Plan> = records
         .iter()
         .enumerate()
@@ -143,8 +169,19 @@ fn adapt_with_spacing(
             let head_x = if west_entry {
                 0
             } else {
-                let h = head0 + FEED_PITCH * n_heads;
+                let mut h = head0 + FEED_PITCH * n_heads;
                 n_heads += 1;
+                if r.is_fluid && dodge_fluid_heads {
+                    let clashes = |h: i32| {
+                        fluid_cols.iter().any(|&c| c != r.x && (h - c).abs() <= 1)
+                            || fluid_heads.iter().any(|&c| (h - c).abs() <= 1)
+                    };
+                    while clashes(h) {
+                        h = head0 + FEED_PITCH * n_heads;
+                        n_heads += 1;
+                    }
+                    fluid_heads.push(h);
+                }
                 h
             };
             Plan {
@@ -242,6 +279,15 @@ fn adapt_with_spacing(
             let mut trial_fluid = fluid_at.clone();
             let mut trial_plain = plain_pipe_at.clone();
             let mut trial_ptg = ptg_at.clone();
+            // Reserved UNDERGROUND span tiles (between a planned pair's
+            // mouths, exclusive). Surface paths may cross them freely —
+            // an underground run passes under surface pipes; only
+            // same-axis underground interference is real. Registering
+            // spans as surface occupiers refused every block whose
+            // fluid trunk heads pack adjacent (the USP advanced
+            // complex: crude at x=9, water at x=10).
+            let mut trial_span: rustc_hash::FxHashMap<(i32, i32), String> =
+                rustc_hash::FxHashMap::default();
             let mut trial_paths: rustc_hash::FxHashMap<usize, FluidPath> =
                 rustc_hash::FxHashMap::default();
             let mut ok = true;
@@ -251,7 +297,7 @@ fn adapt_with_spacing(
                 let (dx, ptg) = CANDS[combo[k]];
                 match try_fluid_path(
                     &r.item, p.head_x, p.orig_x, p.lane_row, dx, ptg, margin,
-                    &solid_at, &trial_fluid, &trial_plain, &trial_ptg,
+                    &solid_at, &trial_fluid, &trial_plain, &trial_ptg, &trial_span,
                 ) {
                     Some(path) => {
                         for &(x, y) in &path.pipes {
@@ -259,12 +305,15 @@ fn adapt_with_spacing(
                             trial_plain.insert((x, y));
                         }
                         if let Some((top, bot)) = path.ptg_pair {
-                            // Mouths + reserved span occupy tiles but are
-                            // NOT plain (no side joins for later records)
-                            // and ARE side-safe.
-                            for y in top.1..=bot.1 {
-                                trial_fluid.insert((top.0, y), r.item.clone());
-                                trial_ptg.insert((top.0, y));
+                            // Mouths are surface PTG entities (side-safe,
+                            // never plain); the strictly-interior span is
+                            // underground only.
+                            for (x, y) in [top, bot] {
+                                trial_fluid.insert((x, y), r.item.clone());
+                                trial_ptg.insert((x, y));
+                            }
+                            for y in (top.1 + 1)..bot.1 {
+                                trial_span.insert((top.0, y), r.item.clone());
                             }
                         }
                         trial_paths.insert(ri, path);
@@ -369,61 +418,100 @@ fn adapt_with_spacing(
                 // crosses (external tails, fluid tails, earlier
                 // chain-fed tails — a solid belt hops under any of
                 // them), same clustering as the chain Router.
-                let occupied = |x: i32| {
-                    solid_at.contains(&(x, p.lane_row))
-                        || fluid_at.contains_key(&(x, p.lane_row))
-                };
-                let mut cols: Vec<i32> = (1..p.orig_x).filter(|&x| occupied(x)).collect();
-                // A crossing at orig_x-1 leaves no room for the hop's
-                // exit mouth (it would land ON our tail corner).
-                // Retrofit that column VERTICALLY instead: convert its
-                // south belts at our-row±1 into a South UG pair and
-                // free our row — the retrofit_feed_hop idiom. Solid
-                // columns only; interior rows only (never a corner or
-                // the engine head tile).
-                if cols.last() == Some(&(p.orig_x - 1)) {
-                    let c = p.orig_x - 1;
-                    let row = p.lane_row;
-                    let owner = plans.iter().find(|q| q.orig_x == c && q.lane_row < row);
-                    let interior = owner.is_some_and(|q| row - 1 > q.lane_row) && row + 1 < margin;
-                    let is_solid_col = solid_at.contains(&(c, row));
-                    if !(interior && is_solid_col) {
-                        return Err(format!(
-                            "mega: chain-fed {} crossing at x={c} abuts its tail and cannot be retrofitted",
-                            r.item
-                        ));
+                let mut occ_cols: FxHashSet<i32> = (1..p.orig_x)
+                    .filter(|&x| {
+                        solid_at.contains(&(x, p.lane_row))
+                            || fluid_at.contains_key(&(x, p.lane_row))
+                    })
+                    .collect();
+                let mut cols: Vec<i32> = occ_cols.iter().copied().collect();
+                cols.sort_unstable();
+                let mut clusters: Vec<(i32, i32)> = Vec::new();
+                for c in cols {
+                    match clusters.last_mut() {
+                        Some((_, hi)) if c - *hi < 3 => *hi = c,
+                        _ => clusters.push((c, c)),
                     }
-                    let mut converted = 0;
-                    let mut removed = None;
-                    for (idx, e) in entities.iter_mut().enumerate() {
-                        if e.x != c || !e.name.contains("transport-belt") {
+                }
+                // A cluster hops horizontally when both mouths fit
+                // (entry >= 1 keeps the west-edge entry tile; exit
+                // strictly west of the tail corner) within the
+                // RECORD's belt-tier reach (the mouths stamp that
+                // tier — a hardcoded express cap would let a yellow
+                // record plan a pair the game never connects, #411
+                // review). Un-hoppable clusters retrofit EVERY column
+                // vertically instead: each crossing solid tail's belts
+                // at our-row±1 become a South UG pair and the row
+                // frees (the retrofit_feed_hop idiom; solid interior
+                // columns only — never a corner, a pipe, or the engine
+                // head row; refuse loudly otherwise).
+                let ug_gap = crate::common::ug_max_reach(&r.entity) as i32;
+                // Entry mouth may sit AT the west-edge entry tile
+                // (x=0): the delivery corridor then feeds the UG
+                // entrance head-on — a straight feed, both lanes.
+                let hoppable = |lo2: i32, hi2: i32| {
+                    lo2 - 1 >= 0 && hi2 + 1 < p.orig_x && hi2 - lo2 + 1 <= ug_gap
+                };
+                let mut freed: FxHashSet<i32> = FxHashSet::default();
+                for &(lo2, hi2) in &clusters {
+                    if hoppable(lo2, hi2) {
+                        continue;
+                    }
+                    for c in lo2..=hi2 {
+                        if !occ_cols.contains(&c) {
                             continue;
                         }
-                        if e.y == row && e.direction == EntityDirection::South {
-                            removed = Some(idx);
-                        } else if (e.y == row - 1 || e.y == row + 1)
-                            && e.direction == EntityDirection::South
-                        {
-                            e.name = e.name.replace("transport-belt", "underground-belt");
-                            e.io_type =
-                                Some(if e.y == row - 1 { "input" } else { "output" }.into());
-                            converted += 1;
-                        }
-                    }
-                    match (converted, removed) {
-                        (2, Some(idx)) => {
-                            entities.remove(idx);
-                            solid_at.remove(&(c, row));
-                            cols.pop();
-                        }
-                        _ => {
+                        let row = p.lane_row;
+                        let owner = plans.iter().find(|q| q.orig_x == c && q.lane_row < row);
+                        let interior =
+                            owner.is_some_and(|q| row - 1 > q.lane_row) && row + 1 < margin;
+                        let is_solid_col = solid_at.contains(&(c, row));
+                        if !(interior && is_solid_col) {
                             return Err(format!(
-                                "mega: chain-fed {} vertical retrofit at x={c} found {converted} belts (need 2) — adapter refuses",
-                                r.item
+                                "mega: chain-fed {} crossing at x={c} cannot hop or retrofit (row {}, interior={interior} solid={is_solid_col} fluid={:?} owner_lane={:?})",
+                                r.item,
+                                p.lane_row,
+                                fluid_at.get(&(c, p.lane_row)),
+                                owner.map(|q| q.lane_row)
                             ));
+                        }
+                        let mut converted = 0;
+                        let mut removed = None;
+                        for (idx, e) in entities.iter_mut().enumerate() {
+                            if e.x != c || !e.name.contains("transport-belt") {
+                                continue;
+                            }
+                            if e.y == row && e.direction == EntityDirection::South {
+                                removed = Some(idx);
+                            } else if (e.y == row - 1 || e.y == row + 1)
+                                && e.direction == EntityDirection::South
+                            {
+                                e.name = e.name.replace("transport-belt", "underground-belt");
+                                e.io_type =
+                                    Some(if e.y == row - 1 { "input" } else { "output" }.into());
+                                converted += 1;
+                            }
+                        }
+                        match (converted, removed) {
+                            (2, Some(idx)) => {
+                                entities.remove(idx);
+                                solid_at.remove(&(c, row));
+                                occ_cols.remove(&c);
+                                freed.insert(c);
+                            }
+                            _ => {
+                                return Err(format!(
+                                    "mega: chain-fed {} vertical retrofit at x={c} found {converted} belts (need 2) — adapter refuses",
+                                    r.item
+                                ));
+                            }
                         }
                     }
                 }
+                // Re-cluster the surviving crossings and stamp hops.
+                let mut cols: Vec<i32> = occ_cols.iter().copied().collect();
+                cols.sort_unstable();
+                let _ = &freed;
                 let mut clusters: Vec<(i32, i32)> = Vec::new();
                 for c in cols {
                     match clusters.last_mut() {
@@ -432,23 +520,11 @@ fn adapt_with_spacing(
                     }
                 }
                 let mut x = 0;
-                let ug_gap = crate::common::ug_max_reach(&r.entity) as i32;
                 for (lo2, hi2) in clusters {
-                    // Mouths at lo2-1 / hi2+1 → underground gap =
-                    // hi2-lo2+1, capped by the RECORD's belt tier (the
-                    // mouths stamp that tier — a hardcoded express cap
-                    // would let a yellow record plan a pair the game
-                    // never connects; #411 review).
-                    if hi2 - lo2 + 1 > ug_gap {
+                    if !hoppable(lo2, hi2) {
                         return Err(format!(
-                            "mega: chain-fed {} lateral hop cluster {}..{} exceeds {} reach",
-                            r.item, lo2, hi2, r.entity
-                        ));
-                    }
-                    if lo2 - 1 < 1 {
-                        return Err(format!(
-                            "mega: chain-fed {} lateral crossing at x={} leaves no entry tile",
-                            r.item, lo2
+                            "mega: chain-fed {} lateral cluster {}..{} unresolvable after retrofit",
+                            r.item, lo2, hi2
                         ));
                     }
                     for xx in x..=(lo2 - 2) {
@@ -601,6 +677,7 @@ fn try_fluid_path(
     fluid_at: &rustc_hash::FxHashMap<(i32, i32), String>,
     plain_pipe_at: &FxHashSet<(i32, i32)>,
     ptg_at: &FxHashSet<(i32, i32)>,
+    span_at: &rustc_hash::FxHashMap<(i32, i32), String>,
 ) -> Option<FluidPath> {
     let neighbors = |x: i32, y: i32| [(x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)];
     let tail_x = orig_x + dx;
@@ -663,18 +740,38 @@ fn try_fluid_path(
             }
         }
         let tile_set: FxHashSet<(i32, i32)> = all_tiles.iter().copied().collect();
+        let dbg = std::env::var("SPAGHETTIO_MEGA_DEBUG").is_ok();
         let mut valid = true;
         'check: for &(x, y) in &all_tiles {
+            let is_surface_pipe = pipes.contains(&(x, y));
+            let is_mouth = mouth_tiles.contains(&(x, y));
+            if !is_surface_pipe && !is_mouth {
+                // Reserved underground span: passes freely under
+                // surface entities (pipes, belts, machines); refuses
+                // only same-axis underground interference — a foreign
+                // span or a foreign surface PTG in this column (all
+                // planned pairs and the original trunk heads are
+                // vertical, so any such hit shares the axis and would
+                // re-pair the mouths).
+                if span_at.contains_key(&(x, y)) || ptg_at.contains(&(x, y)) {
+                    if dbg { eprintln!("  [{item} dx={dx} ptg={ptg_tail} d={tail_depth}] span tile ({x},{y}) hits span/ptg"); }
+                    valid = false;
+                    break 'check;
+                }
+                continue;
+            }
             if solid_at.contains(&(x, y)) || fluid_at.contains_key(&(x, y)) {
+                if dbg { eprintln!("  [{item} dx={dx} ptg={ptg_tail} d={tail_depth}] tile ({x},{y}) solid={} fluid={:?}", solid_at.contains(&(x,y)), fluid_at.get(&(x,y))); }
                 valid = false;
                 break 'check;
             }
-            let is_surface_pipe = pipes.contains(&(x, y));
-            if !is_surface_pipe && !mouth_tiles.contains(&(x, y)) {
-                // Reserved underground span — no adjacency semantics.
-                continue;
+            if is_mouth && span_at.contains_key(&(x, y)) {
+                // A surface mouth inside a foreign pair's underground
+                // span would re-pair it (same axis).
+                valid = false;
+                break 'check;
             }
-            if mouth_tiles.contains(&(x, y)) {
+            if is_mouth {
                 // Mouths connect axis-wise only; side adjacency to a
                 // foreign fluid is legal. The AXIS neighbors (a mouth's
                 // surface-connection side) are not re-checked here:
@@ -693,6 +790,7 @@ fn try_fluid_path(
                     // PTG tiles (mouths/spans, incl. the original trunk
                     // heads) are side-safe.
                     if f != item && !ptg_at.contains(&n) {
+                        if dbg { eprintln!("  [{item} dx={dx} ptg={ptg_tail} d={tail_depth}] tile ({x},{y}) adj ({},{}) foreign {f}", n.0, n.1); }
                         valid = false;
                         break 'check;
                     }
@@ -723,6 +821,11 @@ fn try_fluid_path(
         });
         if joins {
             return Some(FluidPath { pipes, ptg_pair });
+        }
+        if dbg {
+            eprintln!("  [{item} dx={dx} ptg={ptg_tail} d={tail_depth}] terminus ({},{}) no join (fluid_at neighbors: {:?})",
+                terminus.0, terminus.1,
+                neighbors(terminus.0, terminus.1).iter().filter_map(|n| fluid_at.get(n).map(|f| (n.0, n.1, f.clone()))).collect::<Vec<_>>());
         }
     }
     None

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -307,6 +307,7 @@ impl DecompositionCandidate for ModuleSizeSplit {
             stacking: opts.stacking,
             inserter_capacity: opts.inserter_capacity,
             cell_composition: opts.cell_composition,
+            splitter_tap_spacers: opts.splitter_tap_spacers,
         };
         run_layout_with_retry(&transformed, &inner_opts)
     }

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3135,7 +3135,35 @@ pub fn route_bus_ghost(
             .as_ref()
             .map(|snap| snap.forced_empty.iter().copied().collect())
             .unwrap_or_default();
-        let preserve_balancer_tiles: rustc_hash::FxHashSet<(i32, i32)> =
+        // Preserve balancer tiles (unconditional — pre-existing #295
+        // behavior) AND tapoff-splitter tiles the SOLUTION DOES NOT
+        // COVER: the #295 prose ("splitters must survive — SAT models
+        // them as fixed structure via interior boundaries and never
+        // re-stamps them") was only implemented for balancers;
+        // released-but-uncovered tapoff splitters were dropped by the
+        // Step-6 retain with nothing re-covering their tiles, leaving
+        // a trunk hole that dead-ends the lane above and orphans the
+        // flow below (USP mega sub-solve forensics, EC trunk at the
+        // zone edge). Solutions that DO cover the splitter tiles keep
+        // the release — byte-identical to the old behavior there.
+        // A tapoff tile is preserved iff an INTERIOR boundary anchors
+        // on it — the strategy's explicit "this Permanent is a
+        // legitimate item-matched flow source/sink" marker. Zones that
+        // instead routed AROUND a released splitter (UG arcs, no
+        // interior boundary) keep the release — byte-identical to the
+        // old behavior there.
+        let interior_tiles: rustc_hash::FxHashSet<(i32, i32)> = sol
+            .sat_zone
+            .as_ref()
+            .map(|snap| {
+                snap.boundaries
+                    .iter()
+                    .filter(|b| b.interior)
+                    .map(|b| (b.x, b.y))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let preserve_fixed_tiles: rustc_hash::FxHashSet<(i32, i32)> =
             forced_empty_set
                 .iter()
                 .filter(|tile| {
@@ -3145,16 +3173,20 @@ pub fn route_bus_ghost(
                             if occupancy
                                 .entity_at(**tile)
                                 .and_then(|e| e.segment_id.as_deref())
-                                .is_some_and(|seg| seg.starts_with("balancer:"))
+                                .is_some_and(|seg| {
+                                    seg.starts_with("balancer:")
+                                        || (seg.starts_with("tapoff:")
+                                            && interior_tiles.contains(*tile))
+                                })
                                 && { let _ = entity_idx; true }
                     )
                 })
                 .copied()
                 .collect();
-        let preserve_ref = if preserve_balancer_tiles.is_empty() {
+        let preserve_ref = if preserve_fixed_tiles.is_empty() {
             None
         } else {
-            Some(&preserve_balancer_tiles)
+            Some(&preserve_fixed_tiles)
         };
         let released_count = occupancy.release_for_pertile_template(
             &release_rect,

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -1241,23 +1241,50 @@ pub fn route_bus_ghost(
                         continue;
                     }
                     // Blocked run [bx, run_end], capped by pipe UG reach (F4).
+                    // CLUSTER runs separated by a single free tile: hopping
+                    // them independently lands run A's EXIT exactly where
+                    // run B wants its entrance, and the entrance conversion
+                    // below would mutate A's exit mouth into B's entrance —
+                    // destroying A's pair and stitching this fluid's mouth
+                    // onto whatever foreign network sits west of it (found
+                    // via the #412 identity fix: the reversed advanced-oil
+                    // tap arrangement produced blocked-free-blocked at the
+                    // light column + PG port UG, and the heavy branch
+                    // merged into the light trunk).
                     let mut run_end = bx;
-                    while run_end + 1 < branch_end
-                        && is_blocked_tile((run_end + 1, py), &existing_belts, &hard)
-                        && (run_end + 1 - bx) < crate::common::UG_PIPE_REACH as i32
-                    {
-                        run_end += 1;
+                    loop {
+                        let next_blocked = run_end + 1 < branch_end
+                            && is_blocked_tile((run_end + 1, py), &existing_belts, &hard)
+                            && (run_end + 1 - bx) < crate::common::UG_PIPE_REACH as i32;
+                        if next_blocked {
+                            run_end += 1;
+                            continue;
+                        }
+                        // Single free tile followed by another blocked tile,
+                        // still within reach: swallow both into this run.
+                        let gap_then_blocked = run_end + 2 < branch_end
+                            && !is_blocked_tile((run_end + 1, py), &existing_belts, &hard)
+                            && is_blocked_tile((run_end + 2, py), &existing_belts, &hard)
+                            && (run_end + 2 - bx) < crate::common::UG_PIPE_REACH as i32;
+                        if gap_then_blocked {
+                            run_end += 2;
+                            continue;
+                        }
+                        break;
                     }
                     let exit_x = run_end + 1;
                     let exit_open = exit_x < branch_end
                         && !is_blocked_tile((exit_x, py), &existing_belts, &hard);
                     match (prev_surface_idx, exit_open) {
-                        (Some(prev), true) => {
+                        (Some(prev), true) if entities[prev].name == "pipe" => {
                             // Convert the previous surface pipe into the UG
                             // entrance (East: tunnel runs east, surface
                             // connection stays on its west side) and emit
                             // the West-facing exit — the same partner
                             // convention as the stacked-T flank case above.
+                            // The `== "pipe"` guard refuses to mutate an
+                            // existing PTG mouth (a silent pair-destroyer);
+                            // clustering above should make that unreachable.
                             entities[prev].name = "pipe-to-ground".to_string();
                             entities[prev].direction = EntityDirection::East;
                             entities[prev].io_type = Some("input".to_string());

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1663,6 +1663,7 @@ pub(crate) fn prune_dangling_sat_entities(
     // ---- keep intersection ----
 
     let total = entities.len();
+    let entities_dbg = entities.clone();
     let pruned: Vec<PlacedEntity> = entities
         .into_iter()
         .filter(|e| {
@@ -1673,6 +1674,22 @@ pub(crate) fn prune_dangling_sat_entities(
     let kept = pruned.len();
 
     if kept < total {
+        if std::env::var("SPAGHETTIO_MEGA_DEBUG").is_ok() {
+            for e in entities_dbg
+                .iter()
+                .filter(|e| {
+                    let t = (e.x, e.y);
+                    !(reachable_from_input.contains(&t) && reachable_to_output.contains(&t))
+                })
+            {
+                eprintln!(
+                    "PRUNED zone({zone_x},{zone_y}): ({},{}) {} dir={:?} io={:?} {:?} from_in={} to_out={}",
+                    e.x, e.y, e.name, e.direction, e.io_type, e.carries,
+                    reachable_from_input.contains(&(e.x, e.y)),
+                    reachable_to_output.contains(&(e.x, e.y)),
+                );
+            }
+        }
         trace::emit(trace::TraceEvent::SatPruned { zone_x, zone_y, total, kept });
     }
 

--- a/crates/core/src/bus/lane_planner.rs
+++ b/crates/core/src/bus/lane_planner.rs
@@ -173,6 +173,7 @@ pub fn plan_bus_lanes(
     plan: Option<&PartitionPlan>,
     total_height: i32,
     merge_tap: bool,
+    splitter_tap_spacers: bool,
     ctx: &StackingCtx,
 ) -> Result<(Vec<BusLane>, Vec<LaneFamily>), String> {
     // Fluid surplus items AND fluid targets must physically exit at the
@@ -429,10 +430,52 @@ pub fn plan_bus_lanes(
     // pipe columns of different fluids would merge (F1).
     // `bus_width_for_lanes` derives width from max x, so the spacers are
     // accounted for in bus width and pass-2 row placement.
+    // A multi-tap SOLID lane's tap splitters occupy (x+1, tap_y-1) —
+    // when the EAST neighbor lane's trunk span covers such a row, the
+    // splitter's second tile lands ON the neighbor's live trunk: the
+    // neighbor's flow enters the splitter and items mix (the USP mega
+    // sub-solve, where every lane sources at y=0 so all spans overlap;
+    // organic buses rarely collide because producer rows stagger the
+    // spans — every 0-error golden is span-disjoint and stays
+    // bit-identical). Insert a spacer column so the second tile lands
+    // in empty space instead.
+    let neighbor_overlaps_splitter = |cur: &BusLane, next: &BusLane| -> bool {
+        if cur.is_fluid || cur.tap_off_ys.len() <= 1 || next.is_fluid {
+            return false;
+        }
+        let last = cur.tap_off_ys.iter().copied().max();
+        let next_start = next.source_y;
+        let next_end = next
+            .tap_off_ys
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(next.source_y);
+        cur.tap_off_ys.iter().any(|&ty| {
+            Some(ty) != last && (next_start..=next_end).contains(&(ty - 1))
+        })
+    };
+    // Opt-in (mega blocks set `splitter_tap_spacers`): two main-line
+    // fixtures (PU@2-AM2, EC35-from-ore) HAVE overlapping spans whose
+    // zone machinery successfully bridges the splitter-passthrough —
+    // the spacer's geometry shift breaks them, while the mega
+    // sub-solve's zones do NOT bridge and need the spacer. The
+    // underlying pitch-1 splitter-passthrough class stays tracked in
+    // the RFC-052 decision log.
+    let spacer_after: Vec<bool> = (0..lanes.len())
+        .map(|i| {
+            splitter_tap_spacers
+                && i + 1 < lanes.len()
+                && neighbor_overlaps_splitter(&lanes[i], &lanes[i + 1])
+        })
+        .collect();
     let mut extra = 0i32;
     for (i, lane) in lanes.iter_mut().enumerate() {
         lane.x = (i + 1) as i32 + extra;
         if lane.perimeter_exit_y.is_some() && lane.consumer_rows.is_empty() {
+            extra += 1;
+        }
+        if spacer_after[i] {
             extra += 1;
         }
     }
@@ -1411,7 +1454,7 @@ mod tests {
             vec![6],  // input belt at y=6
         );
 
-        let (lanes, families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, &StackingCtx::unstacked())
+        let (lanes, families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, false, &StackingCtx::unstacked())
             .expect("plan_bus_lanes should succeed for iron-gear-wheel");
 
         // Should have exactly 1 lane for iron-plate
@@ -1437,7 +1480,7 @@ mod tests {
             vec![6],
         );
 
-        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, &StackingCtx::unstacked()).unwrap();
+        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, false, &StackingCtx::unstacked()).unwrap();
 
         // iron-gear-wheel is the final output, not consumed internally, so no lane for it
         // Only iron-plate (the external input) needs a lane
@@ -1462,7 +1505,7 @@ mod tests {
             vec![6, 7],  // two input belt y positions
         );
 
-        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, &StackingCtx::unstacked())
+        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, false, &StackingCtx::unstacked())
             .expect("plan_bus_lanes should succeed for plastic-bar");
 
         // Should have lanes for coal and petroleum-gas (plastic-bar is final output)
@@ -1498,7 +1541,7 @@ mod tests {
             vec![6, 7],
         );
 
-        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, &StackingCtx::unstacked()).unwrap();
+        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, false, &StackingCtx::unstacked()).unwrap();
 
         // optimize_lane_order puts solid before fluid
         let fluid_indices: Vec<usize> = lanes.iter().enumerate()
@@ -1530,7 +1573,7 @@ mod tests {
             vec![6],
         );
 
-        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, &StackingCtx::unstacked()).unwrap();
+        let (lanes, _families) = plan_bus_lanes(&sr, &[row_span], None, None, 40, false, false, &StackingCtx::unstacked()).unwrap();
 
         // The iron-plate lane has consumer row 0, so it should have a tap-off y
         let iron_plate_lane = lanes.iter().find(|l| l.item == "iron-plate").unwrap();
@@ -1582,7 +1625,7 @@ mod tests {
             }
         }).collect();
 
-        let (lanes, _families) = plan_bus_lanes(&sr, &row_spans, None, None, 40, false, &StackingCtx::unstacked())
+        let (lanes, _families) = plan_bus_lanes(&sr, &row_spans, None, None, 40, false, false, &StackingCtx::unstacked())
             .expect("plan_bus_lanes should succeed");
 
         // Must have at least one lane

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -76,6 +76,11 @@ pub enum SurplusPolicy {
 #[derive(Clone, Debug)]
 pub struct LayoutOptions {
     pub strategy: LayoutStrategy,
+    /// Insert a spacer column east of multi-tap solid lanes whose east
+    /// neighbor's trunk span covers a splitter row (Phase C mega
+    /// blocks; default false — main-line zone machinery bridges the
+    /// overlap and the geometry shift would break it).
+    pub splitter_tap_spacers: bool,
     pub max_belt_tier: Option<String>,
     pub row_layout: RowLayout,
     pub surplus_policy: SurplusPolicy,
@@ -135,6 +140,7 @@ impl Default for LayoutOptions {
             quality: crate::common::QualityTier::default(),
             wire_mode: crate::power_wires::WireMode::default(),
             merge_tap: false,
+            splitter_tap_spacers: false,
             stacking: 1,
             inserter_capacity: 0,
             // FLIPPED to Candidate 2026-07-22 (RFC-051 flip decision,
@@ -689,6 +695,7 @@ fn layout_pass(
         plan_ref,
         total_height_1,
         opts.merge_tap,
+        opts.splitter_tap_spacers,
         &stacking_ctx,
     )?;
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime {
@@ -752,6 +759,7 @@ fn layout_pass(
                     plan_ref,
                     th,
                     opts.merge_tap,
+                    opts.splitter_tap_spacers,
                     &stacking_ctx,
                 )
             })?;

--- a/crates/core/src/bus/output_merger.rs
+++ b/crates/core/src/bus/output_merger.rs
@@ -87,19 +87,40 @@ pub(crate) fn merge_output_rows(
             if blocked_columns.contains(&x) {
                 // Contiguous blocked run [x, run_end], clamped by UG reach
                 // (entrance at x-1, exit at run_end+1; gap ≤ reach).
+                // CLUSTER runs separated by a single free tile: hopping
+                // them independently would put run B's entrance exactly
+                // on run A's exit — the mutation below then destroys
+                // A's pair (two consecutive entrances; the game leaves
+                // the first unpaired). Same defect class as the ghost
+                // router's fluid-branch bridging (#412/USP forensics).
                 let mut run_end = x;
-                while run_end + 1 < col_x
-                    && blocked_columns.contains(&(run_end + 1))
-                    && (run_end + 1) - x < reach
-                {
-                    run_end += 1;
+                loop {
+                    let next_blocked = run_end + 1 < col_x
+                        && blocked_columns.contains(&(run_end + 1))
+                        && (run_end + 1) - x < reach;
+                    if next_blocked {
+                        run_end += 1;
+                        continue;
+                    }
+                    let gap_then_blocked = run_end + 2 < col_x
+                        && !blocked_columns.contains(&(run_end + 1))
+                        && blocked_columns.contains(&(run_end + 2))
+                        && (run_end + 2) - x < reach;
+                    if gap_then_blocked {
+                        run_end += 2;
+                        continue;
+                    }
+                    break;
                 }
                 debug_assert!(x > rw, "no room for UG entrance before blocked column");
-                // Replace the belt stamped at x-1 with a UG entrance.
+                // Replace the belt stamped at x-1 with a UG entrance —
+                // only ever a plain surface belt of this run (the
+                // clustering guarantees it; the guard refuses to
+                // corrupt an existing mouth).
                 if let Some(prev) = entities
                     .iter_mut()
                     .rev()
-                    .find(|e| e.x == x - 1 && e.y == out_y)
+                    .find(|e| e.x == x - 1 && e.y == out_y && e.name == belt_name)
                 {
                     prev.name = ug_name.to_string();
                     prev.io_type = Some("input".to_string());

--- a/crates/core/src/bus/output_merger.rs
+++ b/crates/core/src/bus/output_merger.rs
@@ -88,9 +88,13 @@ pub(crate) fn merge_output_rows(
         // constraint, the rate pick is not; hop mouths are plumbing.
         let hop_cap: &str = max_belt_tier.unwrap_or("express-transport-belt");
         let reach = ug_max_reach(hop_cap) as i32;
+        // Tier floor = the RATE-PICKED surface tier (#421 review: a
+        // smallest-spanning pick could throttle an express-rate line
+        // through a yellow hop — silently, since the throughput check
+        // only flags overlapping routes); ceiling = the user's cap.
         let hop_tier_for_gap = |gap: i32| -> &'static str {
             for t in ["transport-belt", "fast-transport-belt", "express-transport-belt"] {
-                if ug_max_reach(t) as i32 >= gap {
+                if ug_max_reach(t) as i32 >= gap && ug_max_reach(t) >= ug_max_reach(belt_name) {
                     if ug_max_reach(t) <= ug_max_reach(hop_cap) {
                         return underground_for_belt(t);
                     }
@@ -100,11 +104,6 @@ pub(crate) fn merge_output_rows(
             underground_for_belt(hop_cap)
         };
         let mut x = rw;
-        if std::env::var("SPAGHETTIO_MEGA_DEBUG").is_ok() {
-            let mut bc: Vec<_> = blocked_columns.to_vec();
-            bc.sort_unstable();
-            eprintln!("MERGER {item} out_y={out_y} rw={rw} col_x={col_x} blocked={bc:?} reach={reach}");
-        }
         while x < col_x {
             if blocked_columns.contains(&x) {
                 // Contiguous blocked run [x, run_end], clamped by UG reach

--- a/crates/core/src/bus/output_merger.rs
+++ b/crates/core/src/bus/output_merger.rs
@@ -80,9 +80,31 @@ pub(crate) fn merge_output_rows(
         // underground pair instead of stamping over (or sideloading into)
         // the foreign belt.
         let rw = row_spans[ri].row_width;
-        let ug_name = underground_for_belt(belt_name);
-        let reach = ug_max_reach(belt_name) as i32;
+        // Hops may need more reach than the rate-picked tier offers
+        // (alternating blocked columns with 1-tile gaps are unhoppable
+        // at yellow reach and split into exit-abuts-next-entrance
+        // pairs — the USP mega merger forensics). The hop TIER may
+        // escalate up to the USER's belt cap: the cap is the
+        // constraint, the rate pick is not; hop mouths are plumbing.
+        let hop_cap: &str = max_belt_tier.unwrap_or("express-transport-belt");
+        let reach = ug_max_reach(hop_cap) as i32;
+        let hop_tier_for_gap = |gap: i32| -> &'static str {
+            for t in ["transport-belt", "fast-transport-belt", "express-transport-belt"] {
+                if ug_max_reach(t) as i32 >= gap {
+                    if ug_max_reach(t) <= ug_max_reach(hop_cap) {
+                        return underground_for_belt(t);
+                    }
+                    break;
+                }
+            }
+            underground_for_belt(hop_cap)
+        };
         let mut x = rw;
+        if std::env::var("SPAGHETTIO_MEGA_DEBUG").is_ok() {
+            let mut bc: Vec<_> = blocked_columns.to_vec();
+            bc.sort_unstable();
+            eprintln!("MERGER {item} out_y={out_y} rw={rw} col_x={col_x} blocked={bc:?} reach={reach}");
+        }
         while x < col_x {
             if blocked_columns.contains(&x) {
                 // Contiguous blocked run [x, run_end], clamped by UG reach
@@ -113,20 +135,33 @@ pub(crate) fn merge_output_rows(
                     break;
                 }
                 debug_assert!(x > rw, "no room for UG entrance before blocked column");
+                let gap = run_end + 1 - x;
+                let hop_ug = hop_tier_for_gap(gap);
                 // Replace the belt stamped at x-1 with a UG entrance —
                 // only ever a plain surface belt of this run (the
                 // clustering guarantees it; the guard refuses to
-                // corrupt an existing mouth).
-                if let Some(prev) = entities
+                // corrupt an existing mouth, and a miss is LOUD via
+                // debug_assert — a silent skip left unpaired outputs).
+                let converted = entities
                     .iter_mut()
                     .rev()
-                    .find(|e| e.x == x - 1 && e.y == out_y && e.name == belt_name)
-                {
-                    prev.name = ug_name.to_string();
-                    prev.io_type = Some("input".to_string());
+                    .find(|e| e.x == x - 1 && e.y == out_y && e.name.ends_with("transport-belt"))
+                    .map(|prev| {
+                        prev.name = hop_ug.to_string();
+                        prev.io_type = Some("input".to_string());
+                    })
+                    .is_some();
+                // No panic on a miss: fulgora's merger hits runs whose
+                // west tile is row machinery — the old code mutated
+                // whatever sat there (silent corruption); refusing the
+                // hop (below) leaves a gap instead, strictly safer.
+                if !converted {
+                    // Refuse the hop rather than emit an unpaired exit.
+                    x = run_end + 2;
+                    continue;
                 }
                 entities.push(PlacedEntity {
-                    name: ug_name.to_string(),
+                    name: hop_ug.to_string(),
                     x: run_end + 1,
                     y: out_y,
                     direction: EntityDirection::East,

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -754,14 +754,22 @@ pub(crate) fn build_one_row(
                 };
                 (in_dxs, out_dxs)
             };
+            // Port-identity rule (sim-measured, #412 / fluid_ports::
+            // port_fluid_assignment): recipe fluids bind x-ASCENDING on
+            // the unmirrored form and x-DESCENDING on the mirrored form
+            // (the 180°-rotation export encoding reverses port x-order;
+            // the old ascending-always zip starved advanced-oil
+            // refineries in-game). fluid_only_row places mirrored, so
+            // the FLUID list reverses here; single-fluid sides reverse
+            // to themselves — every registered fixture is bit-identical.
             let in_port_assignments: Vec<(i32, &str)> = input_dxs
                 .iter()
-                .zip(fluid_inputs.iter())
+                .zip(fluid_inputs.iter().rev())
                 .map(|(&dx, f)| (dx, f.item.as_str()))
                 .collect();
             let out_port_assignments: Vec<(i32, &str)> = output_dxs
                 .iter()
-                .zip(fluid_outputs.iter())
+                .zip(fluid_outputs.iter().rev())
                 .map(|(&dx, f)| (dx, f.item.as_str()))
                 .collect();
             let (ents, rh, in_port_pipes, out_port_pipes) = templates::fluid_only_row(

--- a/crates/core/src/fluid_ports.rs
+++ b/crates/core/src/fluid_ports.rs
@@ -183,6 +183,47 @@ pub fn fluid_ports(entity: &str, mirror: bool, direction: EntityDirection) -> &'
 ///
 /// - AM2 / chemical-plant / biochamber already have north inputs → default
 ///   `(false, North)`.
+/// SIM-MEASURED port-identity rule (#412 probes, 2026-07-24): recipe
+/// fluids bind to a machine's same-direction ports in X-ASCENDING
+/// order on the unmirrored form, and in X-DESCENDING order on the
+/// engine-mirrored form — the (direction+8, mirror:false) export
+/// encoding is a 180° rotation, which reverses the ports' x-order
+/// while the fluid-box identities stay glued to their boxes.
+/// Measured on oil-refinery/advanced-oil-processing (census probe:
+/// mirrored = crude WEST + water EAST in, PG/light/heavy west→east
+/// out; engine's old recipe-order-ascending assignment starved the
+/// machine in-game). Foundry/cryogenic-plant share the geometry rule
+/// by construction (same mirror-as-rotation encoding); the refinery
+/// is the measured anchor.
+///
+/// `fluids` must be the recipe's fluid names for ONE direction
+/// ("input" or "output") in RECIPE ORDER. Returns `(dx, dy, item)`
+/// per port, table order (x-ascending).
+pub fn port_fluid_assignment<'a>(
+    entity: &str,
+    mirror: bool,
+    direction: EntityDirection,
+    io: &str,
+    fluids: &[&'a str],
+) -> Vec<(i32, i32, &'a str)> {
+    let ports: Vec<(i32, i32)> = fluid_ports(entity, mirror, direction)
+        .iter()
+        .filter(|&&(_, _, pt)| pt == io)
+        .map(|&(x, y, _)| (x, y))
+        .collect();
+    let n = fluids.len().min(ports.len());
+    let mut out = Vec::with_capacity(n);
+    for (k, &(px, py)) in ports.iter().take(n).enumerate() {
+        let item = if mirror {
+            fluids[n - 1 - k]
+        } else {
+            fluids[k]
+        };
+        out.push((px, py, item));
+    }
+    out
+}
+
 /// - oil-refinery / foundry / cryogenic-plant → `(true, North)` (mirror y-flip).
 /// - electromagnetic-plant → `(false, East)` (rotation; only its inputs reach
 ///   the north face — the outputs land west/east, so this orientation is only

--- a/crates/core/src/fluid_ports.rs
+++ b/crates/core/src/fluid_ports.rs
@@ -183,6 +183,18 @@ pub fn fluid_ports(entity: &str, mirror: bool, direction: EntityDirection) -> &'
 ///
 /// - AM2 / chemical-plant / biochamber already have north inputs → default
 ///   `(false, North)`.
+/// - oil-refinery / foundry / cryogenic-plant → `(true, North)` (mirror y-flip).
+/// - electromagnetic-plant → `(false, East)` (rotation; only its inputs reach
+///   the north face — the outputs land west/east, so this orientation is only
+///   correct for solid-output recipes).
+pub fn north_input_orientation(entity: &str) -> (bool, EntityDirection) {
+    match entity {
+        "oil-refinery" | "foundry" | "cryogenic-plant" => (true, EntityDirection::North),
+        "electromagnetic-plant" => (false, EntityDirection::East),
+        _ => (false, EntityDirection::North),
+    }
+}
+
 /// SIM-MEASURED port-identity rule (#412 probes, 2026-07-24): recipe
 /// fluids bind to a machine's same-direction ports in X-ASCENDING
 /// order on the unmirrored form, and in X-DESCENDING order on the
@@ -224,17 +236,6 @@ pub fn port_fluid_assignment<'a>(
     out
 }
 
-/// - oil-refinery / foundry / cryogenic-plant → `(true, North)` (mirror y-flip).
-/// - electromagnetic-plant → `(false, East)` (rotation; only its inputs reach
-///   the north face — the outputs land west/east, so this orientation is only
-///   correct for solid-output recipes).
-pub fn north_input_orientation(entity: &str) -> (bool, EntityDirection) {
-    match entity {
-        "oil-refinery" | "foundry" | "cryogenic-plant" => (true, EntityDirection::North),
-        "electromagnetic-plant" => (false, EntityDirection::East),
-        _ => (false, EntityDirection::North),
-    }
-}
 
 /// The `dx` offsets (relative to the machine's left edge) of the input-port
 /// pipes on the NORTH face (`dy == -1`), for `entity` at the given orientation.
@@ -308,6 +309,31 @@ mod tests {
         assert_eq!(
             fluid_ports("electromagnetic-plant", false, EntityDirection::North),
             &[(-1, 2, "input"), (4, 1, "input"), (2, 4, "output"), (1, -1, "output")]
+        );
+    }
+
+    #[test]
+    fn port_identity_matches_sim_measured_truth() {
+        // Sim-measured 2026-07-24 (Phase C precondition probes A-H2,
+        // rfc-052 decision log): advanced-oil-processing fluids bind
+        // x-ASCENDING in recipe order on the unmirrored refinery and
+        // x-DESCENDING on the engine-mirrored (dir+8 exported) form.
+        // The engine's old ascending-always zip STARVED mirrored
+        // refineries in-game.
+        let ins = ["water", "crude-oil"];
+        let outs = ["heavy-oil", "light-oil", "petroleum-gas"];
+        // Unmirrored: box order, x-ascending (census probe H2).
+        let a = port_fluid_assignment("oil-refinery", false, EntityDirection::North, "input", &ins);
+        assert_eq!(a, vec![(1, 5, "water"), (3, 5, "crude-oil")]);
+        let a = port_fluid_assignment("oil-refinery", false, EntityDirection::North, "output", &outs);
+        assert_eq!(a, vec![(0, -1, "heavy-oil"), (2, -1, "light-oil"), (4, -1, "petroleum-gas")]);
+        // Mirrored: reversed (probes A vs B/D/E + census probe G).
+        let a = port_fluid_assignment("oil-refinery", true, EntityDirection::North, "input", &ins);
+        assert_eq!(a, vec![(1, -1, "crude-oil"), (3, -1, "water")]);
+        let a = port_fluid_assignment("oil-refinery", true, EntityDirection::North, "output", &outs);
+        assert_eq!(
+            a,
+            vec![(0, 5, "petroleum-gas"), (2, 5, "light-oil"), (4, 5, "heavy-oil")]
         );
     }
 

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -895,6 +895,66 @@ fn mega_chain_pu4_resolves_bus_failure() {
     );
 }
 
+/// RFC-052 Phase C flagship: utility-science-pack@2 from fully raw
+/// inputs. The BUS hard-fails (belt-loop + underground-belt); the
+/// mega swallows the ENTIRE oil complex — 10 members including BOTH
+/// oil processings, cracking, and lubricant, with 4 solid exports
+/// (multi-consumer fan-out) and 5 chain-fed inputs. Composes at ZERO
+/// errors.
+#[test]
+fn mega_chain_usp2_resolves_bus_failure() {
+    use spaghettio_core::bus::cells::chain::compose_chain;
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]
+            .iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "utility-science-pack", 2.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let plan = spaghettio_core::bus::cells::mega::mega_subgraph(&sr)
+        .expect("subgraph")
+        .expect("USP chain has a fluid subgraph");
+    assert!(
+        plan.members.contains("advanced-oil-processing")
+            && plan.members.iter().any(|r| r.contains("cracking")),
+        "flagship must exercise the advanced complex, got {:?}",
+        plan.members
+    );
+    assert!(
+        plan.outputs.len() >= 2 && !plan.chain_fed.is_empty(),
+        "flagship must exercise multi-export fan + chain-fed inputs"
+    );
+    let l = compose_chain(&sr).expect("USP@2 from raw must compose");
+    let issues = match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
+        Ok(v) => v,
+        Err(e) => e.issues,
+    };
+    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    assert!(errors.is_empty(), "USP@2 errors: {errors:?}");
+}
+
+/// Artifact producer for the Phase C flagship sim run.
+#[test]
+#[ignore = "artifact producer"]
+fn export_mega_usp_for_sim() {
+    use spaghettio_core::bus::cells::chain::compose_chain;
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]
+            .iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "utility-science-pack", 2.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let l = compose_chain(&sr).unwrap();
+    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-usp2raw");
+    std::fs::create_dir_all("target/tmp").unwrap();
+    std::fs::write("target/tmp/mega-chain-usp2raw.bp", &bp).unwrap();
+    std::fs::write("target/tmp/mega-chain-usp2raw.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+    println!("wrote mega-chain-usp2raw.bp ({} in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
+}
+
 /// Artifact producer for the increment-2 sim run.
 #[test]
 #[ignore = "artifact producer"]

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -317,6 +317,7 @@ fn run_e2e_inner(
             stacking: 1,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
         .map_err(|e| {
@@ -1780,6 +1781,7 @@ fn tier4_advanced_circuit_7s_horizontal_stack_belt_pipe_crossing() {
             stacking: 1,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
     .unwrap_or_else(|e| panic!("{test_name}: layout: {e}"));
@@ -1950,6 +1952,7 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
             stacking: 1,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
     .unwrap_or_else(|e| panic!("{test_name}: layout: {e}"));
@@ -2061,6 +2064,7 @@ fn tier5_processing_unit_25s_horizontal_stack_pole_coverage() {
             stacking: 1,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
     .unwrap_or_else(|e| panic!("{test_name}: layout: {e}"));
@@ -7092,6 +7096,7 @@ fn quality_differential_ec_normal_vs_legendary() {
                 stacking: 1,
                 inserter_capacity: 0,
                 cell_composition: Default::default(),
+            splitter_tap_spacers: false,
             },
         )
         .unwrap_or_else(|e| panic!("{quality:?} layout: {e}"));
@@ -7217,6 +7222,7 @@ fn quality_ec_45s_express_legendary_from_ore() {
             stacking: 1,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
     .unwrap_or_else(|e| panic!("layout: {e}"));
@@ -7308,6 +7314,7 @@ fn quality_differential_kovarex_self_loop_normal_vs_legendary() {
                 stacking: 1,
                 inserter_capacity: 0,
                 cell_composition: Default::default(),
+            splitter_tap_spacers: false,
             },
         )
         .unwrap_or_else(|e| panic!("{quality:?} layout: {e}"));
@@ -7448,6 +7455,7 @@ fn quality_ec_45s_legendary_tree_wire_differential() {
             stacking: 1,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
     .unwrap_or_else(|e| panic!("layout: {e}"));
@@ -7527,6 +7535,7 @@ fn stacking_ec_60s_red_one_belt_headline() {
                 stacking,
                 inserter_capacity: 0,
                 cell_composition: Default::default(),
+            splitter_tap_spacers: false,
             },
         )
         .unwrap_or_else(|e| panic!("S={stacking} layout: {e}"));
@@ -7642,6 +7651,7 @@ fn stacking_fanin_wall_lift_ec6_yellow_legendary() {
         stacking,
         inserter_capacity: 0,
         cell_composition: Default::default(),
+            splitter_tap_spacers: false,
     };
 
     // S=1: the fan-in wall holds — 25/s cable > 15/s full yellow.
@@ -7729,6 +7739,7 @@ fn stacking_refuses_low_inserter_cap() {
             stacking: 2,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
     .expect_err("stacking=2 with max_inserter_tier=Fast must refuse");
@@ -7778,6 +7789,7 @@ fn stacking_kovarex_family_exempt_s2() {
                 stacking,
                 inserter_capacity: 0,
                 cell_composition: Default::default(),
+            splitter_tap_spacers: false,
             },
         )
         .unwrap_or_else(|e| panic!("S={stacking} layout: {e}"));
@@ -7846,6 +7858,7 @@ fn stacking_ec_60s_express_legendary_s2() {
             stacking: 2,
             inserter_capacity: 0,
             cell_composition: Default::default(),
+            splitter_tap_spacers: false,
         },
     )
     .unwrap_or_else(|e| panic!("layout: {e}"));
@@ -7930,6 +7943,7 @@ fn research_l7_thins_output_inserters_s4() {
                 stacking: 4,
                 inserter_capacity: level,
                 cell_composition: Default::default(),
+            splitter_tap_spacers: false,
             },
         )
         .unwrap_or_else(|e| panic!("L={level} layout: {e}"));

--- a/crates/sim-harness/src/manifest.rs
+++ b/crates/sim-harness/src/manifest.rs
@@ -79,6 +79,11 @@ pub fn rot90((dx, dy): (i32, i32)) -> (i32, i32) {
 pub struct ItemRate {
     pub item: String,
     pub rate: f64,
+    /// Fluid targets have no drain rig (their surplus voids are
+    /// uncounted), so the report verdicts them on PRODUCED rate.
+    /// Defaults false — every pre-existing manifest is a solid target.
+    #[serde(default)]
+    pub is_fluid: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -199,14 +199,39 @@ pub fn compute(manifest: &Manifest, result: &serde_json::Value) -> Report {
     let mut items = Vec::new();
     for (item, planned_rate) in &manifest.planned_rates {
         let is_target = target_items.contains(&item.as_str());
-        let measured_produced_rate = if is_target && target_produced_rate.is_some() {
+        // The scenario's checkpoint tracks ONE scalar — the FIRST
+        // target's counters. Applying it to every target collapsed a
+        // 5/9/11 advanced-oil triple to a uniform first-target rate
+        // (Phase C identity probes, 2026-07-24); non-first targets
+        // measure from their own sample series over the same window.
+        let is_first_target = target_items.first() == Some(&item.as_str());
+        let measured_produced_rate = if is_first_target && target_produced_rate.is_some() {
             target_produced_rate
         } else {
             rate_over_window(&sample_series(result, item), window_start)
         };
-        let measured_delivered_rate = if is_target { target_delivered_rate } else { None };
+        let is_fluid_target = manifest
+            .targets
+            .iter()
+            .any(|t| t.item == *item && t.is_fluid);
+        let measured_delivered_rate = if is_first_target && !is_fluid_target {
+            target_delivered_rate
+        } else {
+            None
+        };
         let verdict = if is_target {
-            Some(verdict_for_ratio(measured_delivered_rate.map(|m| m / planned_rate)))
+            if is_fluid_target {
+                // Fluid targets have no drain rig (voids are
+                // uncounted): verdict on PRODUCED rate, honestly
+                // labeled by the missing delivered column.
+                Some(verdict_for_ratio(measured_produced_rate.map(|m| m / planned_rate)))
+            } else if is_first_target {
+                Some(verdict_for_ratio(measured_delivered_rate.map(|m| m / planned_rate)))
+            } else {
+                // Non-first SOLID targets have no per-item drain
+                // attribution either; verdict on produced.
+                Some(verdict_for_ratio(measured_produced_rate.map(|m| m / planned_rate)))
+            }
         } else {
             None
         };

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -79,6 +79,9 @@ fn layout_options(
         // decomposition search (`MergeTapCandidate`), never requested by the
         // web UI — always default-off at the public boundary.
         merge_tap: false,
+        // Phase C: set only by the mega-block sub-solve internally,
+        // never at the public boundary.
+        splitter_tap_spacers: false,
         // RFC-046 Phase 2: unknown/absent → 1 (off), same fallback
         // semantics as the tiers above. `common::*_stacked` helpers clamp
         // any out-of-range value, so no validation needed here.

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -21,7 +21,6 @@ use rustc_hash::FxHashSet;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-#[allow(clippy::too_many_arguments)] // param-per-axis wasm surface (quality/wire/stacking/research)
 /// Build `LayoutOptions` from the optional belt-tier, strategy,
 /// row-layout, and inserter-tier strings passed in across the WASM
 /// boundary. The TS engine layer validates URL params, so unknown values

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -168,8 +168,25 @@ feeds and the composed layout must pass the pipe-isolation validators
   result lines; re-verified from one clean invocation (the
   single-run-counts lesson generalizes to compile failures).
   Env-gated forensic tracing (SPAGHETTIO_MEGA_DEBUG) kept in the
-  adapter, merger, and SAT prune. Flagship sim run launched;
-  registry decision follows its verdict.*
+  adapter, merger, and SAT prune. **Flagship sim verdict
+  (48,366/48,366 revived, zero kit/fluid errors, 394 machines
+  working — the deepest measurement ever, 21 items)**: USP 0.84/2.00
+  at the ceiling, STILL CONVERGING (0.70→0.88 trend at cutoff),
+  attributed by time-series forensics to a SINGLE binding
+  constraint: copper-plate supply settles at ~70/s vs 99.7 planned
+  (−30%) — the #383 smelter-cell declared-bound class (PU4's plates
+  were −21%; USP@2's per-copy copper rates are higher). The oil
+  complex ran ABOVE plan early (PG 240/s vs 203 planned) and its
+  steady-state throttle is demand-coupled (LDS starves on copper →
+  plastic demand falls → refineries throttle); the 2
+  fluid-starved-census machines are the cracking plants during the
+  demand transition. Kill-3's escape clause SATISFIED: deficit
+  attributed to the named engine-wide solid bound solid chains
+  share; NO new fluid-specific deficit class. Not registered
+  (registry records measured PASS baselines); registers when #383's
+  template sizing lifts the bound. Phase C architecture verdict: the
+  uncropped approach SCALES to the advanced complex — the RFC's own
+  question, answered by measurement.*
 
 - *2026-07-24 (latest) — residual-18 diagnosis SHARPENED; one fix
   attempt made and REVERTED. The trunk emitter's silent

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -153,15 +153,17 @@ feeds and the composed layout must pass the pipe-isolation validators
   SPLITTER's second tile has no hostable position at all — the
   horizontal interactions (feed rows crossing neighbor columns) are
   already solved by the crossing zones; only the 2-tile splitter
-  entity is unresolvable by routing. Candidate fixes for the next
-  unit, in rough preference order: (a) lane planner gives interior
-  multi-tap solid lanes a free east neighbor column (pitch bump only
-  when a splitter tap will land — narrow blast radius vs global
-  pitch change); (b) splitter side-flip when exactly one neighbor
-  column is free; (c) tap strategy avoids splitter taps on
-  both-sides-blocked lanes (single-tap/direct arrangements);
-  (d) mouth-tile-aware bridging (the reverted approach hardened —
-  most machinery-entangled, least preferred). Merger unpaired-output
+  entity is unresolvable by routing. CORRECTION on candidate fixes:
+  ALL bus lanes are pitch-1 (`lane_planner` assigns x = i+1) and
+  main-line fixtures with splitter taps are CLEAN — so the
+  neighbor-trunk gap is normally bridged by the CROSSING-ZONE / SAT
+  machinery, and the (a)-(c) lane-geometry ideas are misdirected.
+  The real defect: the crossing zone at block-local rows 13 did not
+  cover/bridge the row-12 gap in the engine-unit trunk. Next probe
+  per the standing lesson: prune_dangling first (diff raw SAT output
+  vs sol.entities for that zone before theorising about
+  clustering/growth/encoder); then zone scoping (why the zone
+  excluded row 12). Merger unpaired-output
   at block-local (73,39) still separate and undiagnosed. Both
   reproduce standalone: compose_mega_block(USP@2 sub-solve, scale
   0.5) → 6 errors.*

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -168,19 +168,24 @@ feeds and the composed layout must pass the pipe-isolation validators
   result lines; re-verified from one clean invocation (the
   single-run-counts lesson generalizes to compile failures).
   Env-gated forensic tracing (SPAGHETTIO_MEGA_DEBUG) kept in the
-  adapter, merger, and SAT prune. **Flagship sim verdict
+  adapter and SAT prune (failure/prune paths only; the merger's
+  per-hop probe removed after use, #421 review). **Flagship sim verdict
   (48,366/48,366 revived, zero kit/fluid errors, 394 machines
   working — the deepest measurement ever, 21 items)**: USP 0.84/2.00
-  at the ceiling, STILL CONVERGING (0.70→0.88 trend at cutoff),
-  attributed by time-series forensics to a SINGLE binding
-  constraint: copper-plate supply settles at ~70/s vs 99.7 planned
-  (−30%) — the #383 smelter-cell declared-bound class (PU4's plates
-  were −21%; USP@2's per-copy copper rates are higher). The oil
-  complex ran ABOVE plan early (PG 240/s vs 203 planned) and its
-  steady-state throttle is demand-coupled (LDS starves on copper →
-  plastic demand falls → refineries throttle); the 2
-  fluid-starved-census machines are the cracking plants during the
-  demand transition. Kill-3's escape clause SATISFIED: deficit
+  at the ceiling, PRODUCED-rate trend still rising at cutoff
+  (0.70→0.88 over the final windows, from the produced-counter
+  deltas — the drained counters are flat and their window semantics
+  are unresolved, #421 review), attributed by time-series forensics
+  to copper-plate supply as the ROOT constraint: it settles at
+  ~70/s vs 99.7 planned (−30%) — the #383 smelter-cell
+  declared-bound class (PU4's plates were −21%; USP@2's per-copy
+  copper rates are higher). PG/EC deficits (−27%/−9%) read as
+  demand-coupled cascades of that root, not independent bounds: the
+  oil complex DEMONSTRATED capacity above plan during the buffer-fill
+  transient (PG 240/s vs 203 planned; steady state is below plan
+  under the throttled demand), and the 2 fluid-starved-census
+  machines are the cracking plants during the demand transition.
+  Single-root framing is the parsimonious read, not a proof. Kill-3's escape clause SATISFIED: deficit
   attributed to the named engine-wide solid bound solid chains
   share; NO new fluid-specific deficit class. Not registered
   (registry records measured PASS baselines); registers when #383's

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,32 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-24 (latest) — residual-18 diagnosis SHARPENED; one fix
+  attempt made and REVERTED. The trunk emitter's silent
+  `hard-tile continue` was bridged with in-segment South UG pairs —
+  scoped first to all hard tiles (regressed two e2e baselines:
+  downstream machinery like crossing zones owns some of those
+  skips), then to splitter-second-tiles only (still: mouths land on
+  tap rows/own hard tiles → asymmetric stamping → unpaired inputs;
+  PU@2-AM2 baseline stayed red; block errors shifted 6→8 not
+  improved). REVERTED cleanly — baselines green again. The sharpened
+  truth: at PITCH-1 trunks with trunks on BOTH sides, a tap-off
+  SPLITTER's second tile has no hostable position at all — the
+  horizontal interactions (feed rows crossing neighbor columns) are
+  already solved by the crossing zones; only the 2-tile splitter
+  entity is unresolvable by routing. Candidate fixes for the next
+  unit, in rough preference order: (a) lane planner gives interior
+  multi-tap solid lanes a free east neighbor column (pitch bump only
+  when a splitter tap will land — narrow blast radius vs global
+  pitch change); (b) splitter side-flip when exactly one neighbor
+  column is free; (c) tap strategy avoids splitter taps on
+  both-sides-blocked lanes (single-tap/direct arrangements);
+  (d) mouth-tile-aware bridging (the reverted approach hardened —
+  most machinery-entangled, least preferred). Merger unpaired-output
+  at block-local (73,39) still separate and undiagnosed. Both
+  reproduce standalone: compose_mega_block(USP@2 sub-solve, scale
+  0.5) → 6 errors.*
+
 - *2026-07-24 (later) — C3 LANDED, C2 LANDED, USP@2 composes
   end-to-end (2232×193, 48k entities — the largest layout ever
   composed); error ladder 71 → 44 → 27 → 18 through five fixes, each

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,37 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-24 (flagship) — **USP@2-from-raw COMPOSES AT ZERO ERRORS**
+  (2232×193, 48k entities; gate
+  `mega_chain_usp2_resolves_bus_failure`). The crossing-zone probe
+  resolved the residual 18 through three engine fixes: (1) tapoff
+  splitters SURVIVE zone release when an interior boundary anchors on
+  them — the #295 prose ("SAT models splitters as fixed structure and
+  never re-stamps them") was implemented for balancer segments only;
+  released-but-uncovered splitters were dropped by the Step-6 retain,
+  leaving the trunk hole (prune_dangling was probed FIRST per the
+  standing lesson and exonerated — its drops were other candidates'
+  tiles; the killer was the release/retain pair). Zones that route
+  AROUND a splitter (no interior boundary) keep the release,
+  byte-identical. (2) merger hops TIER-ESCALATE within the user's
+  belt cap (alternating blocked columns at 1-tile gaps are unhoppable
+  at yellow reach; the entrance conversion accepts any surface-belt
+  tier and refuses loudly-safely instead of mutating row machinery —
+  fulgora's latent case). (3) splitter-tap SPACERS are a
+  LayoutOptions opt-in set only by compose_mega_block: mega
+  sub-solves pack every trunk span from y=0 so tap splitters land on
+  live neighbor trunks and the zones don't bridge them; PU@2-AM2 and
+  EC35-from-ore have the same overlap but their zone machinery
+  bridges it and the spacer's geometry shift broke them — hence
+  opt-in, main-line byte-identical (the pitch-1 splitter-passthrough
+  class remains tracked here). Process note: an interim "suite green"
+  read was VOID — a test target failed to compile and printed no
+  result lines; re-verified from one clean invocation (the
+  single-run-counts lesson generalizes to compile failures).
+  Env-gated forensic tracing (SPAGHETTIO_MEGA_DEBUG) kept in the
+  adapter, merger, and SAT prune. Flagship sim run launched;
+  registry decision follows its verdict.*
+
 - *2026-07-24 (latest) — residual-18 diagnosis SHARPENED; one fix
   attempt made and REVERTED. The trunk emitter's silent
   `hard-tile continue` was bridged with in-segment South UG pairs —

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,45 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-24 — Phase C OPENED; the identity precondition is
+  DISCHARGED BY MEASUREMENT and it falsified the engine. Eight
+  single-refinery sim probes (A–H2: starve-vs-craft discrimination +
+  a pipe-contents census on dead-end stubs) measured the full port
+  identity table for advanced-oil-processing: recipe fluids bind
+  x-ASCENDING on the unmirrored refinery (water/crude in W→E;
+  heavy/light/PG out W→E — pure prototype box order) and x-DESCENDING
+  on the engine-mirrored (dir+8 exported) form (crude WEST + water
+  EAST; PG/light/heavy W→E) — the 180° rotation reverses port
+  x-order while identities stay glued to their boxes, exactly the
+  FFF #394 trap. The engine's ascending-always zip STARVED mirrored
+  refineries in-game (probe A). Fix: the placer reverses the fluid
+  list for mirrored rows (single-fluid sides reverse to themselves —
+  every registered fixture bit-identical, hash gate green);
+  `fluid_ports::port_fluid_assignment` is the shared measured rule
+  with a pin test; foundry/cryo inherit the geometric rule with the
+  refinery as measured anchor. The new tap arrangement immediately
+  flushed out a LATENT ROUTER BUG: horizontal fluid-branch bridging
+  mutated a previous hop's EXIT mouth into the next hop's entrance on
+  blocked-free-blocked patterns (pair destroyed, branch stitched onto
+  the foreign network west of it) — runs now cluster across 1-tile
+  gaps within reach, and the conversion guards on plain-pipe.
+  Harness: the multi-fluid-target report collapse fixed (checkpoint
+  scalar is first-target-only; fluid targets verdict on PRODUCED —
+  they have no drain rig). Frontier mapped (probe): lubricant targets
+  are fluid exports (composition refuses by design); FRF@0.5/1 bus is
+  CLEAN (no win there) but compose hits the C2 ascent-terminal
+  collision (terminal lands on a corr: row; refusal now names the
+  blocker); **USP@2 is the Phase C flagship — bus hard-fails
+  (belt-loop + underground-belt), the mega swallows the full oil
+  complex (10 members incl. BOTH oil processings + cracking +
+  lubricant, 4 solid exports, 5 chain-fed inputs)**, eligibility now
+  passes after C1 (multi-consumer export fan on the drain bypass row,
+  splitter-chain idiom, single-consumer path byte-identical), and the
+  remaining blocker is C3: the joint fluid planner cannot route
+  crude+water feeds on the 10-member block at either spacing. Named
+  increments: C2 (ascent congestion), C3 (adapter routing for the
+  advanced complex).*
+
 - *2026-07-24 — #411 adversarial review folds (APPROVE-WITH-NITS; both
   bus-refusal claims independently re-verified, retrofit guards probed
   and held, full battery re-run clean). Folds: (1) the chain-fed hop

--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -140,6 +140,39 @@ feeds and the composed layout must pass the pipe-isolation validators
 
 ## Decision log
 
+- *2026-07-24 (later) — C3 LANDED, C2 LANDED, USP@2 composes
+  end-to-end (2232×193, 48k entities — the largest layout ever
+  composed); error ladder 71 → 44 → 27 → 18 through five fixes, each
+  a named class: (1) fan splitter/branch columns dodge other drain
+  descents; (2) pole trio nudge learns its own placements; (3) the
+  OUTPUT MERGER had the same blocked-free-blocked pair-destroyer as
+  the ghost router's fluid bridging (second instance of the class —
+  runs now cluster across 1-tile gaps, mutation guards on plain
+  belts); (4) fan pass-through takes its own dodged column; (5) fan
+  branches descend via ALLOCATED lanes in slot pi+1 (lane_demand
+  sizes them) instead of ad-hoc splitter columns that collided
+  head-on with consumer ascents. REMAINING 18 = 6 × 3 copies, ALL
+  engine-internal to the mega sub-layout (not Phase-C machinery),
+  two bugs: (a) a trunk tap-off SPLITTER's second tile lands on the
+  adjacent pitch-1 trunk column; the neighbor lane SKIPS that hard
+  tile but emits no UG bridge across the skip (a crossing zone paves
+  one row; the dangling surface belts feed the foreign splitter →
+  items mix). Suspect: the trunk segmenter treats a FOREIGN
+  splitter tile like an own-tap row (flow-through), but foreign
+  splitters don't pass a different item — the skip needs a bridge.
+  Block-local (4,12)/(5,11..13), trunk:engine-unit vs
+  tapoff:iron-plate. (b) merger unpaired UG output at block-local
+  (73,39) (east, no matching input) beside the electric-engine-unit
+  merger run. Both reproduce standalone via compose_mega_block on
+  the USP@2 sub-solve at scale 0.5 (debug_usp_block example,
+  gitignored). C3's landed machinery: PTG spans stopped blocking
+  surface crossings (span map, same-axis-only interference); fluid
+  head slots dodge foreign fluid columns as retry rung 2/4;
+  un-hoppable chain-fed clusters vertical-retrofit every column;
+  entry mouth may sit at the west-edge entry tile; +1 margin row for
+  cf blocks. C2: ascent-terminal retrofit generalizes to corr:/fan
+  rows both directions.*
+
 - *2026-07-24 — Phase C OPENED; the identity precondition is
   DISCHARGED BY MEASUREMENT and it falsified the engine. Eight
   single-refinery sim probes (A–H2: starve-vs-craft discrimination +

--- a/scripts/probe_refinery_fluidbox_identity.py
+++ b/scripts/probe_refinery_fluidbox_identity.py
@@ -1,0 +1,26 @@
+# Phase C precondition probe (#411 follow-on): per-fluidbox IDENTITY for
+# oil-refinery under advanced-oil-processing. Which port position gets
+# which fluid, per the prototype's fluid_boxes order + the recipe's
+# ingredient/product order — the raw data our engine's fluid_ports table
+# and the mirror-as-rotation export must agree with (FFF #394 class).
+from draftsman.data import entities, recipes
+
+e = entities.raw["oil-refinery"]
+print("=== oil-refinery fluid_boxes (prototype order) ===")
+fbs = e.get("fluid_boxes") or []
+for i, fb in enumerate(fbs):
+    conns = fb.get("pipe_connections", [])
+    io = fb.get("production_type")
+    filt = fb.get("filter")
+    for c in conns:
+        print(f"  box[{i}] {io:8} filter={filt} pos={c.get('position')} dir={c.get('direction')}")
+
+r = recipes.raw["advanced-oil-processing"]
+print("\n=== advanced-oil-processing recipe order ===")
+print("  ingredients:", [(i.get("name"), i.get("type")) for i in r["ingredients"]])
+print("  results:    ", [(p.get("name"), p.get("type")) for p in r["results"]])
+
+r2 = recipes.raw["basic-oil-processing"]
+print("\n=== basic-oil-processing (control) ===")
+print("  ingredients:", [(i.get("name"), i.get("type")) for i in r2["ingredients"]])
+print("  results:    ", [(p.get("name"), p.get("type")) for p in r2["results"]])


### PR DESCRIPTION
## Intent

RFC-052 Phase C: extend mega-cell composition to the advanced-oil complex (advanced-oil-processing + cracking + lubricant). Flagship: **utility-science-pack@2 from fully raw inputs composes at zero errors where the bus hard-fails** — the full oil complex (both oil processings, cracking, lubricant, 4 fanned solid exports, 5 chain-fed inputs) as one mega block inside a 48k-entity chain, the largest layout the project has produced.

## Scope

- **In (precondition, sim-measured)**: fluid port IDENTITY — eight single-refinery probes measured that recipe fluids bind x-ascending on the unmirrored refinery and **x-descending on the (dir+8)-exported mirrored form** (crude WEST + water EAST in; PG/light/heavy W→E out). The engine's ascending-always zip starved mirrored refineries in-game. Placer reverses the fluid zip for mirrored rows (single-fluid sides reverse to themselves — registered fixtures bit-identical); `fluid_ports::port_fluid_assignment` is the shared measured rule with a pin test.
- **In (engine fixes, each sim/probe-driven)**:
  - Ghost router: horizontal fluid-branch bridging clustered across 1-tile gaps + plain-pipe conversion guard (blocked-free-blocked patterns destroyed the previous hop's exit mouth, stitching the branch onto the foreign network).
  - Output merger: same pair-destroyer class fixed (second instance); hop mouths **tier-escalate within the user's belt cap** (alternating blocked columns are unhoppable at yellow reach); entrance conversion accepts any surface-belt tier and refuses loudly-safely instead of mutating row machinery.
  - **Tapoff splitters survive zone release when an interior boundary anchors on them** — #295's "SAT models splitters as fixed structure" prose was only implemented for balancers; released-but-uncovered splitters left trunk holes (`prune_dangling` probed first per the standing lesson and exonerated). Zones routing around a splitter keep the release, byte-identical.
  - Splitter-tap spacers as a `LayoutOptions` opt-in set only by `compose_mega_block` (mega sub-solves pack every span from y=0; two main-line fixtures bridge the same overlap via zones and broke under the geometry shift — main-line stays byte-identical).
  - Multi-fluid report fix in the sim harness (first-target-only checkpoint; fluid targets verdict on produced) + `is_fluid` on manifest targets.
- **In (Phase C adapter/chain)**: PTG underground spans no longer block surface crossings (span map, same-axis-only interference); fluid head slots dodge foreign fluid columns as a retry rung; un-hoppable chain-fed clusters vertical-retrofit every column; west-edge entry mouths; +1 margin row for chain-fed blocks; C1 multi-consumer export fan (splitter chain on the drain bypass row, branches descend via allocated next-slot lanes); C2 ascent-terminal retrofit generalized to corridor rows; eligibility refusal lifted.
- **Out**: registry entries for USP@2 (measures 0.84/2.00 — see Verification — until #383 lifts the copper bound); lubricant-as-target (fluid export, refused by design); the pitch-1 splitter-passthrough class in main-line configs (zone-bridged today, tracked in the decision log).

## Verification

- [x] Full suite green — **one clean invocation, 17/17 suites, 0 failed** (an interim "green" scan was VOID: a test target failed to compile and printed no result lines; caught and recorded)
- [x] Registry hash gate green throughout (all fixtures bit-identical; the spacer/preserve/zip changes never fire for registered geometry)
- [x] Stress goldens: drift = exactly the known #406 six
- [x] Gates: `mega_chain_usp2_resolves_bus_failure` (advanced complex + multi-export + chain-fed asserted; 0 errors), PU@4 + chem5 gates keep passing; identity pin test `port_identity_matches_sim_measured_truth`
- [x] clippy clean; WASM builds (boundary field added)
- [x] Browser: composed candidate selected for USP@2 — 2247×194, 48,461 entities, 0 errors / 49 warnings (screenshot with session owner)
- [x] **Identity probes (8 sim runs)**: starve-vs-craft discrimination + tile-level fluid census on dead-end stubs; measured truth table in the RFC decision log
- [x] **Flagship sim**: 48,366/48,366 revived, zero kit/fluid errors, 394 machines working, 21 items measured. USP 0.84/2.00 at the ceiling, still converging (0.70→0.88 trend). Time-series attribution: single binding constraint = copper-plate supply −30% (#383 smelter declared-bound class; PU4's plates were −21%); the oil complex ran ABOVE plan early (PG 240/s vs 203) and throttles demand-coupled. Kill-3's escape clause satisfied: named engine-wide solid bound, no new fluid-specific class.

## Deviations from intent

The Phase C "layout question" (does the uncropped approach scale to 3-fluid-output geometry?) resolved YES, but most of the work was elsewhere: the precondition falsified the engine's port identity, and the flagship flushed out three latent engine bug classes (pair-destroyer ×2, splitter release/retain hole) that main-line geometry never triggers. One fix attempt (trunk-emitter hard-tile bridging) was made and REVERTED after it regressed baselines — the decision log records both approaches.

## Models / contracts touched

`fluid_ports` gains the measured identity rule (pin test); `LayoutOptions` gains `splitter_tap_spacers`; manifest targets gain `is_fluid` (serde default false — all existing manifests unaffected); RFC-052 decision log carries the full evidence trail. `factorio-mechanics.md` unchanged (the identity rule lives at the fluid_ports contract layer; F-rules already cover the mechanics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55