### PR TITLE
fix(cells): #415 — thread inserter_capacity into chain-composed cells

### DIFF
--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -627,6 +627,18 @@ pub fn compose_chain_with_capacity(
     // take mega_plan = None and every branch below is bit-identical to
     // the pre-Phase-B placer (the registry gate enforces it).
     let mega_plan = super::mega::mega_subgraph(sr)?;
+    // #415 stop-gap (#422 review finding 1): the mega bootstrap
+    // (`mega.rs` generate path) does not yet thread capacity — a
+    // mega-containing chain at L>0 would size its solid cells at the
+    // declared level but its mega interior at L0, then DECLARE the
+    // whole layout at L>0. Refuse loudly instead of declaring a mixed
+    // world; threading the mega path is the recorded follow-up that
+    // unblocks this.
+    if inserter_capacity != 0 && mega_plan.is_some() {
+        return Err(format!(
+            "declared inserter capacity L{inserter_capacity} is not yet threaded into              mega-cell interiors (#415 follow-up) — refusing a mixed-world declaration"
+        ));
+    }
     const MEGA_PREFIX: &str = "mega:";
 
     let produced: FxHashSet<&str> = sr

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -26,7 +26,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use crate::models::{BoundaryRecord, EntityDirection, LayoutResult, PlacedEntity, SolverResult};
 
-use super::extract::{extract_cell, generate_cell_layout, Cell, Port};
+use super::extract::{extract_cell, Cell, Port};
 use super::compose::stamp_path;
 
 /// Feed columns need >=4 tiles of lateral separation (#363: sim-kit
@@ -609,6 +609,16 @@ fn retrofit_feed_hop(
 /// (calibrated orientation: north feeds, south drains, west→east
 /// record order — #363).
 pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
+    compose_chain_with_capacity(sr, 0)
+}
+
+/// `compose_chain` with the declared inserter-capacity level threaded to
+/// every member cell's generation (#415). Capacity 0 is byte-identical
+/// to `compose_chain` by construction.
+pub fn compose_chain_with_capacity(
+    sr: &SolverResult,
+    inserter_capacity: u8,
+) -> Result<LayoutResult, String> {
     chain_eligible(sr)?;
     let kq = required_copies(sr);
     let scale = 1.0 / kq as f64;
@@ -796,7 +806,7 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
                     });
                 } else {
                     let input_names: Vec<&str> = m.inputs.iter().map(|i| i.item.as_str()).collect();
-                    let (_csr, cl) = generate_cell_layout(&out_item, rate, &input_names);
+                    let (_csr, cl) = super::extract::generate_cell_layout_with_capacity(&out_item, rate, &input_names, inserter_capacity);
                     cell_cache.push(extract_cell(&cl));
                 }
             }
@@ -1339,6 +1349,9 @@ pub fn compose_chain(sr: &SolverResult) -> Result<LayoutResult, String> {
         width,
         height,
         stacking: 1,
+        // The composed layout DECLARES the capacity its cells were sized
+        // at — registry world-matching (`verification_note`) reads this.
+        inserter_capacity,
         boundary_inputs: {
             let mut b = b_in;
             b.sort_by_key(|r| r.x); // west→east (#363 rig-depth rule)

--- a/crates/core/src/bus/cells/extract.rs
+++ b/crates/core/src/bus/cells/extract.rs
@@ -23,6 +23,23 @@ pub fn generate_cell_layout(
     rate: f64,
     inputs: &[&str],
 ) -> (crate::models::SolverResult, LayoutResult) {
+    generate_cell_layout_with_capacity(item, rate, inputs, 0)
+}
+
+/// `generate_cell_layout` with the caller's declared inserter-capacity
+/// research level threaded through (#415): without this the chain path
+/// always sized cells at L0 and #381's ladder was structurally inert on
+/// composed layouts (#383's measured input bound). Capacity 0 is
+/// byte-identical to the plain fn by construction (registry gate
+/// enforces). Follow-up audit (#415): quality / max inserter tier are
+/// plausibly placement-relevant too — extend deliberately, with the
+/// same L0-bit-identity discipline, when a measurement needs them.
+pub fn generate_cell_layout_with_capacity(
+    item: &str,
+    rate: f64,
+    inputs: &[&str],
+    inserter_capacity: u8,
+) -> (crate::models::SolverResult, LayoutResult) {
     let inputs: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
         item,
@@ -40,6 +57,7 @@ pub fn generate_cell_layout(
     // overflow the moment the default flipped).
     let opts = layout::LayoutOptions {
         cell_composition: super::CellComposition::Off,
+        inserter_capacity,
         ..Default::default()
     };
     let l = layout::build_bus_layout(&sr, opts)

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -156,7 +156,7 @@ impl DecompositionCandidate for CellComposedCandidate {
                 ));
             }
         }
-        let mut l = crate::bus::cells::chain::compose_chain(solver_result)?;
+        let mut l = crate::bus::cells::chain::compose_chain_with_capacity(solver_result, opts.inserter_capacity)?;
         // Self-validate before competing: `score_layout.accepted` never
         // runs the full validator, so an error-laden composition that
         // "wins" on a bus refusal would reach real callers as a

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -480,6 +480,36 @@ fn probe_registry_hashes() {
 /// measurement time). The fix when it fires: re-run the sim on the new
 /// geometry, then update the hash + measurement in
 /// cell-sim-registry.json.
+/// #415: the declared inserter-capacity level must actually REACH the
+/// composed cells' placer. L0 stays byte-identical to `compose_chain`
+/// (the registry gate enforces that side); a nonzero level must change
+/// the geometry — #381's ladder sizes hands differently — or the option
+/// silently died on the way down again (#383's original symptom: d1/d7
+/// fixtures with byte-identical blueprints).
+#[test]
+fn chain_capacity_reaches_the_placer() {
+    use spaghettio_core::bus::cells::chain::{compose_chain, compose_chain_with_capacity};
+    use spaghettio_core::bus::cells::registry::geometry_hash;
+    let inputs: FxHashSet<String> =
+        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "electronic-circuit", 15.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let l0 = compose_chain(&sr).unwrap();
+    let l0_explicit = compose_chain_with_capacity(&sr, 0).unwrap();
+    assert_eq!(
+        geometry_hash(&l0), geometry_hash(&l0_explicit),
+        "capacity 0 must be byte-identical to the plain path"
+    );
+    let l7 = compose_chain_with_capacity(&sr, 7).unwrap();
+    assert_eq!(l7.inserter_capacity, 7, "composed layout must declare its capacity");
+    assert_ne!(
+        geometry_hash(&l0), geometry_hash(&l7),
+        "declared L7 must change composed geometry (ladder-resized hands) —          identical hashes mean the option died on the way to the placer again (#383)"
+    );
+}
+
 #[test]
 fn cell_registry_hashes_current() {
     use spaghettio_core::bus::cells::chain::compose_chain;

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -510,6 +510,23 @@ fn chain_capacity_reaches_the_placer() {
     );
 }
 
+/// #422 review finding 1: mega-containing chains must REFUSE nonzero
+/// declared capacity until the mega bootstrap threads it too — an L7
+/// declaration over an L0-sized mega interior is a mixed-world lie.
+#[test]
+fn mega_chain_refuses_nonzero_capacity() {
+    use spaghettio_core::bus::cells::chain::compose_chain_with_capacity;
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore", "crude-oil", "water", "coal"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "advanced-circuit", 2.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let err = compose_chain_with_capacity(&sr, 7).expect_err("mixed world must refuse");
+    assert!(err.contains("mega-cell interiors"), "refusal must cite the gap: {err}");
+    compose_chain_with_capacity(&sr, 0).expect("L0 mega chain still composes");
+}
+
 #[test]
 fn cell_registry_hashes_current() {
     use spaghettio_core::bus::cells::chain::compose_chain;


### PR DESCRIPTION
## Intent

Close #415: the declared inserter-capacity level never reached the placer for chain-composed cells (`generate_cell_layout` hardcoded defaults), leaving #381's ladder structurally inert on that path — the root of #383's immovable input bound.

## Scope

- **In:** additive `generate_cell_layout_with_capacity` / `compose_chain_with_capacity` (plain fns delegate with 0 — byte-identical by construction, zero churn for the active cell stream's callers); `CellComposedCandidate` passes `opts.inserter_capacity`; composed `LayoutResult` declares its capacity (registry `verification_note` world-matching reads it); in-code follow-up note for the quality/tier audit.
- **Out:** the mega composer's own bootstrap path (fluid interiors — deliberate follow-up, same discipline); the EC-row output ceiling (#383's other half).

## Verification

- [x] `chain_capacity_reaches_the_placer` pins both directions: capacity 0 hash-identical to the plain path, capacity 7 changes geometry AND is declared — identical hashes would mean the option died on the way down again (#383's original symptom).
- [x] Registry gate green (L0 bit-identity of all registered chains holds).
- [x] Full pinned suite: 17/17 targets ok (lib 838/0, cell_composition 15/0, e2e 61/0); pin restored. Clippy `-D warnings` clean.
- Next real-world step (post-merge, noted on #383): regenerate the chain-ec fixtures at d1/d7 — they should now differ — and re-measure in the sim to isolate the output-ceiling half cleanly.

## Deviations from intent

None.

## Models / contracts touched

Chain-composed geometry for nonzero-capacity worlds only (the point); L0 worlds provably unchanged. Session-side adversarial review dispatched per layout-engine rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)