### PR TITLE
RFC-052 close-out: status Landed + ledger entry

### DIFF
--- a/docs/rfc-052-oil-mega-cell.md
+++ b/docs/rfc-052-oil-mega-cell.md
@@ -1,6 +1,6 @@
 # RFC-052: Oil mega-cells — fluid subgraphs as uncropped composed units
 
-**Status**: Design (circulated for review)
+**Status**: Landed (Phases A/B/C delivered; close-out 2026-07-24 — see the status ledger and the decision log's close-out entry)
 
 ## Summary
 
@@ -139,6 +139,27 @@ feeds and the composed layout must pass the pipe-isolation validators
   Own go/no-go on Phase A/B evidence.
 
 ## Decision log
+
+- *2026-07-24 — CLOSE-OUT (#421 merged). All three phases delivered;
+  every kill criterion resolved without firing: (1)
+  generic-attachment held — the mega attaches through boundary
+  records, the generic corridor machinery, and the (new) fan/west-
+  entry idioms, no per-recipe hand-composition; (2) value-existence
+  proven three times over (chem5, PU@4, USP@2 — each composes 0
+  errors where the bus hard-fails, permanently gated); (3) sim-gate
+  escape clause satisfied at every rung — deficits attribute to the
+  #383 solid declared-bound class shared with solid chains, and NO
+  fluid-specific deficit class ever appeared (kit and fluid errors
+  empty in every measurement); (4) isolation clean on every composed
+  fixture. Registration of chem5/PU4/USP2 waits on #383 lifting the
+  smelter bound (registry records measured PASS baselines).
+  Remaining tracked threads: #423 (pitch-1 splitter-passthrough —
+  the one engine class Phase C worked AROUND rather than through),
+  #409 landed independently and the flagship re-verified against it,
+  and the harness drained-counter window semantics oddity noted in
+  the #421 review. Phase C's answer to the RFC's own question: the
+  uncropped approach scales to the advanced complex, by
+  measurement.*
 
 - *2026-07-24 (flagship) — **USP@2-from-raw COMPOSES AT ZERO ERRORS**
   (2232×193, 48k entities; gate

--- a/docs/status.md
+++ b/docs/status.md
@@ -127,6 +127,26 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 
 ## Recent RFC close-outs
 
+**`rfc-052-oil-mega-cell.md` close-out (2026-07-24, Phases A/B/C —
+PRs #401/#403/#405/#408/#411/#421)**: fluid subgraphs compose as
+UNCROPPED mega-cells inside solid chains. Delivered: the first
+working refineries in project history (#400's three stacked defects),
+the game-faithful pipe-UG reach model (#407: entity-distance 10, not
+gap 10 — sim-falsified), sim-measured fluid PORT IDENTITY (mirrored
+refineries bind fluids x-DESCENDING; the old ascending zip starved
+them in-game — FFF #394 class, pin-tested), chain-fed mega inputs,
+multi-consumer export fans, and three latent engine-bug classes fixed
+(hop pair-destroyer ×2, tapoff release/retain hole). Bus-refusal wins
+gated at chem-pack@5, PU@4, USP@2 (each composes 0 errors where the
+bus hard-fails; USP@2 = 48k entities, the largest layout produced).
+Sim evidence: plastic/sulfur/AC-from-raw PASS and registered; PU@4
+and USP@2 measured end-to-end (deepest chains ever run — zero
+kit/fluid errors) with deficits attributed to the #383 smelter
+declared-bound class; they register when #383 lifts. Tracked
+follow-ups: #383 (bound lift), #409 (landed independently), #423
+(pitch-1 splitter-passthrough). Full trail:
+[`rfc-052-oil-mega-cell.md`](rfc-052-oil-mega-cell.md) decision log.
+
 **`rfc-inserter-sizing.md` close-out (2026-07-13)**: bus inserters sized to
 planned per-machine throughput via a shared regular→fast→stack ladder
 (long-handed count-ladder for reach-2 sides), with an ingredient-to-belt


### PR DESCRIPTION
## Intent

Docs-only close-out for RFC-052 after #421: RFC status → Landed, kill-criteria resolution recorded in the decision log, cross-cutting ledger entry in docs/status.md.

## Scope / Verification / Deviations

Docs-only (two files); no code, no tests to run. Trivial-PR sections omitted per template guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55