### PR TITLE
fix(parser): #349 — version-aware legacy blueprint direction parsing

### DIFF
--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -52,6 +52,14 @@ struct BpData {
     wires: Vec<Vec<i64>>,
     #[serde(default)]
     label: Option<String>,
+    /// Factorio's packed version u64 — four 16-bit fields (major, minor,
+    /// patch, dev), most significant first. Distinguishes pre-2.0 8-way
+    /// direction encoding from 2.0+'s 16-way (#349). `#[serde(default)]`
+    /// gives 0 for blueprints that omit the field entirely; see
+    /// `blueprint_major_version` for why that's treated as "modern" rather
+    /// than a real major-0 version.
+    #[serde(default)]
+    version: u64,
 }
 
 /// Parsed module item. All three Factorio formats collapse into this.
@@ -275,19 +283,40 @@ fn entity_footprint(name: &str, direction: EntityDirection) -> (i32, i32) {
 
 // ---- Direction parsing ----
 
-/// Map Factorio direction integer to EntityDirection.
+/// Decode the major version component from Factorio's packed blueprint
+/// `version` u64: four 16-bit fields (major, minor, patch, dev), most
+/// significant first (major in the high bits).
 ///
-/// Modern Factorio (≥0.17) uses 0/4/8/12 for N/E/S/W.
-/// Older versions (0-7 eight-way): 0=N, 2=E, 4=S, 6=W.
-/// We handle both by treating even values in 0-6 range as old-format
-/// and values 8/12 as unambiguously modern.
-fn parse_direction(d: u8) -> EntityDirection {
+/// Real Factorio versions always have a nonzero low 48 bits — even pre-1.0
+/// releases like 0.17.79 carry a nonzero minor — so a literal packed `0` is
+/// never a genuine version. That value is what `#[serde(default)]` produces
+/// for a blueprint with no `version` key at all, so it's reserved as an
+/// "absent" sentinel (`None`) rather than decoded as a real major-0 version.
+fn blueprint_major_version(packed: u64) -> Option<u16> {
+    if packed == 0 {
+        None
+    } else {
+        Some((packed >> 48) as u16)
+    }
+}
+
+/// Map Factorio direction integer to EntityDirection, version-aware (#349).
+///
+/// Factorio < 2.0 blueprints encode direction 8-way: 0=N, 2=E, 4=S, 6=W.
+/// 2.0+ encodes 16-way: 0=N, 4=E, 8=S, 12=W. Raw `4` is the ambiguous case
+/// — South under the legacy encoding, East under the modern one — which is
+/// what this issue is about; `is_legacy` disambiguates it. Raw `2`/`6` are
+/// decoded as East/West unconditionally: they only appear as legacy
+/// cardinals for the entity kinds this parser handles (2.0 buildings that
+/// don't support diagonal placement — belts, inserters, machines — only
+/// ever emit multiples of 4), so there's no modern case to conflict with.
+fn parse_direction(d: u8, is_legacy: bool) -> EntityDirection {
     match d {
         0 => EntityDirection::North,
+        4 if is_legacy => EntityDirection::South,
         4 => EntityDirection::East,
-        8 => EntityDirection::South,
-        12 => EntityDirection::West,
-        // Old 8-way format
+        8 if !is_legacy => EntityDirection::South,
+        12 if !is_legacy => EntityDirection::West,
         2 => EntityDirection::East,
         6 => EntityDirection::West,
         _ => EntityDirection::North,
@@ -339,6 +368,11 @@ fn decode_bp_string(bp: &str) -> Result<BpRoot, String> {
 /// Convert a `BpData` to a `LayoutResult`, normalizing positions to (0,0).
 fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
     let wires_raw = bp_data.wires;
+    // #349: < 2.0 blueprints (including major-0 pre-1.0 releases) use the
+    // legacy 8-way direction encoding; a missing version field (packed 0,
+    // see `blueprint_major_version`) fails toward "modern" to keep prior
+    // behavior for blueprints that don't carry a version at all.
+    let is_legacy = matches!(blueprint_major_version(bp_data.version), Some(major) if major < 2);
     let mut entities: Vec<PlacedEntity> = Vec::with_capacity(bp_data.entities.len());
     // entity_number (explicit, else positional 1-based) → 0-based index in
     // `entities`, so the `wires` array can be resolved to entity indices.
@@ -356,7 +390,7 @@ fn bp_data_to_layout(bp_data: BpData) -> LayoutResult {
         // raw-byte arithmetic would destroy legacy v0/v1 8-way values
         // (E=2/W=6 both landed on the catch-all) and could overflow on
         // garbage bytes (PR #348 review).
-        let parsed = parse_direction(raw.direction);
+        let parsed = parse_direction(raw.direction, is_legacy);
         // Pipe-to-ground shares the flip (#364): game direction is the
         // surface-opening side, engine convention is the underground side.
         // Mirrored fluid machines share it too (#400): the engine's
@@ -658,6 +692,125 @@ mod tests {
         assert_eq!(parsed.entities[0].direction, EntityDirection::West);
         assert_eq!(parsed.entities[1].direction, EntityDirection::East);
         assert_eq!(parsed.entities[2].direction, EntityDirection::East);
+    }
+
+    /// #349: packed-`version` u64 decode. Real released version constants —
+    /// 1.1.104 (final 1.1 stable, major 1) and 2.0.28 (a 2.0 stable, major
+    /// 2) — built from the documented (major, minor, patch, dev) packing
+    /// rather than hand-computed magic numbers. The all-zero packed value
+    /// is reserved as the "field absent" sentinel and must decode to
+    /// `None`, not a real major-0 version.
+    #[test]
+    fn blueprint_major_version_decodes_packed_u64() {
+        let v1_1_104 = (1u64 << 48) | (1u64 << 32) | (104u64 << 16);
+        let v2_0_28 = (2u64 << 48) | (28u64 << 16);
+        assert_eq!(blueprint_major_version(v1_1_104), Some(1));
+        assert_eq!(blueprint_major_version(v2_0_28), Some(2));
+        assert_eq!(
+            blueprint_major_version(0),
+            None,
+            "packed 0 is the serde-default sentinel for a missing version field, not a real 0.0.0.0 version"
+        );
+    }
+
+    /// #349: raw direction `4` is ambiguous between the legacy 8-way (South)
+    /// and modern 16-way (East) encodings. A blueprint carrying an explicit
+    /// pre-2.0 `version` must decode it as South.
+    #[test]
+    fn legacy_v1_raw4_direction_is_south() {
+        let legacy_version = (1u64 << 48) | (1u64 << 32) | (104u64 << 16);
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "version": legacy_version,
+                "entities": [
+                    {"entity_number": 1, "name": "transport-belt",
+                     "position": {"x": 0.5, "y": 0.5}, "direction": 4},
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.entities[0].direction, EntityDirection::South);
+    }
+
+    /// #349: the same raw `4`, but under an explicit 2.0+ `version`, must
+    /// decode as East (16-way) — the modern corpus must not regress.
+    #[test]
+    fn modern_v2_raw4_direction_is_east() {
+        let modern_version = (2u64 << 48) | (28u64 << 16);
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "version": modern_version,
+                "entities": [
+                    {"entity_number": 1, "name": "transport-belt",
+                     "position": {"x": 0.5, "y": 0.5}, "direction": 4},
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.entities[0].direction, EntityDirection::East);
+    }
+
+    /// #349: a blueprint with no `version` key at all must fail toward the
+    /// pre-fix (modern) behavior — raw 4 = East — rather than being treated
+    /// as a legacy major-0 version. Byte-identical to the pre-#349 result
+    /// for the large slice of the corpus (and every synthetic fixture in
+    /// this file) that never set `version`.
+    #[test]
+    fn missing_version_field_treated_as_modern() {
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "entities": [
+                    {"entity_number": 1, "name": "transport-belt",
+                     "position": {"x": 0.5, "y": 0.5}, "direction": 4},
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.entities[0].direction, EntityDirection::East);
+    }
+
+    /// #349: a genuinely pre-1.0 version (major 0, e.g. 0.17.79) is still
+    /// legacy 8-way — must NOT be confused with the packed-0 "absent"
+    /// sentinel, since its packed value is nonzero (minor/patch bits set).
+    #[test]
+    fn pre_1_0_major_zero_version_is_still_legacy() {
+        let v0_17_79 = (17u64 << 32) | (79u64 << 16);
+        assert_eq!(blueprint_major_version(v0_17_79), Some(0));
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "version": v0_17_79,
+                "entities": [
+                    {"entity_number": 1, "name": "transport-belt",
+                     "position": {"x": 0.5, "y": 0.5}, "direction": 4},
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.entities[0].direction, EntityDirection::South);
+    }
+
+    /// #349: the version-aware South decode composes correctly with the
+    /// separate pickup→drop inserter flip (#348) — legacy South pickup
+    /// flips to North drop-side, not the pre-fix East-turned-West.
+    #[test]
+    fn legacy_inserter_raw4_flips_after_version_aware_south_decode() {
+        let legacy_version = (1u64 << 48) | (1u64 << 32) | (104u64 << 16);
+        let bp = encode_envelope(&serde_json::json!({
+            "blueprint": {
+                "item": "blueprint",
+                "version": legacy_version,
+                "entities": [
+                    {"entity_number": 1, "name": "inserter",
+                     "position": {"x": 0.5, "y": 0.5}, "direction": 4},
+                ]
+            }
+        }));
+        let parsed = parse_blueprint_string(&bp).expect("should parse");
+        assert_eq!(parsed.entities[0].direction, EntityDirection::North);
     }
 
     /// #400/#403: the mirror-as-rotation wire encoding COLLIDES with a


### PR DESCRIPTION
## Intent

Closes #349. `parse_direction()` in `crates/core/src/blueprint_parser.rs`
treated raw direction `4` as 16-way East unconditionally, but blueprints
from Factorio < 2.0 encode direction 8-way, where `4` = South. Found
during the PR #348 review — 272 of 338 corpus files are affected, causing
belts and other entities to parse rotated on import.

## Scope

- **In:** Deserialize the blueprint's packed `version` u64 onto `BpData`
  (`#[serde(default)]`, so a missing field is `0`). Decode its major
  component (`blueprint_major_version`) and make `parse_direction` branch
  on it: major < 2 → legacy 8-way (raw `4` = South), major ≥ 2 → modern
  16-way (raw `4` = East, unchanged). A missing/all-zero version fails
  toward "modern" — the pre-#349 behavior — since a genuinely all-zero
  packed u64 never occurs in a real Factorio version (even 0.17.x has
  nonzero minor bits), so `0` is safe to use as an "absent" sentinel
  distinct from a real major-0 (pre-1.0) version, which is still legacy.
- **Out:** Raw `2`/`6` stay unconditionally East/West — they only ever
  appear as legacy 8-way cardinals for the entity kinds this parser
  handles (belts, inserters, machines never emit non-multiples-of-4 in
  16-way, since they don't support diagonal placement), so there's no
  modern case they'd need disambiguating from.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — full pinned
      suite (`SPAGHETTIO_ZONE_CACHE_PATH` pointed at
      `crates/core/data/sat-zones-ci.bin`, restored after): 842 lib tests
      + 61 e2e tests + all other integration suites, all green, 0
      failures. Added 6 new unit tests to `blueprint_parser.rs`:
      `blueprint_major_version_decodes_packed_u64`,
      `legacy_v1_raw4_direction_is_south`,
      `modern_v2_raw4_direction_is_east`,
      `missing_version_field_treated_as_modern`,
      `pre_1_0_major_zero_version_is_still_legacy`,
      `legacy_inserter_raw4_flips_after_version_aware_south_decode`
      (checks composition with the separate #348 pickup→drop flip).
- [x] `cargo clippy -p spaghettio_core -- -D warnings` (the exact
      pre-commit-hook/CI invocation) — clean.
- [ ] WASM rebuild + browser eyeball — not done; this is a pure parser
      change with no layout-engine involvement, exercised by the corpus
      browser/blueprint-analyze path rather than the solve→layout
      pipeline.

## Deviations from intent

None.

## Models / contracts touched

None — internal to `blueprint_parser.rs`'s import path; no exported
contract or doc changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7TFG8si9QxRz6FrMmMnrp