### PR TITLE
fix(export): #351 — exporter entity_size lacks the parser's non-machine multi-tile entities

### DIFF
--- a/crates/core/src/blueprint_parser.rs
+++ b/crates/core/src/blueprint_parser.rs
@@ -237,40 +237,20 @@ struct BpPosition {
 
 /// Returns (width_tiles, height_tiles) for entities that aren't 1×1.
 /// Direction is needed for splitters (2 tiles perpendicular to flow).
+///
+/// Delegates entirely to `common::entity_size` (machines, poles, and the
+/// #351 non-machine multi-tile table) plus `common::oriented_splitter_dims`
+/// for the direction-dependent splitter family — the single shared source
+/// both this parser and the blueprint exporter consult, so the two can no
+/// longer drift apart the way they did before #351 (parser knew beacon/lab/
+/// storage-tank/electric-mining-drill/steel-furnace/rocket-silo/crusher/
+/// biolab as multi-tile; the exporter treated them all as 1×1).
 fn entity_footprint(name: &str, direction: EntityDirection) -> (i32, i32) {
-    match name {
-        "assembling-machine-1"
-        | "assembling-machine-2"
-        | "assembling-machine-3"
-        | "chemical-plant"
-        | "electric-furnace"
-        | "centrifuge"
-        | "lab"
-        | "beacon"
-        | "storage-tank"
-        | "electric-mining-drill"
-        | "biochamber" => (3, 3),
-
-        "oil-refinery" | "foundry" | "biolab" | "cryogenic-plant" => (5, 5),
-        "rocket-silo" => (9, 9),
-        "big-electric-pole" | "substation" | "steel-furnace" => (2, 2),
-        "electromagnetic-plant" => (4, 4),
-        "recycler" => (2, 4),
-        "crusher" => (2, 3),
-
-        // Splitters: 2 tiles wide perpendicular to flow direction. The
-        // shared helper covers turbo-splitter too (115 corpus instances
-        // were misparsed half a tile off before PR #350's review caught
-        // the exporter/parser table divergence) and correctly excludes
-        // the 1×1 lane-splitter.
-        "splitter" | "fast-splitter" | "express-splitter" | "turbo-splitter" => {
-            let (w, h) = crate::common::oriented_splitter_dims(name, direction)
-                .expect("splitter family covered by oriented_splitter_dims");
-            (w as i32, h as i32)
-        }
-
-        _ => (1, 1),
+    if let Some((w, h)) = crate::common::oriented_splitter_dims(name, direction) {
+        return (w as i32, h as i32);
     }
+    let (w, h) = crate::common::entity_size(name);
+    (w as i32, h as i32)
 }
 
 // ---- Direction parsing ----
@@ -1134,5 +1114,46 @@ mod tests {
         assert_eq!(machine.items[2].item, "speed-module");
         assert_eq!(machine.items[2].count, 1);
         assert_eq!(machine.items[2].quality, None);
+    }
+
+    /// #351: `entity_footprint` (this parser) and `common::entity_size`
+    /// (the blueprint exporter) must agree on every multi-tile entity's
+    /// dims, or re-exporting an imported blueprint shifts that entity.
+    /// Both now delegate to the same shared tables (`machine_dims`,
+    /// `non_machine_multi_tile_dims`, the pole arm), so this test mostly
+    /// pins the actual expected values against silent drift in those
+    /// shared tables — not just self-consistency between the two call
+    /// sites, which the delegation already guarantees structurally.
+    #[test]
+    fn entity_footprint_matches_entity_size_for_every_known_multi_tile_entity() {
+        let mut cases: Vec<(&str, (u32, u32))> = crate::common::MACHINE_ENTITY_NAMES
+            .iter()
+            .map(|&name| (name, crate::common::machine_dims(name)))
+            .collect();
+        cases.extend([
+            ("substation", (2, 2)),
+            ("big-electric-pole", (2, 2)),
+            ("beacon", (3, 3)),
+            ("storage-tank", (3, 3)),
+            ("electric-mining-drill", (3, 3)),
+            ("lab", (3, 3)),
+            ("biolab", (5, 5)),
+            ("rocket-silo", (9, 9)),
+            ("steel-furnace", (2, 2)),
+            ("crusher", (2, 3)),
+        ]);
+
+        for (name, (w, h)) in cases {
+            assert_eq!(
+                crate::common::entity_size(name),
+                (w, h),
+                "entity_size({name}) drifted from the expected dims"
+            );
+            assert_eq!(
+                entity_footprint(name, EntityDirection::North),
+                (w as i32, h as i32),
+                "entity_footprint({name}) disagrees with entity_size — parser/exporter drift"
+            );
+        }
     }
 }

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -166,13 +166,6 @@ pub fn machine_dims(entity: &str) -> (u32, u32) {
     }
 }
 
-/// Footprint `(width, height)` in tiles for ANY placed entity — the single
-/// source both the blueprint center math and the power validator's pole
-/// geometry consult (RFC `docs/rfc-power-supply.md` Phase 3a-i). Machines defer
-/// to [`machine_dims`]; the substation is 2×2; everything else (medium/small
-/// poles, belts, inserters, pipes) is 1×1. Before this, `blueprint.rs` hard-
-/// coded `(1,1)` for every non-machine, so a substation would have exported at
-/// center `x+0.5` instead of `x+1.0`.
 /// Direction-aware footprint for the 2-wide splitter family — the ONE
 /// source both the blueprint exporter's center math and the parser's
 /// footprint table consume (PR #350 review: exporter and parser keeping
@@ -198,13 +191,59 @@ pub fn oriented_splitter_dims(
     }
 }
 
+/// Direction-agnostic footprint for non-machine, non-pole, non-splitter
+/// multi-tile entities — everything the parser's `entity_footprint` knows
+/// about that isn't already routed through [`machine_dims`],
+/// [`oriented_splitter_dims`], or the substation/big-electric-pole arm of
+/// [`entity_size`]. `None` for anything else (defaults to 1×1).
+///
+/// #351: before this table existed, `entity_size` treated every one of
+/// these as 1×1 while the parser's `entity_footprint` already knew their
+/// real size, so re-exporting an imported blueprint containing any of them
+/// shifted the entity (measured: 8 of 39 corpus round-trips translation-
+/// drift for this reason). Dims verified against `entity_footprint`, the
+/// parser's source-of-truth table (itself draftsman-derived).
+///
+/// None of these are reachable from engine-generated layouts: none appear
+/// in [`MACHINE_ENTITY_NAMES`] or `recipe_db::category_machines`,
+/// `crusher`'s only recipe category (`"crushing"`) is permanently excluded
+/// from solving (`recipe_db::EXCLUDED_CATEGORIES` / `is_excluded_recipe`),
+/// and the web UI's furnace picker never offers `steel-furnace` as a
+/// selectable option (only `electric-furnace` is enabled; `stone-furnace`
+/// is disabled and `steel-furnace` isn't even listed) — so extending this
+/// table only changes behavior for imported-blueprint round-trips, never
+/// for engine-generated output.
+pub fn non_machine_multi_tile_dims(entity: &str) -> Option<(u32, u32)> {
+    match entity {
+        "beacon" | "storage-tank" | "electric-mining-drill" | "lab" => Some((3, 3)),
+        "biolab" => Some((5, 5)),
+        "rocket-silo" => Some((9, 9)),
+        "steel-furnace" => Some((2, 2)),
+        "crusher" => Some((2, 3)),
+        _ => None,
+    }
+}
+
+/// Footprint `(width, height)` in tiles for ANY placed entity — the single
+/// source both the blueprint center math and the power validator's pole
+/// geometry consult (RFC `docs/rfc-power-supply.md` Phase 3a-i). Machines
+/// defer to [`machine_dims`]; the substation and big pole are 2×2; the
+/// remaining non-machine multi-tile entities the parser recognizes defer to
+/// [`non_machine_multi_tile_dims`]; everything else (medium/small poles,
+/// belts, inserters, pipes) is 1×1. Direction-dependent entities (the
+/// splitter family) are NOT covered here — callers with a direction consult
+/// [`oriented_splitter_dims`] first. Before the pole fix, `blueprint.rs`
+/// hard-coded `(1,1)` for every non-machine, so a substation would have
+/// exported at center `x+0.5` instead of `x+1.0`; before #351, the same was
+/// true for beacon/storage-tank/electric-mining-drill/lab/biolab/rocket-
+/// silo/steel-furnace/crusher.
 pub fn entity_size(entity: &str) -> (u32, u32) {
     if is_machine_entity(entity) {
         machine_dims(entity)
     } else if entity == "substation" || entity == "big-electric-pole" {
         (2, 2)
     } else {
-        (1, 1)
+        non_machine_multi_tile_dims(entity).unwrap_or((1, 1))
     }
 }
 


### PR DESCRIPTION
## Intent

Closes #351. `common::entity_size` (the exporter's footprint source) treated
`beacon`/`storage-tank`/`electric-mining-drill`/`lab`/`biolab`/`rocket-silo`/
`steel-furnace`/`crusher` as 1×1, while the blueprint parser's
`entity_footprint` already knew their real multi-tile dims (`big-electric-pole`
2×2 already landed via #389). Re-exporting an imported community blueprint
containing any of these shifted the entity — measured at 8 of 39 corpus
round-trips translation-drifting for this reason.

## Scope

- **In:** a shared `common::non_machine_multi_tile_dims` table, consulted by
  `entity_size`. Dims verified against the parser's `entity_footprint`, the
  existing source of truth (draftsman-derived): beacon/storage-tank/electric-
  mining-drill/lab → 3×3, biolab → 5×5, rocket-silo → 9×9, steel-furnace →
  2×2, crusher → 2×3.
- **In:** refactored the parser's `entity_footprint` to delegate entirely to
  `entity_size` + `oriented_splitter_dims` instead of keeping its own
  divergent match table — the "one shared table" fix direction the issue
  asked for (extending the pattern already used for the splitter family and
  the substation/big-pole arm). The two sides can no longer drift apart
  structurally.
- **In:** a unit test (`entity_footprint_matches_entity_size_for_every_known_multi_tile_entity`)
  iterating every machine name plus the pole/non-machine multi-tile set,
  asserting both `entity_size` and `entity_footprint` agree with pinned
  expected dims — guards the shared tables themselves against silent drift,
  not just self-consistency between the two call sites (which the delegation
  already guarantees).
- **Out:** `common::machine_dims`, used directly by the row placer/ghost
  router/templates for engine-generated placement spacing, is untouched.
  `machine_dims("steel-furnace")` and `machine_dims("crusher")` still fall
  through to the generic (3,3) default — but per the caller audit below,
  neither is ever actually placed by the engine, so this is dormant and out
  of scope for this fix (which is `entity_size` only, per the issue).

## Caller audit (additive-safety, following the #389 precedent)

`entity_size` has five production callers: `power_wires.rs::pole_center`,
`validate/power.rs::check_power_coverage` (×2), `blueprint.rs`'s export
center math, `classify.rs` (×3, community-blueprint strategy classification),
and `validate/belt_structural.rs`. All are name-gated — the new branches only
fire for the 8 entity names added to `non_machine_multi_tile_dims`. None of
those names can appear in an engine-generated `LayoutResult.entities` list:

- `beacon`, `storage-tank`, `electric-mining-drill`, `lab`, `biolab`,
  `rocket-silo`: none are in `MACHINE_ENTITY_NAMES` or referenced by
  `recipe_db::category_machines`; no placer/bus-layout code ever constructs
  one (confirmed by grep — the only non-parser/non-test references are the
  module-slot/inventory lookup tables, which are consulted generically for
  every entity name and don't gate placement).
- `crusher`: its only recipe category, `"crushing"`, is in
  `recipe_db::EXCLUDED_CATEGORIES` and refused by `is_excluded_recipe`
  unconditionally (not opt-in like recycling) — the solver can never select
  it, on either the netflow or legacy tree-walk path.
- `steel-furnace`: reachable in principle via `recipe_db::MachinePalette`
  (the `smelting` category supports `electric-furnace`/`stone-furnace`/
  `steel-furnace`), and the palette *is* wired end-to-end through
  `solve_with_palette` → the web app's `?smelt=` URL param. But the sidebar's
  furnace `<select>` only lists `electric-furnace` (enabled) and
  `stone-furnace` (disabled, "coming later") — `steel-furnace` isn't an
  option at all. `web/src/ui/sidebar.ts`'s URL-restore logic explicitly
  whitelists incoming palette values against the select's non-disabled
  options and falls back to the default otherwise, so even a hand-edited
  `?smelt=steel-furnace` URL silently resolves to `electric-furnace`. No
  other production caller constructs a palette with `steel-furnace`
  (`mining-cli`'s `blueprint-analyze` only imports/analyzes, never solves).

So every existing engine-generated-layout caller is behaviorally unchanged;
only imported-blueprint round-trips (parse → re-export, or parse → validate/
classify) are affected, and only for strict correctness.

## Verification

- [x] `SPAGHETTIO_ZONE_CACHE_PATH=$(pwd)/crates/core/data/sat-zones-ci.bin cargo test --manifest-path crates/core/Cargo.toml` — clean single run, all green: unit tests 838 passed/0 failed/3 ignored (includes the new drift-guard test), plus every integration binary (e2e 61/0/22, cp_sat_round_trip 13/0/0, solver_netflow_parity 10/0/3, cell_composition 17/0/20, balancer_* suites, sat_pins, region/sat/junction fixtures) — 0 failures anywhere.
- [x] `cargo clippy --manifest-path crates/core/Cargo.toml -- -D warnings` — clean (one `manual_unwrap_or` lint fixed during development).
- [x] `crates/core/data/sat-zones-ci.bin` restored via `git checkout --` after the pinned run (not part of this diff).
- [ ] WASM rebuild + browser eyeball — not applicable; this only affects the parser/exporter's non-machine multi-tile table, which the web app's generator flow never exercises (see caller audit). No visual surface to check.

## Deviations from intent

None — implemented per the issue's own suggested fix direction (shared
oriented-dims table consumed by both sides) rather than just patching
`entity_size`'s match arm, since that's what permanently closes the drift
class rather than re-opening it at the next entity addition.

## Models / contracts touched

`common::entity_size` / `common::entity_footprint` (parser) contract:
now formally the same shared table for every non-splitter multi-tile
entity, both machine and non-machine. No RFC or `docs/` doc owns this
narrow a contract; the doc comments on `non_machine_multi_tile_dims` and
`entity_size` carry the reasoning and the reachability argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7TFG8si9QxRz6FrMmMnrp