### PR TITLE
fix(fulgora): #309 — merge_output_rows bridges past dual-fate ret-belt collisions

### DIFF
--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -81,6 +81,15 @@ pub struct GhostRouteResult {
     /// the old path made retries fire only under a trace guard. The trace
     /// event is still emitted for the debugger; this is the control-flow copy.
     pub cap_coords: Vec<(i32, i32)>,
+    /// Tiles a routed bus entity claims that used to belong to a row
+    /// entity (`bus/placer.rs`'s `row_entities`, which this module never
+    /// sees — it's merged into the final layout by the caller). Populated
+    /// by `output_merger::merge_output_rows`'s row-exit bridging (RFC
+    /// Fulgora dual-fate items, #309): the row's now-stale tile there
+    /// must be dropped rather than double-placed alongside the new one.
+    /// `bus/layout.rs` folds this into its existing splitter-eviction
+    /// filter over `row_entities`.
+    pub row_tile_overrides: FxHashSet<(i32, i32)>,
 }
 
 /// A spec for one connecting belt run.
@@ -3304,6 +3313,21 @@ pub fn route_bus_ghost(
         true
     });
 
+    // Snapshot of every tile Step 4-6 (+ the `retain` cleanup above) has
+    // already claimed, threaded into every `merge_output_rows` call below
+    // as its `existing_tiles` param — a dual-fate byproduct's `ret` belt
+    // (an intermediate lane's producer connection, #309) can land on the
+    // exact row-exit tile Step 7's east extension is about to start from.
+    // Taken once here; Step 7's OWN entities (target/surplus/voider merges
+    // below) don't need to be visible to each other through this set —
+    // `blocked_columns` already covers that ordering within this step.
+    let existing_tiles: FxHashSet<(i32, i32)> = entities.iter().map(|e| (e.x, e.y)).collect();
+    // Tiles `merge_output_rows`'s row-exit bridging overrides — a row
+    // entity the caller must drop before merging `row_entities` with this
+    // function's returned `entities` (see
+    // `GhostRouteResult::row_tile_overrides`).
+    let mut row_tile_overrides: FxHashSet<(i32, i32)> = FxHashSet::default();
+
     // -------------------------------------------------------------------------
     // Step 7: Merge output rows for final products
     // -------------------------------------------------------------------------
@@ -3360,6 +3384,8 @@ pub fn route_bus_ghost(
                 merge_x_cursor,
                 &blocked_columns,
                 ctx,
+                &existing_tiles,
+                &mut row_tile_overrides,
             );
             blocked_columns.extend((item_merge_x - output_rows.len() as i32)..item_merge_x);
             merge_x_cursor = item_merge_x + 1;
@@ -3454,6 +3480,8 @@ pub fn route_bus_ghost(
             merge_x_cursor,
             &blocked_columns,
             ctx,
+            &existing_tiles,
+            &mut row_tile_overrides,
         );
         blocked_columns.extend((item_merge_x - output_rows.len() as i32)..item_merge_x);
         merge_x_cursor = item_merge_x + 1;
@@ -3542,6 +3570,8 @@ pub fn route_bus_ghost(
             merge_x_cursor,
             &blocked_columns,
             ctx,
+            &existing_tiles,
+            &mut row_tile_overrides,
         );
         blocked_columns.extend((item_merge_x - output_rows.len() as i32)..item_merge_x);
         merge_x_cursor = item_merge_x + 1;
@@ -3968,6 +3998,7 @@ pub fn route_bus_ghost(
         warnings,
         surplus_exits,
         cap_coords,
+        row_tile_overrides,
     })
 }
 

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -840,6 +840,7 @@ fn layout_pass(
     // stream) so `run_layout_with_retry_inner` detects caps whether or not a
     // trace collector is active — see that function and package #3.
     let cap_coords = ghost_result.cap_coords;
+    let row_tile_overrides = ghost_result.row_tile_overrides;
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime {
         phase: "ghost_routing".to_string(),
         duration_ms: t_ghost.elapsed().as_millis() as u64,
@@ -876,6 +877,11 @@ fn layout_pass(
             }
         }
     }
+    // Dual-fate byproduct row exits (RFC Fulgora, #309): `merge_output_rows`'s
+    // row-exit bridging spliced a UG entrance over the row's own last belt
+    // tile so the row's stale plain belt there doesn't double-place
+    // alongside it — same eviction mechanism as the splitter case above.
+    bus_occupied.extend(row_tile_overrides);
     let row_entities: Vec<PlacedEntity> = if bus_occupied.is_empty() {
         row_entities
     } else {

--- a/crates/core/src/bus/output_merger.rs
+++ b/crates/core/src/bus/output_merger.rs
@@ -13,37 +13,6 @@ use crate::bus::balancer::splitter_for_belt;
 use crate::bus::placer::RowSpan;
 use crate::bus::stacking_ctx::StackingCtx;
 
-/// Total rate + belt/underground tier for an item's merge cascade — split
-/// out so a caller can compute it once and reuse it, though today only
-/// [`merge_output_rows`] itself calls it.
-pub(crate) fn merger_rate_and_tier(
-    output_rows: &[usize],
-    item: &str,
-    row_spans: &[RowSpan],
-    max_belt_tier: Option<&str>,
-    ctx: &StackingCtx,
-) -> (f64, &'static str, &'static str, u32) {
-    use crate::bus::balancer::underground_for_belt;
-    use crate::common::{belt_entity_for_rate_stacked, ug_max_reach};
-
-    let total_rate = output_rows.iter()
-        .map(|&ri| {
-            if ri >= row_spans.len() {
-                0.0
-            } else {
-                row_spans[ri].spec.outputs.iter()
-                    .filter(|o| o.item == item)
-                    .map(|o| o.rate * row_spans[ri].machine_count as f64)
-                    .sum::<f64>()
-            }
-        })
-        .sum::<f64>();
-    let belt_name = belt_entity_for_rate_stacked(total_rate * 2.0, max_belt_tier, ctx.for_item(item));
-    let ug_name = underground_for_belt(belt_name);
-    let reach = ug_max_reach(belt_name);
-    (total_rate, belt_name, ug_name, reach)
-}
-
 pub(crate) fn merge_output_rows(
     output_rows: &[usize],
     output_ys: &[i32],
@@ -58,7 +27,7 @@ pub(crate) fn merge_output_rows(
     row_tile_overrides: &mut FxHashSet<(i32, i32)>,
 ) -> (Vec<PlacedEntity>, i32, i32) {
     use crate::bus::balancer::underground_for_belt;
-    use crate::common::ug_max_reach;
+    use crate::common::{belt_entity_for_rate_stacked, ug_max_reach};
 
     debug_assert_eq!(
         output_rows.len(),
@@ -74,8 +43,20 @@ pub(crate) fn merge_output_rows(
     }
     let merger_seg_id = Some(format!("merger:{}", item));
 
-    let (total_rate, belt_name, _ug_name, _reach) =
-        merger_rate_and_tier(output_rows, item, row_spans, max_belt_tier, ctx);
+    let total_rate = output_rows.iter()
+        .map(|&ri| {
+            if ri >= row_spans.len() {
+                0.0
+            } else {
+                row_spans[ri].spec.outputs.iter()
+                    .filter(|o| o.item == item)
+                    .map(|o| o.rate * row_spans[ri].machine_count as f64)
+                    .sum::<f64>()
+            }
+        })
+        .sum::<f64>();
+    let belt_name = belt_entity_for_rate_stacked(total_rate * 2.0, max_belt_tier, ctx.for_item(item));
+    let reach = ug_max_reach(belt_name) as i32;
     let splitter_name = splitter_for_belt(belt_name);
 
     // Column position: east of the widest participating row, but never west
@@ -83,11 +64,48 @@ pub(crate) fn merge_output_rows(
     // successive per-item merges so two output items' splitter cascades and
     // south columns tile left-to-right instead of stamping the same tiles
     // (multi-item solid output support, Phase 2 of rfc-solver-net-flow).
-    let merge_x = (output_rows.iter()
+    let mut merge_x = (output_rows.iter()
         .map(|&ri| if ri < row_spans.len() { row_spans[ri].row_width } else { 0 })
         .max()
         .unwrap_or(0) + 1)
         .max(min_merge_x);
+
+    // #309 review finding: a row whose east extension starts blocked (its
+    // own `row_width` tile occupied by Step 4-6 residue — a dual-fate
+    // item's `ret` belt) needs the underground bridge's EXIT tile placed
+    // before the south column starts. The formula above doesn't know
+    // about that yet, so a tight `min_merge_x` (e.g. this is the only /
+    // first item processed) can put `col_x` exactly where the exit would
+    // land — the exit and the south column's own top tile would then
+    // double-place on the same coordinate. Mirror the main loop's
+    // blocked-run walk here (unbounded by `col_x`, which isn't known
+    // yet — bounded only by `reach`, same as the walk will end up doing
+    // once `col_x` is resolved, so they agree on where each run ends)
+    // and widen `merge_x` just enough that every row's exit — bridged or
+    // not — lands strictly before its own column. A no-op (same `merge_x`
+    // as before) for every row whose `row_width` tile isn't blocked,
+    // which is every layout except this one.
+    for (idx, &ri) in output_rows.iter().enumerate() {
+        if ri >= row_spans.len() {
+            continue;
+        }
+        let out_y = output_ys[idx];
+        let rw = row_spans[ri].row_width;
+        if !(blocked_columns.contains(&rw) || existing_tiles.contains(&(rw, out_y))) {
+            continue;
+        }
+        let mut run_end = rw;
+        while (blocked_columns.contains(&(run_end + 1))
+            || existing_tiles.contains(&(run_end + 1, out_y)))
+            && (run_end + 1) - rw < reach
+        {
+            run_end += 1;
+        }
+        // This row's column sits at `merge_x + (n - 1 - idx)`; need that
+        // to be `>= run_end + 2` (strictly past the exit at `run_end + 1`).
+        let needed = run_end + 2 - (n as i32 - 1 - idx as i32);
+        merge_x = merge_x.max(needed);
+    }
 
     for (idx, &ri) in output_rows.iter().enumerate() {
         if ri >= row_spans.len() {
@@ -110,7 +128,6 @@ pub(crate) fn merge_output_rows(
         // into) the foreign belt.
         let rw = row_spans[ri].row_width;
         let ug_name = underground_for_belt(belt_name);
-        let reach = ug_max_reach(belt_name) as i32;
         let mut x = rw;
         while x < col_x {
             if blocked_columns.contains(&x) || existing_tiles.contains(&(x, out_y)) {
@@ -572,6 +589,20 @@ mod tests {
             entities.iter().all(|e| (e.x, e.y) != (row_width, out_y)),
             "no entity may be placed on the pre-occupied tile: {entities:#?}"
         );
+        // Tile-uniqueness, not just the pre-occupied tile: a review finding
+        // on this exact fixture shape caught a SECOND, latent collision —
+        // when `col_x` (the south column) landed adjacent to the bridge's
+        // exit tile, both the exit and the south column's own top tile got
+        // placed at the same coordinate. The narrower "not on the blocked
+        // tile" check above can't see that; only a full uniqueness sweep
+        // over every emitted entity does.
+        let mut seen: FxHashSet<(i32, i32)> = FxHashSet::default();
+        let dups: Vec<(i32, i32)> = entities
+            .iter()
+            .map(|e| (e.x, e.y))
+            .filter(|&tile| !seen.insert(tile))
+            .collect();
+        assert!(dups.is_empty(), "duplicate tile(s) among emitted entities {dups:?}: {entities:#?}");
         assert!(
             row_tile_overrides.contains(&(row_width - 1, out_y)),
             "the row's own last belt tile must be reported for eviction: {row_tile_overrides:?}"

--- a/crates/core/src/bus/output_merger.rs
+++ b/crates/core/src/bus/output_merger.rs
@@ -6,10 +6,43 @@
 //! the bottom-right of the layout. Called once per final product at
 //! the end of `route_bus_ghost` (Step 7).
 
+use rustc_hash::FxHashSet;
+
 use crate::models::{EntityDirection, PlacedEntity};
 use crate::bus::balancer::splitter_for_belt;
 use crate::bus::placer::RowSpan;
 use crate::bus::stacking_ctx::StackingCtx;
+
+/// Total rate + belt/underground tier for an item's merge cascade — split
+/// out so a caller can compute it once and reuse it, though today only
+/// [`merge_output_rows`] itself calls it.
+pub(crate) fn merger_rate_and_tier(
+    output_rows: &[usize],
+    item: &str,
+    row_spans: &[RowSpan],
+    max_belt_tier: Option<&str>,
+    ctx: &StackingCtx,
+) -> (f64, &'static str, &'static str, u32) {
+    use crate::bus::balancer::underground_for_belt;
+    use crate::common::{belt_entity_for_rate_stacked, ug_max_reach};
+
+    let total_rate = output_rows.iter()
+        .map(|&ri| {
+            if ri >= row_spans.len() {
+                0.0
+            } else {
+                row_spans[ri].spec.outputs.iter()
+                    .filter(|o| o.item == item)
+                    .map(|o| o.rate * row_spans[ri].machine_count as f64)
+                    .sum::<f64>()
+            }
+        })
+        .sum::<f64>();
+    let belt_name = belt_entity_for_rate_stacked(total_rate * 2.0, max_belt_tier, ctx.for_item(item));
+    let ug_name = underground_for_belt(belt_name);
+    let reach = ug_max_reach(belt_name);
+    (total_rate, belt_name, ug_name, reach)
+}
 
 pub(crate) fn merge_output_rows(
     output_rows: &[usize],
@@ -21,9 +54,11 @@ pub(crate) fn merge_output_rows(
     min_merge_x: i32,
     blocked_columns: &[i32],
     ctx: &StackingCtx,
+    existing_tiles: &FxHashSet<(i32, i32)>,
+    row_tile_overrides: &mut FxHashSet<(i32, i32)>,
 ) -> (Vec<PlacedEntity>, i32, i32) {
     use crate::bus::balancer::underground_for_belt;
-    use crate::common::{belt_entity_for_rate_stacked, ug_max_reach};
+    use crate::common::ug_max_reach;
 
     debug_assert_eq!(
         output_rows.len(),
@@ -39,21 +74,8 @@ pub(crate) fn merge_output_rows(
     }
     let merger_seg_id = Some(format!("merger:{}", item));
 
-    // Calculate total rate
-    let total_rate = output_rows.iter()
-        .map(|&ri| {
-            if ri >= row_spans.len() {
-                0.0
-            } else {
-                row_spans[ri].spec.outputs.iter()
-                    .filter(|o| o.item == item)
-                    .map(|o| o.rate * row_spans[ri].machine_count as f64)
-                    .sum::<f64>()
-            }
-        })
-        .sum::<f64>();
-
-    let belt_name = belt_entity_for_rate_stacked(total_rate * 2.0, max_belt_tier, ctx.for_item(item));
+    let (total_rate, belt_name, _ug_name, _reach) =
+        merger_rate_and_tier(output_rows, item, row_spans, max_belt_tier, ctx);
     let splitter_name = splitter_for_belt(belt_name);
 
     // Column position: east of the widest participating row, but never west
@@ -75,32 +97,67 @@ pub(crate) fn merge_output_rows(
         let col_x = merge_x + (n - 1 - idx) as i32; // first row rightmost, last row at merge_x
 
         // Extend EAST belts from the row's rightmost tile to the merge
-        // column. Earlier items' south columns (`blocked_columns`) lie in
-        // this run's path — bridge each contiguous blocked range with an
-        // underground pair instead of stamping over (or sideloading into)
-        // the foreign belt.
+        // column. Earlier items' south columns (`blocked_columns`) AND
+        // tiles Step 4-6 (ghost-routed lanes) already claimed there
+        // (`existing_tiles` — #309: a DUAL-FATE byproduct, produced by a
+        // row and BOTH partly consumed internally AND registered surplus,
+        // `docs/rfc-fulgora-scrap.md` 2026-07-11 decision log: stone/ice
+        // on the scrap-recycling sushi row, gets an ordinary
+        // intermediate-lane `ret` belt walking the consumed portion back
+        // to its bus trunk from this exact row-exit tile) lie in this
+        // run's path — bridge each contiguous blocked range with an
+        // underground pair instead of stamping over (or sideloading
+        // into) the foreign belt.
         let rw = row_spans[ri].row_width;
         let ug_name = underground_for_belt(belt_name);
         let reach = ug_max_reach(belt_name) as i32;
         let mut x = rw;
         while x < col_x {
-            if blocked_columns.contains(&x) {
+            if blocked_columns.contains(&x) || existing_tiles.contains(&(x, out_y)) {
                 // Contiguous blocked run [x, run_end], clamped by UG reach
                 // (entrance at x-1, exit at run_end+1; gap ≤ reach).
                 let mut run_end = x;
                 while run_end + 1 < col_x
-                    && blocked_columns.contains(&(run_end + 1))
+                    && (blocked_columns.contains(&(run_end + 1))
+                        || existing_tiles.contains(&(run_end + 1, out_y)))
                     && (run_end + 1) - x < reach
                 {
                     run_end += 1;
                 }
-                debug_assert!(x > rw, "no room for UG entrance before blocked column");
-                // Replace the belt stamped at x-1 with a UG entrance.
-                if let Some(prev) = entities
+                if x == rw {
+                    // No local tile to convert — the row's own last belt
+                    // tile at (x-1, out_y) is placed by `place_rows` long
+                    // before this function runs, and lives in the
+                    // CALLER's `row_entities`: an immutable slice this
+                    // module never sees, merged with the routed bus
+                    // entities only after `route_bus_ghost` returns
+                    // (`bus/layout.rs`). Push a FRESH entrance there
+                    // instead and record the override — `layout.rs`
+                    // already drops a `row_entities` tile whenever a
+                    // routed bus entity claims the same coordinate (the
+                    // existing splitter-eviction mechanism, generalized
+                    // by #309 to any override reported here), so the
+                    // row's now-stale plain belt at (x-1, out_y) is
+                    // filtered out of the final layout rather than
+                    // double-placed alongside this entrance.
+                    row_tile_overrides.insert((x - 1, out_y));
+                    entities.push(PlacedEntity {
+                        name: ug_name.to_string(),
+                        x: x - 1,
+                        y: out_y,
+                        direction: EntityDirection::East,
+                        io_type: Some("input".to_string()),
+                        carries: Some(item.to_string()),
+                        segment_id: merger_seg_id.clone(),
+                        rate: Some(total_rate),
+                        ..Default::default()
+                    });
+                } else if let Some(prev) = entities
                     .iter_mut()
                     .rev()
                     .find(|e| e.x == x - 1 && e.y == out_y)
                 {
+                    // Replace the belt stamped at x-1 with a UG entrance.
                     prev.name = ug_name.to_string();
                     prev.io_type = Some("input".to_string());
                 }
@@ -293,10 +350,10 @@ mod tests {
             vec![5],
         );
         let rows = [row0, row1];
-        let (a_ents, a_end_y, a_max_x) = merge_output_rows(&[0], &[rows[0].output_belt_y], "iron-gear-wheel", &rows, 15, None, 11, &[], &StackingCtx::unstacked());
+        let (a_ents, a_end_y, a_max_x) = merge_output_rows(&[0], &[rows[0].output_belt_y], "iron-gear-wheel", &rows, 15, None, 11, &[], &StackingCtx::unstacked(), &FxHashSet::default(), &mut FxHashSet::default());
         // Caller threads: next min_merge_x = returned max_x + 1, start_y = max_y.
         let blocked: Vec<i32> = ((a_max_x - 1)..a_max_x).collect();
-        let (b_ents, _b_end_y, b_max_x) = merge_output_rows(&[1], &[rows[1].output_belt_y], "iron-stick", &rows, a_end_y.max(15), None, a_max_x + 1, &blocked, &StackingCtx::unstacked());
+        let (b_ents, _b_end_y, b_max_x) = merge_output_rows(&[1], &[rows[1].output_belt_y], "iron-stick", &rows, a_end_y.max(15), None, a_max_x + 1, &blocked, &StackingCtx::unstacked(), &FxHashSet::default(), &mut FxHashSet::default());
         assert!(b_max_x > a_max_x);
         let a_tiles: FxHashSet<(i32, i32)> = a_ents.iter().map(|e| (e.x, e.y)).collect();
         let overlap: Vec<(i32, i32)> = b_ents
@@ -306,7 +363,7 @@ mod tests {
             .collect();
         assert!(overlap.is_empty(), "merge blocks overlap at {overlap:?}");
         // And without the cursor they WOULD overlap (guard the guard):
-        let (c_ents, _c_end_y, _c) = merge_output_rows(&[1], &[rows[1].output_belt_y], "iron-stick", &rows, 15, None, 0, &[], &StackingCtx::unstacked());
+        let (c_ents, _c_end_y, _c) = merge_output_rows(&[1], &[rows[1].output_belt_y], "iron-stick", &rows, 15, None, 0, &[], &StackingCtx::unstacked(), &FxHashSet::default(), &mut FxHashSet::default());
         let c_overlap = c_ents.iter().map(|e| (e.x, e.y)).any(|t| a_tiles.contains(&t));
         assert!(c_overlap, "expected uncursored merges to collide — geometry changed?");
     }
@@ -324,7 +381,7 @@ mod tests {
 
         let output_rows = vec![0];
         let output_ys = vec![row_span.output_belt_y];
-        let (entities, _end_y, _merge_max_x) = merge_output_rows(&output_rows, &output_ys, "iron-plate", &[row_span], 20, None, 0, &[], &StackingCtx::unstacked());
+        let (entities, _end_y, _merge_max_x) = merge_output_rows(&output_rows, &output_ys, "iron-plate", &[row_span], 20, None, 0, &[], &StackingCtx::unstacked(), &FxHashSet::default(), &mut FxHashSet::default());
 
         // Single row should extend EAST and SOUTH without splitters
         assert!(!entities.is_empty());
@@ -352,7 +409,7 @@ mod tests {
 
         let output_rows = vec![0, 1];
         let output_ys = vec![row_span1.output_belt_y, row_span2.output_belt_y];
-        let (entities, _end_y, _merge_max_x) = merge_output_rows(&output_rows, &output_ys, "iron-plate", &[row_span1, row_span2], 20, None, 0, &[], &StackingCtx::unstacked());
+        let (entities, _end_y, _merge_max_x) = merge_output_rows(&output_rows, &output_ys, "iron-plate", &[row_span1, row_span2], 20, None, 0, &[], &StackingCtx::unstacked(), &FxHashSet::default(), &mut FxHashSet::default());
 
         // Multiple rows should include splitters
         let splitters = entities.iter().filter(|e| e.name.contains("splitter")).count();
@@ -401,6 +458,8 @@ mod tests {
             0,
             &[],
             &StackingCtx::unstacked(),
+            &FxHashSet::default(),
+            &mut FxHashSet::default(),
         );
 
         // Splitters must be present
@@ -456,12 +515,74 @@ mod tests {
             0,
             &[],
             &StackingCtx::unstacked(),
+            &FxHashSet::default(),
+            &mut FxHashSet::default(),
         );
 
         let splitters: Vec<_> = entities.iter().filter(|e| e.name.contains("splitter")).collect();
         for s in &splitters {
             assert_eq!(s.direction, EntityDirection::South, "Merger splitters should face SOUTH");
         }
+    }
+
+    /// #309 regression: when something Step 4-6 already placed (a
+    /// dual-fate item's intermediate-lane `ret` belt) occupies the row's
+    /// own exit tile — `row_width`, the FIRST tile this function's east
+    /// extension would otherwise stamp a plain belt onto — the row-exit
+    /// bridge must detour underground around it instead of colliding
+    /// (issue #309's illegal entity overlaps). No entity may land on the
+    /// occupied tile, and the row's own last belt tile (`row_width - 1`,
+    /// owned by the caller's `row_entities` — this function never places
+    /// it) must be reported via `row_tile_overrides` so the caller drops
+    /// it before merging, rather than double-placing it alongside the
+    /// fresh UG entrance this function pushes there.
+    #[test]
+    fn test_merge_output_rows_bridges_pre_occupied_row_exit() {
+        let row = make_test_row_span(
+            "iron-plate",
+            0,
+            vec![],
+            vec![ItemFlow { item: "iron-plate".to_string(), rate: 1.0, is_fluid: false, module_id: 0 }],
+            1,
+            vec![],
+        );
+        let out_y = row.output_belt_y;
+        let row_width = row.row_width;
+        // Simulate a `ret` belt already sitting on the row's own exit
+        // tile — exactly the #309 collision.
+        let mut existing_tiles: FxHashSet<(i32, i32)> = FxHashSet::default();
+        existing_tiles.insert((row_width, out_y));
+        let mut row_tile_overrides: FxHashSet<(i32, i32)> = FxHashSet::default();
+
+        let (entities, _end_y, _merge_max_x) = merge_output_rows(
+            &[0],
+            &[out_y],
+            "iron-plate",
+            &[row],
+            20,
+            None,
+            0,
+            &[],
+            &StackingCtx::unstacked(),
+            &existing_tiles,
+            &mut row_tile_overrides,
+        );
+
+        assert!(
+            entities.iter().all(|e| (e.x, e.y) != (row_width, out_y)),
+            "no entity may be placed on the pre-occupied tile: {entities:#?}"
+        );
+        assert!(
+            row_tile_overrides.contains(&(row_width - 1, out_y)),
+            "the row's own last belt tile must be reported for eviction: {row_tile_overrides:?}"
+        );
+        let entrance = entities
+            .iter()
+            .find(|e| (e.x, e.y) == (row_width - 1, out_y))
+            .expect("a fresh UG entrance must replace the row's own last belt tile");
+        assert_eq!(entrance.name, "underground-belt");
+        assert_eq!(entrance.io_type.as_deref(), Some("input"));
+        assert_eq!(entrance.direction, EntityDirection::East);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -6943,8 +6943,9 @@ fn fulgora_scrap_sorter_mechanism_present() {
     // saturation/boundary checks above exist precisely to replace them.
     // The ice-melting defect is a fluid defect, so the fluid validators are
     // the faithful gate for this arc. (Full validate() also surfaces
-    // pre-existing non-fluid fulgora issues — entity-overlap etc. — that
-    // are out of this unit's scope; reported separately.)
+    // pre-existing non-fluid fulgora issues out of this unit's scope — an
+    // AM3 single-exit-bus cluster at the holmium-plate row, tracked on
+    // #309 — that this test still doesn't assert on.)
     let mut fluid_errors: Vec<&ValidationIssue> = Vec::new();
     let fp = validate::check_fluid_port_connectivity(&layout, LayoutStyle::Bus);
     let fn_ = validate::check_fluid_network_connectivity(&layout, None);
@@ -6959,6 +6960,25 @@ fn fulgora_scrap_sorter_mechanism_present() {
         "fulgora layout has {} fluid error(s) (ice-melting output regression?): {:#?}",
         fluid_errors.len(),
         fluid_errors
+    );
+
+    // #309: the scrap-recycling row's DUAL-FATE byproducts (stone, ice —
+    // partly consumed internally via a real recipe, partly surplus and
+    // exported through the merger) used to collide: an intermediate
+    // lane's `ret` belt and the surplus merger's east extension both
+    // claimed the row's own exit tile, producing illegal entity overlaps
+    // (a real blueprint-import defect — Factorio silently drops one of
+    // the colliding entities). `merge_output_rows` (`output_merger.rs`)
+    // now bridges its east extension underground past any tile Step 4-6
+    // already claimed there, so this narrow class — entity-overlap only,
+    // not the general belt-loop/underground-belt false positives excluded
+    // above — must stay clean.
+    let overlaps = belt_structural::check_entity_overlaps(&layout);
+    assert!(
+        overlaps.is_empty(),
+        "fulgora layout has {} illegal entity overlap(s) (#309 regression?): {:#?}",
+        overlaps.len(),
+        overlaps
     );
 }
 

--- a/docs/rfc-fulgora-scrap.md
+++ b/docs/rfc-fulgora-scrap.md
@@ -685,8 +685,22 @@ and 3 wait on its artifacts as marked. Phase 3 is the long pole.
   reports (holmium-plate row, zero output inserters) is a THIRD,
   unrelated defect in row/template generation upstream of ghost
   routing — confirmed pre-existing and untouched by this fix via the
-  same git-stash comparison; not investigated to a fix here, tracked
-  on #309. Real resolution of the dual-fate split still needs the
+  same git-stash comparison. Root-caused (not fixed): `row_kind()`
+  (`placer.rs` ~561) classifies any `solid_inputs==0, fluid_inputs==1,
+  machine_size<5` row as `RowKind::OilRefinery` → `fluid_only_row`
+  (hard-coded fluid-in/fluid-out, no solid-output path) without
+  checking `solid_outputs` — holmium-plate (fluid in, solid out) is
+  apparently the first Fulgora recipe shaped that way. The obvious
+  guard fix (route to `RowKind::FluidInput` instead) does NOT work:
+  `fluid_input_row` (`templates.rs:2316`) unconditionally requires a
+  solid *input* too (places its own inserter+belt from a mandatory
+  `solid_item` param) — holmium-plate has none, so redirecting there
+  would place a disconnected bogus inserter, not fix anything. Needs a
+  genuinely new template variant (fluid-input-only + the solid-output
+  tail `fluid_input_row` already has at y+7/y+8), which touches a
+  template function shared by every non-Fulgora fluid+solid recipe —
+  correctly out of this PR's blast radius; tracked on #309. Real
+  resolution of the dual-fate split still needs the
   physical flow-split this entry already calls for (a splitter at the
   sort point, sending the consumed sub-rate one way and the surplus
   remainder the other) — this fix buys back the illegal-blueprint

--- a/docs/rfc-fulgora-scrap.md
+++ b/docs/rfc-fulgora-scrap.md
@@ -651,3 +651,43 @@ and 3 wait on its artifacts as marked. Phase 3 is the long pole.
   test assertion); (3) reconsider architecture (d) chest-buffering
   for the resume, which deletes the exemption surface instead of
   hardening it.*
+- *2026-07-24 — issue #309's illegal entity overlaps were exactly the
+  "dual-fate split-feed" collision recorded above (stone/ice: an
+  ordinary intermediate lane's `ret` belt and the surplus merger's east
+  extension both claim the row's own exit tile, since neither knows
+  about the other). Fixed the GEOMETRIC collision only, not the
+  full split this entry calls for: `merge_output_rows`
+  (`output_merger.rs`) now treats any tile Step 4-6 already claimed
+  the same way it already treats another item's south column —
+  bridge underground around it — with a `row_tile_overrides` escape
+  hatch (`GhostRouteResult`, folded into `layout.rs`'s existing
+  splitter-eviction filter) for the one case where the tile to
+  convert into a UG entrance belongs to the row's own immutable
+  `row_entities`, not this module's local list. Zero entity-overlap
+  errors on the holmium-plate fixture now (was 2-3, host-dependent).
+  **Explicitly NOT fixed**: the consumed fraction still never reaches
+  its real consumer — `check_input_rate_delivery` warns 0.0/s
+  delivered against the item's true demand (0.05/s stone, 0.025/s
+  ice) both before and after this change, byte-identical. The `ret`
+  lane's rate is still sized off the ROW's full production (`item_to_rate`
+  sums the whole row, `lane_planner.rs`), not the true downstream
+  demand, and fixing the overlap surfaced (did not introduce — same
+  geometry, previously masked because the two colliding entities'
+  directions weren't both visible to `check_belt_junctions` when they
+  shared one tile) a real head-on belt conflict where the row's own
+  east-facing exit meets the ret belt's west-facing bend, 4 new
+  `belt-junction` errors, confirmed via git-stash diff against the
+  pre-fix baseline to be new. This is the SAME class of general-belt-
+  validator noise the sushi region already generates (belt-loop /
+  underground-belt, ~100 instances, `fulgora_scrap_sorter_mechanism_present`'s
+  own comment) — the fix only asserts zero entity-overlap, deliberately
+  not zero belt-junction. The AM3 single-exit-bus cluster #309 also
+  reports (holmium-plate row, zero output inserters) is a THIRD,
+  unrelated defect in row/template generation upstream of ghost
+  routing — confirmed pre-existing and untouched by this fix via the
+  same git-stash comparison; not investigated to a fix here, tracked
+  on #309. Real resolution of the dual-fate split still needs the
+  physical flow-split this entry already calls for (a splitter at the
+  sort point, sending the consumed sub-rate one way and the surplus
+  remainder the other) — this fix buys back the illegal-blueprint
+  defect without attempting that redesign.*

--- a/docs/rfc-fulgora-scrap.md
+++ b/docs/rfc-fulgora-scrap.md
@@ -677,11 +677,13 @@ and 3 wait on its artifacts as marked. Phase 3 is the long pole.
   shared one tile) a real head-on belt conflict where the row's own
   east-facing exit meets the ret belt's west-facing bend, 4 new
   `belt-junction` errors, confirmed via git-stash diff against the
-  pre-fix baseline to be new. This is the SAME class of general-belt-
-  validator noise the sushi region already generates (belt-loop /
-  underground-belt, ~100 instances, `fulgora_scrap_sorter_mechanism_present`'s
-  own comment) — the fix only asserts zero entity-overlap, deliberately
-  not zero belt-junction. The AM3 single-exit-bus cluster #309 also
+  pre-fix baseline to be new. `check_belt_junctions` (head-on) is a
+  separate check from `check_belt_loops` / `check_underground_belts` —
+  these new errors are a SIBLING of the belt-loop/underground-belt
+  false positives the sushi region already generates
+  (`fulgora_scrap_sorter_mechanism_present`'s own comment, ~100
+  instances), not literally the same check firing — the fix only
+  asserts zero entity-overlap, deliberately not zero belt-junction. The AM3 single-exit-bus cluster #309 also
   reports (holmium-plate row, zero output inserters) is a THIRD,
   unrelated defect in row/template generation upstream of ghost
   routing — confirmed pre-existing and untouched by this fix via the


### PR DESCRIPTION
## Intent

Fixes the 3 illegal entity overlaps in issue #309: the Fulgora scrap-sorter sushi layout (`fulgora_scrap_sorter_mechanism_present`) has entity overlaps that full `validate()` surfaces but the committed test — deliberately scoped to sushi-specific saturation/boundary checks — doesn't catch. An illegal overlap is a real blueprint defect: Factorio silently drops one of the colliding entities on import.

## Root cause

The scrap-recycling row's **dual-fate byproducts** — stone and ice, each partly consumed by a real downstream recipe (chemical-plant's holmium-solution needs stone; ice-melting needs ice for water) and partly registered as surplus for export — get routed by two independent systems that don't know about each other:

1. An ordinary **intermediate lane** creates a `ret` belt walking the consumed portion back to its bus trunk, originating from the row's own east-facing exit tile (`ghost_router.rs`'s `row_exit_origin`).
2. The **surplus merger** (`output_merger.rs`'s `merge_output_rows`, Step 7b) independently extends east from that *same* tile to route the surplus portion to the export point.

Both claim the identical `(row_width, out_y)` tile — the observed overlaps. This is exactly the "dual-fate split-feed issue" the Fulgora RFC's 2026-07-11 decision log already named and parked (`docs/rfc-fulgora-scrap.md`), alongside the harder "merger self-collision at N≈8 simultaneous surplus streams" wall.

**Reproduced with 2 overlap instances** in the current holmium-plate fixture (stone, ice), not the 3 reported when the issue was filed — plausibly solver/routing drift since 2026-07-19, but the same root-cause class; the fix is general (any tile, any item) rather than special-cased to 2 or 3 instances.

## Fix

`merge_output_rows`'s east extension already bridges around *other items'* south columns (`blocked_columns`) via an underground pair. It now treats any tile Step 4-6 (ghost-routed lanes) already claimed the same way — bridge underground around it instead of colliding.

The one wrinkle: when the very first tile of that bridge needs converting (the row's own last belt tile), that tile lives in the caller's immutable `row_entities` slice, which this module never sees — it's merged into the final layout only after `route_bus_ghost` returns (`layout.rs`). Rather than plumb mutable access through, a new `row_tile_overrides: FxHashSet<(i32,i32)>` on `GhostRouteResult` reports the tile, and `layout.rs` folds it into its **existing** splitter-eviction filter over `row_entities` (previously scoped to bus splitters only) — so the row's now-stale tile is dropped rather than double-placed.

## Folded from review

The adversarial review caught a real latent bug in the first version of this fix, and two nomenclature/cleanliness notes. All three folded:

1. **Latent self-overlap** (the substantive finding): the `x == rw` branch placed the UG exit at `run_end + 1` without checking it against `col_x` (the south-column reservation). When `col_x` sits exactly one tile past `rw` — a tight `min_merge_x`, e.g. this is the only/first item processed, not the fulgora fixture's own shape today but a real trap for a future single-item dual-fate case — the exit and the south column's own top tile land on the same coordinate. Reviewer reproduced it with a probe on the fixture the new regression test already builds. Fixed with a pre-pass before `merge_x` is finalized: mirror the main loop's blocked-run walk (bounded only by UG reach, since `col_x` isn't known yet) and widen `merge_x` just enough that every row's exit — bridged or not — lands strictly before its own south column. A no-op for every row whose `row_width` tile isn't blocked, i.e. byte-identical for every layout but this one; verified by temporarily disabling the pre-pass and confirming the strengthened test (below) fails exactly as predicted, then re-enabling it and confirming green.
2. **Test strengthened**: `test_merge_output_rows_bridges_pre_occupied_row_exit` now asserts no duplicate `(x, y)` among *all* emitted entities (not just the originally-blocked tile) — the assertion shape the reviewer's finding needed to be caught by the test in the first place.
3. **`merger_rate_and_tier` inlined back into `merge_output_rows`** — it had exactly one caller (itself) after an earlier design iteration removed the second call site; the split no longer bought anything.
4. **RFC decision-log nomenclature fixed**: the new `belt-junction` errors are a sibling of, not literally the same check as, the belt-loop/underground-belt noise (see the Scope bullet above).

## Scope

- **In:** the entity-overlap geometry fix; extending `fulgora_scrap_sorter_mechanism_present` to assert zero entity-overlap errors; a focused unit test for the new bridging path (`test_merge_output_rows_bridges_pre_occupied_row_exit`); an RFC decision-log entry recording exactly what is and isn't fixed.
- **Out — AM3 single-exit-bus cluster (holmium-plate row, zero output inserters/belt):** confirmed via `git stash` A/B comparison against the pre-fix baseline to be **100% pre-existing and untouched by this fix** — a third, unrelated defect in row/template generation upstream of ghost routing, in a completely different subsystem from the Step 7 merger-collision fix above.

  **Root cause, precisely**: `row_kind()` (`crates/core/src/bus/placer.rs` ~561) classifies any row with `solid_inputs == 0, fluid_inputs == 1, machine_size < 5` as `RowKind::OilRefinery` (dispatched to `templates::fluid_only_row`) without checking `solid_outputs` — that template is hard-coded fluid-in/fluid-out (its own doc comment: "fluid inputs sit at the NORTH edge... fluid outputs sit at the SOUTH edge"; the motivating case is lubricant, light-oil→lubricant on chemical-plant) and has no solid-output code path at all. holmium-plate (holmium-solution [fluid] → holmium-plate [**solid**] on assembling-machine-3) hits this branch and silently gets zero output inserter/belt — apparently the first Fulgora recipe shaped this way, so the gap was never exercised before.

  The straightforward-looking fix — add a `solid_outputs.is_empty()` guard and route non-empty-solid-output rows to `RowKind::FluidInput` instead — **does not actually work**: I traced `templates::fluid_input_row` (`templates.rs:2316`) and it unconditionally places a solid-**input** belt+inserter at y+2/y+3 from a mandatory `solid_item`/`solid_rate` parameter, alongside the machine-row and the output inserter+belt at y+7/y+8 that already exist and would be exactly what holmium-plate needs. holmium-plate has zero solid inputs, so redirecting to `FluidInput` would place a bogus, disconnected solid-input inserter rather than fix anything. A real fix needs a genuinely new template variant — fluid-input-only (no solid input stage) with the existing solid-output tail — not a one-line dispatch change, and `row_kind()`/the template functions are shared across every non-Fulgora recipe too, so the safe surface for that work is larger than this PR's scope. Left tracked on #309 rather than attempted here under time pressure against a heavily-shared, heavily-tested subsystem.
- **Out — the deeper dual-fate flow-rate split:** this fix resolves the *geometric* collision only. The `ret` lane is still sized off the row's full production (`lane_planner.rs`'s `item_to_rate` sums the whole row, not true downstream demand), and `check_input_rate_delivery` still warns 0.0/s delivered against the item's real demand (0.05/s stone, 0.025/s ice) — **byte-identical before and after this fix** (verified via the same A/B comparison), confirming this was already broken and is untouched. Real resolution needs the physical flow-split (a splitter at the sort point) the RFC's decision log already calls for.
- **Side effect, verified pre-existing not new:** fixing the overlap surfaced 4 new `belt-junction` "head-on" errors (the row's east-facing exit now visibly abuts the ret belt's west-facing bend — previously masked because the two colliding entities' directions weren't both visible to the checker when they shared one tile). Confirmed via the same A/B diff that this defect (the underlying geometry) is pre-existing, not newly introduced. Nomenclature: `check_belt_junctions` (head-on) is a *separate check* from `check_belt_loops`/`check_underground_belts` — these new errors are a **sibling** of the belt-loop/underground-belt false positives the sushi region already generates (~100 instances, per the test's own comment), not literally the same check firing. The test deliberately asserts zero entity-overlap only, not zero belt-junction, matching that existing scope boundary.

## Verification

- [x] `SPAGHETTIO_ZONE_CACHE_PATH=$(pwd)/crates/core/data/sat-zones-ci.bin cargo test --manifest-path crates/core/Cargo.toml` — full pinned suite, 951 passed, 0 failed (837 lib + 61 e2e + rest), zone-cache pin restored after (`git checkout --`).
- [x] `cargo clippy -p spaghettio_core -- -D warnings` (exact pre-commit hook invocation, lib target) — clean. (A broader `--all-targets` run fails on pre-existing, unrelated lints in `e2e.rs`/`layout.rs`/`power_wires.rs` doc comments — confirmed via the same A/B stash comparison to be present on unmodified `origin/main` too, not introduced here.)
- [x] `cargo build --features wasm -p spaghettio_core` + `cargo build --workspace` — clean; no wasm-bindgen-exposed signatures touched.
- [x] Entity-level snapshot inspection: dumped exact tile contents at every previously-overlapping coordinate before/after via a scratch example (`crates/core/examples/repro_309_fulgora.rs`, gitignored), confirming zero shared tiles and tracing the full `ret` belt path.
- [x] `git stash` A/B against the pre-fix baseline for every claim above (belt-junction new-vs-preexisting, AM3 pre-existing, input-rate-delivery byte-identical).
- [ ] Browser eyeball — **not applicable**: this fixture requires `allow_recycling`/scrap-chain netflow options that aren't exposed via the web app's URL/UI (`allow_recycling` doesn't appear anywhere in `web/src/`), only reachable via the test harness's `solve_netflow_with_options`.

## Deviations from intent

None from the assigned scope. The AM3 cluster and the flow-rate-split gap were investigated (root-caused to the same or a different subsystem, precisely as asked) and explicitly left tracked rather than folded in, per the task's own scope guard.

## Models / contracts touched

`GhostRouteResult` gained one field (`row_tile_overrides`); `merge_output_rows`'s signature gained two params (`existing_tiles`, `row_tile_overrides`) — both `pub(crate)`/internal to `bus/`, no public API change. Decision log updated in `docs/rfc-fulgora-scrap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7TFG8si9QxRz6FrMmMnrp

