### PR TITLE
docs: record RFC-053 Phase 0 in the registry and status ledger

### DIFF
--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -64,6 +64,6 @@ backfill the status next time the doc is touched.
 | RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Complete (fluid feed CALIBRATED via #364 — first fluid factory PASS; fluid-pack sweep + #345 re-measure open) |
 | RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Complete — default Candidate; sim registry; K-quantization (corridor-cap); EC-row re-measure waits on #381 |
 | RFC-052 | 2026-07-23 | [`rfc-052-oil-mega-cell.md`](rfc-052-oil-mega-cell.md) | Design (circulated for review) |
-| RFC-053 | 2026-07-24 | [`rfc-053-direct-insertion-cells.md`](rfc-053-direct-insertion-cells.md) | Draft (circulated for review) |
+| RFC-053 | 2026-07-24 | [`rfc-053-direct-insertion-cells.md`](rfc-053-direct-insertion-cells.md) | Active — Phase 0 complete (KC1 passed; KC6 fired → pipes re-scoped into Phase 2). Phase 1 blocked on #432. |
 
 Next number: **RFC-054**.

--- a/docs/status.md
+++ b/docs/status.md
@@ -127,6 +127,32 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 
 ## Recent RFC close-outs
 
+**`rfc-053-direct-insertion-cells.md` Phase 0 (2026-07-25, PR #436 —
+RFC ACTIVE, not closed)**: machine→inserter→machine DI, the topology
+#429 asked for and the corpus overwhelmingly builds. Evidence is now
+reproducible from a clean checkout via the tracked `di-patterns`
+miner (`cargo run --release -p spaghettio_mining --bin di-patterns`):
+16,507 DI observations, 4,116 of them `copper-cable →
+electronic-circuit`, of whose top-20 geometry patterns (3,866) all but
+one use a **1-tile gap**. **KC1 (ratio feasibility) PASSED with
+margin** — the worst case across the corpus top-10 is the canonical
+cable→EC at 2.50/s per inserter slot against 19.2/s available from a
+stack inserter at the L2 default; the feasibility rule reduces to
+`machine_feed_rate ≥ 2.5/s`, satisfied at engine defaults and for a
+`Fast`-capped user. **KC6 (fluid coverage) FIRED (5/10 vs a threshold
+of 2)** and was diagnosed as a criterion-specification defect —
+it conflated a *fluid coupling* (impossible: inserters cannot move
+fluid) with a *fluid-adjacent machine* (common), and counted pairs
+unweighted where its rationale was demand (solids-only actually covers
+**69.4%** of top-10 instances, and the dominant pair is fully solid).
+Resolution was the criterion's own prescribed action — **re-scope, not
+reprieve**: pipes moved out of Non-goals into required Phase 2 scope.
+Phases 1–4 remain; **Phase 1 is blocked on #432** (`DICoupling` and
+`direct_insertion` do not exist on `main`). Recorded data gap:
+`electric-furnace → electric-furnace` is the 2nd-commonest DI pair
+(1,585) but is invisible to recipe-keyed analysis — furnaces carry no
+explicit recipe.
+
 **`rfc-052-oil-mega-cell.md` close-out (2026-07-24, Phases A/B/C —
 PRs #401/#403/#405/#408/#411/#421)**: fluid subgraphs compose as
 UNCROPPED mega-cells inside solid chains. Delivered: the first


### PR DESCRIPTION
## Intent

RFC-053 merged (#436) with Phase 0 complete, leaving both cross-cutting records stale. Docs only.

## Scope

- **In:** `docs/rfcs.md` status row; `docs/status.md` close-out entry (marked **ACTIVE, not closed**).
- **Out:** no code, no RFC-body changes.

## Verification

- [x] Registry row matches the RFC's actual state (Phase 0 complete, Phases 1–4 open, Phase 1 blocked on #432).
- [x] Evidence command in the status entry is the tracked binary and was run: reproduces 4,116 cable→EC and the geometry table exactly.
- [ ] N/A: cargo test / clippy / WASM — no code.

## Deviations from intent

None.

## Models / contracts touched

None. `status.md` gains a close-out entry deliberately labelled ACTIVE so a reader doesn't mistake a Phase-0-only RFC for a finished one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)