### PR TITLE
docs(rfc-053): #432 merged — Phase 1 unblocked

### DIFF
--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -27,26 +27,27 @@ reach/throughput/adjacency constraints. **Phase 1 is solids-only
 the original "no pipes at all" cut tripped kill criterion 6 in Phase 0
 and was widened (see Phase 0 results).
 
-## Prerequisite: #432 must merge first
+## Prerequisite: #432 — ✅ MERGED 2026-07-25 (`4df8b0a7`)
 
-**This RFC builds on types that do not exist on `main` yet.**
+This RFC builds on types that landed with PR
+[#432](https://github.com/storkme/spaghettio/pull/432):
 `SolverResult.di_couplings`, the `DICoupling` struct,
-`LayoutOptions.direct_insertion` and `validate::is_di_bridge_inserter`
-all live on `feat/strategy-gap-analysis` (PR
-[#432](https://github.com/storkme/spaghettio/pull/432), open at time of
-writing). `main` has only `classify::direct_insertion`, which *counts*
-DI in parsed community blueprints and is unrelated to producing it.
+`LayoutOptions.direct_insertion` (default `false`) and
+`validate::is_di_bridge_inserter` are all on `main` now, verified after
+the merge. **Phase 1 is unblocked.**
 
-Consequences, stated so nobody trips over them:
+Notes carried forward from when this was a live blocker:
 
-- The Motivation's "reproducible today" case reproduces **on #432's
-  branch** (`a50c45cf`), not on `main`.
-- Phase 1 cannot start until #432 lands. Phase 0 (mining + feasibility)
-  has no such dependency and can run immediately.
-- **Rebase drift is a live risk**: if #432's `DICoupling` shape changes
-  before merge, this RFC's integration section moves with it. Phase 0's
-  deliverable must be re-checked against the merged shape rather than
-  the branch shape.
+- The Motivation's "reproducible today" case was measured on #432's
+  branch at `a50c45cf`; it reproduces on `main` from `4df8b0a7`.
+- The rebase-drift risk is **closed** — the merged `DICoupling` shape is
+  the one this RFC's integration section describes (re-verified against
+  `main`, not the branch).
+- #432 also merged `main` in before landing, so it carries the L2
+  inserter-capacity default (#431) and the recalibrated bridged floor
+  (#434). The `input-rate-delivery` figures quoted below (3 warnings at
+  L0 / 1 at L2 / 0 at L7) predate those and should be re-measured in
+  Phase 1 rather than trusted verbatim.
 
 ## Motivation
 
@@ -483,6 +484,7 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
 - **Phase 0 — mine + feasibility. ✅ COMPLETE (2026-07-24).** Census
   delivered above: KC1 passes with margin (worst case 2.50/s vs 19.2/s
   available at defaults); **KC6 fired and forced the pipes re-scope**.
+  **#432 merged 2026-07-25 (`4df8b0a7`), so Phase 1 is ready to start.**
   The miner is now the **tracked** `di-patterns` binary
   (`crates/mining-cli/src/bin/di_patterns.rs`), so every corpus figure in
   this RFC is reproducible from a clean checkout — it was written as a

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -64,6 +64,6 @@ backfill the status next time the doc is touched.
 | RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Complete (fluid feed CALIBRATED via #364 — first fluid factory PASS; fluid-pack sweep + #345 re-measure open) |
 | RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Complete — default Candidate; sim registry; K-quantization (corridor-cap); EC-row re-measure waits on #381 |
 | RFC-052 | 2026-07-23 | [`rfc-052-oil-mega-cell.md`](rfc-052-oil-mega-cell.md) | Design (circulated for review) |
-| RFC-053 | 2026-07-24 | [`rfc-053-direct-insertion-cells.md`](rfc-053-direct-insertion-cells.md) | Active — Phase 0 complete (KC1 passed; KC6 fired → pipes re-scoped into Phase 2). Phase 1 blocked on #432. |
+| RFC-053 | 2026-07-24 | [`rfc-053-direct-insertion-cells.md`](rfc-053-direct-insertion-cells.md) | Active — Phase 0 complete (KC1 passed; KC6 fired → pipes re-scoped into Phase 2). #432 merged; Phase 1 ready. |
 
 Next number: **RFC-054**.


### PR DESCRIPTION
## Intent

PR #432 landed (`4df8b0a7`), so RFC-053's Prerequisite section was actively misleading — it told readers the DI types don't exist on `main`. Docs only.

## Scope

- **In:** RFC-053 Prerequisite section (blocked → merged, rebase-drift risk closed), Phase 0 note, registry status row.
- **Out:** no code; no change to the design, kill criteria, or Phase 0 findings.

## Verification

- [x] Confirmed post-merge on `origin/main`: `DICoupling` + `di_couplings` (models.rs, netflow.rs), `LayoutOptions.direct_insertion` (layout.rs:135), `validate::is_di_bridge_inserter` (validate/mod.rs:219).
- [ ] N/A: cargo test / clippy / WASM — no code.

## Deviations from intent

One caveat deliberately **carried forward rather than dropped**: #432 merged `main` in before landing, so it now includes the L2 inserter-capacity default (#431) and the recalibrated bridged floor (#434). The `input-rate-delivery` figures quoted in Motivation (3 warnings at L0 / 1 at L2 / 0 at L7) were measured *before* those landed, so the RFC now says to re-measure them in Phase 1 rather than trust them verbatim.

## Models / contracts touched

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)