### PR TITLE
docs(rfc-053): record the Phase 1c integration seam

### DIFF
--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -515,9 +515,32 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
     when counting DI in community blueprints). Refuses rather than
     under-feeding when the chosen inserter can't cover an edge within
     the slots that edge owns.
-  - **1c — placer wiring** (remaining): call the planner/stamper from
-    `place_rows`, suppress the coupled item's row belts, and teach the
-    lane planner to skip the item.
+  - **1c — placer wiring** (remaining, and the invasive step). Pick-up
+    notes, so this doesn't need re-deriving:
+    - **Seam**: `bus::placer::place_rows`, the DI branch that currently
+      calls `stamp_di_bridge` (search `is_di_consumer` / `di_lookup`).
+      Today that branch fires *after* both rows already exist.
+    - **Why it is not a small change**: a cell REPLACES both row
+      emissions rather than decorating them. `build_one_row` gives a row
+      its own belts and pitch; a cell needs the producer and consumer
+      machines at `StraddlePlan` positions, one tile apart, with **no
+      belt for the coupled item** — so the two specs must be intercepted
+      *before* `build_one_row`, while still getting the producer's other
+      input belts and the consumer's output belt from the template
+      system. Expect a new `RowKind` (cell-shaped) rather than a
+      post-hoc stamp.
+    - **Order of work**: (1) `RowKind` + template that emits a cell band
+      via `stamp_di_cell`; (2) intercept the producer/consumer spec pair
+      in `place_rows`; (3) lane-planner skip for the coupled item —
+      `di_input` already exists and is item-keyed, so reuse it rather
+      than inventing a second mechanism; (4) fall back to the existing
+      bridge, then the bus, whenever `plan_straddle` returns `None` or
+      the ladder cannot supply `required_rate()`.
+    - **Verification this step needs** (the earlier phases did not, being
+      pure functions): the full layout-engine protocol — snapshot
+      inspection at the cell's coordinates and a browser eyeball, not
+      just a green suite. A DI cell that validates clean but starves is
+      exactly the #383/#432 failure mode.
 - **Phase 2 — face allocation, now including fluids (re-scoped by the
   KC6 trip).** The consumer's remaining flows on the opposite face,
   mixed reach (reach-2 stepping over a near belt), **plus pipe placement


### PR DESCRIPTION
## Intent

Phases 1a (#441) and 1b (#442) landed as pure functions and needed no placer surgery. **Phase 1c does**, and it's the invasive step — this records the seam, why it isn't small, the order of work, and the verification it needs, so a cold pick-up doesn't re-derive it. Docs only.

## Scope

- **In:** Phase 1c pick-up notes in RFC-053's phasing.
- **Out:** the wiring itself.

## The finding worth recording

A cell **replaces** both row emissions rather than decorating them. The existing DI branch stamps a bridge *after* both rows exist — fine for belt→belt, but it cannot express a cell: the machines must sit at `StraddlePlan` positions one tile apart with **no belt for the coupled item**, so the spec pair has to be intercepted *before* `build_one_row` while still getting the producer's other input belts and the consumer's output belt from the template system. That points at a new cell-shaped `RowKind`, not a post-hoc stamp.

Also recorded: reuse the existing item-keyed `di_input` for the lane-planner skip rather than inventing a second mechanism; fall back bridge → bus when `plan_straddle` returns `None` or the ladder can't supply `required_rate()`.

## Verification

- [x] Seam verified against `origin/main` (not a stale local `main` — I initially assessed the wrong tree and caught it; the DI wiring only exists post-#432).
- [ ] N/A: cargo test / clippy — no code.

Flagged in the notes: unlike 1a/1b, Phase 1c will need the **full layout-engine protocol** (snapshot inspection at the cell's coordinates plus a browser eyeball), because a DI cell that validates clean but starves is exactly the #383/#432 failure mode.

## Deviations from intent

None.

## Models / contracts touched

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)