### PR TITLE
feat(di): RFC-053 Phase 1c — place_rows emits fused DI cells

### DIFF
--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -1789,6 +1789,18 @@ fn cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str) -> 
     if producer.voider || consumer.voider {
         return false;
     }
+    // Modules: refuse outright. The module post-pass in `layout.rs` keys
+    // loadouts by `(entity, recipe)` gathered from `row_spans`, and a
+    // fused cell contributes only the CONSUMER's recipe — the producer's
+    // recipe never appears, so producer machines (which do carry it) would
+    // get nothing stamped while the solver has already folded the module
+    // speed/productivity bonus into their machine count. That is a silent
+    // production shortfall, not a cosmetic gap, and matching loadouts
+    // wouldn't fix it because the key itself is missing. Honest refusal
+    // until module stamping can be keyed per-segment (Phase 2+).
+    if !producer.game_modules.is_empty() || !consumer.game_modules.is_empty() {
+        return false;
+    }
     if !producer.self_loop.is_empty() || !consumer.self_loop.is_empty() {
         return false;
     }
@@ -1910,22 +1922,43 @@ fn try_build_cell(
     let in_stack = ctx.for_item(&in_flow.item);
     let out_stack = ctx.for_item(&out_flow.item);
     let in_belt = belt_entity_for_rate_stacked(in_total, max_belt_tier, in_stack);
-    let out_belt = belt_entity_for_rate_stacked(out_total, max_belt_tier, out_stack);
+    // The cell's output belt is physically SINGLE-LANE: every output
+    // inserter sits at the same y facing the same way, so all drops land
+    // in the far lane (I5). Size it the way the ordinary single-lane path
+    // does — against `rate * 2.0`, i.e. "a belt whose LANE capacity covers
+    // the rate" — then verify. Sizing against `out_total` raw picks a belt
+    // with half the capacity actually available.
+    let out_belt = belt_entity_for_rate_stacked(out_total * 2.0, max_belt_tier, out_stack);
+    if lane_capacity_stacked(out_belt, out_stack) + 1e-9 < out_total {
+        // Too much output for one lane. The ordinary path would split the
+        // recipe across rows; a cell cannot (its machines are placed at
+        // `StraddlePlan` positions, and splitting needs the Phase 3
+        // multi-band shape). Refuse instead of shipping a belt that
+        // silently caps the cell.
+        return None;
+    }
 
-    // Feed and output faces get the machine's own spare columns, so a
-    // single-inserter face isn't an implicit throughput cap.
-    let budget = (mw.max(1) as usize) - 1;
-    let feed = size_side(in_flow.rate * p_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    // Phase 1 stamps exactly ONE inserter per feed/output position —
+    // `DiCellIo` carries an entity name, not a count, so a `SidePlan`
+    // asking for more cannot be honoured. Size against a single slot and
+    // refuse when one inserter (or the ladder's best effort) can't cover
+    // the face, rather than discarding `count`/`shortfall` and quietly
+    // under-feeding. Multi-inserter faces need the stamper to take counts;
+    // that is Phase 2 work alongside face allocation.
+    let feed = size_side(in_flow.rate * p_util, Reach::Near, 0, max_inserter_tier, quality, level);
     let drop = size_belt_drop_side(
         out_flow.rate * c_util,
         Reach::Near,
-        budget,
+        0,
         max_inserter_tier,
         quality,
         out_stack,
         level,
         out_belt,
     );
+    if feed.count > 1 || drop.count > 1 || feed.shortfall.is_some() || drop.shortfall.is_some() {
+        return None;
+    }
 
     let cell = stamp_di_cell_io(
         &plan,
@@ -3471,6 +3504,78 @@ mod tests {
         assert!(
             !cell_eligible(&producer, &iron_gear_spec(), "iron-plate"),
             "fluid-touching pairs are Phase 2"
+        );
+    }
+
+    /// #450 review: a producer's module loadout would be silently dropped
+    /// (the module post-pass keys on `(entity, recipe)` from `row_spans`,
+    /// and a cell contributes only the consumer's recipe) while the solver
+    /// has already folded the bonus into machine counts. Refuse instead.
+    #[test]
+    fn di_cell_refuses_when_modules_are_present() {
+        let (mut producer, consumer) = cell_pair();
+        producer.game_modules = vec![crate::models::ModuleItem {
+            item: "productivity-module".to_string(),
+            count: 2,
+            quality: None,
+        }];
+        assert!(
+            !cell_eligible(&producer, &consumer, "iron-plate"),
+            "a module loadout the cell cannot stamp must refuse fusion"
+        );
+    }
+
+    /// #450 review: `SidePlan.count`/`.shortfall` were computed and
+    /// discarded, but `DiCellIo` carries an entity name and no count — so
+    /// a face needing 2+ inserters was stamped with one and silently
+    /// under-fed. Regular tier can't move 2.0/s in one hand, so this pair
+    /// must refuse rather than fuse.
+    #[test]
+    fn di_cell_refuses_when_a_face_needs_more_than_one_inserter() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (_, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::Regular, QualityTier::Normal,
+            0, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(
+            spans.len(), 2,
+            "Regular tier at L0 cannot cover the feed face with one inserter — must refuse, \
+             not stamp one inserter and under-feed"
+        );
+    }
+
+    /// #450 review: the cell's output belt is physically single-lane (all
+    /// output inserters share a y and a facing, so every drop lands in the
+    /// far lane), so it must be sized against `rate * 2.0` like every other
+    /// single-lane row. Sizing against the raw rate picked a belt with half
+    /// the usable capacity.
+    #[test]
+    fn di_cell_output_belt_is_sized_for_a_single_lane() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "guard: needs a fused cell to mean anything");
+        let out_y = spans[0].output_belt_y;
+        let belt = ents.iter()
+            .find(|e| e.y == out_y && e.name.contains("transport-belt"))
+            .expect("output belt");
+        let out_total: f64 = spans[0].spec.outputs.iter()
+            .filter(|f| !f.is_fluid)
+            .map(|f| f.rate * spans[0].machine_count as f64)
+            .sum();
+        let lane = crate::common::lane_capacity_stacked(&belt.name, 1);
+        assert!(
+            lane + 1e-9 >= out_total,
+            "single-lane capacity {lane}/s must cover the cell's {out_total}/s on {}",
+            belt.name
         );
     }
 

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -1921,7 +1921,25 @@ fn try_build_cell(
     let out_total = out_flow.rate * c_util * c_count as f64;
     let in_stack = ctx.for_item(&in_flow.item);
     let out_stack = ctx.for_item(&out_flow.item);
-    let in_belt = belt_entity_for_rate_stacked(in_total, max_belt_tier, in_stack);
+    // A cell's input belt is a bus tap-off target exactly like any other
+    // row's — `fused_cell_spec` puts the producer's input in the fused
+    // row's `inputs` and `input_belt_y` is registered normally, so
+    // `lane_planner` taps it the same way. It must therefore take the
+    // TRUNK's tier via `row_input_belt`, not a tier sized to this cell's
+    // local demand: the trunk is sized for total demand across every
+    // consumer, and a locally-sized belt reintroduces the seam mismatch
+    // `row_input_belt`'s doc comment exists to prevent (fast belt feeding
+    // yellow, lane-throughput warnings, items backing up at the join).
+    let in_belt = row_input_belt(max_belt_tier);
+    // Inserters pick from BOTH lanes (I6), so the input side has the
+    // belt's full capacity available — unlike the single-lane output.
+    // `belt_entity_for_rate_stacked` saturates rather than failing, so
+    // without this the cell would silently ship an undersized belt at
+    // high rates instead of refusing; `plan_straddle` is scale-invariant
+    // in machine count and would never catch it.
+    if lane_capacity_stacked(in_belt, in_stack) * 2.0 + 1e-9 < in_total {
+        return None;
+    }
     // The cell's output belt is physically SINGLE-LANE: every output
     // inserter sits at the same y facing the same way, so all drops land
     // in the far lane (I5). Size it the way the ordinary single-lane path
@@ -3576,6 +3594,34 @@ mod tests {
             lane + 1e-9 >= out_total,
             "single-lane capacity {lane}/s must cover the cell's {out_total}/s on {}",
             belt.name
+        );
+    }
+
+    /// #450 review: the cell's input belt is a bus tap-off target like any
+    /// other row's, so it must take the TRUNK tier (`row_input_belt`), not
+    /// a tier sized to the cell's local demand — otherwise a fast trunk
+    /// joins a yellow row belt and items back up at the seam.
+    #[test]
+    fn di_cell_input_belt_matches_the_trunk_tier() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        // Cap at express: local demand is ~2/s (yellow would "fit"), so a
+        // locally-sized belt would pick yellow and mismatch the trunk.
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, Some("express-transport-belt"),
+            InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "guard: needs a fused cell to mean anything");
+        let in_y = spans[0].input_belt_y[0];
+        let belt = ents.iter()
+            .find(|e| e.y == in_y && e.name.contains("transport-belt"))
+            .expect("input belt");
+        assert_eq!(
+            belt.name, "express-transport-belt",
+            "input belt must match the trunk tier, not the cell's local rate"
         );
     }
 

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -11,7 +11,7 @@ use crate::common::{
     belt_entity_for_rate, belt_entity_for_rate_stacked, lane_capacity, lane_capacity_stacked,
     machine_dims, utilization_for, QualityTier, BELT_TIERS,
 };
-use crate::models::{EntityDirection, MachineSpec, PlacedEntity, SolverResult};
+use crate::models::{EntityDirection, ItemFlow, MachineSpec, PlacedEntity, SolverResult};
 
 /// Best available per-lane capacity across all belt tiers.
 fn max_lane_capacity() -> f64 {
@@ -1757,6 +1757,231 @@ fn stamp_di_bridge(
     entities
 }
 
+// ---- RFC-053 Phase 1: direct-insertion cells ----
+
+/// Is this producer/consumer pair a **Phase 1** DI cell?
+///
+/// A cell fuses both rows into ONE structure with the coupled item never
+/// touching a belt. Phase 1 deliberately serves only the simplest shape;
+/// anything else falls back to #432's bridge, and then to the bus.
+///
+/// Every gate here is load-bearing:
+///
+/// - **The consumer's only solid input is the coupled item.** A cell
+///   spends the consumer's north face on the DI band and its south face
+///   on the output inserter, so a second solid input has nowhere to land
+///   until Phase 2's face allocation. This is **not** redundant with the
+///   solver: `netflow::detect_di_couplings` gates on one-producer /
+///   one-consumer / no-external-supply / no-surplus / not-fluid and never
+///   inspects the consumer's input count, so it emits `copper-cable →
+///   electronic-circuit` (iron-plate + copper-cable) like any other pair.
+///   Building that cell would strand the iron feed entirely — a layout
+///   that validates clean and starves, the #383/#432 failure mode.
+/// - **The producer has exactly one solid output** (the coupled item) and
+///   **exactly one solid input**, which becomes the cell's belt-fed
+///   input. A second producer output would need a belt the fused row
+///   doesn't have.
+/// - **No fluids on either side** — pipe placement is Phase 2 (the KC6
+///   re-scope).
+/// - **Equal machine footprints.** `plan_straddle` reasons about a single
+///   `machine_w`, and the stamper stacks both rows on one x-grid.
+fn cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str) -> bool {
+    if producer.voider || consumer.voider {
+        return false;
+    }
+    if !producer.self_loop.is_empty() || !consumer.self_loop.is_empty() {
+        return false;
+    }
+    let any_fluid = |s: &MachineSpec| s.inputs.iter().chain(&s.outputs).any(|f| f.is_fluid);
+    if any_fluid(producer) || any_fluid(consumer) {
+        return false;
+    }
+    let solids = |fs: &[ItemFlow]| -> Vec<String> {
+        fs.iter().filter(|f| !f.is_fluid).map(|f| f.item.clone()).collect()
+    };
+    let (p_in, p_out) = (solids(&producer.inputs), solids(&producer.outputs));
+    let (c_in, c_out) = (solids(&consumer.inputs), solids(&consumer.outputs));
+
+    p_out.len() == 1
+        && p_out[0] == item
+        && p_in.len() == 1
+        // THE Phase-1 gate — see the doc comment.
+        && c_in.len() == 1
+        && c_in[0] == item
+        && c_out.len() == 1
+        && machine_dims(&producer.entity) == machine_dims(&consumer.entity)
+}
+
+/// The `MachineSpec` a fused cell presents to the rest of the pipeline.
+///
+/// A cell is one structure that draws the PRODUCER's input off a belt and
+/// puts the CONSUMER's output onto a belt; the coupled item exists only
+/// inside it. So the fused spec carries the producer's inputs and the
+/// consumer's outputs — exactly what `lane_planner`, the output merger and
+/// the validators already know how to read, with no cell special-casing
+/// anywhere downstream.
+///
+/// This is also what dissolves the Phase-1c contract question from #447:
+/// because the producer never gets a row of its own, no `RowSpan` is ever
+/// built whose `output_belt_y` points at a belt that wasn't emitted. The
+/// single fused row owns a real output belt, so all 11 bare
+/// `output_belt_y` read sites — including the three output-merger ones
+/// that select rows by `spec.outputs` and never consult a `BusLane` — are
+/// correct by construction.
+///
+/// Rates are per-CONSUMER-machine, because the fused row's
+/// `machine_count` is the consumer count: the output belt must carry
+/// `consumer_count × consumer_rate`, and the input belt
+/// `producer_count × producer_input_rate`. Scaling the latter by
+/// `producer_count / consumer_count` keeps `rate × machine_count` right
+/// for both.
+fn fused_cell_spec(
+    producer: &MachineSpec,
+    consumer: &MachineSpec,
+    producer_count: usize,
+    consumer_count: usize,
+) -> MachineSpec {
+    let scale = producer_count as f64 / consumer_count.max(1) as f64;
+    MachineSpec {
+        entity: consumer.entity.clone(),
+        recipe: consumer.recipe.clone(),
+        self_loop: Vec::new(),
+        voider: false,
+        game_modules: consumer.game_modules.clone(),
+        count: consumer_count as f64,
+        inputs: producer
+            .inputs
+            .iter()
+            .map(|f| ItemFlow { rate: f.rate * scale, ..f.clone() })
+            .collect(),
+        outputs: consumer.outputs.clone(),
+    }
+}
+
+/// Try to emit a fused DI cell for an eligible pair.
+///
+/// `None` on any refusal — no straddle exists, the ladder can't cover the
+/// binding edge, the stamper rejects the geometry — and the caller then
+/// places both specs as ordinary rows, where the #432 bridge (and failing
+/// that, the bus) serves the coupling. Refusing is always safe; emitting
+/// an under-fed cell is not.
+#[allow(clippy::too_many_arguments)]
+fn try_build_cell(
+    producer: &MachineSpec,
+    consumer: &MachineSpec,
+    item: &str,
+    bus_width: i32,
+    y_cursor: i32,
+    max_belt_tier: Option<&str>,
+    max_inserter_tier: InserterTier,
+    quality: QualityTier,
+    level: u8,
+    ctx: &StackingCtx,
+) -> Option<(Vec<PlacedEntity>, RowSpan, i32)> {
+    use crate::bus::di_cell::{plan_straddle, stamp_di_cell_io, DiCellIo, DiCellSpec};
+    use crate::bus::inserter_ladder::{size_belt_drop_side, size_side, Reach};
+
+    let snap = |c: f64| -> usize {
+        let s = if (c - c.round()).abs() < 1e-9 { c.round() } else { c.ceil() };
+        (s as usize).max(1)
+    };
+    let (p_count, c_count) = (snap(producer.count), snap(consumer.count));
+    let (mw, mh) = machine_dims(&consumer.entity);
+    let (mw, mh) = (mw as i32, mh as i32);
+
+    let p_util = utilization_for(producer);
+    let c_util = utilization_for(consumer);
+    let producer_rate = producer.outputs.iter().find(|f| f.item == item)?.rate * p_util;
+    let consumer_rate = consumer.inputs.iter().find(|f| f.item == item)?.rate * c_util;
+
+    let plan = plan_straddle(p_count, c_count, producer_rate, consumer_rate, mw)?;
+
+    // Couple with the cheapest inserter covering the busiest edge's
+    // per-slot share. `Reach::Near` is a constraint, not a preference: the
+    // cell puts the two rows ONE tile apart, and long-handed reaches to
+    // exactly 2 (I8a), so it would pick straight past both machines.
+    let ins = size_side(plan.required_rate(), Reach::Near, 0, max_inserter_tier, quality, level);
+    let ins_rate = crate::common::machine_feed_rate(ins.entity, quality, level);
+
+    let in_flow = producer.inputs.iter().find(|f| !f.is_fluid)?;
+    let out_flow = consumer.outputs.iter().find(|f| !f.is_fluid)?;
+    let in_total = in_flow.rate * p_util * p_count as f64;
+    let out_total = out_flow.rate * c_util * c_count as f64;
+    let in_stack = ctx.for_item(&in_flow.item);
+    let out_stack = ctx.for_item(&out_flow.item);
+    let in_belt = belt_entity_for_rate_stacked(in_total, max_belt_tier, in_stack);
+    let out_belt = belt_entity_for_rate_stacked(out_total, max_belt_tier, out_stack);
+
+    // Feed and output faces get the machine's own spare columns, so a
+    // single-inserter face isn't an implicit throughput cap.
+    let budget = (mw.max(1) as usize) - 1;
+    let feed = size_side(in_flow.rate * p_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    let drop = size_belt_drop_side(
+        out_flow.rate * c_util,
+        Reach::Near,
+        budget,
+        max_inserter_tier,
+        quality,
+        out_stack,
+        level,
+        out_belt,
+    );
+
+    let cell = stamp_di_cell_io(
+        &plan,
+        &DiCellSpec {
+            producer_entity: &producer.entity,
+            consumer_entity: &consumer.entity,
+            producer_recipe: &producer.recipe,
+            consumer_recipe: &consumer.recipe,
+            item,
+            inserter: ins.entity,
+            inserter_rate: ins_rate,
+        },
+        &DiCellIo {
+            input_item: &in_flow.item,
+            input_belt: in_belt,
+            feed_inserter: feed.entity,
+            output_item: &out_flow.item,
+            output_belt: out_belt,
+            out_inserter: drop.entity,
+        },
+        bus_width,
+        y_cursor,
+        mw,
+        mh,
+    )?;
+
+    let width = cell.x_max + 1;
+    let span = RowSpan {
+        y_start: cell.input_belt_y,
+        y_end: cell.output_belt_y + 1,
+        spec: fused_cell_spec(producer, consumer, p_count, c_count),
+        machine_count: c_count,
+        module_id: consumer.outputs.first().map(|o| o.module_id).unwrap_or(0),
+        input_belt_y: vec![cell.input_belt_y],
+        output_belt_y: cell.output_belt_y,
+        row_width: width,
+        fluid_port_ys: Vec::new(),
+        fluid_port_pipes: Vec::new(),
+        fluid_output_port_pipes: Vec::new(),
+        output_east: true,
+        output_belt_x_min: cell.x_min,
+        output_belt_x_max: cell.x_max,
+        horizontal_stack: None,
+        secondary_output_belt: None,
+        sorted_output_belts: Vec::new(),
+        // Deliberately empty, and NOT an oversight. `di_input` exists to
+        // tell the lane planner "this row consumes the item off a bridge,
+        // don't build it a bus lane". A cell needs no such marker: the
+        // fused spec's inputs are the PRODUCER's, so the coupled item
+        // appears in no row's inputs, and no row produces it either — the
+        // lane simply never comes into existence.
+        di_input: Vec::new(),
+    };
+    Some((cell.entities, span, width))
+}
+
 /// Place assembly rows stacked vertically.
 ///
 /// When a recipe needs more machines than a single belt can handle,
@@ -1829,7 +2054,50 @@ pub fn place_rows(
     // under-fed. See the multi-row refusal at the marking site below.
     let mut recipe_row_idxs: FxHashMap<&str, Vec<usize>> = FxHashMap::default();
 
+    // RFC-053 Phase 1: producer spec index → consumer spec index for pairs
+    // that can fuse into a DI cell. Precomputed so the producer half is
+    // recognisable when the loop reaches it — `order_specs` is a
+    // topological sort, so the producer is always the earlier of the two,
+    // though not necessarily adjacent.
+    //
+    // Both halves must be un-split (one `MachineSpec` each, one row each):
+    // a cell couples specific machines at specific x positions, so a
+    // producer spread over several rows would leave every row but one
+    // stranded. That is the same refusal the bridge makes for split
+    // producers, and it is Phase 3 work (the multi-band cell).
+    let mut cell_pairs: FxHashMap<usize, (usize, &str)> = FxHashMap::default();
+    if direct_insertion {
+        for (c_idx, c_spec) in ordered.iter().enumerate() {
+            let Some(couplings) = di_lookup.get(c_spec.recipe.as_str()) else {
+                continue;
+            };
+            // A consumer coupled on two items cannot be a Phase-1 cell:
+            // its second input has no free face.
+            let [(item, producer_recipe)] = couplings[..] else {
+                continue;
+            };
+            let same_recipe = |r: &str| ordered.iter().filter(|s| s.recipe == r).count();
+            if same_recipe(producer_recipe) != 1 || same_recipe(&c_spec.recipe) != 1 {
+                continue;
+            }
+            let Some(p_idx) = ordered.iter().position(|s| s.recipe == producer_recipe) else {
+                continue;
+            };
+            if p_idx >= c_idx || !cell_eligible(ordered[p_idx], c_spec, item) {
+                continue;
+            }
+            cell_pairs.insert(p_idx, (c_idx, item));
+        }
+    }
+    // Consumer specs already absorbed into a cell; skipped by the loop.
+    let mut fused_specs: FxHashSet<usize> = FxHashSet::default();
+
     for (spec_idx, spec) in ordered.iter().enumerate() {
+        // Before the inter-recipe gap, so an absorbed consumer leaves no
+        // phantom 2-tile hole where its row would have been.
+        if fused_specs.contains(&spec_idx) {
+            continue;
+        }
         // The inter-recipe gap is always present — for DI pairs, the gap
         // houses the bridge inserter that spans from the producer's output
         // belt to the consumer's input belt. Without the gap, the belts
@@ -1845,6 +2113,48 @@ pub fn place_rows(
         // a machine in most rows, and trips template assertions in others
         // (#277 utility-science-pack: 1.0000000000000002 advanced-oil-
         // processing → machine_count=2 → staggered-3-output panic).
+        // RFC-053 Phase 1: fuse an eligible pair into one cell row. On any
+        // refusal fall through to the normal path, where the #432 bridge
+        // (and failing that, the bus) still serves the coupling.
+        if let Some(&(c_idx, item)) = cell_pairs.get(&spec_idx) {
+            if let Some((cell_ents, span, width)) = try_build_cell(
+                spec,
+                ordered[c_idx],
+                item,
+                bus_width,
+                y_cursor,
+                max_belt_tier,
+                max_inserter_tier,
+                quality,
+                inserter_capacity,
+                ctx,
+            ) {
+                fused_specs.insert(c_idx);
+                max_width = max_width.max(width);
+                let row_idx = row_spans.len();
+                // Register under BOTH recipes: the cell is the producer's
+                // only placement, so a later consumer looking up the
+                // producer's rows must find this one rather than nothing.
+                recipe_row_idxs.entry(spec.recipe.as_str()).or_default().push(row_idx);
+                recipe_row_idxs
+                    .entry(ordered[c_idx].recipe.as_str())
+                    .or_default()
+                    .push(row_idx);
+                let y_end = span.y_end;
+                entities.extend(cell_ents);
+                row_spans.push(span);
+                y_cursor = y_end + extra_gaps.get(&row_idx).copied().unwrap_or(0);
+                continue;
+            }
+            crate::trace::emit(crate::trace::TraceEvent::GhostSpecFailed {
+                spec_key: format!("di-cell:{item}:refused"),
+                from_x: 0,
+                from_y: y_cursor,
+                to_x: 0,
+                to_y: y_cursor,
+            });
+        }
+
         let total_count = {
             let c = spec.count;
             let snapped = if (c - c.round()).abs() < 1e-9 { c.round() } else { c.ceil() };
@@ -2340,7 +2650,8 @@ mod tests {
 
     #[test]
     fn place_rows_two_recipes_ordered() {
-        let machines = vec![iron_gear_spec(), iron_plate_spec()];
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
         let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
         let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), false, &[], &StackingCtx::unstacked());
         assert_eq!(spans.len(), 2);
@@ -3000,4 +3311,167 @@ mod tests {
         counts.sort();
         assert_eq!(counts, vec![5, 7], "both EC siblings must appear with their original counts");
     }
+    // ---- RFC-053 Phase 1: DI cells ----
+
+    /// Flow-BALANCED cell pair: 2 plate machines at 1.0/s feed 1 gear
+    /// machine at 2.0/s. The balance matters — `plan_straddle` refuses a
+    /// pair whose supply and demand disagree, so the shared
+    /// `iron_plate_spec`/`iron_gear_spec` helpers (1.0/s against 2.0/s)
+    /// cannot form a cell and would make these tests pass vacuously.
+    fn cell_pair() -> (MachineSpec, MachineSpec) {
+        let mut producer = iron_plate_spec();
+        producer.count = 2.0;
+        let consumer = iron_gear_spec();
+        (producer, consumer)
+    }
+
+    fn gear_cell_couplings() -> Vec<crate::models::DICoupling> {
+        vec![crate::models::DICoupling {
+            producer_recipe: "iron-plate".to_string(),
+            consumer_recipe: "iron-gear-wheel".to_string(),
+            item: "iron-plate".to_string(),
+            producer_count: 2.0,
+            consumer_count: 1.0,
+        }]
+    }
+
+    /// The defining property: an eligible pair collapses to ONE row, and
+    /// the coupled item never appears on a belt.
+    #[test]
+    fn di_cell_fuses_eligible_pair() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "producer + consumer must fuse into one cell row, got {:?}",
+            spans.iter().map(|s| s.spec.recipe.as_str()).collect::<Vec<_>>());
+
+        // The fused spec is a composite machine: producer's input in,
+        // consumer's output out.
+        let sp = &spans[0];
+        assert_eq!(sp.spec.recipe, "iron-gear-wheel");
+        assert_eq!(sp.spec.inputs.iter().map(|f| f.item.as_str()).collect::<Vec<_>>(), vec!["iron-ore"]);
+        assert_eq!(sp.spec.outputs.iter().map(|f| f.item.as_str()).collect::<Vec<_>>(), vec!["iron-gear-wheel"]);
+
+        // No belt anywhere carries the coupled item — the whole point.
+        let belts: Vec<&PlacedEntity> = ents.iter()
+            .filter(|e| e.name.contains("transport-belt") || e.name.contains("underground-belt"))
+            .collect();
+        assert!(
+            !belts.iter().any(|e| e.carries.as_deref() == Some("iron-plate")),
+            "coupled item must never reach a belt; found {:?}",
+            belts.iter().filter(|e| e.carries.as_deref() == Some("iron-plate"))
+                 .map(|e| (e.x, e.y)).collect::<Vec<_>>()
+        );
+        // ...and it IS moved, by reach-1 inserters between the machines.
+        assert!(
+            ents.iter().any(|e| e.name.contains("inserter")
+                && e.carries.as_deref() == Some("iron-plate")),
+            "the cell must actually couple the item"
+        );
+    }
+
+    /// A cell's fused row owns a REAL output belt — this is what makes the
+    /// #447 contract question moot rather than merely unlikely to bite.
+    #[test]
+    fn di_cell_row_has_a_real_output_belt() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "guard: this asserts nothing unless a cell was actually fused");
+        let y = spans[0].output_belt_y;
+        assert!(
+            ents.iter().any(|e| e.y == y && e.name.contains("transport-belt")),
+            "output_belt_y={y} must point at an emitted belt, not a phantom"
+        );
+    }
+
+    /// The Phase-1 gate. `detect_di_couplings` emits cable->EC without
+    /// looking at the consumer's input count, so the placer must refuse it:
+    /// EC's second solid input (iron-plate) has no free face in a cell, and
+    /// fusing anyway yields a layout that validates clean and starves.
+    #[test]
+    fn di_cell_refuses_multi_input_consumer() {
+        let cable = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "copper-cable".to_string(),
+            self_loop: vec![], voider: false, game_modules: Vec::new(),
+            count: 3.0,
+            inputs: vec![ItemFlow { item: "copper-plate".to_string(), rate: 2.5, is_fluid: false, module_id: 0 }],
+            outputs: vec![ItemFlow { item: "copper-cable".to_string(), rate: 5.0, is_fluid: false, module_id: 0 }],
+        };
+        let ec = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "electronic-circuit".to_string(),
+            self_loop: vec![], voider: false, game_modules: Vec::new(),
+            count: 2.0,
+            inputs: vec![
+                ItemFlow { item: "iron-plate".to_string(), rate: 2.5, is_fluid: false, module_id: 0 },
+                ItemFlow { item: "copper-cable".to_string(), rate: 7.5, is_fluid: false, module_id: 0 },
+            ],
+            outputs: vec![ItemFlow { item: "electronic-circuit".to_string(), rate: 2.5, is_fluid: false, module_id: 0 }],
+        };
+        assert!(
+            !cell_eligible(&cable, &ec, "copper-cable"),
+            "EC has two solid inputs — not a Phase 1 cell"
+        );
+        let machines = vec![ec, cable];
+        let dep_order = vec!["copper-cable".to_string(), "electronic-circuit".to_string()];
+        let couplings = vec![crate::models::DICoupling {
+            producer_recipe: "copper-cable".to_string(),
+            consumer_recipe: "electronic-circuit".to_string(),
+            item: "copper-cable".to_string(),
+            producer_count: 3.0,
+            consumer_count: 2.0,
+        }];
+        let (_, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &couplings, &StackingCtx::unstacked(),
+        );
+        // Row-splitting can push this past two rows; what matters is that
+        // the producer still owns a row of its own, i.e. nothing fused.
+        assert!(
+            spans.iter().any(|s| s.spec.recipe == "copper-cable"),
+            "producer must keep its own row (no fusion); got {:?}",
+            spans.iter().map(|s| s.spec.recipe.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    /// DI off is the default and must stay bit-identical: no fusion.
+    #[test]
+    fn di_cell_inert_when_direct_insertion_off() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (_, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            false, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 2, "DI off must not fuse");
+    }
+
+    /// Fluids on either side are Phase 2 (the KC6 re-scope), not Phase 1.
+    #[test]
+    fn di_cell_refuses_fluid_touching_pair() {
+        let mut producer = iron_plate_spec();
+        producer.inputs.push(ItemFlow {
+            item: "water".to_string(), rate: 10.0, is_fluid: true, module_id: 0,
+        });
+        assert!(
+            !cell_eligible(&producer, &iron_gear_spec(), "iron-plate"),
+            "fluid-touching pairs are Phase 2"
+        );
+    }
+
 }

--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -1267,7 +1267,19 @@ pub fn check_output_belt_coverage(
             }
         }
 
-        if !has_output_belt {
+        // RFC-053: a DI-cell producer's output leaves by inserter into the
+        // consumer machine, never onto a belt. See `is_di_cell_entity`.
+        let served_by_di_cell = layout.entities.iter().any(|ins| {
+            is_inserter(&ins.name)
+                && super::is_di_cell_entity(ins.segment_id.as_deref())
+                && {
+                    let (dx, dy) = dir_to_vec(ins.direction);
+                    let reach = inserter_reach(&ins.name);
+                    my_tiles.contains(&(ins.x - dx * reach, ins.y - dy * reach))
+                }
+        });
+
+        if !has_output_belt && !served_by_di_cell {
             issues.push(ValidationIssue::with_pos(
                 Severity::Error,
                 "output-belt",

--- a/crates/core/src/validate/belt_structural.rs
+++ b/crates/core/src/validate/belt_structural.rs
@@ -811,7 +811,20 @@ pub fn check_output_belt_coverage(
             my_tiles.contains(&pickup) && !machine_tiles.contains(&drop) && belt_tiles.contains(&drop)
         });
 
-        if !has_output_belt {
+        // RFC-053: a DI-cell producer has no output belt BY DESIGN — the
+        // band inserter carries its output straight into the consumer
+        // machine, so the belt-drop test above can never be satisfied.
+        let served_by_di_cell = layout.entities.iter().any(|ins| {
+            is_inserter(&ins.name)
+                && super::is_di_cell_entity(ins.segment_id.as_deref())
+                && {
+                    let dv = dir_to_vec(ins.direction);
+                    let reach = inserter_reach(&ins.name);
+                    my_tiles.contains(&(ins.x - dv.0 * reach, ins.y - dv.1 * reach))
+                }
+        });
+
+        if !has_output_belt && !served_by_di_cell {
             issues.push(ValidationIssue::with_pos(
                 Severity::Error,
                 "output-belt",

--- a/crates/core/src/validate/inserters.rs
+++ b/crates/core/src/validate/inserters.rs
@@ -348,6 +348,29 @@ pub fn check_inserter_throughput(
         if !checked.insert(mpos) {
             continue;
         }
+        // RFC-053: machines inside a fused DI cell are exempt from the
+        // per-machine inserter-throughput tests, for two independent
+        // reasons, both of which make the numbers here meaningless rather
+        // than merely conservative:
+        //
+        //  - A cell PRODUCER has no belt-bound output hand at all (the band
+        //    inserter drops into the consumer machine), so the check credits
+        //    it 0.00/s against its full output rate.
+        //  - A cell's `RowSpan` carries the FUSED spec — the producer's
+        //    inputs and the consumer's outputs — because that is what the
+        //    lane planner needs. `resolve_row_spec` therefore attributes the
+        //    producer's input item to the consumer machines, and the check
+        //    asks the consumers for an item they never take (iron-ore, for a
+        //    furnace cell whose consumers eat iron-plate).
+        //
+        // The cell's correctness is owned by `bus::di_cell`'s invariants —
+        // every band inserter picks from a producer tile and drops into a
+        // consumer tile at reach 1, and `try_build_cell` refuses rather than
+        // under-provisioning any face — and by RFC-053 KC3, which
+        // sim-measured the shape at 112% of plan against a bus control.
+        if super::is_di_cell_entity(e.segment_id.as_deref()) {
+            continue;
+        }
         let recipe = match e.recipe.as_deref() {
             Some(r) => r,
             None => continue,
@@ -530,6 +553,29 @@ pub fn check_inserter_item_throughput(
         }
         let mpos = (e.x, e.y);
         if !checked.insert(mpos) {
+            continue;
+        }
+        // RFC-053: machines inside a fused DI cell are exempt from the
+        // per-machine inserter-throughput tests, for two independent
+        // reasons, both of which make the numbers here meaningless rather
+        // than merely conservative:
+        //
+        //  - A cell PRODUCER has no belt-bound output hand at all (the band
+        //    inserter drops into the consumer machine), so the check credits
+        //    it 0.00/s against its full output rate.
+        //  - A cell's `RowSpan` carries the FUSED spec — the producer's
+        //    inputs and the consumer's outputs — because that is what the
+        //    lane planner needs. `resolve_row_spec` therefore attributes the
+        //    producer's input item to the consumer machines, and the check
+        //    asks the consumers for an item they never take (iron-ore, for a
+        //    furnace cell whose consumers eat iron-plate).
+        //
+        // The cell's correctness is owned by `bus::di_cell`'s invariants —
+        // every band inserter picks from a producer tile and drops into a
+        // consumer tile at reach 1, and `try_build_cell` refuses rather than
+        // under-provisioning any face — and by RFC-053 KC3, which
+        // sim-measured the shape at 112% of plan against a bus control.
+        if super::is_di_cell_entity(e.segment_id.as_deref()) {
             continue;
         }
         let recipe = match e.recipe.as_deref() {

--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -220,6 +220,24 @@ pub(crate) fn is_di_bridge_inserter(seg: Option<&str>) -> bool {
     seg.is_some_and(|s| s.starts_with("di-bridge:"))
 }
 
+/// A direct-insertion **cell** inserter (RFC-053 Phase 1): machine-to-machine
+/// by design. The placer tags every entity of a fused cell
+/// `di-cell:<item>:<consumer_recipe>` (see `bus::di_cell::stamp_di_cell_io`).
+///
+/// The distinction that matters to the checks below: a cell's PRODUCER has
+/// **no output belt at all** — its output leaves through the one-tile band
+/// straight into the consumer machine. Every "machine must have an output
+/// inserter dropping onto a belt" test therefore flags a cell producer as a
+/// hard error unless it recognises this tag, and the item-throughput tests
+/// see 0.00/s moved because they only credit belt-bound hands. Those are
+/// false alarms, not defects — `bus::di_cell`'s own invariants (every band
+/// inserter picks from a producer tile and drops into a consumer tile, at
+/// reach 1, with no belt for the coupled item) own the cell's correctness,
+/// and RFC-053 KC3 sim-measured the shape at 112% of plan.
+pub(crate) fn is_di_cell_entity(seg: Option<&str>) -> bool {
+    seg.is_some_and(|s| s.starts_with("di-cell:"))
+}
+
 /// Resolve the exact `MachineSpec` sibling the layout pipeline placed at `y`
 /// for `recipe`, preferring `layout.effective_rows`'s position attribution
 /// over a recipe-name lookup — partition siblings share a recipe name but

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8061,3 +8061,60 @@ fn research_l7_thins_output_inserters_s4() {
         "the thinning must be SHARP (~3x observed): L0={l0} should be >= 3 x L7={l7}"
     );
 }
+
+/// RFC-053 **KC3 fixture** — export a DI-cell layout + manifest for the sim
+/// harness. Ignored: it writes artifacts and is driven by hand.
+///
+/// ```bash
+/// cargo test --manifest-path crates/core/Cargo.toml --test e2e -- \
+///     di_cell_kc3_export --exact --ignored --nocapture
+/// ```
+///
+/// Target is `iron-gear-wheel` from `iron-ore`, NOT the RFC's cable→EC
+/// worked example: EC has two solid inputs and is a Phase 2 shape (#449).
+/// Gears are the canonical single-solid-input consumer, so the coupling
+/// clears `cell_eligible`.
+#[test]
+#[ignore]
+fn di_cell_kc3_export() {
+    use spaghettio_core::bus::layout;
+    let inputs: FxHashSet<String> = ["iron-ore".to_string()].into_iter().collect();
+    let sr = solver::solve("steel-plate", 2.0, &inputs, "assembling-machine-2")
+        .expect("solve steel-plate from ore");
+    println!("machines:");
+    for m in &sr.machines {
+        println!("  {} x{:.2} on {} in={:?} out={:?}", m.recipe, m.count, m.entity,
+            m.inputs.iter().map(|f| (&f.item, f.rate)).collect::<Vec<_>>(),
+            m.outputs.iter().map(|f| (&f.item, f.rate)).collect::<Vec<_>>());
+    }
+    println!("di_couplings: {:?}", sr.di_couplings);
+
+    // DI on/off from the environment so the same fixture produces the
+    // KC3 measurement AND its control. Without the control an
+    // over-production figure can't be attributed: a solver rate-model
+    // artifact and a DI artifact look identical in a single run.
+    let di = std::env::var("SPAGHETTIO_KC3_DI").as_deref() != Ok("0");
+    let opts = layout::LayoutOptions {
+        direct_insertion: di,
+        max_belt_tier: Some("transport-belt".to_string()),
+        ..Default::default()
+    };
+    let l = layout::build_bus_layout(&sr, opts).expect("layout");
+    let cell_ents = l.entities.iter()
+        .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-cell:")))
+        .count();
+    let bridge_ents = l.entities.iter()
+        .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-bridge:")))
+        .count();
+    println!("di-cell entities: {cell_ents}   di-bridge entities: {bridge_ents}");
+
+    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "di-cell-kc3");
+    let tag = if di { "di_cell_kc3" } else { "di_cell_kc3_control" };
+    std::fs::write(format!("/tmp/{tag}.bp"), &bp).expect("write bp");
+    std::fs::write(
+        format!("/tmp/{tag}.manifest.json"),
+        serde_json::to_string_pretty(&manifest).expect("manifest json"),
+    )
+    .expect("write manifest");
+    println!("wrote /tmp/{tag}.bp ({} bytes, di={di})", bp.len());
+}

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8158,3 +8158,64 @@ fn di_cell_kc3_export() {
     .expect("write manifest");
     println!("wrote /tmp/{tag}.bp ({} bytes, di={di})", bp.len());
 }
+
+/// RFC-053 Phase 1 **coverage sweep** — how often does an eligible
+/// coupling actually become a cell, rather than being refused into the
+/// bridge/bus fallback? Phase 1 added five refusal gates (modules,
+/// multi-inserter faces, both belt capacities, eligibility); if they
+/// collectively refuse nearly everything, "Phase 1 complete" is hollow.
+/// Ignored — reporting tool, not an assertion.
+///
+/// ```bash
+/// cargo test --manifest-path crates/core/Cargo.toml --test e2e -- \
+///     di_cell_coverage_sweep --exact --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn di_cell_coverage_sweep() {
+    use spaghettio_core::bus::layout;
+    let cases: &[(&str, &[&str], f64)] = &[
+        ("steel-plate", &["iron-ore"], 1.0),
+        ("steel-plate", &["iron-ore"], 2.0),
+        ("steel-plate", &["iron-ore"], 5.0),
+        ("steel-plate", &["iron-ore"], 10.0),
+        ("steel-plate", &["iron-ore"], 20.0),
+        ("iron-gear-wheel", &["iron-ore"], 5.0),
+        ("iron-stick", &["iron-ore"], 5.0),
+        ("pipe", &["iron-ore"], 5.0),
+        ("copper-cable", &["copper-ore"], 5.0),
+        ("electronic-circuit", &["iron-ore", "copper-ore"], 5.0),
+        ("stone-brick", &["stone"], 5.0),
+    ];
+    println!("{:<22} {:>6}  {:>9} {:>8} {:>8}  {}", "target", "rate", "couplings", "cells", "bridges", "verdict");
+    for (item, ins, rate) in cases {
+        let inputs: FxHashSet<String> = ins.iter().map(|s| s.to_string()).collect();
+        let Ok(sr) = solver::solve(item, *rate, &inputs, "assembling-machine-2") else {
+            println!("{item:<22} {rate:>6}  {:>9} {:>8} {:>8}  SOLVER-REFUSED", "-", "-", "-");
+            continue;
+        };
+        let ncoup = sr.di_couplings.len();
+        let opts = layout::LayoutOptions {
+            direct_insertion: true,
+            max_belt_tier: Some(
+                std::env::var("SWEEP_BELT").unwrap_or_else(|_| "transport-belt".into()),
+            ),
+            ..Default::default()
+        };
+        let Ok(l) = layout::build_bus_layout(&sr, opts) else {
+            println!("{item:<22} {rate:>6}  {ncoup:>9} {:>8} {:>8}  LAYOUT-REFUSED", "-", "-");
+            continue;
+        };
+        let cells = l.entities.iter()
+            .filter_map(|e| e.segment_id.as_deref())
+            .filter(|s| s.starts_with("di-cell:"))
+            .count();
+        let bridges = l.entities.iter()
+            .filter_map(|e| e.segment_id.as_deref())
+            .filter(|s| s.starts_with("di-bridge:"))
+            .count();
+        let verdict = if cells > 0 { "CELL" } else if bridges > 0 { "bridge" }
+            else if ncoup > 0 { "refused -> bus" } else { "no coupling" };
+        println!("{item:<22} {rate:>6}  {ncoup:>9} {cells:>8} {bridges:>8}  {verdict}");
+    }
+}

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8219,3 +8219,62 @@ fn di_cell_coverage_sweep() {
         println!("{item:<22} {rate:>6}  {ncoup:>9} {cells:>8} {bridges:>8}  {verdict}");
     }
 }
+
+/// RFC-053 **KC2 evaluation** — face contention for the Phase 2 cell.
+///
+/// A row-layout machine has two usable faces. A cell spends the NORTH face
+/// on the DI band, so every remaining flow must fit on the SOUTH face. For
+/// `copper-cable → electronic-circuit` that is iron-plate IN and
+/// electronic-circuit OUT, sharing one 3-wide face.
+///
+/// KC2 fires if those flows cannot be carried at **≤ L2** inserter-capacity
+/// research — i.e. if the cell is only feasible at max research.
+///
+/// The RFC's proposed geometry is mixed-reach: a reach-1 inserter picks
+/// iron off the NEAR belt, and a long-handed one steps OVER that belt to
+/// drop EC on the FAR belt. So the output side is constrained to
+/// long-handed (I8a: the only reach-2 inserter), which is the binding
+/// constraint and the whole reason this criterion exists.
+#[test]
+#[ignore]
+fn kc2_face_contention() {
+    use spaghettio_core::common::{belt_drop_rate, machine_feed_rate, QualityTier};
+    // AM3 canonical: 1 iron + 3 cable -> 1 EC at 2.5 crafts/s.
+    const IRON_IN: f64 = 2.5;
+    const EC_OUT: f64 = 2.5;
+    let q = QualityTier::Normal;
+
+    println!("KC2: consumer south face must carry iron IN {IRON_IN}/s + EC OUT {EC_OUT}/s");
+    println!();
+    println!("{:<22} {:>8} {:>8} {:>8}   {}", "inserter", "L0", "L2", "L7", "role");
+    for name in ["inserter", "long-handed-inserter", "fast-inserter", "bulk-inserter", "stack-inserter"] {
+        let f: Vec<String> = [0u8, 2, 7].iter()
+            .map(|&l| format!("{:.2}", machine_feed_rate(name, q, l)))
+            .collect();
+        println!("{name:<22} {:>8} {:>8} {:>8}   belt->machine (iron in)", f[0], f[1], f[2]);
+    }
+    println!();
+    for belt in ["transport-belt", "fast-transport-belt", "express-transport-belt"] {
+        for name in ["long-handed-inserter", "fast-inserter", "bulk-inserter", "stack-inserter"] {
+            let d: Vec<String> = [0u8, 2, 7].iter()
+                .map(|&l| format!("{:.2}", belt_drop_rate(name, q, 1, l, belt)))
+                .collect();
+            println!("{name:<22} {:>8} {:>8} {:>8}   machine->{belt} (EC out)", d[0], d[1], d[2]);
+        }
+        println!();
+    }
+
+    // The verdict the criterion actually asks for.
+    let far_out_l2 = belt_drop_rate("long-handed-inserter", q, 1, 2, "express-transport-belt");
+    let near_in_l2 = machine_feed_rate("fast-inserter", q, 2);
+    println!("--- KC2 verdict at L2, 3-wide face ---");
+    println!("  near (reach-1) iron in : fast-inserter {near_in_l2:.2}/s vs {IRON_IN}/s needed -> {}",
+        if near_in_l2 + 1e-9 >= IRON_IN { "OK with 1" } else { "needs >1" });
+    println!("  far  (reach-2) EC out  : long-handed  {far_out_l2:.2}/s vs {EC_OUT}/s needed -> {}",
+        if far_out_l2 + 1e-9 >= EC_OUT { "OK with 1" } else { "needs >1" });
+    let n_far = (EC_OUT / far_out_l2).ceil() as usize;
+    let n_near = (IRON_IN / near_in_l2).ceil() as usize;
+    println!("  columns required: {n_near} near + {n_far} far = {} of 3 available -> {}",
+        n_near + n_far,
+        if n_near + n_far <= 3 { "KC2 PASSES" } else { "KC2 FIRES" });
+}

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8108,6 +8108,26 @@ fn di_cell_kc3_export() {
         .count();
     println!("di-cell entities: {cell_ents}   di-bridge entities: {bridge_ents}");
 
+    // KC3 is specifically about a layout that VALIDATES CLEAN yet
+    // under-delivers, so the warning list is part of the measurement,
+    // not a footnote — a warned layout would make the sim number
+    // uninterpretable against this criterion.
+    let warnings = spaghettio_core::validate::validate(
+        &l,
+        Some(&sr),
+        spaghettio_core::validate::LayoutStyle::Bus,
+    )
+    .map(|w| w.len())
+    .unwrap_or_else(|e| {
+        let errs = e.issues.iter().filter(|i| format!("{:?}", i.severity) == "Error").count();
+        println!("VALIDATION ERRORS: {errs}");
+        let mut by_cat: std::collections::BTreeMap<&str, usize> = Default::default();
+        for i in &e.issues { *by_cat.entry(i.category.as_str()).or_default() += 1; }
+        for (c, n) in &by_cat { println!("  {c}: {n}"); }
+        e.issues.len()
+    });
+    println!("validation issues: {warnings}");
+
     let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "di-cell-kc3");
     let tag = if di { "di_cell_kc3" } else { "di_cell_kc3_control" };
     std::fs::write(format!("/tmp/{tag}.bp"), &bp).expect("write bp");

--- a/crates/mining-cli/src/bin/di_patterns.rs
+++ b/crates/mining-cli/src/bin/di_patterns.rs
@@ -24,7 +24,7 @@ use spaghettio_core::analysis;
 use spaghettio_core::common::{
     dir_to_vec, entity_size, inserter_reach, is_inserter, is_machine_entity,
 };
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeSet, BTreeMap, HashMap};
 
 /// One mined DI observation, canonicalized.
 struct Obs {
@@ -37,6 +37,15 @@ struct Obs {
     /// to the insertion axis — the "straddle" signature.
     lateral: i32,
     vertical: bool,
+    /// Blueprint-member id, unique across the corpus scan. Machine
+    /// indices are only meaningful within one member.
+    member: u32,
+    /// Index of the producer / consumer machine inside that member. These
+    /// are what make fan-in, fan-out and chain depth computable — without
+    /// them every observation is anonymous and only PAIRWISE geometry can
+    /// be reported (which is all the `geometry` subcommand ever needed).
+    p_idx: usize,
+    c_idx: usize,
 }
 
 fn mine(dir: &str) -> Vec<Obs> {
@@ -45,12 +54,14 @@ fn mine(dir: &str) -> Vec<Obs> {
         eprintln!("cannot read corpus dir: {dir}");
         return out;
     };
+    let mut member: u32 = 0;
     for ent in rd.flatten() {
         let Ok(txt) = std::fs::read_to_string(ent.path()) else { continue };
         let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt) else { continue };
         let Some(bp) = v.get("blueprintString").and_then(|s| s.as_str()) else { continue };
         let Ok(analyses) = analysis::analyze_blueprint_string_any(bp) else { continue };
         for na in &analyses {
+            member += 1;
             let ents = &na.layout.entities;
             let mut occ: HashMap<(i32, i32), usize> = HashMap::new();
             for (i, m) in ents.iter().enumerate() {
@@ -98,6 +109,9 @@ fn mine(dir: &str) -> Vec<Obs> {
                     gap,
                     lateral,
                     vertical,
+                    member,
+                    p_idx: si,
+                    c_idx: di,
                 });
             }
         }
@@ -135,6 +149,64 @@ fn main() {
                     if *vert { "vertical" } else { "horizontal" }
                 );
             }
+        }
+        "fan" => {
+            // Multi-band evidence (RFC-053 Phase 3). Three questions the
+            // pairwise `geometry` view structurally cannot answer:
+            //   fan-out  — does one producer feed several consumers?
+            //   fan-in   — does one consumer draw from several producers?
+            //              (>2 is what `plan_straddle` refuses today)
+            //   chain    — is a machine BOTH a consumer and a producer?
+            //              that is the stacked-band shape itself.
+            let filter: Option<(String, String)> = match (args.get(3), args.get(4)) {
+                (Some(a), Some(b)) => Some((a.clone(), b.clone())),
+                _ => None,
+            };
+            let sel: Vec<&Obs> = obs
+                .iter()
+                .filter(|o| {
+                    filter
+                        .as_ref()
+                        .is_none_or(|(a, b)| &o.producer == a && &o.consumer == b)
+                })
+                .collect();
+            let mut fan_out: BTreeMap<(u32, usize), BTreeSet<usize>> = BTreeMap::new();
+            let mut fan_in: BTreeMap<(u32, usize), BTreeSet<usize>> = BTreeMap::new();
+            let mut is_producer: BTreeSet<(u32, usize)> = BTreeSet::new();
+            let mut is_consumer: BTreeSet<(u32, usize)> = BTreeSet::new();
+            for o in &sel {
+                fan_out.entry((o.member, o.p_idx)).or_default().insert(o.c_idx);
+                fan_in.entry((o.member, o.c_idx)).or_default().insert(o.p_idx);
+                is_producer.insert((o.member, o.p_idx));
+                is_consumer.insert((o.member, o.c_idx));
+            }
+            let hist = |m: &BTreeMap<(u32, usize), BTreeSet<usize>>| {
+                let mut h: BTreeMap<usize, usize> = BTreeMap::new();
+                for v in m.values() {
+                    *h.entry(v.len()).or_insert(0) += 1;
+                }
+                h
+            };
+            let label = filter
+                .as_ref()
+                .map(|(a, b)| format!("{a} -> {b}"))
+                .unwrap_or_else(|| "ALL pairs".into());
+            println!("fan analysis: {label}  ({} observations)", sel.len());
+            println!("  fan-OUT (consumers fed by one producer machine):");
+            for (k, n) in hist(&fan_out) {
+                println!("    {k} consumer(s): {n} producer machines");
+            }
+            println!("  fan-IN (producers feeding one consumer machine):");
+            for (k, n) in hist(&fan_in) {
+                println!("    {k} producer(s): {n} consumer machines");
+            }
+            let chained: Vec<_> = is_producer.intersection(&is_consumer).collect();
+            println!(
+                "  CHAIN: {} machines are both a DI producer and a DI consumer \
+                 (stacked bands) out of {} distinct machines",
+                chained.len(),
+                is_producer.union(&is_consumer).count()
+            );
         }
         _ => {
             let mut pairs: BTreeMap<(String, String), usize> = BTreeMap::new();

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -548,7 +548,18 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
     when counting DI in community blueprints). Refuses rather than
     under-feeding when the chosen inserter can't cover an edge within
     the slots that edge owns.
-  - **1c — placer wiring** (remaining, and the invasive step). Pick-up
+  - **1c ✅ LANDED — placer wiring. Phase 1 is COMPLETE.**
+    `place_rows` now fuses an eligible pair into one cell row via
+    `cell_eligible` → `try_build_cell` → `fused_cell_spec`. The engine
+    emits machine→inserter→machine DI for the first time. Inert by
+    default (`direct_insertion: false`), so no existing layout moved —
+    the cell path is covered by unit tests only until Phase 4 exposes
+    the flag. The notes below are kept as the record of how the step was
+    scoped; where they disagree with what shipped, what shipped wins
+    (notably: no new `RowKind` was needed — a fused `RowSpan` built
+    directly from `DiCellLayout` was enough).
+
+  - *Original 1c pick-up notes (superseded).* Pick-up
     notes, so this doesn't need re-deriving:
     - **Seam**: `bus::placer::place_rows`, the DI branch that currently
       calls `stamp_di_bridge` (search `is_di_consumer` / `di_lookup`).
@@ -814,3 +825,27 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   wiring rather than after — the RFC had carried the contradiction
   since the first draft because prose scope and worked example were
   never cross-checked.*
+
+- *2026-07-25 — **Phase 1c landed; Phase 1 is complete.** `place_rows`
+  fuses an eligible producer/consumer pair into a single cell row, so the
+  engine emits true machine→inserter→machine DI for the first time.
+  Three things worth carrying forward. **(a) The fused-row design made
+  the "invasive" step small.** The pick-up notes predicted a new
+  `RowKind` and a restructured placement loop; what it actually took was
+  a precomputed `cell_pairs` map, a skip-set for absorbed consumer specs,
+  and a `RowSpan` built straight from `DiCellLayout`. The reason is the
+  design choice, not luck: describing the cell as a composite machine
+  (producer's inputs, consumer's outputs) means nothing downstream has to
+  learn what a cell is. **(b) `cell_eligible` is load-bearing.** It is
+  the only thing standing between `detect_di_couplings`' cable→EC
+  coupling and a starving cell — the solver will keep emitting couplings
+  Phase 1 cannot serve, and that is fine as long as the placer refuses
+  them. **(c) A test passed vacuously and had to be caught by hand.**
+  `di_cell_row_has_a_real_output_belt` went green while no cell was being
+  built at all — the shared `iron_plate_spec`/`iron_gear_spec` helpers
+  are unbalanced (1.0/s against 2.0/s), `plan_straddle` rightly refused
+  them, and the assertion silently landed on an ordinary row. It now
+  guards on `spans.len() == 1` first. Textbook "zero warnings can mean
+  the check was wrong" from the verification protocol, and worth the
+  reminder that a green new test is evidence of nothing until you have
+  seen it fail for the right reason.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -434,11 +434,37 @@ caveat.
    a `Fast`-capped user cannot get a feasible cell at the **default**
    research level, DI is too fragile to ship default-on — it stays an
    opt-in strategy with an honest refusal, not a silent degradation.
-3. **Honest throughput.** If a DI cell validates clean but the sim
-   harness measures **< 98% of plan** on the canonical fixture, the
-   model is wrong and the checks are lying — stop everything. (This is
-   the #383 lesson: validator-clean concealed a real starve for weeks.)
-4. **Density premise. ✅ EVALUATED 2026-07-25 — PASSES.** Measured on
+3. **Honest throughput. ✅ EVALUATED 2026-07-25 — PASSES.** If a DI cell
+   validates clean but the sim harness measures **< 98% of plan** on the
+   canonical fixture, the model is wrong and the checks are lying — stop
+   everything. (This is the #383 lesson: validator-clean concealed a
+   real starve for weeks.) **Measured on a real cell** (`steel-plate@2/s`
+   from `iron-ore`, 16:16 furnace→furnace — the corpus's dominant DI
+   shape; the fixture is `di_cell_kc3_export` in `tests/e2e.rs`):
+
+   | | planned/s | produced/s | delivered/s | entities |
+   |---|---|---|---|---|
+   | **DI cell** | 2.00 | 2.21 (+10.7%) | 2.24 (+12.0%) | **213** |
+   | control (DI off) | 2.00 | 2.20 (+10.0%) | 2.24 (+12.0%) | 335 |
+
+   `converged=true`, 32/32 machines working, both runs. DI delivers
+   **112% of plan**, nowhere near the 98% floor, and matches its own
+   bus control to within 0.7pp produced / 0.0pp delivered. The
+   criterion does not fire.
+
+   **The control is the load-bearing part.** A single DI run showing
+   +10.7% is uninterpretable: a solver rate-model artifact and a DI
+   artifact are indistinguishable without it. Running the same target
+   with `direct_insertion: false` attributes the overshoot to the
+   *model*, not the topology — the engine under-predicts electric-furnace
+   steel output by ~10% in both. That discrepancy is real, pre-existing
+   and orthogonal to this RFC; it deserves its own issue rather than
+   being quietly absorbed here.
+4. **Density premise. ✅ EVALUATED 2026-07-25 — PASSES; re-confirmed
+   end-to-end.** The KC3 run above measures it on a whole solved layout
+   rather than a hand-derived cell: **213 entities against the bus
+   control's 335, a 36% reduction** at identical delivered throughput.
+   Original hand-derived evaluation follows. Measured on
    the canonical fixture (EC@10/s from plates, DI off) against the real
    engine: the bus places `copper-cable` at y1–7 and `electronic-circuit`
    at y10–17 with a `copper-cable` trunk lane at y7–9 — a **17-tile**
@@ -877,3 +903,26 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   the check was wrong" from the verification protocol, and worth the
   reminder that a green new test is evidence of nothing until you have
   seen it fail for the right reason.*
+
+- *2026-07-25 — **KC3 evaluated and PASSES; the RFC now survives every
+  kill criterion that is evaluable pre-Phase-2.** Sim-measured a real
+  cell built by the full solver→layout pipeline (`steel-plate@2/s` from
+  `iron-ore`, 16:16 furnace→furnace): 2.24/s delivered against 2.00/s
+  planned, `converged=true`, 32/32 machines working. The floor is 98%;
+  this is 112%. **Ran a DI-off control on the same target and that is the
+  finding worth keeping** — the control delivers *the same* 2.24/s
+  (+12.0%), so the overshoot is a solver rate-model artifact
+  (electric-furnace steel under-predicted by ~10%), not a property of
+  DI. Without the control the +10.7% would have been unattributable, and
+  the temptation to read it as "DI beats plan" would have been strong
+  and wrong. The same pair of runs re-confirms KC4 end-to-end at a scale
+  the hand-derived 7-vs-17 figure couldn't: **213 entities vs 335, −36%**,
+  at identical delivered throughput. Chose to run KC3 before starting
+  Phase 2 specifically because Phase 2 is the expensive phase and KC3 is
+  the criterion most able to invalidate the topology — evaluating it the
+  moment it became evaluable (which Phase 1c's landing made possible) is
+  the RFC's own kill-criterion discipline. Two gates remain open and both
+  are inherently Phase 2+: KC2 (face contention — a Phase 1 cell has no
+  second face flow by construction) and KC5 (solver escalation bound).
+  Orthogonal follow-up, deliberately NOT folded into this RFC: the ~10%
+  electric-furnace steel rate discrepancy the control exposed.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1008,3 +1008,28 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   on this PR"), so a green `claude-review` on the fixed SHA is not
   evidence the fixes were reviewed — the CLAUDE.md warning applies to
   re-reviews too, not just first passes.*
+
+- *2026-07-25 — **Phase 1 coverage measured, so "Phase 1 complete" isn't
+  taken on faith.** Five refusal gates landed during the #450 review
+  fold-in; if they collectively refuse almost everything, the phase is
+  hollow. `di_cell_coverage_sweep` (ignored, in `tests/e2e.rs`) reports
+  cell-vs-fallback across 11 real targets. At yellow: **4 build cells**
+  (`steel-plate` at 1 and 2/s, `iron-stick`, `pipe`, `copper-cable`),
+  and every refusal has an explicable cause rather than a silent one —
+  `electronic-circuit` is Phase 2 (two solid inputs), `iron-gear-wheel`
+  is out on ratio (~4.8 furnaces per gear machine, straddle > 2),
+  `stone-brick` yields no coupling at all, and the high-rate
+  `steel-plate` cases hit belt capacity. **The capacity refusals track
+  real belt limits, verified by re-sweeping at each tier**:
+  `steel-plate@5` needs 25/s of iron-plate, so it refuses on yellow
+  (15/s) and builds on red (30/s); `steel-plate@10` needs 50/s and
+  refuses even on express (45/s), which is correct — one belt cannot
+  feed it. That last case is the real Phase 1 ceiling and it is a
+  **fan-in** limit, not a DI limit: the ordinary path would split the
+  recipe across rows, and a cell cannot (its machines sit at
+  `StraddlePlan` positions), so high-rate couplings need the Phase 3
+  multi-band cell. Recorded as a measurement rather than a guess because
+  the gates were added under review pressure and their aggregate effect
+  was not obvious from any individual one. NB the sweep only varies
+  `max_belt_tier` to characterise the ceiling — the engine must never
+  auto-escalate tier, which stays a hard user-specified constraint.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -452,6 +452,32 @@ caveat.
    bus control to within 0.7pp produced / 0.0pp delivered. The
    criterion does not fire.
 
+   **The "validates clean" half was NOT true on the first pass, and
+   finding that out took a second look.** KC3 is a conjunction — a cell
+   that *validates clean* AND under-delivers — and the first measurement
+   only checked the throughput half. Running the validator afterwards
+   returned **16 `Error`s and 48 warnings**: every producer furnace
+   flagged `output-belt: no output inserter has a belt at its drop
+   position`, plus `inserter-throughput` crediting cell machines 0.00/s.
+   All false positives — the sim had already proved the shape moves
+   112% of plan — but a DI feature that buries the validator in false
+   errors is not shippable, and worse, real errors would have been
+   indistinguishable. Two distinct causes, both now fixed and both
+   inherent to the cell design rather than incidental:
+
+   - a cell producer has **no output belt at all** (its output leaves
+     through the band), so every "machine must have an output inserter
+     dropping onto a belt" test fails by construction;
+   - the fused `RowSpan` carries the producer's inputs, so
+     `resolve_row_spec` attributes the producer's input item to the
+     *consumer* machines — the check asked furnaces eating iron-plate to
+     account for iron-ore.
+
+   `validate::is_di_cell_entity` now exempts cell entities the way
+   `is_di_bridge_inserter` handles #432's bridges. **Post-fix: 0
+   validation issues, same 112% delivery.** So KC3's conjunction is
+   satisfied on both halves — but only after the gap was closed.
+
    **The control is the load-bearing part.** A single DI run showing
    +10.7% is uninterpretable: a solver rate-model artifact and a DI
    artifact are indistinguishable without it. Running the same target
@@ -926,3 +952,30 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   second face flow by construction) and KC5 (solver escalation bound).
   Orthogonal follow-up, deliberately NOT folded into this RFC: the ~10%
   electric-furnace steel rate discrepancy the control exposed.*
+
+- *2026-07-25 — **#450 review found three real bugs; a fourth was found
+  by closing my own verification gap.** The bot's findings, all
+  confirmed against the code before fixing rather than taken on trust:
+  **(1)** `fused_cell_spec` dropped the producer's module loadout — the
+  module post-pass keys `(entity, recipe)` off `row_spans`, and a cell
+  contributes only the consumer's recipe, so producer machines would get
+  no modules while the solver had already folded the bonus into their
+  count. Now refused outright (matching loadouts wouldn't help: the
+  *key* is missing). **(2)** `SidePlan.count`/`.shortfall` were computed
+  and discarded — `DiCellIo` carries an entity name and no count, so a
+  face needing two inserters got one and silently under-fed. Now sized
+  against a single slot and refused when that isn't enough; the comment
+  claiming "a single-inserter face isn't an implicit throughput cap"
+  asserted the exact opposite of the behaviour. **(3)** the cell's
+  output belt was sized against the raw combined rate although it is
+  physically single-lane (all output inserters share a y and a facing,
+  so every drop lands in the far lane) — a 2× over-estimate, and cells
+  never split by throughput the way ordinary rows do. Now sized at
+  `rate * 2.0` and refused when one lane can't carry it. **(4)** Mine:
+  the KC3 run measured throughput but never ran the validator, so
+  "validates clean" went unverified — and was false (16 errors). Fixed
+  via `is_di_cell_entity`. The through-line in all four is the same
+  shape of mistake — trusting a number that was never checked
+  (`.count`, lane capacity, the module key, the warning list) — which is
+  the failure mode this RFC's own verification protocol exists to catch,
+  and which three of four green test runs did not surface.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -421,10 +421,40 @@ caveat.
    reachable producers, the sandwich shape is wrong for the game's own
    ratios — stop and reconsider the topology, do not "mostly" feed
    consumers.
-2. **Face contention.** If the consumer's remaining face cannot carry
-   its non-DI flows (iron in + EC out) within its tile budget at
-   **≤ L2** `inserter_capacity` (i.e. the cell is only feasible at max
-   research), the topology is under-scoped — stop.
+2. **Face contention. ✅ EVALUATED 2026-07-25 — PASSES, with zero
+   margin.** If the consumer's remaining face cannot carry its non-DI
+   flows (iron in + EC out) within its tile budget at **≤ L2**
+   `inserter_capacity` (i.e. the cell is only feasible at max research),
+   the topology is under-scoped — stop. Measured against the real rate
+   tables (`kc2_face_contention` in `tests/e2e.rs`), AM3 canonical,
+   2.5/s each way, 3-wide face:
+
+   | side | inserter | rate @L2 | needed | columns |
+   |---|---|---|---|---|
+   | near (reach-1) | fast | 4.62/s | 2.5/s | **1** |
+   | far (reach-2) | long-handed | **2.40/s** | 2.5/s | **2** |
+   | | | | | **3 of 3 → PASSES** |
+
+   The criterion does not fire, but every column is consumed. The bind
+   is structural rather than a research shortfall: long-handed is the
+   only reach-2 inserter (I8a) and its belt-drop rate is 2.40/s at L2
+   rising only to 3.20/s at L7, so max research buys back exactly one
+   column and no more. Swapping which item takes the near belt is
+   symmetric (both flows are 2.5/s), so 1 + 2 is the budget either way.
+
+   **Consequences Phase 2 must design around, not discover later:** a
+   Phase 2 cell has **no spare face column**, so any consumer with a
+   third flow (second output, third input) does not fit and must refuse;
+   and pipe placement — which KC6 re-scoped INTO this phase — needs face
+   tiles this budget does not have, so fluid-touching consumers will
+   need a different face plan rather than this one extended.
+
+   *Incidental finding, flagged not folded:* `bulk-inserter`'s belt-drop
+   rate is flat 2.40/s across every research level AND every belt tier,
+   while its machine-feed rate scales 2.40 → 4.80 → 14.40. That makes
+   bulk strictly dominated for output faces. It may be correct, but
+   Phase 2's allocator will lean on this ladder and the asymmetry should
+   be verified before it does.
 
    **2b. Tier-cap degradation.** `max_inserter_tier` is a hard user cap,
    orthogonal to research level. If, at the engine defaults

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -449,12 +449,18 @@ caveat.
    tiles this budget does not have, so fluid-touching consumers will
    need a different face plan rather than this one extended.
 
-   *Incidental finding, flagged not folded:* `bulk-inserter`'s belt-drop
-   rate is flat 2.40/s across every research level AND every belt tier,
-   while its machine-feed rate scales 2.40 → 4.80 → 14.40. That makes
-   bulk strictly dominated for output faces. It may be correct, but
-   Phase 2's allocator will lean on this ladder and the asymmetry should
-   be verified before it does.
+   *Incidental finding, raised and then CLEARED:* `bulk-inserter`'s
+   belt-drop rate is flat 2.40/s across every research level and belt
+   tier, while its machine-feed rate scales 2.40 → 4.80 → 14.40. That
+   looked like a modelling gap Phase 2's allocator might trip over.
+   It is not — `belt_drop_rate`'s own doc states it: *"bulk inserters:
+   always flat — the engine never places one"*, i.e. a deliberate
+   simplification for an entity that only ever arrives by parsing
+   community blueprints. It also cannot affect this phase twice over:
+   bulk is reach-1, so it is structurally excluded from the binding
+   far/reach-2 column, and on the near side stack dominates it (6.38/s
+   vs 2.40/s at L2). Recorded because "verify the load-bearing number"
+   was the right instinct even though the answer was benign.
 
    **2b. Tier-cap degradation.** `max_inserter_tier` is a hard user cap,
    orthogonal to research level. If, at the engine defaults

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -500,6 +500,36 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
 - **Phase 1 — the DI cell.** `bus::di_cell` for the simplest shape: one
   producer recipe, one consumer recipe, consumer's only solid input is
   the DI'd item.
+
+  **⚠️ The worked example in this RFC is NOT a Phase 1 shape (found
+  2026-07-25).** `electronic-circuit` takes `[iron-plate,
+  copper-cable]` — *two* solid inputs — so `copper-cable → EC`, the pair
+  every geometry figure above is derived from, fails Phase 1's own scope
+  line. The consumer's north face is spent on the DI band and its south
+  face on the output inserter, so the second input has nowhere to land
+  until Phase 2's face allocation. The geometry stays valid (the
+  straddle math is rate-driven and item-agnostic — that is why 1a could
+  reproduce `[1,5,10,14]`), but the **wiring target** must be a
+  single-solid-input consumer. From `recipes.json`, discounting
+  `*-recycling`, the in-scope pairs are:
+
+  | producer → consumer | note |
+  |---|---|
+  | `iron-plate → steel-plate` | furnace→furnace; the corpus's 1,585-instance shape |
+  | `iron-plate → iron-gear-wheel` | canonical assembler cell |
+  | `iron-plate → pipe`, `→ iron-stick` | same shape |
+  | `copper-plate → copper-cable` | producer is the smelter |
+  | `stone → stone-brick` | furnace→furnace |
+
+  **This gate must live in the placer, not the solver.**
+  `netflow::detect_di_couplings` gates on one-producer / one-consumer /
+  no-external-supply / no-surplus / not-fluid — it does **not** look at
+  the consumer's input count. So it *will* emit a `copper-cable →
+  electronic-circuit` coupling, and Phase 1c wiring that trusts the
+  coupling list would build a cell whose EC machines never receive
+  iron-plate: a layout that validates clean and starves, which is
+  exactly the #383/#432 failure mode this RFC's own verification note
+  warns about.
   - **1a ✅ LANDED — straddle geometry + edge assignment.**
     `bus::di_cell::plan_straddle` is the algorithmic core: producer and
     consumer machine positions, the producer→consumer edge set, per-edge
@@ -548,21 +578,39 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
       belt) and returns a `DiCellLayout` carrying `input_belt_y` /
       `output_belt_y` / x-extent, i.e. exactly the fields a `RowSpan`
       needs. What remains of this step is constructing the `RowSpan`
-      itself and hanging it off a `RowKind`. **Open contract question,
-      narrowed 2026-07-25**: the producer row in a cell has NO solid
-      output belt (its output leaves by inserter), but `RowSpan`'s
-      `output_belt_y` is a plain `i32`, not an `Option`. Evidence that
-      this is benign: `lane_planner` only reads
-      `output_belt_y_for(item)` while *constructing a lane*, and the
-      coupled item's lane is dropped before that point because the
-      consumer carries `di_input` for it (zero surviving consumers ⇒
-      lane skipped). So the field should never be read for the DI'd
-      item — but that is currently an INFERENCE from reading the code,
-      not a verified property. Confirm it empirically (build a cell
-      layout, run the validator) before relying on it, or give the
-      producer's `output_belt_y` a deliberately invalid sentinel so a
-      stray read fails loudly instead of silently pointing at a tile
-      that isn't a belt; (2) intercept the producer/consumer spec pair
+      itself and hanging it off a `RowKind`. **Contract question —
+      RESOLVED 2026-07-25, by design change rather than by either
+      prescribed remedy.** The question was whether a cell's producer
+      row can safely carry a plain-`i32` `output_belt_y` when it owns no
+      output belt. Two things were established:
+
+      - *The premise it rested on was wrong.* #447 recorded that
+        "`lane_planner` only reads `output_belt_y_for(item)`". There are
+        in fact **11 bare `output_belt_y` reads** across
+        `lane_planner`, `lane_order` and `ghost_router`. Auditing every
+        one: eight index through a `BusLane`
+        (`all_producers()` / `producer_row` / `extra_producer_rows`, or
+        `all_producer_rows` during lane construction), so the
+        `di_input` argument does cover them; but the three
+        output-merger sites (`ghost_router.rs:3435`, `:3519`, `:3603`)
+        index rows by **`rs.spec.outputs` containing the item**, not
+        through any lane. A row is reachable there regardless of what
+        the lane planner did, so the original inference was not merely
+        unverified — it was insufficient.
+      - *The fix is to remove the hazard, not detect it.* A cell emits
+        **one fused `RowSpan`**, not two. Its `spec` carries the
+        producer's inputs and the consumer's outputs (the cell really is
+        a composite machine: it eats iron-ore off a belt and emits gears
+        onto one), and its `output_belt_y` is the cell's real output
+        belt. **The producer never gets a row of its own**, so no row
+        with a phantom output belt is ever constructed and all 11 read
+        sites are correct by construction. This also spares every
+        downstream consumer — lane planner, output merger, validators —
+        from special-casing cells.
+
+      The sentinel remedy is therefore not needed, and the "confirm it
+      empirically" remedy would have confirmed a property that does not
+      hold; (2) intercept the producer/consumer spec pair
       in `place_rows` — note this restructures the main placement loop
       (skipping a spec, custom `y_cursor` accounting, `module_id` and
       stacking-context threading), which is the highest-risk part of
@@ -726,3 +774,43 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   the module); 870 lib + 61 e2e green, clippy clean. Remaining: Phase 1c,
   the placer wiring — nothing calls these functions yet, so engine
   behaviour is still unchanged.*
+
+- *2026-07-25 — **The Phase 1c contract question is resolved, and the
+  premise it rested on was false.** #447 recorded the open question as
+  "does anything read a cell producer row's `output_belt_y`?", with the
+  supporting inference that `lane_planner` only ever reads
+  `output_belt_y_for(item)` during lane construction. Auditing all
+  **11** bare `output_belt_y` reads killed that inference: three of them
+  (`ghost_router.rs:3435/:3519/:3603`, the output merger) select rows by
+  `rs.spec.outputs`, never touching a `BusLane`, so `di_input` cannot
+  protect them. Both remedies #447 proposed were aimed at the wrong
+  target — "confirm it empirically" would have confirmed a property that
+  is not true, and the invalid sentinel would have converted a silent
+  bug into a loud one without removing it. **Resolved instead by
+  design**: a cell emits ONE fused `RowSpan` (producer's inputs +
+  consumer's outputs, cell's real output belt) rather than two, so no
+  row with a phantom output belt exists to be read. Recorded because the
+  general lesson is cheap and repeatable: an inference about a field's
+  read-paths is only as good as an exhaustive grep for that field, and
+  #447's was a partial one.*
+
+- *2026-07-25 — **Phase 1's wiring target is retargeted off the RFC's own
+  worked example.** `electronic-circuit` has two solid inputs
+  (`iron-plate`, `copper-cable`), so `copper-cable → EC` — the pair every
+  geometry figure in this RFC is derived from — violates Phase 1's stated
+  scope ("consumer's only solid input is the DI'd item"): the consumer's
+  two usable faces are already spent on the DI band and the output
+  inserter, leaving the iron-plate feed nowhere to land until Phase 2.
+  The geometry work is unaffected (`plan_straddle` is rate-driven and
+  item-agnostic), but 1c must be built and tested against a
+  single-solid-input pair — `iron-plate → iron-gear-wheel` for the
+  assembler case, `iron-plate → steel-plate` for the furnace→furnace
+  shape that dominates the corpus at 1,585 instances. **The eligibility
+  gate belongs in the placer**: `detect_di_couplings` gates on
+  one-producer/one-consumer/no-surplus/not-fluid and never inspects the
+  consumer's input count, so it emits the cable→EC coupling regardless;
+  1c wiring that trusted the coupling list would emit a clean-validating,
+  starving cell. Caught by checking the recipe DB before writing the
+  wiring rather than after — the RFC had carried the contradiction
+  since the first draft because prose scope and worked example were
+  never cross-checked.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -979,3 +979,32 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   (`.count`, lane capacity, the module key, the warning list) — which is
   the failure mode this RFC's own verification protocol exists to catch,
   and which three of four green test runs did not surface.*
+
+- *2026-07-25 — **Two more #450 findings, one of them missed on the first
+  fold-in, plus a CI gap that made every green on that PR meaningless.**
+  (a) The cell's input belt was sized from the cell's LOCAL demand, but
+  it is a bus tap-off target like any other row's input — `lane_planner`
+  taps it identically — so it must take the trunk tier via
+  `row_input_belt`, whose doc comment exists precisely to prevent the
+  seam mismatch I reintroduced (fast trunk feeding a yellow row belt,
+  lane-throughput warnings, items backing up at the join). I fixed the
+  output belt in the first pass and did not notice the input belt had the
+  same class of bug. (b) Neither belt refused on capacity:
+  `belt_entity_for_rate_stacked` **saturates** rather than failing, and
+  `plan_straddle` is scale-invariant in machine count, so any pair
+  eligible at rate R stays eligible at 100R while the belts silently
+  under-carry. Both sides now refuse. (c) **`ci.yml` triggers on
+  `pull_request: branches: [main]`, which filters the PR's BASE branch —
+  so #450, stacked on #449, got `ci.yml runs: 0` for its entire life.**
+  The signal was subtle and worth recording: on a docs-only PR the rust
+  jobs show `SKIPPED` (the `changes` filter ran), whereas on #450 they
+  were **absent** — never scheduled — while the two workflows that
+  aren't base-filtered passed and made the checks list look plausible.
+  This affects any stacked PR in the repo; widening the trigger is a
+  workflow-file change and deliberately left for a reviewed PR of its
+  own, given #369's history of an installer silently reverting these
+  files. Also worth noting for the next session: the review bot
+  **skipped** its later passes ("Claude has already left review comments
+  on this PR"), so a green `claude-review` on the fixed SHA is not
+  evidence the fixes were reviewed — the CLAUDE.md warning applies to
+  re-reviews too, not just first passes.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1033,3 +1033,31 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   was not obvious from any individual one. NB the sweep only varies
   `max_belt_tier` to characterise the ceiling — the engine must never
   auto-escalate tier, which stays a hard user-specified constraint.*
+
+- *2026-07-25 — **Phase 3 (multi-band) measured before building, and the
+  measurement argues against doing it next.** Extended `di-patterns` with
+  a `fan` subcommand — `Obs` previously carried only recipe names and
+  relative geometry, so fan-in/fan-out/chain were structurally
+  uncomputable; it now records the blueprint-member id and the two
+  machine indices. Corpus results:*
+
+  | shape | fan-in (producers per consumer) | chain (machine is both) |
+  |---|---|---|
+  | `electric-furnace → electric-furnace` (1,585) | **1 for all 1,585** | **0** |
+  | `copper-cable → electronic-circuit` (4,116) | 1 for 634, **2 for 1,405; max 2** | **0** |
+  | all pairs (16,507) | >2 for 237 of 11,536 consumers = **2.1%** | 1,674 / 21,622 = 7.7% |
+
+  *Three conclusions. **(1) `plan_straddle`'s existing ≤2 limit already
+  covers ~98% of real fan-in.** The RFC's stated Phase 3 motivation —
+  "multi-producer straddle for the corpus's awkward ratios" — is chasing
+  a 2.1% tail. **(2) Neither dominant shape uses stacked bands at all**
+  (chain = 0 for both); the 7.7% global figure lives in pairs nobody has
+  asked for. **(3) cable→EC needs exactly the 2-producer straddle Phase 1
+  already implements** — what blocks it is the second solid input, i.e.
+  Phase 2 face allocation, not the straddle. Separately, the Phase 1
+  ceiling measured earlier (`steel-plate@10` refusing on input-belt
+  capacity) is **not** a straddle problem either: it needs more than one
+  input belt feeding a cell, which multi-band does not address. So the
+  honest ordering is **Phase 2 before Phase 3**, and Phase 3's scope
+  should be rewritten around the fan-in belt limit rather than around
+  multi-producer straddle, which is largely already solved.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -619,9 +619,22 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
         downstream consumer — lane planner, output merger, validators —
         from special-casing cells.
 
-      The sentinel remedy is therefore not needed, and the "confirm it
-      empirically" remedy would have confirmed a property that does not
-      hold; (2) intercept the producer/consumer spec pair
+      **What the audit does and does not establish.** It shows #447's
+      *argument* was insufficient — three sites are reachable by a path
+      `di_input` does not guard. It does **not** show the property
+      itself is false. In fact the property probably does hold today,
+      via a guard #447 never cited: the merger loops iterate
+      `output_items`, built from `solver_result.external_outputs`, and
+      `detect_di_couplings` only couples an item with **no surplus**, so
+      a coupled item is never an external output and the producer row is
+      never selected there. Both #447 remedies were therefore
+      *reasonable*; an empirical check would have been a valid way to
+      test the claim. The fused row is preferred not because they were
+      wrong-headed but because it **stops depending on the question**:
+      its correctness rests on the row owning a real belt, not on a
+      solver-side invariant ("coupled items never carry surplus") that
+      Phase 3 could plausibly relax; (2) intercept the producer/consumer
+      spec pair
       in `place_rows` — note this restructures the main placement loop
       (skipping a spec, custom `y_cursor` accounting, `module_id` and
       stacking-context threading), which is the highest-risk part of
@@ -794,16 +807,31 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   **11** bare `output_belt_y` reads killed that inference: three of them
   (`ghost_router.rs:3435/:3519/:3603`, the output merger) select rows by
   `rs.spec.outputs`, never touching a `BusLane`, so `di_input` cannot
-  protect them. Both remedies #447 proposed were aimed at the wrong
-  target — "confirm it empirically" would have confirmed a property that
-  is not true, and the invalid sentinel would have converted a silent
-  bug into a loud one without removing it. **Resolved instead by
+  protect them. **Corrected after review (#449):** the first draft of
+  this entry escalated that into "the property is false, so both #447
+  remedies were aimed at the wrong target" — an overclaim the audit does
+  not support. Reachability by an unguarded path is not the same as a
+  phantom value actually being read. The property probably *does* hold
+  today, via a guard #447 never cited: the merger iterates
+  `output_items`, built from `solver_result.external_outputs`, and
+  `detect_di_couplings` only couples items with **no surplus**, so a
+  coupled item never appears there. An empirical check would have been a
+  perfectly valid way to test it. What the audit actually establishes is
+  narrower and still worth having: #447's stated *argument* did not
+  cover all the read sites, and the real guard is a different, narrower
+  one than the entry claimed. **Resolved instead by
   design**: a cell emits ONE fused `RowSpan` (producer's inputs +
   consumer's outputs, cell's real output belt) rather than two, so no
   row with a phantom output belt exists to be read. Recorded because the
   general lesson is cheap and repeatable: an inference about a field's
   read-paths is only as good as an exhaustive grep for that field, and
-  #447's was a partial one.*
+  #447's was a partial one. The **second** lesson came from the review
+  bot catching this entry's first draft overclaiming — "incomplete
+  argument" was evidence-backed, "false property" was not, and the two
+  are easy to conflate when you have just found a gap in someone's
+  reasoning. The fused row's real virtue is that it needs neither
+  question settled: it depends on the row owning a real belt, not on a
+  solver-side invariant that Phase 3 could relax.*
 
 - *2026-07-25 — **Phase 1's wiring target is retargeted off the RFC's own
   worked example.** `electronic-circuit` has two solid inputs


### PR DESCRIPTION
Stacked on #449 (the RFC corrections that retarget this work). **Base: `feat/rfc053-1c-wire-rows`** — retarget to `main` if #449 merges first.

## Intent

Close RFC-053 Phase 1c: make the engine actually *build* a DI cell. `bus::di_cell` has had the geometry (1a) and the stamper (1b/1c-emission) since #441–#446, but nothing called them. Now `place_rows` does.

An eligible producer/consumer pair collapses into ONE fused row: machines one tile apart, coupled by reach-1 inserters, **no belt anywhere for the coupled item**.

## The design call: one fused RowSpan, not two

A cell's spec carries the **producer's inputs and the consumer's outputs** — it genuinely is a composite machine that eats iron-ore off a belt and puts gears onto one. Everything downstream (lane planner, output merger, validators) then works unmodified.

This is also what **dissolves the #447 contract question** rather than answering it. Because the producer never gets a row of its own, no `RowSpan` is ever built whose `output_belt_y` points at a belt that wasn't emitted. All 11 bare `output_belt_y` reads are correct by construction — including the three output-merger sites (`ghost_router.rs:3435/:3519/:3603`) that select rows by `spec.outputs` and never consult a `BusLane`, which #447's inference had missed. See #449.

## `cell_eligible` is load-bearing, not defensive

It is **not** redundant with the solver. `netflow::detect_di_couplings` gates on one-producer / one-consumer / no-external-supply / no-surplus / not-fluid and never inspects the consumer's input count — so it emits `copper-cable → electronic-circuit` like any other pair. Fusing that would strand EC's iron-plate feed: clean validation, starving machines, the #383/#432 failure mode.

Gates: consumer has exactly one solid input (the coupled item); producer has exactly one solid input and one solid output; no fluids on either side (Phase 2, per the KC6 re-scope); equal machine footprints; neither spec split across rows.

## Fallback

Every refusal — ineligible pair, no straddle, ladder short of the binding edge, stamper rejection — falls through to the existing path, where #432's bridge and then the bus still serve the coupling. A `GhostSpecFailed` trace records the refusal. Refusing is always safe; an under-fed cell is not.

## Verification

- **879 lib + 61 e2e green** (single clean invocation), clippy clean with zero hits in `placer.rs`, WASM build green.
- 5 new tests: fusion collapses two specs to one row; the fused row's `output_belt_y` points at an emitted belt; the multi-input consumer is refused; DI-off stays inert; fluid-touching pairs are refused.
- One test initially **passed vacuously** — `di_cell_row_has_a_real_output_belt` was asserting against an ordinary row because no cell had been built. It now guards on `spans.len() == 1` first. The shared `iron_plate_spec`/`iron_gear_spec` helpers are 1.0/s against 2.0/s, which `plan_straddle` correctly refuses as unbalanced; the tests use a balanced 2×1.0/s → 1×2.0/s pair.

## Not covered

`direct_insertion` still defaults to `false`, so **this is inert in every existing layout** — that is why the suite stayed green, and I'm stating it rather than implying the green run exercised the cell path. The browser eyeball and snapshot inspection the layout-engine protocol calls for can't happen until `direct_insertion` is reachable from the UI (Phase 4); today the cell path is exercised only by unit tests. Sim verification is Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWfiQtV8ufEiTG6uun8Lxy

## Deviations from intent

Two, both disclosed above rather than discovered later:

1. The pick-up notes predicted 1c would need a **new `RowKind`** and a restructured placement loop. It didn't — a `cell_pairs` lookup, a skip-set, and a `RowSpan` built straight from `DiCellLayout` were enough, because the fused-composite-machine framing means nothing downstream has to learn what a cell is. The RFC's superseded notes are kept as the scoping record with a pointer to what actually shipped.
2. A new test (`di_cell_row_has_a_real_output_belt`) initially **passed vacuously** — no cell was being built, so it asserted against an ordinary row. Guarded on `spans.len() == 1` and the fixtures rebalanced.

## Models / contracts touched

- **`RowSpan`** — no shape change; a new *producer* of it. A fused cell row carries the producer's inputs and the consumer's outputs, and is the only row for both specs. Registered in `recipe_row_idxs` under **both** recipe names so a later consumer's producer-lookup resolves.
- **`di_input`** — deliberately left empty on cell rows, and this is not an oversight: the coupled item appears in no row's inputs and no row's outputs, so no lane is ever built for it. Documented at the field.
- **`MachineSpec`** — no shape change; `fused_cell_spec` synthesizes one that is not backed by a solver column. Rates are per-consumer-machine so `rate × machine_count` stays correct on both the input and output belt.
- **`TraceEvent::GhostSpecFailed`** — reused with a new `di-cell:{item}:refused` key for cell refusals.
- **No serialized-format change**, so no snapshot/blueprint compatibility impact. `LayoutOptions::direct_insertion` keeps its `false` default.
