### PR TITLE
feat(448): row-input-belt-margin check — catch zero-margin shared input belts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
 1. **Solver** (`crates/core/src/solver.rs`) — Resolves recipe dependencies via the net-flow LP in `netflow.rs` (free cost-based recipe selection, default since 2026-07; legacy recursive tree walk retained as the compat/parity oracle), computes machine counts and flow rates. Loads `crates/core/data/recipes.json` via `include_str!`. Returns a `SolverResult`.
 2. **Bus layout** (`crates/core/src/bus/`) — Deterministic row-based layout. Machines group by recipe into rows, trunks run on parallel columns, tap-offs are routed via the ghost router (negotiated congestion A* + region-growth junction solver). See [`docs/ghost-pipeline-contracts.md`](docs/ghost-pipeline-contracts.md) for the phase-by-phase contracts the router promises.
 3. **Blueprint export** (`crates/core/src/blueprint.rs`) — Emits the JSON + zlib + base64 envelope directly (no draftsman dependency).
-4. **Validation** (`crates/core/src/validate/`) — 34 functional checks: pipe isolation, fluid port connectivity, inserter chains + direction, power coverage + pole connectivity, belt flow/structural, underground belt pairs + sideloading, lane throughput, input-rate delivery, module slots + eligibility.
+4. **Validation** (`crates/core/src/validate/`) — 36 functional checks: pipe isolation, fluid port connectivity, inserter chains + direction, power coverage + pole connectivity, belt flow/structural, underground belt pairs + sideloading, lane throughput, input-rate delivery, module slots + eligibility.
 
 ## Key models (`crates/core/src/models.rs`)
 
@@ -137,7 +137,7 @@ Most-visited files. Full reference in [`docs/file-reference.md`](docs/file-refer
 | `crates/core/src/bus/lane_planner.rs` | `BusLane` / `LaneFamily` types, `plan_bus_lanes`, lane splitting + tap-off coordinate finding |
 | `crates/core/src/bus/ghost_router.rs` | Ghost A* + negotiated congestion routing; junction solver integration; output merger call-site |
 | `crates/core/src/netflow.rs` | Net-flow LP solver (default since 2026-07, compatibility mode; byproduct crediting, typed cycle refusals). Legacy tree walk retained in `solver.rs` as the recipe-selection oracle. See `docs/rfc-solver-net-flow.md`. |
-| `crates/core/src/validate/` | The 34 functional checks, dispatched from `mod.rs` (`belt_flow` lane-rate walker, `belt_structural`, `fluids`, `inserters`, `modules`, `power`, `underground`) |
+| `crates/core/src/validate/` | The 36 functional checks, dispatched from `mod.rs` (`belt_flow` lane-rate walker, `belt_structural`, `fluids`, `inserters`, `modules`, `power`, `underground`) |
 | `crates/core/src/trace.rs` | Thread-local trace event collector; `TraceEvent` variants drive the snapshot debugger and stress scoreboards |
 | `crates/core/src/snapshot.rs` | `.fls` snapshot reader/writer for the layout debugger |
 | `crates/core/tests/e2e.rs` | End-to-end test harness: tier regression tests and stress corpus with scoreboards |
@@ -177,7 +177,7 @@ Layout bugs are easy to get wrong — zero validation errors can mean the check 
 | Balancer templates | `crates/core/src/bus/balancer_library.rs`. Regenerate: `python scripts/generate_balancer_library.py` (needs Factorio-SAT on `PATH`). |
 | Belt tier thresholds | `crates/core/src/common.rs` (`belt_entity_for_rate`, `ug_max_reach`) |
 | Entity sizes | `crates/core/src/common.rs` (`entity_size`) |
-| Validation checks | `crates/core/src/validate/` (34 checks, dispatched from `mod.rs`) |
+| Validation checks | `crates/core/src/validate/` (36 checks, dispatched from `mod.rs`) |
 | Snapshot format | `crates/core/src/snapshot.rs` + [`docs/layout-snapshot-debugger.md`](docs/layout-snapshot-debugger.md) |
 | Sim measurement semantics + forensics | [`docs/sim-harness-forensics.md`](docs/sim-harness-forensics.md) (what each spaghettio-sim number means, artifact classes, debug playbook) |
 | Belt lane physics | [`docs/factorio-mechanics.md`](docs/factorio-mechanics.md) |

--- a/crates/core/src/validate/inserters.rs
+++ b/crates/core/src/validate/inserters.rs
@@ -899,6 +899,271 @@ pub fn check_row_output_lane_budget(
     issues
 }
 
+// ── check_row_input_belt_margin ──────────────────────────────────────────────
+
+/// Issue #448: a row of N consumer machines sharing ONE input belt whose
+/// aggregate demand meets or exceeds the belt's carrying capacity starves
+/// its TAIL machine — permanently, not transiently.
+///
+/// **The mechanism (sim-measured, not theorized).** Inserters along a
+/// shared input belt pick greedily head-first and every machine buffers
+/// its ingredients deeply. At <100% belt utilization the head machines'
+/// buffers fill and stop absorbing, and the surplus flows on to the tail.
+/// At exactly 100% there is no surplus: the head absorbs every item the
+/// belt can carry as fast as it arrives, and the row converges to a
+/// stable state in which the last machine is permanently short. It is a
+/// converged steady state, not a start-up transient — the sim run holds
+/// it indefinitely.
+///
+/// **Measured instance (`chain-ec15`).** The electronic-circuit row is 6
+/// machines × 7.5/s copper-cable = 45.00/s aggregate, fed by one express
+/// belt whose nominal carry is exactly 45.0/s. Per-machine sim dumps show
+/// the row holding cable 42 → 34 → 20 → 6 → … → 2 down its length, the
+/// tail machine parked in `item_ingredient_shortage` with 20 iron plates
+/// idle beside it, and an upstream copper-cable producer sitting
+/// `full_output` with 32 cable stuck in it. Cost: ~5.3% of the row's
+/// throughput (one of six machines at ~68% duty), and it is
+/// research-invariant — no inserter-capacity level clears it, because the
+/// binding constraint is the belt, not the inserters.
+///
+/// **Why the existing checks miss it.**
+/// [`crate::validate::belt_structural::check_lane_throughput`] compares
+/// demand against capacity and 45 ≤ 45 passes.
+/// [`crate::validate::belt_flow::check_input_rate_delivery`] compares each
+/// machine's pickup-tile lane rate against that machine's OWN requirement
+/// — but the lane-rate propagation never subtracts what upstream machines
+/// on the same belt have already consumed, so the tail machine "sees" the
+/// full 45/s and looks fed. This check is the row-AGGREGATE counterpart:
+/// it never asks what any single machine sees, only whether the belt has
+/// any margin left over for the tail at all.
+///
+/// **Threshold: `aggregate_demand >= capacity - EPSILON`.** Grounded
+/// exactly at 100% utilization because that is the *measured-failing*
+/// condition (ec15 at 45.00 vs 45.0) and nothing weaker is measured. We
+/// deliberately do NOT invent a "safe margin" percentage — no measurement
+/// supports one yet, and load-bearing constants in this repo are
+/// sim-derived, never theoretical (the RFC-047/049 calibration
+/// discipline; see `ROW_LANE_FACTOR_BRIDGED`'s history above for what
+/// happens to a number that isn't). This makes the threshold a **lower
+/// bound on the true requirement**: a belt at 98% may well starve its
+/// tail too, and this check stays silent there. A margin sweep — the same
+/// declared-level sweep shape #431 used, varying provisioned belt margin
+/// instead of research level, and reading the tail machine's duty cycle —
+/// would tighten it to the real number. Until that runs, only the
+/// zero-margin case is claimed.
+///
+/// **Scope: `row:<recipe>:belt-in:<item>` segments only.** That tag is the
+/// bus/cell templates' own name for "this row's dedicated input belt for
+/// this item", the exact input-side mirror of the `belt-out` tag
+/// [`check_row_output_lane_budget`] keys on. The `k`-trunk template's
+/// `row:<recipe>:trunk:<item>` / `current-feed` / `trunk-dive` input path
+/// is deliberately EXCLUDED: it provisions `k` parallel belts for one
+/// item, so comparing that row's whole demand against a single belt's
+/// capacity would be a systematic false positive. Multi-belt input
+/// provisioning is a separate check, not a tweak to this one.
+///
+/// **Scope: SHARED belts only (≥ 2 consumers).** The mechanism is
+/// head-hogging along a shared belt: with one consumer there is no head
+/// and no tail, and a single machine sitting at exactly its belt's carry
+/// is limited by its inserters (already
+/// [`check_inserter_throughput`]'s and
+/// [`check_inserter_item_throughput`]'s business), not by anything this
+/// check measures. Empirically this is not hypothetical: the
+/// `tier_fish_breeding_self_loop` fixture is one chemical plant at 15.00/s
+/// against a 15.0/s yellow belt, and both inserter checks already warn on
+/// it. Note this is a SCOPE bound on the mechanism, not a softening of the
+/// threshold — the 100% line itself is untouched.
+///
+/// **Row identification** is `check_row_output_lane_budget`'s, for its
+/// reasons: a recipe needing more than one physical row shares the exact
+/// same literal segment string across every row, and the cell-composition
+/// pipeline never populates `LayoutResult::effective_rows` at all — so
+/// tiles are split into physical rows by adjacency
+/// ([`cluster_tiles_by_adjacency`]) and each machine is attributed to a
+/// row through its OWN input inserter's pickup tile (physical
+/// connectivity, not a distance heuristic). An input run interrupted by an
+/// underground belt splits into two clusters at the gap; each then carries
+/// only its own consumers' demand, which is conservative (under-reports)
+/// rather than false-positive.
+///
+/// **Demand** is `super::resolve_row_spec` + `utilization_for` per
+/// attributed machine — the same pair `check_input_rate_delivery` uses, so
+/// the number this check prints is the same number the rest of the
+/// validator reasons with. **Capacity** is the belt's full both-lane
+/// stacked nominal (`2 × lane_capacity_stacked`, per-item stacking via
+/// `StackingCtx` exactly as `check_lane_throughput` derives it): a bus tap
+/// feeds an input belt straight, loading both lanes, and inserters pick
+/// from both — so the generous both-lane figure is the honest ceiling
+/// here, and using it keeps the check silent on anything but a genuinely
+/// saturated belt.
+///
+/// Severity is Warning: the layout is physically valid and mostly works —
+/// it just cannot reach its planned rate.
+pub fn check_row_input_belt_margin(
+    layout: &LayoutResult,
+    solver_result: Option<&SolverResult>,
+) -> Vec<ValidationIssue> {
+    let sr = match solver_result {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+
+    let recipe_to_spec: FxHashMap<&str, &MachineSpec> =
+        sr.machines.iter().map(|s| (s.recipe.as_str(), s)).collect();
+
+    // `row:<recipe>:belt-in:<item>` — exact shape only (see doc comment
+    // for why `trunk`/`current-feed`/`trunk-dive` are excluded).
+    const BELT_IN: &str = ":belt-in:";
+    let mut belt_in: FxHashMap<(&str, &str), Vec<&PlacedEntity>> = FxHashMap::default();
+    for e in &layout.entities {
+        let Some(seg) = e.segment_id.as_deref() else {
+            continue;
+        };
+        let Some(rest) = seg.strip_prefix("row:") else {
+            continue;
+        };
+        let Some(idx) = rest.find(BELT_IN) else {
+            continue;
+        };
+        let recipe = &rest[..idx];
+        let item = &rest[idx + BELT_IN.len()..];
+        if recipe.is_empty() || item.is_empty() {
+            continue;
+        }
+        belt_in.entry((recipe, item)).or_default().push(e);
+    }
+    if belt_in.is_empty() {
+        return Vec::new();
+    }
+
+    let mut keys: Vec<(&str, &str)> = belt_in.keys().copied().collect();
+    keys.sort_unstable();
+
+    let machine_origin = machine_origin_by_tile(layout);
+    let mut machine_at_origin: FxHashMap<(i32, i32), &PlacedEntity> = FxHashMap::default();
+    for e in &layout.entities {
+        if is_machine_entity(&e.name) {
+            machine_at_origin.insert((e.x, e.y), e);
+        }
+    }
+
+    let stacking_ctx = crate::bus::stacking_ctx::StackingCtx::derive(sr, layout.stacking);
+
+    // Same tolerance the surrounding rate comparisons use.
+    const EPSILON: f64 = 0.02;
+    let mut issues = Vec::new();
+
+    for (recipe, item) in keys {
+        let tiles = &belt_in[&(recipe, item)];
+        let positions: Vec<(i32, i32)> = tiles.iter().map(|e| (e.x, e.y)).collect();
+        let components = cluster_tiles_by_adjacency(&positions);
+        let num_clusters = components.iter().copied().max().map_or(0, |m| m + 1);
+        let mut clusters: Vec<Vec<&PlacedEntity>> = vec![Vec::new(); num_clusters];
+        let mut tile_to_cluster: FxHashMap<(i32, i32), usize> = FxHashMap::default();
+        for (i, &e) in tiles.iter().enumerate() {
+            clusters[components[i]].push(e);
+            tile_to_cluster.insert((e.x, e.y), components[i]);
+        }
+
+        // Attribute machines to clusters through their own input
+        // inserter: pickup on one of this item's belt-in tiles, drop onto
+        // a machine running THIS recipe.
+        let mut consumers: Vec<FxHashSet<(i32, i32)>> =
+            vec![FxHashSet::default(); num_clusters];
+        for ins in &layout.entities {
+            if !is_inserter(&ins.name) {
+                continue;
+            }
+            let (dx, dy) = dir_to_vec(ins.direction);
+            let reach = inserter_reach(&ins.name);
+            let pickup = (ins.x - dx * reach, ins.y - dy * reach);
+            let drop = (ins.x + dx * reach, ins.y + dy * reach);
+            let Some(&cluster_idx) = tile_to_cluster.get(&pickup) else {
+                continue;
+            };
+            let Some(&origin) = machine_origin.get(&drop) else {
+                continue;
+            };
+            let Some(m) = machine_at_origin.get(&origin) else {
+                continue;
+            };
+            if m.recipe.as_deref() != Some(recipe) {
+                continue;
+            }
+            consumers[cluster_idx].insert(origin);
+        }
+
+        let Some(&fallback_spec) = recipe_to_spec.get(recipe) else {
+            continue;
+        };
+
+        for (idx, cluster) in clusters.iter().enumerate() {
+            // ≥ 2: the defect is head-hogging along a SHARED belt, which
+            // needs a head and a tail to exist at all (see doc comment).
+            let mcount = consumers[idx].len();
+            if mcount < 2 {
+                continue;
+            }
+            // Sum per-machine demand rather than multiplying one rate by
+            // the count: partition siblings share a recipe name but carry
+            // different utilizations, and `resolve_row_spec` resolves each
+            // machine's own sibling by its y.
+            let mut demand = 0.0;
+            for &(_mx, my) in &consumers[idx] {
+                let spec = super::resolve_row_spec(layout, recipe, my, fallback_spec);
+                let utilization = utilization_for(spec);
+                demand += spec
+                    .inputs
+                    .iter()
+                    .find(|f| !f.is_fluid && f.item == item)
+                    .map(|f| f.rate * utilization)
+                    .unwrap_or(0.0);
+            }
+            if demand <= 0.0 {
+                continue;
+            }
+
+            let belts: Vec<&PlacedEntity> = cluster
+                .iter()
+                .copied()
+                .filter(|e| is_surface_belt(&e.name))
+                .collect();
+            if belts.is_empty() {
+                continue;
+            }
+            let tier = row_belt_tier(&belts);
+            // Both physical lanes: a bus tap feeds an input belt straight
+            // (loading both lanes) and inserters pick from both.
+            let capacity =
+                crate::common::lane_capacity_stacked(tier, stacking_ctx.for_item(item)) * 2.0;
+
+            if demand >= capacity - EPSILON {
+                let (ax, ay) = belts.iter().map(|e| (e.x, e.y)).min().unwrap();
+                issues.push(
+                    ValidationIssue::with_pos(
+                        Severity::Warning,
+                        "row-input-belt-margin",
+                        format!(
+                            "{recipe} row input belt at ({ax},{ay}) carries {item} for \
+                             {mcount} machine{plural} demanding {demand:.2}/s against a \
+                             {tier} carrying only {capacity:.2}/s — zero margin, so the \
+                             head machines absorb the whole belt and the TAIL machine \
+                             starves in a converged steady state (#448); widen the belt \
+                             tier or split the row",
+                            plural = if mcount == 1 { "" } else { "s" },
+                        ),
+                        ax,
+                        ay,
+                    )
+                    .with_detail(capacity, demand),
+                );
+            }
+        }
+    }
+
+    issues
+}
+
 /// Splits `positions` into connected components under 4-adjacency
 /// (sharing a tile edge), returning each position's component id by
 /// index. Used to tell apart physically distinct rows/cells that
@@ -2360,5 +2625,197 @@ mod tests {
         let tiles: Vec<PlacedEntity> = belt_out_row_bridged("x", "x", 5, 4, "transport-belt");
         let refs: Vec<&PlacedEntity> = tiles.iter().collect();
         assert_eq!(row_lanes_loaded(&refs), 2);
+    }
+
+    // ── check_row_input_belt_margin (#448) ──────────────────────────────────
+
+    fn input_margin_warnings(issues: &[ValidationIssue]) -> Vec<&ValidationIssue> {
+        issues
+            .iter()
+            .filter(|i| i.category == "row-input-belt-margin")
+            .collect()
+    }
+
+    fn row_input_spec(recipe: &str, item: &str, rate_per_machine: f64, count: f64) -> SolverResult {
+        SolverResult {
+            machines: vec![MachineSpec {
+                entity: "assembling-machine-1".into(),
+                recipe: recipe.into(),
+                self_loop: vec![],
+                voider: false,
+                game_modules: Vec::new(),
+                count,
+                inputs: vec![ItemFlow {
+                    item: item.into(),
+                    rate: rate_per_machine,
+                    is_fluid: false,
+                    module_id: 0,
+                }],
+                outputs: vec![],
+            }],
+            external_inputs: vec![],
+            external_outputs: vec![],
+            surplus_outputs: vec![],
+            dependency_order: vec![],
+            ..Default::default()
+        }
+    }
+
+    /// A single input-belt run: `count` tiles heading EAST at row `y`, all
+    /// tagged `row:<recipe>:belt-in:<item>` and carrying `item`.
+    fn belt_in_row(
+        recipe: &str,
+        item: &str,
+        y: i32,
+        count: i32,
+        belt: &str,
+    ) -> Vec<PlacedEntity> {
+        (0..count)
+            .map(|i| PlacedEntity {
+                name: belt.into(),
+                x: i,
+                y,
+                direction: EntityDirection::East,
+                carries: Some(item.into()),
+                segment_id: Some(format!("row:{recipe}:belt-in:{item}")),
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    /// `count` machines (origin at `x = i*4`, `y = machine_y`), each with a
+    /// South-facing reach-1 INPUT inserter that picks up from the belt-in
+    /// line at `y = machine_y - 2` and drops onto the machine's own origin
+    /// tile — the physical connection `check_row_input_belt_margin` traces
+    /// to attribute a machine to its input belt. Callers must place their
+    /// `belt_in_row` at `y = machine_y - 2`, wide enough to cover every
+    /// `i*4` pickup x.
+    fn machine_row_with_input_inserters(
+        recipe: &str,
+        machine_y: i32,
+        count: i32,
+    ) -> Vec<PlacedEntity> {
+        let mut v = Vec::new();
+        for i in 0..count {
+            let x = i * 4;
+            v.push(PlacedEntity {
+                name: "assembling-machine-1".into(),
+                x,
+                y: machine_y,
+                recipe: Some(recipe.into()),
+                segment_id: Some(format!("row:{recipe}:machine")),
+                ..Default::default()
+            });
+            v.push(PlacedEntity {
+                name: "inserter".into(),
+                x,
+                y: machine_y - 1,
+                direction: EntityDirection::South,
+                ..Default::default()
+            });
+        }
+        v
+    }
+
+    #[test]
+    fn row_input_margin_fires_at_exactly_full_belt() {
+        // The measured chain-ec15 shape in miniature: 6 machines sharing
+        // one input belt, aggregate demand EXACTLY the belt's both-lane
+        // nominal (6 × 2.5 = 15.0 on yellow). Zero margin for the tail.
+        let sr = row_input_spec("test-widget", "test-input", 2.5, 6.0);
+        let mut entities = machine_row_with_input_inserters("test-widget", 2, 6);
+        entities.extend(belt_in_row("test-widget", "test-input", 0, 24, "transport-belt"));
+        let lr = LayoutResult { entities, width: 40, height: 20, stacking: 1, ..Default::default() };
+        let issues = check_row_input_belt_margin(&lr, Some(&sr));
+        let warns = input_margin_warnings(&issues);
+        assert_eq!(warns.len(), 1, "{issues:?}");
+        assert!(warns[0].message.contains("test-input"), "{:?}", warns[0]);
+        assert!(warns[0].message.contains("6 machines"), "{:?}", warns[0]);
+        assert!(warns[0].message.contains("#448"), "{:?}", warns[0]);
+        let detail = warns[0].detail.as_ref().expect("must carry IssueDetail");
+        assert!((detail.needed - 15.0).abs() < 1e-9, "{detail:?}");
+        assert!((detail.delivered - 15.0).abs() < 1e-9, "{detail:?}");
+    }
+
+    #[test]
+    fn row_input_margin_silent_with_real_margin() {
+        // Same six-machine row, demand 12.0/s against yellow's 15.0/s —
+        // 20% headroom, the head machines' buffers fill and the surplus
+        // reaches the tail. Must stay silent.
+        let sr = row_input_spec("test-widget", "test-input", 2.0, 6.0);
+        let mut entities = machine_row_with_input_inserters("test-widget", 2, 6);
+        entities.extend(belt_in_row("test-widget", "test-input", 0, 24, "transport-belt"));
+        let lr = LayoutResult { entities, width: 40, height: 20, stacking: 1, ..Default::default() };
+        let issues = check_row_input_belt_margin(&lr, Some(&sr));
+        assert!(input_margin_warnings(&issues).is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn row_input_margin_no_solver_result_is_noop() {
+        let mut entities = machine_row_with_input_inserters("test-widget", 2, 6);
+        entities.extend(belt_in_row("test-widget", "test-input", 0, 24, "transport-belt"));
+        let lr = LayoutResult { entities, width: 40, height: 20, stacking: 1, ..Default::default() };
+        assert!(check_row_input_belt_margin(&lr, None).is_empty());
+    }
+
+    #[test]
+    fn row_input_margin_epsilon_boundary() {
+        // A hair UNDER the belt nominal minus epsilon must stay silent;
+        // reaching nominal-minus-epsilon must fire. The threshold is
+        // `demand >= capacity - EPSILON`, deliberately pinned at 100%
+        // utilization (#448) — no invented safety margin.
+        let mut entities = machine_row_with_input_inserters("test-widget", 2, 2);
+        entities.extend(belt_in_row("test-widget", "test-input", 0, 8, "transport-belt"));
+        let lr = LayoutResult { entities, width: 40, height: 20, stacking: 1, ..Default::default() };
+
+        // 2 × 7.485 = 14.97 < 15.0 - 0.02 = 14.98
+        let under = row_input_spec("test-widget", "test-input", 7.485, 2.0);
+        assert!(
+            input_margin_warnings(&check_row_input_belt_margin(&lr, Some(&under))).is_empty(),
+            "just under capacity-epsilon must not fire"
+        );
+        // 2 × 7.495 = 14.99 >= 14.98
+        let at = row_input_spec("test-widget", "test-input", 7.495, 2.0);
+        assert_eq!(
+            input_margin_warnings(&check_row_input_belt_margin(&lr, Some(&at))).len(),
+            1,
+            "at capacity-epsilon must fire"
+        );
+    }
+
+    #[test]
+    fn row_input_margin_single_consumer_is_out_of_scope() {
+        // One machine at exactly its belt's carry: no head, no tail, so
+        // the #448 mechanism cannot occur. (The real
+        // `tier_fish_breeding_self_loop` fixture is exactly this — one
+        // chemical plant at 15.00/s on yellow — and both inserter-
+        // throughput checks already warn on it.)
+        let sr = row_input_spec("test-widget", "test-input", 15.0, 1.0);
+        let mut entities = machine_row_with_input_inserters("test-widget", 2, 1);
+        entities.extend(belt_in_row("test-widget", "test-input", 0, 8, "transport-belt"));
+        let lr = LayoutResult { entities, width: 40, height: 20, stacking: 1, ..Default::default() };
+        let issues = check_row_input_belt_margin(&lr, Some(&sr));
+        assert!(input_margin_warnings(&issues).is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn row_input_margin_ignores_multi_trunk_input_segments() {
+        // `row:<recipe>:trunk:<item>` provisions k PARALLEL belts for one
+        // item, so a single-belt capacity comparison would be a systematic
+        // false positive there. The check must not select that segment
+        // even when its row is far past one belt's carry.
+        let sr = row_input_spec("test-widget", "test-input", 20.0, 6.0);
+        let mut entities = machine_row_with_input_inserters("test-widget", 2, 6);
+        entities.extend(
+            belt_in_row("test-widget", "test-input", 0, 24, "transport-belt")
+                .into_iter()
+                .map(|mut e| {
+                    e.segment_id = Some("row:test-widget:trunk:test-input".into());
+                    e
+                }),
+        );
+        let lr = LayoutResult { entities, width: 40, height: 20, stacking: 1, ..Default::default() };
+        let issues = check_row_input_belt_margin(&lr, Some(&sr));
+        assert!(input_margin_warnings(&issues).is_empty(), "{issues:?}");
     }
 }

--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -488,6 +488,7 @@ pub fn validate(
         Box::new(|| inserters::check_inserter_throughput(layout, solver)),
         Box::new(|| inserters::check_inserter_item_throughput(layout, solver)),
         Box::new(|| inserters::check_row_output_lane_budget(layout, solver)),
+        Box::new(|| inserters::check_row_input_belt_margin(layout, solver)),
         Box::new(|| check_pipe_isolation(layout)),
         Box::new(|| check_fluid_port_connectivity(layout, layout_style)),
         Box::new(|| check_fluid_network_connectivity(layout, solver)),

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -419,9 +419,33 @@ fn cell_candidate_resolves_ec15_refusal() {
     let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).unwrap();
     let errors = issues.iter().filter(|i| i.severity == Severity::Error).count();
     assert_eq!(errors, 0, "composed candidate errors: {issues:?}");
+    // **2026-07-25 (#448):** `row-input-belt-margin` joins the tolerated
+    // set, and this fixture is the check's own motivating measurement —
+    // not a tolerated unknown. This row's copper-cable INPUT belt is 6
+    // machines × 7.5/s = 45.00/s aggregate against an express belt whose
+    // both-lane nominal is exactly 45.0/s. Per-machine sim dumps show the
+    // row holding cable 42 → 34 → 20 → 6 → … → 2, the tail machine parked
+    // in `item_ingredient_shortage` with 20 iron plates idle beside it,
+    // and an upstream cable producer `full_output` with 32 cable stuck —
+    // ~5.3% of the row's throughput lost, research-invariant. It is a
+    // real defect this layout has; the warning is the point. Note the
+    // symmetry with the OUTPUT-side note above: the belt-out at exactly
+    // 15.0/s of a 15.0/s bridged budget is measured FINE (#431 sweep),
+    // while the belt-in at exactly 45.0/s of 45.0/s is measured BROKEN —
+    // the asymmetry is real (an output belt is filled by inserters that
+    // simply stall when it is full; an input belt is drained head-first
+    // by consumers who buffer).
     assert!(
-        issues.iter().all(|i| i.category == "inserter-item-throughput"),
-        "only the adjudicated category tolerated: {issues:?}"
+        issues
+            .iter()
+            .all(|i| i.category == "inserter-item-throughput"
+                || i.category == "row-input-belt-margin"),
+        "only the adjudicated categories tolerated: {issues:?}"
+    );
+    assert_eq!(
+        issues.iter().filter(|i| i.category == "row-input-belt-margin").count(),
+        1,
+        "expected exactly the one measured copper-cable input finding: {issues:?}"
     );
     // Post-#431 recalibration the row sits exactly at the bridged
     // budget (2.0 × 7.5 = 15.0/s) — any lane-budget warning here would

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -1106,7 +1106,15 @@ fn tier2_electronic_circuit_from_ore() {
     // full 15.0/s 2-lane nominal (measured at plan, zero output-blocked
     // machines, once the L2 input bind clears) — the old floor was
     // confounded by the input side. Warning legitimately gone.
-    assert_warnings_exactly(&result, &[]);
+    // 2026-07-25 (#448): the same copper-plate row's INPUT side is a new,
+    // genuine finding — 24 electric furnaces × 0.625/s copper-ore = 15.00/s
+    // aggregate against ONE yellow belt whose both-lane nominal is exactly
+    // 15.0/s. Zero margin means the head furnaces absorb the entire belt
+    // and the tail furnace starves in a converged steady state (the
+    // mechanism sim-measured per-machine on chain-ec15). Every other
+    // belt-in group in this same fixture sits at 80% or below and stays
+    // silent, so this is a discriminating hit, not a blanket trip.
+    assert_warnings_exactly(&result, &[("row-input-belt-margin", 1)]);
     assert_produces(&result, "electronic-circuit", 10.0);
     assert_round_trip(&result);
     assert_golden_hash(&result, "tier2_electronic_circuit_from_ore");
@@ -4352,7 +4360,19 @@ fn stress_electronic_circuit_60s_red_from_ore() {
             // row here, so all 11 warnings correctly stop firing — this
             // fixture is back to a clean zero. Tightened 11 -> 0 (matching the
             // re-blessed golden) so any regression re-exposes them.
-            max_warnings: 0,
+            // 2026-07-25 (#448): +5 row-input-belt-margin, the new
+            // shared-input-belt zero-margin check. Every one is the
+            // measured-defect shape and none is a threshold artifact —
+            // three copper-plate smelter rows of 48 electric furnaces
+            // (48 x 0.625 = 30.00/s copper-ore) and two iron-plate rows
+            // of 48 (30.00/s iron-ore), each fed by ONE red belt whose
+            // nominal both-lane carry is exactly 30.0/s. At 100% the head
+            // furnaces absorb the whole belt and the tail furnaces starve
+            // in a converged steady state (per-machine sim dumps on
+            // chain-ec15/mega-chain-pu4raw). Neighbouring rows in the same
+            // fixture sit at 90%/75%/50% and correctly stay silent, so
+            // this is not a blanket trip. 0 -> 5.
+            max_warnings: 5,
             max_errors_by_category: Default::default(),
         },
     );

--- a/crates/core/tests/goldens/stress/stress_electronic_circuit_30s_from_ore.txt
+++ b/crates/core/tests/goldens/stress/stress_electronic_circuit_30s_from_ore.txt
@@ -1,6 +1,6 @@
 === stress_electronic_circuit_30s_from_ore scoreboard ===
 entities:         4966
-total warnings:   0
+total warnings:   5
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -13,7 +13,7 @@ total poles:      196
 zero-slack poles: 0
 median slack:     4.0
 warnings by category:
-  (none)
+  row-input-belt-margin: 5
 errors by category:
   (none)
 layout hash: fcb254ed8d57dadf978ea4b2210da4349a3ceeb6e9a8c8a6cc6fca1ecd1641ce

--- a/crates/core/tests/goldens/stress/stress_electronic_circuit_40s_from_ore.txt
+++ b/crates/core/tests/goldens/stress/stress_electronic_circuit_40s_from_ore.txt
@@ -1,6 +1,6 @@
 === stress_electronic_circuit_40s_from_ore scoreboard ===
 entities:         7201
-total warnings:   227
+total warnings:   231
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -16,6 +16,7 @@ warnings by category:
   belt-flow-path: 25
   belt-flow-reachability: 121
   input-rate-delivery: 81
+  row-input-belt-margin: 4
 errors by category:
   belt-dead-end: 13
 layout hash: cf1f51aaa09649c9cdf0690e2b934b2a80cbfc69b75430598bd0673d37ce06fa

--- a/crates/core/tests/goldens/stress/stress_electronic_circuit_60s_red_from_ore.txt
+++ b/crates/core/tests/goldens/stress/stress_electronic_circuit_60s_red_from_ore.txt
@@ -1,6 +1,6 @@
 === stress_electronic_circuit_60s_red_from_ore scoreboard ===
 entities:         5568
-total warnings:   0
+total warnings:   5
 zones solved:     0
 zones skipped:    0
 bridges dropped:  0
@@ -13,7 +13,7 @@ total poles:      361
 zero-slack poles: 0
 median slack:     4.0
 warnings by category:
-  (none)
+  row-input-belt-margin: 5
 errors by category:
   (none)
 layout hash: f12597061318762909146582a883a3622c6c484927100037259689bb2caa7f6d

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -4,7 +4,7 @@ Runs an exported layout in a **real headless Factorio server** and reports
 planned vs measured per-item rates. This is the ground-truth check the
 validator can't give you: the prototype run found an inserter-direction
 export bug that deadlocked every factory the project had ever exported,
-invisible to all 34 validation checks. Design rationale, kill criteria,
+invisible to all 36 validation checks. Design rationale, kill criteria,
 and the decision log live in
 [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md); this
 doc is the how-to.

--- a/docs/status.md
+++ b/docs/status.md
@@ -345,6 +345,62 @@ effective_rows`, which the cell-composition pipeline never populates.
 Full trail: `docs/rfc-047-lane-aware-tap-delivery.md` decision log
 (2026-07-23 entry).
 
+**#448 — row-input belt margin (2026-07-25)**: the INPUT-side
+counterpart, and it looks like the attribution
+[#435](https://github.com/storkme/spaghettio/issues/435) was missing.
+A row of N consumers sharing one input belt provisioned at *exactly*
+its aggregate demand starves its TAIL machine permanently: inserters
+pick greedily head-first, every machine buffers deeply, and at 100%
+belt utilization there is no surplus left to reach the end of the row.
+Per-machine sim dumps on `chain-ec15` show the EC row (6 machines ×
+7.5/s copper-cable = **45.00/s** against an express belt's **45.0/s**
+nominal) holding cable 42 → 34 → 20 → 6 → … → 2, the tail machine in
+`item_ingredient_shortage` with 20 iron plates idle beside it, and an
+upstream cable producer `full_output` with 32 cable stuck — i.e. the
+exact "1 output-blocked, 1 ingredient-starved, 13 working" census the
+declared-level sweep reported at EVERY level, and the exact ~5.3%
+level-invariant residual recorded above as "currently unattributed and,
+since the recalibration, unwarned". It is now warned:
+`validate::inserters::check_row_input_belt_margin`
+(`row-input-belt-margin`, Warning) groups input inserters by the
+`row:<recipe>:belt-in:<item>` segment they pick from (tile-adjacency
+clustering, machines attributed through their own inserter — the same
+identification `check_row_output_lane_budget` uses), sums
+`resolve_row_spec` × `utilization_for` demand across the row, and
+compares against the belt's full both-lane stacked nominal.
+**Threshold `demand >= capacity - EPSILON`, grounded exactly at 100%
+because that is the measured-failing condition** — no "safe margin"
+percentage was invented, so the check is a stated LOWER bound on the
+true requirement; a margin sweep (the #431 sweep shape, varying
+provisioned margin instead of research level) would tighten it.
+Scoped to shared belts (≥2 consumers: with one machine there is no head
+and no tail) and to `belt-in` segments only (the k-trunk
+`row:<recipe>:trunk:<item>` path provisions k parallel belts, which a
+single-belt comparison would systematically false-positive).
+A whole-suite sweep (instrumented run over every test) puts it at **32
+rows across 8 fixture configs**, every one the identical zero-margin
+shape and every one judged genuine: chain-ec15's copper-cable row
+(45.00 vs 45.0 express, n=6; shared by three cell-composition tests),
+`tier2_electronic_circuit_from_ore` (1 row, 24 electric furnaces ×
+0.625 = 15.00 vs 15.0 yellow), the EC-from-ore stress fixtures 30s (5),
+30s_decomposed (7), 40s (4), 60s_red (5, n=48 × 0.625 = 30.00 vs 30.0
+red), `stacking_ec_60s_red_one_belt_headline` (5) and
+`partition_strategy_scoreboard` (4, EC rows at 30.00 vs 30.0 red).
+Discriminating, not blanket: sibling rows at 91.7%, 90%, 87.5%, 80%,
+60%, 40% stay silent in the same layouts. Zero layout-hash change (3
+stress goldens re-blessed for warning counts only).
+**Root cause is one comparison operator**: `common::belt_entity_for_rate`
+picks the cheapest tier with `rate <= throughput`, so any demand landing
+exactly on a tier boundary (15/30/45 at S=1) is provisioned with zero
+margin by construction — which is why every single finding reads
+`demand == capacity` to the penny. The engine-side fix (strict `<`, or a
+measured margin) is deliberately NOT in this change: it needs the margin
+sweep first, and it would move geometry everywhere.
+NOT caught: the `chain-mil5ore` and `mega-chain-pu4raw` tail-starvation
+instances — their belts sit at 5.5% and 27% utilization, so whatever
+starves those rows is a different binding constraint and is still
+unattributed.
+
 **`rfc-047-lane-aware-tap-delivery.md` close-out (2026-07-22)**: made
 delivery **lane-aware** so belt stacking raises rate CEILINGS, not just
 belt tiers. Leg A: the lane-rate walker's convergence-phase splitter model


### PR DESCRIPTION
## Intent

Close the validator blind spot behind #448: a row of N consumers sharing an input belt provisioned at **exactly** aggregate demand. Inserters pick greedily head-first and buffer deeply, so the head absorbs the slack and the **tail machine starves** — a stable converged steady state, not a transient.

Measured, not theorised. `chain-ec15`'s EC row is 6 machines × 7.5/s copper-cable = **45.00/s on an express belt rated 45.0/s — exactly 100%**. In-sim the row holds cable 42→34→20→6→…→2, the tail machine sits in `item_ingredient_shortage` with 20 iron plates idle, and a cable producer is simultaneously `full_output` with 32 cable stuck. Costs ~5.3% throughput (one of six machines at ~68% duty) and is research-invariant.

**Why neither existing check catches it:** `check_lane_throughput` is a capacity check and 45 ≤ 45 passes. `check_input_rate_delivery` compares each machine's pickup tile against that machine's own need — but the lane-rate propagation never subtracts upstream consumption, so machine #6 sees the full 45/s. Every machine passes independently while collectively they cannot all be fed. Nothing modelled **cumulative draw along a shared belt**.

## The threshold, and what it deliberately isn't

Flags `demand >= capacity - EPSILON`, i.e. **100% utilisation**, because that is the *measured-failing* condition. The in-code comment states plainly that this is a **lower bound on the true requirement** — a belt at 98% may starve its tail too, and this check stays silent there.

No "safe margin" percentage was invented. None is measured, and load-bearing constants here are sim-derived, never theoretical — `ROW_LANE_FACTOR_BRIDGED`'s history (a 13.0/s "measured floor" that turned out to be instrument-bound) is exactly what happens otherwise. The margin sweep that would tighten this is the natural follow-up, using #431's sweep shape: vary provisioned belt margin instead of research level and read the tail machine's duty cycle.

## What it catches

**32 rows across 8 fixture configs — every one at exactly `demand == capacity`:**

| fixture | rows | numbers |
|---|---|---|
| chain-ec15 (3 tests) | 1 | EC ← copper-cable, **45.00 vs 45.0 express, n=6** |
| `tier2_electronic_circuit_from_ore` | 1 | copper-plate ← copper-ore, 15.00 vs 15.0 yellow, n=24 |
| `stress_electronic_circuit_30s_from_ore` | 5 | 15.00 vs 15.0 yellow, n=24 |
| `stress_electronic_circuit_30s_decomposed` | 7 | 15.00 vs 15.0 yellow, n=24 |
| `stress_electronic_circuit_40s_from_ore` | 4 | 15.00 vs 15.0 yellow, n=24 |
| `stress_electronic_circuit_60s_red_from_ore` | 5 | 30.00 vs 30.0 red, n=48 |
| `stacking_ec_60s_red_one_belt_headline` | 5 | 30.00 vs 30.0 red, n=48 |
| `partition_strategy_scoreboard` | 4 | EC ← copper-cable, 30.00 vs 30.0 red, n=4 |

It discriminates rather than blanket-tripping: sibling rows in the same layouts at 91.7 / 90 / 87.5 / 80 / 60 / 40% stay silent.

**Why every hit is *exactly* 100%** — the systemic root cause: `common::belt_entity_for_rate` selects with `rate <= throughput`, so any demand landing on a tier boundary (15/30/45 at S=1) gets zero margin **by construction**. There is a pinned test, `belt_entity_for_rate_exact_15`, asserting 15.0/s → yellow. The engine-side fix (strict `<`, or a measured margin) is deliberately **not** in this PR: it moves geometry everywhere and needs the margin sweep first to know what to buy.

## Scope bounds (documented as scope, not threshold)

- **≥2 consumers.** The mechanism needs a head and a tail. This removed the one false positive found: `tier_fish_breeding_self_loop` fired at 15.00/15.0 with a *single* chemical plant, where the mechanism cannot occur (it is inserter-bound, and both inserter checks already say so). Removed by scope, not suppressed.
- **`row:<recipe>:belt-in:<item>` segments only**, excluding the k-trunk path, which provisions *k* parallel belts and would systematically false-positive.

## Honest limitation

This does **not** explain #448's other two fixtures, and the check was not stretched to reach them. Their starved rows have abundant belt margin — mil5's MSP piercing-rounds belt is at **5.5%**, PU@4's EC iron-plate belt at **27%**. Same symptom, different binding constraint; re-opened as unattributed on #448. Fitting the instrument to the desired conclusion would have been the easy mistake here.

## Verification

- Full core suite via nextest: **996 passed, 0 failed, 57 skipped** (independently re-run, one clean invocation).
- Stress goldens: 3 drifted (30s 0→5, 40s 227→231, 60s_red 0→5), re-blessed against the pinned zone cache; `SPAGHETTIO_STRESS_GOLDEN=check` clean afterwards; **all three layout hashes unchanged** — the check is pure validation, no geometry movement. `sat-zones-ci.bin` restored and confirmed absent from the commit.
- `cargo clippy --workspace -- -D warnings`: clean.
- `cargo test -p spaghettio_sim_harness -p spaghettio_mining`: 48 passed.
- 6 new unit tests: fires at exactly-full, silent with margin, epsilon boundary, single-consumer out of scope, multi-trunk excluded, no-solver no-op.

Test pins re-derived honestly with #448 and the measured evidence inline in each; check count 34 → 36 in CLAUDE.md and `docs/sim-harness.md` (it had already drifted one behind — `check_row_output_lane_budget` made it 35). New `docs/status.md` entry with the census, rationale, root cause, and the not-caught cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxdUiAwSgsmUWHoChCek55