### PR TITLE
feat(meter): RFC-054 PR 1 — physics core, KC4 guard, and a negative result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spaghettio_meter"
+version = "0.1.0"
+dependencies = [
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "spaghettio_core",
+]
+
+[[package]]
 name = "spaghettio_mining"
 version = "0.1.0"
 dependencies = [

--- a/crates/meter/Cargo.toml
+++ b/crates/meter/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "spaghettio_meter"
+version = "0.1.0"
+edition = "2021"
+
+# RFC-054: the fast meter. A native item-level discrete simulator.
+#
+# INTEGRITY BOUNDARY (RFC-054 KC4). This crate depends on `spaghettio_core`
+# for DATA only — `blueprint_parser` (reading the exported artifact) and
+# `recipe_db` (ingredients, craft times, machine crafting speeds).
+#
+# It must NEVER import the engine's *derived rate model*:
+#   machine_feed_rate, belt_drop_rate, lane_capacity*, utilization_for,
+#   LANE_UTILIZATION, ROW_LANE_FACTOR_*
+#
+# Those are hand-calibrated estimates. Importing one would make the meter
+# reproduce the engine's belief instead of measuring, and its agreement
+# with the engine would be circular — the failure that made `carries`
+# labels worthless as ground truth (audit §3.3 #17) and that let the
+# backwards-inserter export bug survive behind three artifacts sharing one
+# convention. Enforced by `tests/kc4_independence.rs`.
+[dependencies]
+spaghettio_core = { path = "../core" }
+rustc-hash = "2"
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/meter/examples/row_probe.rs
+++ b/crates/meter/examples/row_probe.rs
@@ -1,0 +1,88 @@
+//! Probe: does a zero-margin shared input belt starve its tail?
+//!
+//! Run: `cargo run -p spaghettio_meter --example row_probe`
+//!
+//! This is the PR-1 instrument for the question PR 2 answers against real
+//! Factorio. It prints, per margin, the per-consumer consumption rate,
+//! ingredient buffer, and starved ticks — the three quantities #448's
+//! per-machine dumps report.
+
+use spaghettio_meter::{BeltTier, InserterKind, RowFixture};
+
+const DEMAND: f64 = 7.5;
+const CONSUMERS: usize = 6;
+const WARMUP: u64 = 30_000;
+const MEASURE: u64 = 60_000;
+
+fn main() {
+    println!("chain-ec15 shape: {CONSUMERS} consumers x {DEMAND}/s on express (45.0 nominal)");
+    println!("stack inserters, capacity L2, smooth boundary supply\n");
+    println!(
+        "{:>7}  {:>8}  {:<44}  {:<28}  {}",
+        "margin", "supply/s", "consumption/s (head->tail)", "buffer", "starved ticks"
+    );
+
+    for margin in [1.0, 1.02, 1.05, 1.10, 1.25, 1.50] {
+        let mut fx = RowFixture::build(
+            BeltTier::Blue,
+            InserterKind::Stack,
+            2,
+            CONSUMERS,
+            DEMAND,
+            margin,
+            "copper-cable",
+        );
+        fx.world.run_for(WARMUP);
+        for &c in &fx.chests {
+            fx.world.chests[c].consumed = 0;
+            fx.world.chests[c].starved_ticks = 0;
+        }
+        let start = fx.world.ticks;
+        fx.world.run_for(MEASURE);
+        let elapsed = fx.world.ticks - start;
+
+        let rates: Vec<String> = fx
+            .chests
+            .iter()
+            .map(|&c| format!("{:.2}", fx.world.chests[c].consumption_rate(elapsed)))
+            .collect();
+        let buffers: Vec<String> = fx
+            .chests
+            .iter()
+            .map(|&c| fx.world.chests[c].buffer.to_string())
+            .collect();
+        let starved: u64 = fx
+            .chests
+            .iter()
+            .map(|&c| fx.world.chests[c].starved_ticks)
+            .sum();
+
+        println!(
+            "{:>7.2}  {:>8.1}  {:<44}  {:<28}  {}",
+            margin,
+            DEMAND * CONSUMERS as f64 * margin,
+            rates.join(" "),
+            buffers.join(" "),
+            starved
+        );
+    }
+
+    println!("\nbelt occupancy per tile (both lanes, 8 slots max), margin 1.0:");
+    let mut fx = RowFixture::build(
+        BeltTier::Blue,
+        InserterKind::Stack,
+        2,
+        CONSUMERS,
+        DEMAND,
+        1.0,
+        "copper-cable",
+    );
+    fx.world.run_for(WARMUP);
+    println!("  {:?}", fx.tile_occupancy());
+    let src_rejected: u64 = fx.world.sources.iter().map(|s| s.rejected).sum();
+    let src_injected: u64 = fx.world.sources.iter().map(|s| s.injected).sum();
+    println!(
+        "  source injected {src_injected}, rejected {src_rejected} \
+         (rejected > 0 means the belt backed up to its head)"
+    );
+}

--- a/crates/meter/src/belt.rs
+++ b/crates/meter/src/belt.rs
@@ -1,0 +1,379 @@
+//! Item-level belt model.
+//!
+//! **The load-bearing design decision of RFC-054: items, not rates.** A
+//! rate-based belt would reproduce the validator's blindness by
+//! construction. Here a lane is a sequence of discrete slots at Factorio's
+//! item spacing, and an item advances only when the slot ahead is free.
+//!
+//! Three properties fall out of that, unprogrammed, and they are the whole
+//! reason the meter can see the #448 class:
+//!
+//! 1. **Compression happens only against a blockage.** Items on a
+//!    free-flowing lane all advance together, so spacing is preserved.
+//! 2. **Gaps do not heal.** An item removed mid-run leaves a hole that
+//!    travels downstream forever unless something upstream is backed up.
+//! 3. **Order is FIFO.**
+//!
+//! Nothing below special-cases tail starvation. It is a consequence.
+//!
+//! ## PR 1 scope: linear runs only
+//!
+//! This lands the physics for a *linear* belt run — the topology the #448
+//! mechanism lives in and the one PR 2's margin sweep needs. Branching
+//! (splitters, sideloads, underground pairs linking separate runs) is
+//! **refused loudly** rather than silently approximated; see
+//! [`crate::world::World::from_blueprint`]. Generalisation lands with PR 3.
+
+use crate::entity_data::{BeltTier, SLOTS_PER_TILE};
+
+/// Interned item identifier. The meter never reasons about item names in
+/// the hot loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ItemId(pub u16);
+
+/// What happens to an item that reaches the downstream end of a run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunEnd {
+    /// Nothing consumes it: items pile up and the run backs up.
+    ///
+    /// This is the ordinary shape of a bus row's input belt, and it is
+    /// central to #448: a dead end *would* re-compress the lane if surplus
+    /// ever reached it, but a starving tail consumes everything that
+    /// arrives, so it never backs up and the upstream gaps never heal.
+    DeadEnd,
+    /// Items are removed and counted (a drain, or the world edge).
+    Sink,
+}
+
+/// One lane of a linear belt run.
+#[derive(Debug, Clone)]
+pub struct Lane {
+    /// Slot 0 is the upstream (entry) end; the last slot is the exit.
+    slots: Vec<Option<ItemId>>,
+    /// Sub-slot advance carried between ticks. Belt speeds are not
+    /// integer slots-per-tick (express is 2.67 ticks/slot), so the
+    /// fractional remainder must persist or the model would quantise
+    /// every tier down to the same speed.
+    progress: f64,
+    /// Items that left this lane through the run end, by tick of exit.
+    pub exited: u64,
+}
+
+impl Lane {
+    fn new(slot_count: usize) -> Self {
+        Lane {
+            slots: vec![None; slot_count],
+            progress: 0.0,
+            exited: 0,
+        }
+    }
+
+    pub fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub fn occupancy(&self) -> usize {
+        self.slots.iter().filter(|s| s.is_some()).count()
+    }
+
+    /// Fraction of slots occupied — the density that governs how much an
+    /// inserter above this lane can actually pick up.
+    pub fn density(&self) -> f64 {
+        if self.slots.is_empty() {
+            return 0.0;
+        }
+        self.occupancy() as f64 / self.slots.len() as f64
+    }
+
+    /// Occupied slot count within one tile of the run.
+    pub fn occupancy_in_tile(&self, tile_index: usize) -> usize {
+        let lo = tile_index * SLOTS_PER_TILE;
+        let hi = (lo + SLOTS_PER_TILE).min(self.slots.len());
+        if lo >= hi {
+            return 0;
+        }
+        self.slots[lo..hi].iter().filter(|s| s.is_some()).count()
+    }
+
+    /// Try to place an item at the upstream end. Returns false when slot 0
+    /// is occupied — i.e. the lane is backed up all the way to its source,
+    /// which is what makes a producer go `full_output`.
+    pub fn try_insert(&mut self, item: ItemId) -> bool {
+        match self.slots.first_mut() {
+            Some(slot @ None) => {
+                *slot = Some(item);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Remove up to `max` items from `tile_index`, most-downstream first.
+    ///
+    /// Downstream-first matters: it is what leaves the *upstream* part of
+    /// the tile empty for the next arrival, and it is how a real inserter
+    /// grabbing from a belt behaves.
+    pub fn take_from_tile(&mut self, tile_index: usize, max: u32, out: &mut Vec<ItemId>) {
+        if max == 0 {
+            return;
+        }
+        let lo = tile_index * SLOTS_PER_TILE;
+        let hi = (lo + SLOTS_PER_TILE).min(self.slots.len());
+        if lo >= hi {
+            return;
+        }
+        let mut taken = 0u32;
+        for idx in (lo..hi).rev() {
+            if taken >= max {
+                break;
+            }
+            if let Some(item) = self.slots[idx].take() {
+                out.push(item);
+                taken += 1;
+            }
+        }
+    }
+
+    /// Advance one tick. Returns the number of whole-slot steps applied.
+    fn tick(&mut self, tier: BeltTier, end: RunEnd) -> u32 {
+        self.progress += tier.slots_per_tick();
+        let mut steps = 0;
+        while self.progress >= 1.0 {
+            self.progress -= 1.0;
+            self.step(end);
+            steps += 1;
+        }
+        steps
+    }
+
+    /// One whole-slot advance, processed **downstream-first**.
+    ///
+    /// Downstream-first is what lets a fully compressed lane move at full
+    /// speed: each item may enter the slot its neighbour vacated in this
+    /// same step. Processing upstream-first would cap a compressed lane at
+    /// one item per step per gap, which is not how belts work.
+    fn step(&mut self, end: RunEnd) {
+        if self.slots.is_empty() {
+            return;
+        }
+        let last = self.slots.len() - 1;
+
+        // 1. The exit slot: eject if the run end accepts, else it stays put
+        //    and everything behind it backs up.
+        if self.slots[last].is_some() && end == RunEnd::Sink {
+            self.slots[last] = None;
+            self.exited += 1;
+        }
+
+        // 2. Shift the rest forward into any free slot ahead.
+        for idx in (1..=last).rev() {
+            if self.slots[idx].is_none() {
+                self.slots[idx] = self.slots[idx - 1].take();
+            }
+        }
+    }
+}
+
+/// A linear run of belt tiles, both lanes.
+#[derive(Debug, Clone)]
+pub struct BeltRun {
+    pub tier: BeltTier,
+    pub end: RunEnd,
+    /// Tile coordinates in flow order; slot `s` of a lane sits in tile
+    /// `s / SLOTS_PER_TILE`.
+    pub tiles: Vec<(i32, i32)>,
+    /// Index 0 = left lane, 1 = right lane (`factorio-mechanics.md` B2/B3).
+    pub lanes: [Lane; 2],
+}
+
+impl BeltRun {
+    pub fn new(tier: BeltTier, tiles: Vec<(i32, i32)>, end: RunEnd) -> Self {
+        let slot_count = tiles.len() * SLOTS_PER_TILE;
+        BeltRun {
+            tier,
+            end,
+            tiles,
+            lanes: [Lane::new(slot_count), Lane::new(slot_count)],
+        }
+    }
+
+    pub fn tile_index(&self, pos: (i32, i32)) -> Option<usize> {
+        self.tiles.iter().position(|&t| t == pos)
+    }
+
+    pub fn tick(&mut self) {
+        let (tier, end) = (self.tier, self.end);
+        for lane in &mut self.lanes {
+            lane.tick(tier, end);
+        }
+    }
+
+    /// Total items currently on the run.
+    pub fn item_count(&self) -> usize {
+        self.lanes.iter().map(|l| l.occupancy()).sum()
+    }
+
+    /// Mean occupancy across both lanes, 0.0..=1.0.
+    pub fn density(&self) -> f64 {
+        (self.lanes[0].density() + self.lanes[1].density()) / 2.0
+    }
+
+    /// Occupied slots in one tile across both lanes — what an inserter
+    /// above that tile can see. Inserters pick from **both lanes**
+    /// (`factorio-mechanics.md` I6).
+    pub fn occupancy_in_tile(&self, tile_index: usize) -> usize {
+        self.lanes
+            .iter()
+            .map(|l| l.occupancy_in_tile(tile_index))
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const IRON: ItemId = ItemId(0);
+
+    fn straight(tier: BeltTier, len: usize, end: RunEnd) -> BeltRun {
+        BeltRun::new(tier, (0..len as i32).map(|x| (x, 0)).collect(), end)
+    }
+
+    /// The defining property: on a free-flowing lane, a hole punched in
+    /// the middle travels downstream and never closes.
+    #[test]
+    fn gaps_do_not_heal_on_a_moving_lane() {
+        let mut run = straight(BeltTier::Yellow, 6, RunEnd::Sink);
+        // Fill the lane solid.
+        for _ in 0..run.lanes[0].slot_count() {
+            for _ in 0..8 {
+                run.tick();
+            }
+            run.lanes[0].try_insert(IRON);
+        }
+        // Punch a hole in the middle by removing one item.
+        let mut taken = Vec::new();
+        run.lanes[0].take_from_tile(3, 1, &mut taken);
+        assert_eq!(taken.len(), 1);
+        let before = run.lanes[0].occupancy();
+
+        // Advance without feeding. The hole must persist: occupancy falls
+        // only because items leave at the sink, never because the gap closed.
+        for _ in 0..8 {
+            run.tick();
+        }
+        let exited = run.lanes[0].exited as usize;
+        assert_eq!(
+            run.lanes[0].occupancy(),
+            before - exited,
+            "items vanished or were created — the gap must simply travel"
+        );
+    }
+
+    /// A compressed lane must move at full belt speed, not one item per
+    /// step. This is what downstream-first ordering buys.
+    #[test]
+    fn compressed_lane_moves_at_full_speed() {
+        let mut run = straight(BeltTier::Yellow, 4, RunEnd::Sink);
+        for _ in 0..run.lanes[0].slot_count() {
+            run.lanes[0].try_insert(IRON);
+            // Advance exactly one slot (yellow = 8 ticks/slot).
+            for _ in 0..8 {
+                run.tick();
+            }
+        }
+        // 16 slots at 8 ticks each: a solid lane should drain steadily.
+        let start = run.lanes[0].exited;
+        for _ in 0..80 {
+            run.tick();
+        }
+        let moved = run.lanes[0].exited - start;
+        assert!(
+            moved >= 9,
+            "compressed yellow lane should eject ~10 items in 80 ticks, got {moved}"
+        );
+    }
+
+    /// A dead end backs up; a sink does not. #448 turns on this difference.
+    #[test]
+    fn dead_end_backs_up_and_refuses_further_input() {
+        let mut run = straight(BeltTier::Yellow, 2, RunEnd::DeadEnd);
+        let capacity = run.lanes[0].slot_count();
+        let mut accepted = 0;
+        for _ in 0..(capacity * 20) {
+            if run.lanes[0].try_insert(IRON) {
+                accepted += 1;
+            }
+            run.tick();
+        }
+        assert_eq!(
+            accepted, capacity,
+            "a dead-ended lane must accept exactly its slot count, then refuse"
+        );
+        assert_eq!(run.lanes[0].exited, 0, "a dead end must not eject items");
+    }
+
+    /// Faster tiers must actually move faster — the sub-slot accumulator
+    /// exists so express (2.67 ticks/slot) is not quantised to red's 4.
+    #[test]
+    fn tiers_move_at_distinct_speeds() {
+        let drained = |tier: BeltTier| {
+            let mut run = straight(tier, 4, RunEnd::Sink);
+            for _ in 0..600 {
+                run.lanes[0].try_insert(IRON);
+                run.tick();
+            }
+            run.lanes[0].exited
+        };
+        let (y, r, b) = (
+            drained(BeltTier::Yellow),
+            drained(BeltTier::Red),
+            drained(BeltTier::Blue),
+        );
+        assert!(y < r && r < b, "expected yellow < red < blue, got {y} {r} {b}");
+    }
+
+    /// Throughput must *emerge* at the documented per-lane rate rather
+    /// than being read from a table (B5: yellow 7.5/s per lane).
+    #[test]
+    fn saturated_lane_throughput_matches_mechanics_b5() {
+        for (tier, want_per_lane) in [
+            (BeltTier::Yellow, 7.5),
+            (BeltTier::Red, 15.0),
+            (BeltTier::Blue, 22.5),
+        ] {
+            let mut run = straight(tier, 8, RunEnd::Sink);
+            // Warm up past the fill transient before measuring. Without
+            // this the run under-reads by exactly its slot count (32),
+            // which is the "buffer fill reads as convergence" artifact
+            // class the sim harness already learned the hard way — see
+            // docs/sim-harness-forensics.md.
+            for _ in 0..1200 {
+                run.lanes[0].try_insert(IRON);
+                run.tick();
+            }
+            run.lanes[0].exited = 0;
+            let ticks = 3600;
+            for _ in 0..ticks {
+                run.lanes[0].try_insert(IRON);
+                run.tick();
+            }
+            let per_s = run.lanes[0].exited as f64 / (ticks as f64 / 60.0);
+            assert!(
+                (per_s - want_per_lane).abs() / want_per_lane < 0.02,
+                "{tier:?}: derived {per_s:.2}/s per lane, mechanics B5 says {want_per_lane}"
+            );
+        }
+    }
+
+    #[test]
+    fn take_from_tile_prefers_downstream_slots() {
+        let mut run = straight(BeltTier::Yellow, 2, RunEnd::DeadEnd);
+        for i in 0..SLOTS_PER_TILE {
+            run.lanes[0].slots[i] = Some(ItemId(i as u16));
+        }
+        let mut out = Vec::new();
+        run.lanes[0].take_from_tile(0, 2, &mut out);
+        assert_eq!(out, vec![ItemId(3), ItemId(2)]);
+    }
+}

--- a/crates/meter/src/entity_data.rs
+++ b/crates/meter/src/entity_data.rs
@@ -153,27 +153,40 @@ impl InserterKind {
     /// Hand size at a declared inserter-capacity research level (0–7).
     ///
     /// Schedule per `factorio-mechanics.md` **I8b** (RFC-049, pinned from
-    /// raw wikitext): bulk 2→12 across the ladder; stack = bulk + 4;
-    /// non-bulk 1→3. Only bulk-class inserters scale with capacity
-    /// research; regular/long-handed/fast take the small non-bulk chain.
+    /// raw wikitext). Both ladders are **literal tables**, not closed
+    /// forms: neither is expressible as a clean saturating expression, and
+    /// an earlier draft's arithmetic silently mis-transcribed both (review,
+    /// PR #458 — bulk over-credited at L1–L6, non-bulk wrong at L2 and
+    /// L4–L6). Transcribe, don't derive.
     pub fn hand_size(self, level: u8) -> u32 {
-        let level = level.min(7) as u32;
+        let level = level.min(7) as usize;
         match self {
-            // Non-bulk chain: 1 at L0..L2, then +1 at L3 and L4, capped 3.
             InserterKind::Regular | InserterKind::LongHanded | InserterKind::Fast => {
-                1 + level.saturating_sub(2).min(2)
+                NON_BULK_HAND_BY_LEVEL[level]
             }
-            // Bulk: 2 at L0, then +1 per level to 12 at L7 is the wiki
-            // schedule's shape (2,4,5,6,7,9,11,12 across L0..L7).
-            InserterKind::Bulk => BULK_HAND_BY_LEVEL[level as usize],
-            InserterKind::Stack => BULK_HAND_BY_LEVEL[level as usize] + 4,
+            InserterKind::Bulk => BULK_HAND_BY_LEVEL[level],
+            // Stack = bulk-class + 4 built-in (`stack_size_bonus: 4` in the
+            // entity prototype), giving I8b's 6,7,8,9,10,12,14,16.
+            InserterKind::Stack => BULK_HAND_BY_LEVEL[level] + 4,
         }
     }
 }
 
 /// Bulk-inserter hand size by inserter-capacity research level 0..=7.
-/// `factorio-mechanics.md` I8b. Stack inserters are this + 4.
-const BULK_HAND_BY_LEVEL: [u32; 8] = [2, 4, 5, 6, 7, 9, 11, 12];
+/// `factorio-mechanics.md` I8b: +1 at L1–4, +2 at L5–7.
+const BULK_HAND_BY_LEVEL: [u32; 8] = [2, 3, 4, 5, 6, 8, 10, 12];
+
+/// Regular / long-handed / fast hand size by research level 0..=7.
+/// `factorio-mechanics.md` I8b: +1 at L2 and L7 only.
+///
+/// **Known unmodelled**: I8b also notes Transport-belt-capacity-2 grants a
+/// further literal "non-bulk inserter capacity +1" → max 4, which the
+/// *engine* bundles at L7. That bundling is an engine modelling choice
+/// rather than a measured fact, so the meter takes the literal chain and
+/// leaves the extra +1 out. Candidate `docs/meter-divergence.md` entry;
+/// revisit against measurement in PR 2/3 rather than by inheriting the
+/// engine's decision.
+const NON_BULK_HAND_BY_LEVEL: [u32; 8] = [1, 1, 2, 2, 2, 2, 2, 3];
 
 #[cfg(test)]
 mod tests {

--- a/crates/meter/src/entity_data.rs
+++ b/crates/meter/src/entity_data.rs
@@ -1,0 +1,233 @@
+//! Factorio prototype constants the meter needs.
+//!
+//! **Provenance discipline (RFC-054).** Everything here is a *game
+//! constant* — a fact about Factorio prototypes — never a derived rate.
+//! The meter deliberately keeps its own copy rather than importing
+//! `spaghettio_core::common`, because that module mixes prototype facts
+//! with hand-calibrated estimates (`machine_feed_rate`, `belt_drop_rate`,
+//! lane capacities, utilization factors) and the meter must not inherit
+//! the engine's beliefs. See the crate manifest and `tests/kc4_independence.rs`.
+//!
+//! Each constant below carries its derivation so a reviewer can check it
+//! against the game rather than against us.
+
+/// Item spacing on a belt lane, in tiles. Factorio packs items on a
+/// transport line every 0.25 tiles, so a 1×1 belt tile holds 4 items per
+/// lane when fully compressed.
+pub const ITEM_SPACING_TILES: f64 = 0.25;
+
+/// Slots per lane per belt tile. `1.0 / ITEM_SPACING_TILES`.
+pub const SLOTS_PER_TILE: usize = 4;
+
+/// Ticks per second.
+pub const TICKS_PER_SECOND: f64 = 60.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BeltTier {
+    Yellow,
+    Red,
+    Blue,
+    Turbo,
+}
+
+impl BeltTier {
+    pub fn from_entity_name(name: &str) -> Option<Self> {
+        // Underground/splitter variants share their tier's speed.
+        let base = name
+            .trim_end_matches("-transport-belt")
+            .trim_end_matches("-underground-belt")
+            .trim_end_matches("-splitter");
+        match name {
+            "transport-belt" | "underground-belt" | "splitter" => Some(BeltTier::Yellow),
+            _ => match base {
+                "fast" => Some(BeltTier::Red),
+                "express" => Some(BeltTier::Blue),
+                "turbo" => Some(BeltTier::Turbo),
+                _ => None,
+            },
+        }
+    }
+
+    /// Belt speed in tiles per second.
+    ///
+    /// Cross-check against `factorio-mechanics.md` **B5** (throughput per
+    /// belt, both lanes): `tiles/s × 4 slots/tile × 2 lanes`.
+    ///   yellow 1.875 × 4 × 2 = 15/s ✓
+    ///   red    3.75  × 4 × 2 = 30/s ✓
+    ///   blue   5.625 × 4 × 2 = 45/s ✓
+    ///   turbo  7.5   × 4 × 2 = 60/s ✓ (Space Age)
+    ///
+    /// Note the meter derives throughput from speed and spacing; it never
+    /// reads a throughput table. That is the whole point — a belt's
+    /// nominal rate is an *output* of the physics here, not an input.
+    pub fn tiles_per_second(self) -> f64 {
+        match self {
+            BeltTier::Yellow => 1.875,
+            BeltTier::Red => 3.75,
+            BeltTier::Blue => 5.625,
+            BeltTier::Turbo => 7.5,
+        }
+    }
+
+    /// Slot advances per tick for one item on a free-flowing belt.
+    pub fn slots_per_tick(self) -> f64 {
+        self.tiles_per_second() / TICKS_PER_SECOND / ITEM_SPACING_TILES
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InserterKind {
+    Regular,
+    LongHanded,
+    Fast,
+    Bulk,
+    Stack,
+}
+
+impl InserterKind {
+    pub fn from_entity_name(name: &str) -> Option<Self> {
+        match name {
+            "inserter" => Some(InserterKind::Regular),
+            "long-handed-inserter" => Some(InserterKind::LongHanded),
+            "fast-inserter" => Some(InserterKind::Fast),
+            "bulk-inserter" => Some(InserterKind::Bulk),
+            "stack-inserter" => Some(InserterKind::Stack),
+            _ => None,
+        }
+    }
+
+    /// Prototype `rotation_speed`, in turns per tick.
+    ///
+    /// A full pick-and-drop cycle is one turn, so
+    /// `swings/s = rotation_speed × 60` and `cycle_ticks = 1 / rotation_speed`.
+    /// Cross-check against `factorio-mechanics.md` **I8**, whose throughputs
+    /// are stated as `rotation_speed × 60 × items_per_swing`:
+    ///   regular     0.014 × 60 × 1 = 0.84/s ✓
+    ///   long-handed 0.020 × 60 × 1 = 1.20/s ✓
+    ///   fast        0.040 × 60 × 1 = 2.40/s ✓ (I8 quotes 2.31 with extension delay)
+    pub fn rotation_speed(self) -> f64 {
+        match self {
+            InserterKind::Regular => 0.014,
+            InserterKind::LongHanded => 0.020,
+            InserterKind::Fast | InserterKind::Bulk | InserterKind::Stack => 0.040,
+        }
+    }
+
+    /// Full swing cycle in ticks.
+    pub fn cycle_ticks(self) -> f64 {
+        1.0 / self.rotation_speed()
+    }
+
+    /// Reach in tiles (pickup and drop are each this far from the inserter).
+    /// `factorio-mechanics.md` **I3**/**I4**: long-handed is the only
+    /// reach-2 inserter in vanilla (**I8a**).
+    pub fn reach(self) -> i32 {
+        match self {
+            InserterKind::LongHanded => 2,
+            _ => 1,
+        }
+    }
+
+    /// Base hand size at inserter-capacity research level 0.
+    ///
+    /// **Deliberate divergence from the engine's table, recorded because
+    /// it is exactly the kind of inherited belief KC4 exists to prevent.**
+    /// `factorio-mechanics.md` I8 lists stack 5 / bulk 1, and its own
+    /// "I8 wiki cross-check (2026-07-20, #313)" note records that the wiki
+    /// says **stack 6 / bulk 2**, with the engine keeping the lower values
+    /// *on purpose* — conservative under-crediting is the safe direction
+    /// for a sizing ladder and a throughput validator.
+    ///
+    /// The meter is not sizing anything. Under-crediting would make it
+    /// measure something the game does not do, so it takes the game-true
+    /// values. Any resulting fast-vs-real disagreement belongs in
+    /// `docs/meter-divergence.md`, not in a fudge here.
+    pub fn base_hand_size(self) -> u32 {
+        match self {
+            InserterKind::Regular | InserterKind::LongHanded | InserterKind::Fast => 1,
+            InserterKind::Bulk => 2,
+            InserterKind::Stack => 6,
+        }
+    }
+
+    /// Hand size at a declared inserter-capacity research level (0–7).
+    ///
+    /// Schedule per `factorio-mechanics.md` **I8b** (RFC-049, pinned from
+    /// raw wikitext): bulk 2→12 across the ladder; stack = bulk + 4;
+    /// non-bulk 1→3. Only bulk-class inserters scale with capacity
+    /// research; regular/long-handed/fast take the small non-bulk chain.
+    pub fn hand_size(self, level: u8) -> u32 {
+        let level = level.min(7) as u32;
+        match self {
+            // Non-bulk chain: 1 at L0..L2, then +1 at L3 and L4, capped 3.
+            InserterKind::Regular | InserterKind::LongHanded | InserterKind::Fast => {
+                1 + level.saturating_sub(2).min(2)
+            }
+            // Bulk: 2 at L0, then +1 per level to 12 at L7 is the wiki
+            // schedule's shape (2,4,5,6,7,9,11,12 across L0..L7).
+            InserterKind::Bulk => BULK_HAND_BY_LEVEL[level as usize],
+            InserterKind::Stack => BULK_HAND_BY_LEVEL[level as usize] + 4,
+        }
+    }
+}
+
+/// Bulk-inserter hand size by inserter-capacity research level 0..=7.
+/// `factorio-mechanics.md` I8b. Stack inserters are this + 4.
+const BULK_HAND_BY_LEVEL: [u32; 8] = [2, 4, 5, 6, 7, 9, 11, 12];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The meter must *derive* the belt throughputs the mechanics doc
+    /// states, not be told them. If this drifts, either a constant is
+    /// wrong or the slot model is.
+    #[test]
+    fn belt_throughput_derives_from_speed_and_spacing() {
+        let both_lanes = |t: BeltTier| {
+            t.tiles_per_second() / ITEM_SPACING_TILES * 2.0
+        };
+        assert_eq!(both_lanes(BeltTier::Yellow), 15.0);
+        assert_eq!(both_lanes(BeltTier::Red), 30.0);
+        assert_eq!(both_lanes(BeltTier::Blue), 45.0);
+        assert_eq!(both_lanes(BeltTier::Turbo), 60.0);
+    }
+
+    #[test]
+    fn inserter_swing_rates_match_mechanics_i8() {
+        let per_s = |k: InserterKind| TICKS_PER_SECOND / k.cycle_ticks();
+        assert!((per_s(InserterKind::Regular) - 0.84).abs() < 1e-9);
+        assert!((per_s(InserterKind::LongHanded) - 1.20).abs() < 1e-9);
+        assert!((per_s(InserterKind::Fast) - 2.40).abs() < 1e-9);
+    }
+
+    #[test]
+    fn long_handed_is_the_only_reach_two_inserter() {
+        for k in [
+            InserterKind::Regular,
+            InserterKind::Fast,
+            InserterKind::Bulk,
+            InserterKind::Stack,
+        ] {
+            assert_eq!(k.reach(), 1, "{k:?} should be reach-1 (I8a)");
+        }
+        assert_eq!(InserterKind::LongHanded.reach(), 2);
+    }
+
+    #[test]
+    fn belt_tier_parses_all_variants() {
+        for (name, want) in [
+            ("transport-belt", BeltTier::Yellow),
+            ("underground-belt", BeltTier::Yellow),
+            ("splitter", BeltTier::Yellow),
+            ("fast-transport-belt", BeltTier::Red),
+            ("fast-underground-belt", BeltTier::Red),
+            ("express-transport-belt", BeltTier::Blue),
+            ("express-splitter", BeltTier::Blue),
+            ("turbo-transport-belt", BeltTier::Turbo),
+        ] {
+            assert_eq!(BeltTier::from_entity_name(name), Some(want), "{name}");
+        }
+        assert_eq!(BeltTier::from_entity_name("assembling-machine-3"), None);
+    }
+}

--- a/crates/meter/src/inserter.rs
+++ b/crates/meter/src/inserter.rs
@@ -1,0 +1,303 @@
+//! Inserter state machine.
+//!
+//! The point of modelling inserters as a **state machine over ticks**
+//! rather than as a throughput number is that density-dependent
+//! throughput becomes *derived* rather than asserted.
+//!
+//! A real inserter's hand arrives at the pickup tile on a fixed cycle. If
+//! nothing is under it, that swing is lost. If it grabs multi-item hands,
+//! it can only take what is physically present. So an inserter above a
+//! gappy belt moves less than one above a compressed belt — with no
+//! `machine_feed_rate` table anywhere in sight. That is precisely what
+//! the engine's static model cannot express, and it is why KC4 forbids
+//! importing that table.
+
+use crate::belt::ItemId;
+use crate::entity_data::InserterKind;
+
+/// Where an inserter picks from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PickupTarget {
+    /// A tile of a belt run. Inserters pick from **both lanes**
+    /// (`factorio-mechanics.md` I6).
+    BeltTile { run: usize, tile: usize },
+}
+
+/// Where an inserter drops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropTarget {
+    /// A counting container. PR 1 has no machines; drops land in chests
+    /// so per-position extraction can be measured directly.
+    Chest(usize),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Hand empty, waiting for something to appear under the pickup tile.
+    /// Every tick spent here is a lost swing — the starvation signal.
+    WaitingForSource,
+    /// Mid-cycle: carrying to the drop side, then returning empty.
+    ///
+    /// One phase rather than two, and one **fractional** timer rather than
+    /// two rounded halves. Both details are load-bearing: an earlier draft
+    /// used `Swinging`/`Returning` with `round()`ed half-cycles and lost a
+    /// tick to the grab, which under-credited a fast inserter by ~8%
+    /// (2.222/s against I8's 2.4). A model that mis-times inserters cannot
+    /// measure a defect *about* inserter timing.
+    Cycling,
+}
+
+#[derive(Debug, Clone)]
+pub struct Inserter {
+    pub kind: InserterKind,
+    pub pickup: PickupTarget,
+    pub drop: DropTarget,
+    /// Declared inserter-capacity research level (0–7), a user-facing
+    /// engine axis. The meter takes it as an input, never infers it.
+    pub capacity_level: u8,
+    phase: Phase,
+    /// Ticks remaining in the current cycle. Fractional on purpose —
+    /// `cycle_ticks` is 25 for fast, 71.43 for regular; rounding it
+    /// quantises throughput.
+    cycle_timer: f64,
+    /// Whether this cycle's drop has already happened (at the halfway
+    /// crossing).
+    dropped: bool,
+    hand: Vec<ItemId>,
+    /// Ticks spent with an empty hand waiting for items.
+    pub starved_ticks: u64,
+    /// Items delivered over the run.
+    pub delivered: u64,
+    /// Completed swings, whether or not the hand was full.
+    pub swings: u64,
+    /// Items that could have been carried but were not, because the belt
+    /// did not have a full hand's worth under the pickup tile. This is the
+    /// density penalty, made countable.
+    pub short_hand_items: u64,
+}
+
+impl Inserter {
+    pub fn new(
+        kind: InserterKind,
+        pickup: PickupTarget,
+        drop: DropTarget,
+        capacity_level: u8,
+    ) -> Self {
+        Inserter {
+            kind,
+            pickup,
+            drop,
+            capacity_level,
+            phase: Phase::WaitingForSource,
+            cycle_timer: 0.0,
+            dropped: false,
+            hand: Vec::new(),
+            starved_ticks: 0,
+            delivered: 0,
+            swings: 0,
+            short_hand_items: 0,
+        }
+    }
+
+    pub fn hand_size(&self) -> u32 {
+        self.kind.hand_size(self.capacity_level)
+    }
+
+    /// Full pick→drop→return cycle, in ticks. Never rounded.
+    fn cycle_ticks(&self) -> f64 {
+        self.kind.cycle_ticks()
+    }
+
+    pub fn is_waiting_for_source(&self) -> bool {
+        matches!(self.phase, Phase::WaitingForSource)
+    }
+
+    /// Effective throughput over a measured window, items/s.
+    pub fn rate_per_second(&self, ticks: u64) -> f64 {
+        if ticks == 0 {
+            return 0.0;
+        }
+        self.delivered as f64 / (ticks as f64 / 60.0)
+    }
+
+    /// Called each tick with the items the pickup tile could supply.
+    ///
+    /// `grab` is invoked only at the moment the hand is actually over the
+    /// source, which is what makes lost swings possible.
+    pub fn tick<G, D>(&mut self, mut grab: G, mut deposit: D)
+    where
+        G: FnMut(u32, &mut Vec<ItemId>),
+        D: FnMut(&mut Vec<ItemId>) -> bool,
+    {
+        if self.phase == Phase::WaitingForSource {
+            let want = self.hand_size();
+            grab(want, &mut self.hand);
+            if self.hand.is_empty() {
+                // Nothing under the pickup tile this tick. A real inserter
+                // simply waits here; the swing is lost. This is the
+                // starvation signal, and it is why an inserter above a
+                // gappy belt moves less than one above a compressed belt
+                // without any rate table saying so.
+                self.starved_ticks += 1;
+                return;
+            }
+            // Took a partial hand because the belt was not dense enough to
+            // fill it. Count the shortfall — the density penalty the
+            // engine's flat rate cannot express.
+            self.short_hand_items += (want as u64).saturating_sub(self.hand.len() as u64);
+            self.cycle_timer = self.cycle_ticks();
+            self.dropped = false;
+            self.phase = Phase::Cycling;
+            // Fall through: the grab tick is part of the cycle, not extra.
+        }
+
+        // Consume one tick of the cycle.
+        self.cycle_timer -= 1.0;
+
+        // The drop happens at the halfway crossing (pickup → drop is half
+        // a turn), the return over the remaining half.
+        if !self.dropped && self.cycle_timer <= self.cycle_ticks() / 2.0 {
+            if deposit(&mut self.hand) {
+                self.delivered += self.hand.len() as u64;
+                self.hand.clear();
+                self.swings += 1;
+                self.dropped = true;
+            } else {
+                // Destination full: hold position. Give back the tick so a
+                // blocked inserter does not silently complete its cycle.
+                self.cycle_timer += 1.0;
+                return;
+            }
+        }
+
+        if self.cycle_timer <= 0.0 {
+            self.phase = Phase::WaitingForSource;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const IRON: ItemId = ItemId(0);
+
+    fn run_saturated(kind: InserterKind, level: u8, ticks: u64) -> Inserter {
+        let mut ins = Inserter::new(
+            kind,
+            PickupTarget::BeltTile { run: 0, tile: 0 },
+            DropTarget::Chest(0),
+            level,
+        );
+        for _ in 0..ticks {
+            ins.tick(
+                |want, hand| {
+                    for _ in 0..want {
+                        hand.push(IRON);
+                    }
+                },
+                |_hand| true,
+            );
+        }
+        ins
+    }
+
+    /// With an infinitely dense source the meter must *derive* the
+    /// mechanics doc's I8 throughputs. Chest-to-chest, hand 1.
+    #[test]
+    fn saturated_throughput_matches_mechanics_i8() {
+        for (kind, want) in [
+            (InserterKind::Regular, 0.84),
+            (InserterKind::LongHanded, 1.20),
+            (InserterKind::Fast, 2.40),
+        ] {
+            let ticks = 36_000;
+            let ins = run_saturated(kind, 0, ticks);
+            let got = ins.rate_per_second(ticks);
+            assert!(
+                (got - want).abs() / want < 0.05,
+                "{kind:?}: derived {got:.3}/s, I8 says {want}"
+            );
+        }
+    }
+
+    /// A stack inserter's advantage is hand size, not swing speed.
+    #[test]
+    fn stack_inserter_moves_a_full_hand_per_swing() {
+        let ticks = 36_000;
+        let ins = run_saturated(InserterKind::Stack, 0, ticks);
+        let fast = run_saturated(InserterKind::Fast, 0, ticks);
+        assert_eq!(ins.hand_size(), 6, "stack base hand is 6 (game-true)");
+        // Same rotation speed, 6× the hand.
+        assert!(
+            (ins.rate_per_second(ticks) / fast.rate_per_second(ticks) - 6.0).abs() < 0.3,
+            "stack should be ~6x fast at equal rotation speed"
+        );
+    }
+
+    /// The headline behaviour: a source that cannot fill the hand yields
+    /// proportionally less, and the shortfall is *counted* rather than
+    /// silently absorbed.
+    #[test]
+    fn partial_hands_reduce_throughput_and_are_counted() {
+        let ticks = 18_000;
+        let mut ins = Inserter::new(
+            InserterKind::Stack,
+            PickupTarget::BeltTile { run: 0, tile: 0 },
+            DropTarget::Chest(0),
+            0,
+        );
+        // Source can only ever supply 2 items per grab.
+        for _ in 0..ticks {
+            ins.tick(
+                |want, hand| {
+                    for _ in 0..want.min(2) {
+                        hand.push(IRON);
+                    }
+                },
+                |_hand| true,
+            );
+        }
+        let full = run_saturated(InserterKind::Stack, 0, ticks);
+        assert!(
+            ins.rate_per_second(ticks) < full.rate_per_second(ticks) * 0.5,
+            "a 2-of-6 hand must cost throughput"
+        );
+        assert!(
+            ins.short_hand_items > 0,
+            "the shortfall must be observable, not absorbed"
+        );
+    }
+
+    /// An empty source produces lost swings, not a slower cycle.
+    #[test]
+    fn empty_source_starves_rather_than_slowing() {
+        let ticks = 600;
+        let mut ins = Inserter::new(
+            InserterKind::Fast,
+            PickupTarget::BeltTile { run: 0, tile: 0 },
+            DropTarget::Chest(0),
+            0,
+        );
+        for _ in 0..ticks {
+            ins.tick(|_want, _hand| {}, |_hand| true);
+        }
+        assert_eq!(ins.delivered, 0);
+        assert_eq!(ins.starved_ticks, ticks);
+        assert!(ins.is_waiting_for_source());
+    }
+
+    /// Capacity research raises the hand for bulk-class inserters and
+    /// barely moves the others (`factorio-mechanics.md` I8b).
+    #[test]
+    fn capacity_research_scales_bulk_class_only() {
+        assert_eq!(InserterKind::Stack.hand_size(0), 6);
+        assert_eq!(InserterKind::Stack.hand_size(2), 9);
+        assert_eq!(InserterKind::Stack.hand_size(7), 16);
+        assert_eq!(InserterKind::Bulk.hand_size(0), 2);
+        assert_eq!(InserterKind::Bulk.hand_size(7), 12);
+        // Non-bulk barely moves: 1 -> 3 across the whole ladder.
+        assert_eq!(InserterKind::Fast.hand_size(0), 1);
+        assert_eq!(InserterKind::Fast.hand_size(7), 3);
+    }
+}

--- a/crates/meter/src/inserter.rs
+++ b/crates/meter/src/inserter.rs
@@ -304,17 +304,30 @@ mod tests {
         assert!(ins.is_waiting_for_source());
     }
 
-    /// Capacity research raises the hand for bulk-class inserters and
-    /// barely moves the others (`factorio-mechanics.md` I8b).
+    /// The **full** research ladder, pinned level by level against
+    /// `factorio-mechanics.md` I8b.
+    ///
+    /// Deliberately exhaustive rather than endpoint-sampled. An earlier
+    /// version asserted only L0/L2/L7 and happened to pick endpoints that
+    /// were right, so it pinned a mis-transcribed middle instead of
+    /// catching it (review, PR #458): bulk read `2,4,5,6,7,9,11,12`
+    /// against I8b's `2,3,4,5,6,8,10,12`, and non-bulk `1,1,1,2,3,3,3,3`
+    /// against `1,1,2,2,2,2,2,3`. Sampling a table is not testing it.
     #[test]
-    fn capacity_research_scales_bulk_class_only() {
-        assert_eq!(InserterKind::Stack.hand_size(0), 6);
-        assert_eq!(InserterKind::Stack.hand_size(2), 9);
-        assert_eq!(InserterKind::Stack.hand_size(7), 16);
-        assert_eq!(InserterKind::Bulk.hand_size(0), 2);
-        assert_eq!(InserterKind::Bulk.hand_size(7), 12);
-        // Non-bulk barely moves: 1 -> 3 across the whole ladder.
-        assert_eq!(InserterKind::Fast.hand_size(0), 1);
-        assert_eq!(InserterKind::Fast.hand_size(7), 3);
+    fn hand_size_ladder_matches_mechanics_i8b() {
+        let ladder = |k: InserterKind| (0..=7).map(|l| k.hand_size(l)).collect::<Vec<_>>();
+
+        // bulk chain: +1 at L1-4, +2 at L5-7
+        assert_eq!(ladder(InserterKind::Bulk), vec![2, 3, 4, 5, 6, 8, 10, 12]);
+        // stack = bulk + 4 built-in
+        assert_eq!(ladder(InserterKind::Stack), vec![6, 7, 8, 9, 10, 12, 14, 16]);
+        // non-bulk: +1 at L2 and L7 only
+        for k in [
+            InserterKind::Regular,
+            InserterKind::LongHanded,
+            InserterKind::Fast,
+        ] {
+            assert_eq!(ladder(k), vec![1, 1, 2, 2, 2, 2, 2, 3], "{k:?}");
+        }
     }
 }

--- a/crates/meter/src/inserter.rs
+++ b/crates/meter/src/inserter.rs
@@ -124,10 +124,14 @@ impl Inserter {
     ///
     /// `grab` is invoked only at the moment the hand is actually over the
     /// source, which is what makes lost swings possible.
+    /// `deposit` inserts as much of the hand as fits, draining what it
+    /// took, and returns the count accepted. A partial return means the
+    /// inserter keeps the remainder and retries — which is what the game
+    /// does, and is not the same as being blocked.
     pub fn tick<G, D>(&mut self, mut grab: G, mut deposit: D)
     where
         G: FnMut(u32, &mut Vec<ItemId>),
-        D: FnMut(&mut Vec<ItemId>) -> bool,
+        D: FnMut(&mut Vec<ItemId>) -> usize,
     {
         if self.phase == Phase::WaitingForSource {
             let want = self.hand_size();
@@ -145,7 +149,14 @@ impl Inserter {
             // fill it. Count the shortfall — the density penalty the
             // engine's flat rate cannot express.
             self.short_hand_items += (want as u64).saturating_sub(self.hand.len() as u64);
-            self.cycle_timer = self.cycle_ticks();
+            // ACCUMULATE, never assign. The previous cycle ended with the
+            // timer slightly below zero; that overshoot is the fractional
+            // part of the true period and must carry forward. A hard
+            // assignment quantises the period up to `ceil(cycle_ticks)` —
+            // for a regular inserter, 72 ticks instead of 71.43, i.e.
+            // 0.8333/s against I8's 0.84/s. Same discipline as
+            // `Lane::tick`, `Source::tick` and `Chest::tick`.
+            self.cycle_timer += self.cycle_ticks();
             self.dropped = false;
             self.phase = Phase::Cycling;
             // Fall through: the grab tick is part of the cycle, not extra.
@@ -157,13 +168,14 @@ impl Inserter {
         // The drop happens at the halfway crossing (pickup → drop is half
         // a turn), the return over the remaining half.
         if !self.dropped && self.cycle_timer <= self.cycle_ticks() / 2.0 {
-            if deposit(&mut self.hand) {
-                self.delivered += self.hand.len() as u64;
-                self.hand.clear();
+            self.delivered += deposit(&mut self.hand) as u64;
+            if self.hand.is_empty() {
                 self.swings += 1;
                 self.dropped = true;
             } else {
-                // Destination full: hold position. Give back the tick so a
+                // Nothing fit, or only part of the hand did. Hold position
+                // with the remainder and retry next tick — the game's
+                // partial-insert behaviour. Give back the tick so a
                 // blocked inserter does not silently complete its cycle.
                 self.cycle_timer += 1.0;
                 return;
@@ -196,7 +208,7 @@ mod tests {
                         hand.push(IRON);
                     }
                 },
-                |_hand| true,
+                |hand| { let n = hand.len(); hand.clear(); n },
             );
         }
         ins
@@ -214,9 +226,14 @@ mod tests {
             let ticks = 36_000;
             let ins = run_saturated(kind, 0, ticks);
             let got = ins.rate_per_second(ticks);
+            // 1%, not 5%. A 5% band hid a real defect: the cycle timer was
+            // hard-assigned rather than accumulated, quantising a regular
+            // inserter's period from 71.43 to 72 ticks (0.8333/s vs 0.84,
+            // −0.79%) — invisible at 5%, caught by review instead of by
+            // the test that exists to catch it.
             assert!(
-                (got - want).abs() / want < 0.05,
-                "{kind:?}: derived {got:.3}/s, I8 says {want}"
+                (got - want).abs() / want < 0.01,
+                "{kind:?}: derived {got:.4}/s, I8 says {want}"
             );
         }
     }
@@ -255,7 +272,7 @@ mod tests {
                         hand.push(IRON);
                     }
                 },
-                |_hand| true,
+                |hand| { let n = hand.len(); hand.clear(); n },
             );
         }
         let full = run_saturated(InserterKind::Stack, 0, ticks);
@@ -280,7 +297,7 @@ mod tests {
             0,
         );
         for _ in 0..ticks {
-            ins.tick(|_want, _hand| {}, |_hand| true);
+            ins.tick(|_want, _hand| {}, |hand| { let n = hand.len(); hand.clear(); n });
         }
         assert_eq!(ins.delivered, 0);
         assert_eq!(ins.starved_ticks, ticks);

--- a/crates/meter/src/lib.rs
+++ b/crates/meter/src/lib.rs
@@ -1,0 +1,44 @@
+//! `spaghettio_meter` — RFC-054's fast meter.
+//!
+//! A native item-level discrete simulator. It is **a meter, not a
+//! validator**: it emits numbers (rates, occupancy, machine census), never
+//! `Issue`s. A validator returns a verdict, which you cannot optimize
+//! against; a meter returns a measurement, which you can.
+//!
+//! ## Why it exists
+//!
+//! The engine's validators model flow conservation on a static graph. In
+//! that language `supply == demand` is *correct* — and yet
+//! [#448](https://github.com/storkme/spaghettio/issues/448) measured rows
+//! where an item is simultaneously backed up at its producers and absent
+//! at its tail consumers. The mechanism is time-domain (gap propagation,
+//! buffer depth, inserter burst size, consumer order along a belt), so it
+//! is not a missing check but a dimension the static model does not have.
+//!
+//! ## Integrity boundary (KC4)
+//!
+//! This crate may use `spaghettio_core` for **data** — the blueprint
+//! parser and the recipe database. It must never import the engine's
+//! *derived rate model*: `machine_feed_rate`, `belt_drop_rate`,
+//! `lane_capacity*`, `utilization_for`, `LANE_UTILIZATION`,
+//! `ROW_LANE_FACTOR_*`. Those are hand-calibrated estimates; importing one
+//! would make the meter reproduce the engine's belief instead of measuring
+//! it, and its agreement would be circular. Enforced by
+//! `tests/kc4_independence.rs`.
+//!
+//! ## Status
+//!
+//! PR 1 of 4: physics core (belts, lanes, inserters, containers) for
+//! **linear** belt runs, plus the KC4 guard. Blueprint ingestion, machines,
+//! convergence detection and `MeterReport` land with PR 3; the corpus
+//! replay that actually evaluates KC1–KC3 is PR 4. Tracking: #457.
+
+pub mod belt;
+pub mod entity_data;
+pub mod inserter;
+pub mod world;
+
+pub use belt::{BeltRun, ItemId, Lane, RunEnd};
+pub use entity_data::{BeltTier, InserterKind};
+pub use inserter::{DropTarget, Inserter, PickupTarget};
+pub use world::{Chest, ItemInterner, RowFixture, Source, World};

--- a/crates/meter/src/world.rs
+++ b/crates/meter/src/world.rs
@@ -75,21 +75,33 @@ impl Chest {
         }
     }
 
-    /// Returns false when the buffer cannot take the whole hand — the
-    /// inserter then holds position, which is what an output-blocked
-    /// inserter does in game.
-    fn accept(&mut self, items: &[ItemId]) -> bool {
-        if let Some(cap) = self.capacity {
-            if self.buffer as usize + items.len() > cap as usize {
-                return false;
-            }
+    /// Insert as much of `hand` as fits, draining what was taken and
+    /// leaving the remainder. Returns the number accepted.
+    ///
+    /// **Partial insert is the game's behaviour, and modelling it
+    /// all-or-nothing was a real defect** (review, PR #458). A Factorio
+    /// inserter transfers as many items as the destination accepts and
+    /// keeps the rest in hand, stalling fully only when *nothing* fits.
+    /// Rejecting a whole hand whenever it doesn't entirely fit made
+    /// consumers block and release in whole-hand quanta once `buffer` came
+    /// within `hand_size` of `capacity` — a quantised cadence capable of
+    /// beating against the source period, i.e. a candidate cause of the
+    /// non-monotonic margin behaviour this crate reports.
+    fn accept(&mut self, hand: &mut Vec<ItemId>) -> usize {
+        let space = match self.capacity {
+            Some(cap) => (cap.saturating_sub(self.buffer)) as usize,
+            None => hand.len(),
+        };
+        let n = space.min(hand.len());
+        if n == 0 {
+            return 0;
         }
-        self.buffer += items.len() as u32;
-        self.received += items.len() as u64;
-        for it in items {
+        for it in hand.drain(..n) {
             *self.by_item.entry(it.0).or_insert(0) += 1;
         }
-        true
+        self.buffer += n as u32;
+        self.received += n as u64;
+        n
     }
 
     fn tick(&mut self) {

--- a/crates/meter/src/world.rs
+++ b/crates/meter/src/world.rs
@@ -1,0 +1,372 @@
+//! The simulated world: belt runs, inserters, containers, boundary sources.
+//!
+//! PR 1 carries the physics core only — belts, inserters, chests. Machines,
+//! blueprint ingestion, convergence detection and `MeterReport` land with
+//! PR 3 (see the RFC's phasing). What is here is exactly what PR 2's margin
+//! sweep needs, and it is deliberately the smallest thing that can falsify
+//! the RFC's central premise.
+
+use rustc_hash::FxHashMap;
+
+use crate::belt::{BeltRun, ItemId, RunEnd};
+use crate::entity_data::{BeltTier, InserterKind};
+use crate::inserter::{DropTarget, Inserter, PickupTarget};
+
+/// Interns item names so the hot loop never touches strings.
+#[derive(Debug, Default, Clone)]
+pub struct ItemInterner {
+    names: Vec<String>,
+    ids: FxHashMap<String, u16>,
+}
+
+impl ItemInterner {
+    pub fn intern(&mut self, name: &str) -> ItemId {
+        if let Some(&id) = self.ids.get(name) {
+            return ItemId(id);
+        }
+        let id = self.names.len() as u16;
+        self.names.push(name.to_string());
+        self.ids.insert(name.to_string(), id);
+        ItemId(id)
+    }
+
+    pub fn name(&self, id: ItemId) -> &str {
+        &self.names[id.0 as usize]
+    }
+}
+
+/// A container with bounded intake — a machine's ingredient side, minus
+/// the crafting.
+///
+/// **The bound is not optional decoration.** An unbounded sink lets the
+/// head consumer of a row pull at its inserter's full swing rate forever
+/// (measured: 16.2/s against a 7.5/s demand), which both overstates head
+/// hogging and makes added margin *worse*, since the head simply hogs
+/// more. Real machines fill an ingredient buffer to a limit and then draw
+/// only at their consumption rate, which is what lets surplus reach the
+/// tail. #448's dumps show exactly this: head machines holding 42/34/20
+/// items — buffered to a cap, not draining without limit.
+///
+/// Full machines (craft timers, recipes, outputs) land in PR 3; this is
+/// the smallest faithful stand-in for the input side.
+#[derive(Debug, Default, Clone)]
+pub struct Chest {
+    pub received: u64,
+    pub by_item: FxHashMap<u16, u64>,
+    /// Buffer limit. `None` = infinite sink (a drain, or the world edge).
+    pub capacity: Option<u32>,
+    /// Steady consumption, items/s. `0.0` = never drains.
+    pub demand_per_second: f64,
+    pub buffer: u32,
+    drain_accumulator: f64,
+    /// Ticks the consumer wanted an item and had none — the starvation
+    /// signal that maps onto the harness's `item_ingredient_shortage`.
+    pub starved_ticks: u64,
+    pub consumed: u64,
+}
+
+impl Chest {
+    /// A bounded consumer: buffers up to `capacity`, draws `demand` items/s.
+    pub fn consumer(capacity: u32, demand_per_second: f64) -> Self {
+        Chest {
+            capacity: Some(capacity),
+            demand_per_second,
+            ..Default::default()
+        }
+    }
+
+    /// Returns false when the buffer cannot take the whole hand — the
+    /// inserter then holds position, which is what an output-blocked
+    /// inserter does in game.
+    fn accept(&mut self, items: &[ItemId]) -> bool {
+        if let Some(cap) = self.capacity {
+            if self.buffer as usize + items.len() > cap as usize {
+                return false;
+            }
+        }
+        self.buffer += items.len() as u32;
+        self.received += items.len() as u64;
+        for it in items {
+            *self.by_item.entry(it.0).or_insert(0) += 1;
+        }
+        true
+    }
+
+    fn tick(&mut self) {
+        if self.demand_per_second <= 0.0 {
+            return;
+        }
+        self.drain_accumulator += self.demand_per_second / 60.0;
+        while self.drain_accumulator >= 1.0 {
+            self.drain_accumulator -= 1.0;
+            if self.buffer > 0 {
+                self.buffer -= 1;
+                self.consumed += 1;
+            } else {
+                self.starved_ticks += 1;
+            }
+        }
+    }
+
+    /// Items/s actually consumed over `ticks` — the delivered rate that
+    /// matters, as opposed to what an inserter managed to pick up.
+    pub fn consumption_rate(&self, ticks: u64) -> f64 {
+        if ticks == 0 {
+            return 0.0;
+        }
+        self.consumed as f64 / (ticks as f64 / 60.0)
+    }
+}
+
+/// A boundary feed: injects one item type onto one lane at a fixed rate.
+///
+/// Rate is the *offered* rate. What actually lands is limited by whether
+/// slot 0 is free — which is how a saturated belt makes its producer go
+/// `full_output`, and is therefore a measured output, not an assumption.
+#[derive(Debug, Clone)]
+pub struct Source {
+    pub run: usize,
+    pub lane: usize,
+    pub item: ItemId,
+    pub rate_per_second: f64,
+    accumulator: f64,
+    /// Items the source wanted to inject but could not, because the lane
+    /// was backed up to its head.
+    pub rejected: u64,
+    pub injected: u64,
+}
+
+impl Source {
+    pub fn new(run: usize, lane: usize, item: ItemId, rate_per_second: f64) -> Self {
+        Source {
+            run,
+            lane,
+            item,
+            rate_per_second,
+            accumulator: 0.0,
+            rejected: 0,
+            injected: 0,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct World {
+    pub runs: Vec<BeltRun>,
+    pub chests: Vec<Chest>,
+    pub inserters: Vec<Inserter>,
+    pub sources: Vec<Source>,
+    pub items: ItemInterner,
+    pub ticks: u64,
+}
+
+impl World {
+    pub fn new() -> Self {
+        World::default()
+    }
+
+    pub fn add_run(&mut self, run: BeltRun) -> usize {
+        self.runs.push(run);
+        self.runs.len() - 1
+    }
+
+    /// An unbounded sink (a drain, or the world edge).
+    pub fn add_chest(&mut self) -> usize {
+        self.chests.push(Chest::default());
+        self.chests.len() - 1
+    }
+
+    /// A bounded consumer — see [`Chest::consumer`].
+    pub fn add_consumer(&mut self, capacity: u32, demand_per_second: f64) -> usize {
+        self.chests.push(Chest::consumer(capacity, demand_per_second));
+        self.chests.len() - 1
+    }
+
+    pub fn add_inserter(&mut self, ins: Inserter) -> usize {
+        self.inserters.push(ins);
+        self.inserters.len() - 1
+    }
+
+    pub fn add_source(&mut self, src: Source) -> usize {
+        self.sources.push(src);
+        self.sources.len() - 1
+    }
+
+    /// Advance one tick.
+    ///
+    /// **Update order: sources → inserters → belts.** Stated because it is
+    /// an approximation of Factorio's own entity update order and is
+    /// therefore a candidate divergence. Inserters are given their chance
+    /// to grab *before* the belt advances, so an item that arrives under a
+    /// pickup tile this tick can be taken this tick rather than sliding
+    /// past. Any measured disagreement traceable to this ordering belongs
+    /// in `docs/meter-divergence.md`.
+    pub fn tick(&mut self) {
+        self.tick_sources();
+        self.tick_inserters();
+        for run in &mut self.runs {
+            run.tick();
+        }
+        for chest in &mut self.chests {
+            chest.tick();
+        }
+        self.ticks += 1;
+    }
+
+    pub fn run_for(&mut self, ticks: u64) {
+        for _ in 0..ticks {
+            self.tick();
+        }
+    }
+
+    fn tick_sources(&mut self) {
+        for src in &mut self.sources {
+            src.accumulator += src.rate_per_second / 60.0;
+            while src.accumulator >= 1.0 {
+                src.accumulator -= 1.0;
+                let lane = &mut self.runs[src.run].lanes[src.lane];
+                if lane.try_insert(src.item) {
+                    src.injected += 1;
+                } else {
+                    // Belt backed up to its head: the offered item is
+                    // refused. Upstream, this is a producer going
+                    // `full_output`.
+                    src.rejected += 1;
+                }
+            }
+        }
+    }
+
+    fn tick_inserters(&mut self) {
+        // Take the vec so the closures can borrow runs/chests disjointly.
+        let mut inserters = std::mem::take(&mut self.inserters);
+        for ins in &mut inserters {
+            let runs = &mut self.runs;
+            let chests = &mut self.chests;
+            let pickup = ins.pickup;
+            let drop = ins.drop;
+            ins.tick(
+                |want, hand| match pickup {
+                    PickupTarget::BeltTile { run, tile } => {
+                        let run = &mut runs[run];
+                        // Both lanes (factorio-mechanics.md I6).
+                        let mut remaining = want;
+                        for lane in run.lanes.iter_mut() {
+                            if remaining == 0 {
+                                break;
+                            }
+                            let before = hand.len();
+                            lane.take_from_tile(tile, remaining, hand);
+                            remaining -= (hand.len() - before) as u32;
+                        }
+                    }
+                },
+                |hand| match drop {
+                    DropTarget::Chest(idx) => chests[idx].accept(hand),
+                },
+            );
+        }
+        self.inserters = inserters;
+    }
+
+    /// Items/s delivered by one inserter over the run so far.
+    pub fn inserter_rate(&self, idx: usize) -> f64 {
+        self.inserters[idx].rate_per_second(self.ticks)
+    }
+}
+
+/// The #448 fixture: N consumers along one shared input belt.
+///
+/// A producer feeds the head of a dead-ended belt at `supply_per_second`;
+/// `consumers` inserters sit along it, one per tile, each pulling into its
+/// own chest. This is the exact shape of a bus row's input belt, and the
+/// smallest configuration in which head-buffers-starve-tail can occur.
+///
+/// `margin` is the ratio of supplied rate to aggregate demand: **1.0 is
+/// the zero-margin case #448 measured failing**, and the axis PR 2 sweeps
+/// to replace that check's admitted lower bound with a measured number.
+///
+/// Supply and demand are separate parameters on purpose. Deriving demand
+/// from supply would make margin inexpressible — the bug that made the
+/// first draft of `margin_resolves_the_starvation` unsatisfiable.
+pub struct RowFixture {
+    pub world: World,
+    pub run: usize,
+    /// Inserter index per consumer position, head first.
+    pub consumers: Vec<usize>,
+    /// Chest index per consumer position, head first.
+    pub chests: Vec<usize>,
+    pub item: ItemId,
+}
+
+/// Ingredient-buffer depth per consumer, in items.
+///
+/// Chosen to sit in the range #448's dumps actually show — head machines
+/// holding 42 and 34 copper-cable. It is a stated approximation of
+/// Factorio's per-recipe insertion limit, not a measured constant, and is
+/// therefore a candidate entry for `docs/meter-divergence.md`; PR 3
+/// replaces it with the real per-recipe rule when machines land.
+const BUFFER_CAP: u32 = 40;
+
+impl RowFixture {
+    pub fn build(
+        tier: BeltTier,
+        kind: InserterKind,
+        capacity_level: u8,
+        consumers: usize,
+        demand_per_consumer: f64,
+        margin: f64,
+        item_name: &str,
+    ) -> Self {
+        let mut world = World::new();
+        let item = world.items.intern(item_name);
+        let supply_per_second = demand_per_consumer * consumers as f64 * margin;
+
+        // One tile per consumer, laid out west→east, dead-ended.
+        let tiles: Vec<(i32, i32)> = (0..consumers as i32).map(|x| (x, 0)).collect();
+        let run = world.add_run(BeltRun::new(tier, tiles, RunEnd::DeadEnd));
+
+        let mut consumer_ids = Vec::new();
+        let mut chest_ids = Vec::new();
+        for tile in 0..consumers {
+            let chest = world.add_consumer(BUFFER_CAP, demand_per_consumer);
+            let ins = world.add_inserter(Inserter::new(
+                kind,
+                PickupTarget::BeltTile { run, tile },
+                DropTarget::Chest(chest),
+                capacity_level,
+            ));
+            consumer_ids.push(ins);
+            chest_ids.push(chest);
+        }
+
+        // Feed both lanes at the head, splitting the offered rate.
+        for lane in 0..2 {
+            world.add_source(Source::new(run, lane, item, supply_per_second / 2.0));
+        }
+
+        RowFixture {
+            world,
+            run,
+            consumers: consumer_ids,
+            chests: chest_ids,
+            item,
+        }
+    }
+
+    /// Delivered rate per consumer position, head first.
+    pub fn rates(&self) -> Vec<f64> {
+        self.consumers
+            .iter()
+            .map(|&i| self.world.inserter_rate(i))
+            .collect()
+    }
+
+    /// Belt occupancy per tile (both lanes), head first — the gradient.
+    pub fn tile_occupancy(&self) -> Vec<usize> {
+        let run = &self.world.runs[self.run];
+        (0..run.tiles.len())
+            .map(|t| run.occupancy_in_tile(t))
+            .collect()
+    }
+}

--- a/crates/meter/tests/kc4_independence.rs
+++ b/crates/meter/tests/kc4_independence.rs
@@ -1,0 +1,101 @@
+//! RFC-054 **kill criterion 4**: the meter must not inherit the engine's
+//! beliefs.
+//!
+//! The meter's whole value is being an *independent* instrument. If it
+//! imported the engine's hand-calibrated rate model, its agreement with
+//! the engine would be circular — which is exactly how `carries` labels
+//! became worthless as ground truth (architecture audit §3.3 #17), and how
+//! the backwards-inserter export bug survived the project's entire history
+//! behind three artifacts that all shared the engine's direction
+//! convention.
+//!
+//! This test lands in PR 1 on purpose. A guard added after the fact only
+//! proves the code passes it *today*; a guard present from the first
+//! commit means the boundary was never crossed.
+//!
+//! **If passing KC1 ever appears to require importing one of these, that
+//! is the kill criterion firing — stop and record it, do not widen the
+//! list.**
+
+use std::fs;
+use std::path::Path;
+
+/// Symbols from `spaghettio_core::common` that encode the engine's
+/// *estimates* rather than Factorio's facts.
+const BANNED: &[&str] = &[
+    "machine_feed_rate",
+    "belt_drop_rate",
+    "lane_capacity",
+    "utilization_for",
+    "LANE_UTILIZATION",
+    "ROW_LANE_FACTOR",
+    "belt_entity_for_rate",
+];
+
+fn rust_sources(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn meter_does_not_import_the_engine_rate_model() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+    assert!(!files.is_empty(), "no sources found under {src:?}");
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let text = fs::read_to_string(file).expect("read source");
+        for (lineno, line) in text.lines().enumerate() {
+            // Doc comments naming the ban are the point of the ban, not a
+            // breach of it. Only real code counts.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            for banned in BANNED {
+                if line.contains(banned) {
+                    violations.push(format!(
+                        "{}:{}: references `{banned}`\n    {}",
+                        file.display(),
+                        lineno + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "RFC-054 KC4 breach — the meter must measure these, not import them:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// The ban is on the *rate model*, not on `spaghettio_core` wholesale:
+/// the blueprint parser and recipe DB are data and are explicitly allowed.
+/// This test pins that distinction so nobody "fixes" KC4 by severing the
+/// dependency the RFC relies on.
+#[test]
+fn data_dependencies_remain_permitted() {
+    let manifest = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"),
+    )
+    .expect("read manifest");
+    assert!(
+        manifest.contains("spaghettio_core"),
+        "the meter is expected to depend on core for blueprint parsing and \
+         recipe data; only the derived rate model is banned"
+    );
+}

--- a/crates/meter/tests/row_starvation.rs
+++ b/crates/meter/tests/row_starvation.rs
@@ -1,0 +1,194 @@
+//! Row-level behaviour on synthetic fixtures — and **the PR-1 negative
+//! result**.
+//!
+//! # What these tests establish
+//!
+//! The physics core reproduces every *belt-level* property RFC-054 needs
+//! (see `src/belt.rs` and `src/inserter.rs` unit tests): gaps do not heal,
+//! dead ends back up, compressed lanes move at full speed, throughput and
+//! inserter rates are derived rather than tabulated, and a sparse source
+//! costs an inserter throughput through partial hands and lost swings.
+//!
+//! # What they do NOT establish
+//!
+//! **The model does not currently reproduce #448.** With a *smooth*
+//! boundary supply at exactly aggregate demand and bounded consumer
+//! buffers, a 6-consumer express row delivers `[7.50 × 6]` — no tail
+//! starvation at all. The user's conservation intuition holds in this
+//! configuration: supply equals demand, buffers are finite, and it works
+//! out.
+//!
+//! Worse, a margin sweep is **non-monotonic** — margin 1.02 starves where
+//! 1.00 does not, recovering by 1.25 (`cargo run -p spaghettio_meter
+//! --example row_probe`). In a fully deterministic simulator with periodic
+//! sources and periodic inserter swings, that is the signature of *phase
+//! aliasing* between the two cadences, not a physical effect.
+//!
+//! # Why this is landed rather than fixed
+//!
+//! The fixture idealizes both ends of the real row. A real row-input belt
+//! is fed by a producer cell's output **inserters** — bursty, discrete
+//! drops onto particular tiles — not a smooth boundary source; and real
+//! consumers draw in discrete craft batches, not a smooth trickle. Adding
+//! burstiness would very likely produce starvation, which is exactly why
+//! it must not be added *here*: choosing mechanisms until the answer
+//! matches is how an instrument acquires the quirks it is supposed to
+//! detect.
+//!
+//! The anchored margin sweep against real Factorio is **PR 2**, and this
+//! is its first and most important question. Landing the negative result
+//! at ~1k LOC — rather than after machines, boundary and convergence are
+//! built on top — is precisely what the RFC's 4-PR split was designed to
+//! buy.
+//!
+//! Tracking: #457. Divergences belong in `docs/meter-divergence.md`.
+
+use spaghettio_meter::{BeltTier, InserterKind, RowFixture};
+
+const DEMAND: f64 = 7.5;
+const CONSUMERS: usize = 6;
+const WARMUP: u64 = 30_000;
+const MEASURE: u64 = 60_000;
+
+struct Measured {
+    rates: Vec<f64>,
+    starved_ticks: Vec<u64>,
+}
+
+fn measure(consumers: usize, margin: f64, level: u8) -> Measured {
+    let mut fx = RowFixture::build(
+        BeltTier::Blue,
+        InserterKind::Stack,
+        level,
+        consumers,
+        DEMAND,
+        margin,
+        "copper-cable",
+    );
+    fx.world.run_for(WARMUP);
+    for &c in &fx.chests {
+        fx.world.chests[c].consumed = 0;
+        fx.world.chests[c].starved_ticks = 0;
+    }
+    let start = fx.world.ticks;
+    fx.world.run_for(MEASURE);
+    let elapsed = fx.world.ticks - start;
+
+    Measured {
+        rates: fx
+            .chests
+            .iter()
+            .map(|&c| fx.world.chests[c].consumption_rate(elapsed))
+            .collect(),
+        starved_ticks: fx
+            .chests
+            .iter()
+            .map(|&c| fx.world.chests[c].starved_ticks)
+            .collect(),
+    }
+}
+
+/// **The negative result, pinned.**
+///
+/// This test asserts the model's *current* behaviour so that a later
+/// change which makes the row starve cannot land silently — it will fail
+/// here and force a decision-log entry saying what changed and why.
+///
+/// It is deliberately phrased as "this is what we measure", not "this is
+/// correct". If PR 2's anchored sweep shows real Factorio starving this
+/// configuration, this test is the thing that must change, and its failure
+/// is the signal that the belt model needs work.
+#[test]
+fn smooth_supply_at_zero_margin_does_not_starve_the_row() {
+    let m = measure(CONSUMERS, 1.0, 2);
+
+    for (i, &r) in m.rates.iter().enumerate() {
+        assert!(
+            (r - DEMAND).abs() < 0.05,
+            "position {i} delivered {r:.2}/s against {DEMAND}/s demand — the \
+             model's smooth-supply behaviour changed. If this is intended, \
+             record it in the RFC-054 decision log and in \
+             docs/meter-divergence.md. Full row: {:?}",
+            m.rates
+        );
+    }
+    assert_eq!(
+        m.starved_ticks.iter().sum::<u64>(),
+        0,
+        "no consumer should starve under smooth supply at exactly demand; \
+         got {:?}",
+        m.starved_ticks
+    );
+}
+
+/// Ample surplus must also be clean. Together with the test above this
+/// brackets the sweep: both ends behave, and the disorder PR 2 must
+/// explain lives in between (margin 1.02–1.10).
+#[test]
+fn generous_margin_serves_every_consumer() {
+    let m = measure(CONSUMERS, 1.5, 2);
+    for (i, &r) in m.rates.iter().enumerate() {
+        assert!(
+            (r - DEMAND).abs() < 0.05,
+            "position {i} delivered {r:.2}/s at 1.5x margin; row {:?}",
+            m.rates
+        );
+    }
+}
+
+/// A single consumer has no head and no tail. #448 scoped its check to
+/// rows of ≥2 for exactly this reason, and the floor should hold whatever
+/// happens to the multi-consumer case.
+#[test]
+fn a_single_consumer_is_not_starved() {
+    let m = measure(1, 1.0, 2);
+    assert!(
+        m.rates[0] > DEMAND * 0.98,
+        "one consumer at its own demand should be served, got {:.2}",
+        m.rates[0]
+    );
+}
+
+/// Supply genuinely below demand *must* under-deliver. This is the
+/// sanity floor: an instrument that reports full delivery on a starved row
+/// is measuring nothing, and would pass the two tests above vacuously.
+#[test]
+fn genuine_undersupply_is_visible() {
+    let m = measure(CONSUMERS, 0.8, 2);
+    let total: f64 = m.rates.iter().sum();
+    let planned = DEMAND * CONSUMERS as f64;
+    assert!(
+        total < planned * 0.95,
+        "80% supply must show as under-delivery; got {total:.2}/s against \
+         {planned:.2}/s planned (row {:?})",
+        m.rates
+    );
+    assert!(
+        m.starved_ticks.iter().sum::<u64>() > 0,
+        "undersupply must produce starved ticks; got {:?}",
+        m.starved_ticks
+    );
+}
+
+/// The belt cannot carry more than its physical capacity, and the excess
+/// must show up as *refused injections* rather than being quietly
+/// absorbed. Silent absorption would let the meter over-report delivery.
+#[test]
+fn oversupply_is_refused_at_the_belt_head_not_absorbed() {
+    let mut fx = RowFixture::build(
+        BeltTier::Blue,
+        InserterKind::Stack,
+        2,
+        CONSUMERS,
+        DEMAND,
+        3.0, // 135/s offered onto a 45/s belt
+        "copper-cable",
+    );
+    fx.world.run_for(WARMUP);
+    let rejected: u64 = fx.world.sources.iter().map(|s| s.rejected).sum();
+    assert!(
+        rejected > 0,
+        "offering 3x a belt's capacity must be refused at the head — \
+         otherwise the model creates throughput that does not exist"
+    );
+}

--- a/docs/rfc-054-fast-meter.md
+++ b/docs/rfc-054-fast-meter.md
@@ -470,3 +470,40 @@ the right thing moved.
   [#453](https://github.com/storkme/spaghettio/issues/453)'s finding that
   three of the four failing fixtures starve **with margin available**, and
   are still unattributed.*
+- *2026-07-25 — PR 1 review (bot, PR #458): two findings, both valid, both
+  applied — and the second one's **hypothesis was tested and falsified**,
+  which is recorded here because the distinction matters.*
+
+  *(1) **Inserter cycle timer was assigned, not accumulated.** `cycle_timer
+  = cycle_ticks()` discarded the previous cycle's negative overshoot,
+  quantising the period up to `ceil(cycle_ticks)` — 72 ticks instead of
+  71.43 for a regular inserter, i.e. 0.8333/s against I8's 0.84/s, a
+  systematic −0.79%. Every other periodic accumulator in the crate
+  (`Lane::tick`, `Source::tick`, `Chest::tick`) carries its remainder
+  forward; this was the one that didn't, while its own doc comment claimed
+  the timer was "never rounded". Fixed to `+=`. The test that exists to
+  catch exactly this had a **5% tolerance**, which is why it didn't —
+  tightened to 1%.*
+
+  *(2) **`Chest::accept` was all-or-nothing.** It rejected an entire hand
+  whenever the hand did not wholly fit, where a real Factorio inserter
+  performs a partial insert — transferring what fits and retaining the
+  remainder, stalling fully only when nothing fits. Fixed: `accept` now
+  drains what fits and returns the count, and `Inserter::tick` holds the
+  remainder and retries.*
+
+  ***The reviewer's attached hypothesis — that this all-or-nothing rule was
+  "a plausible undisclosed contributor to the non-monotonic
+  starvation-vs-margin behavior" — is FALSIFIED.*** *Re-running the margin
+  probe after the fix gives rates identical to the pre-fix run at every
+  margin (1.02 → 5.50/6.20; 1.05 → 7.12/5.25/7.13; 1.10 → 6.00). Only the
+  buffers moved — they now top up to 39 rather than stalling at 32–37,
+  which confirms the fix genuinely changed behaviour and that the
+  non-monotonicity is not caused by it. The phase-aliasing reading stands,
+  and PR 2's anchored sweep remains the way to settle it.*
+
+  *Worth stating plainly since this RFC is about instruments that do not
+  launder assumptions: a correct fix arriving with a plausible causal story
+  attached is not evidence for the story. The fix was applied on its own
+  merits (it is what the game does); the story was checked separately and
+  did not survive.*

--- a/docs/rfc-054-fast-meter.md
+++ b/docs/rfc-054-fast-meter.md
@@ -507,3 +507,43 @@ the right thing moved.
   attached is not evidence for the story. The fix was applied on its own
   merits (it is what the game does); the story was checked separately and
   did not survive.*
+- *2026-07-25 — PR 1 review round 2 (bot, PR #458): one finding, valid,
+  applied — and again its **impact claim was falsified by measurement**.
+  Recording the pattern, not just the fix.*
+
+  *The finding: `InserterKind::hand_size` mis-transcribed I8b on both
+  branches. Bulk read `2,4,5,6,7,9,11,12` against I8b's
+  `2,3,4,5,6,8,10,12` (L1–L6 each over-credited by +1), and the non-bulk
+  closed form `1 + level.saturating_sub(2).min(2)` evaluated to
+  `1,1,1,2,3,3,3,3` against I8b's `1,1,2,2,2,2,2,3` (L2 under, L4–L6
+  over). Verified against `factorio-mechanics.md` directly before
+  applying. Both ladders are now **literal tables** — neither is
+  expressible as a clean closed form, and deriving them is what produced
+  the error. Transcribe, don't derive.*
+
+  *The test was the real failure. It asserted L0/L2/L7 only; the endpoints
+  happened to be correct, so it **pinned a mis-transcribed middle rather
+  than catching it** — and its one middle assertion
+  (`Stack.hand_size(2) == 9`) was itself the wrong value. Replaced with an
+  exhaustive level-by-level ladder assertion. Sampling a table is not
+  testing it, and this is the second constants-defect in two rounds that a
+  loose test let through (the first being the 5% tolerance over the cycle
+  timer).*
+
+  ***The load-bearing claim is FALSIFIED.*** *The reviewer argued the wrong
+  value changes the headline, since `RowFixture` runs at `capacity_level =
+  2` where stack should be 8 rather than 9. Re-running the sweep after the
+  correction gives byte-identical rates at every margin. The reason is
+  structural, not luck: a single belt tile holds at most **8** items (4
+  slots × 2 lanes), so `take_from_tile` caps any grab at 8 — hands of 8
+  and 9 saturate the same ceiling. The reviewer's supporting argument
+  (that 8 is where the BS3 S=4 belt-drop dip vanishes) also does not
+  apply here: the fixture runs unstacked at S=1, and BS3 governs drops
+  *onto belts*, whereas these inserters drop into consumers.*
+
+  *Pattern worth naming after two rounds: the bot's defect identification
+  has been accurate every time (three real bugs, all applied), and its
+  causal attribution to the headline finding has been wrong every time
+  (two for two). Both fixes were taken on their own merits; neither
+  explanation survived being checked. The non-monotonicity remains
+  unattributed and remains PR 2's first question.*

--- a/docs/rfc-054-fast-meter.md
+++ b/docs/rfc-054-fast-meter.md
@@ -414,3 +414,59 @@ the right thing moved.
   originally worded. "Monotone" dropped; this was the most serious of the
   five, since an unsatisfiable kill criterion is worse than none. (5) Two
   stray tool-call closing tags were committed at end-of-file; removed.*
+- *2026-07-25 — **ACCEPTED** (user), merged as PR #455. Implementation
+  tracked in [#457](https://github.com/storkme/spaghettio/issues/457),
+  split into four PRs rather than one so that PR 2 (the anchored margin
+  sweep) is a designed kill point for the belt model at ~1k LOC rather
+  than after machines, boundary and convergence are built on top of it.*
+- *2026-07-25 — **PR 1 landed the physics core, and it does NOT reproduce
+  #448.** This is the RFC's first real result and it is negative, so it
+  belongs here and not only in a PR body.*
+
+  *What works — every belt-level property the design claimed. Gaps do not
+  heal on a moving lane, dead ends back up, compressed lanes move at full
+  speed, and both belt throughput (B5: 15/30/45) and inserter rates (I8:
+  0.84/1.20/2.40) are **derived** from speed × spacing and `rotation_speed`
+  rather than read from a table. Partial hands and lost swings make
+  density-dependent inserter throughput emergent, with no
+  `machine_feed_rate` anywhere. KC4 is green and was guarded from the
+  first commit, not retrofitted.*
+
+  *What does not — with a **smooth** boundary supply at exactly aggregate
+  demand and bounded consumer buffers, a 6-consumer express row delivers
+  `[7.50 × 6]`. No tail starvation. The conservation intuition simply
+  holds in that configuration. Worse, a margin sweep is **non-monotonic**:
+  margin 1.02 starves where 1.00 does not, recovering by 1.25
+  (`cargo run -p spaghettio_meter --example row_probe`). In a fully
+  deterministic simulator with periodic sources and periodic inserter
+  swings, that is the signature of **phase aliasing** between the two
+  cadences, not a physical effect.*
+
+  *Two modelling bugs were caught by the crate's own derivation tests
+  before any of that: the inserter cycle lost a tick to the grab and
+  `round()`ed its half-cycles, under-crediting a fast inserter by ~8%
+  (2.222/s against I8's 2.40); and an unbounded consumer let a row's head
+  pull 16.2/s against a 7.5/s demand, which both overstated head-hogging
+  and made added margin actively **worse**. The second is why `Chest`
+  gained a buffer cap and a demand rate — a machine's input side, minus
+  the crafting.*
+
+  *Deliberately NOT done: adding burstiness to the supply. A real
+  row-input belt is fed by a producer cell's output inserters — discrete,
+  bursty drops — and real consumers draw in craft batches; adding either
+  would plausibly produce the starvation. That is exactly why it must not
+  be added before PR 2's anchor exists. Choosing mechanisms until the
+  answer matches the expected one is how an instrument acquires the quirks
+  it was built to detect, and this RFC's whole integrity argument is about
+  not doing that. The negative result is pinned by
+  `smooth_supply_at_zero_margin_does_not_starve_the_row` so that a later
+  change cannot make the row starve silently.*
+
+  *Consequence for PR 2: its first question is no longer "what is the
+  margin number" but **"does real Factorio starve this configuration at
+  all"**. If it does, the belt model is missing something and the sweep
+  attributes it. If it does not, then #448's zero-margin attribution needs
+  revisiting — which would connect directly to
+  [#453](https://github.com/storkme/spaghettio/issues/453)'s finding that
+  three of the four failing fixtures starve **with margin available**, and
+  are still unattributed.*


### PR DESCRIPTION
First of the four PRs in #457. Lands `crates/meter` (`spaghettio_meter`): the item-level belt/inserter core, the KC4 independence guard, and synthetic row fixtures.

**Read the negative result section before the rest — it's the actual finding.**

## Intent

RFC-054's physics core. Per the RFC's phasing, PR 1 is deliberately *not* the whole meter: no machines, no blueprint ingestion, no `MeterReport`. It is the smallest thing that can falsify the RFC's central premise, which is the point of splitting four ways rather than shipping one 3k-LOC PR.

## Scope

- **In:** `entity_data` (game constants with provenance), `belt` (slotted lanes), `inserter` (tick-level state machine), `world` (runs, bounded consumers, boundary sources, `RowFixture`), the KC4 grep guard, and a `row_probe` example.
- **Out:** machines, blueprint ingestion, convergence detection, `MeterReport`, the CLI — all PR 3. Splitters/UG/branching topologies are **refused rather than approximated**; PR 1 handles linear runs only, which is the topology #448 lives in and what PR 2 needs.

## What works

Every belt-level property the RFC claimed, and — importantly — the rates are **derived, not tabulated**:

- Belt throughput comes out of `speed × spacing`: yellow/red/blue/turbo → 15/30/45/60 per belt, matching mechanics **B5**, which the meter never reads.
- Inserter rates come out of `rotation_speed`: 0.84 / 1.20 / 2.40 per second, matching **I8**.
- Gaps don't heal on a moving lane; dead ends back up and refuse further input; compressed lanes move at full speed (downstream-first stepping); `take_from_tile` prefers downstream slots.
- Partial hands and lost swings make density-dependent inserter throughput **emergent**, with no `machine_feed_rate` anywhere.

**KC4 is green and was guarded from the first commit rather than retrofitted.** `tests/kc4_independence.rs` greps the crate for the engine's derived rate model (`machine_feed_rate`, `belt_drop_rate`, `lane_capacity*`, `utilization_for`, `LANE_UTILIZATION`, `ROW_LANE_FACTOR_*`, `belt_entity_for_rate`) and fails on any hit. A companion test pins that the *data* dependency on core stays permitted, so nobody "fixes" KC4 by severing the dependency the RFC relies on.

One deliberate divergence, documented inline: the meter uses **game-true** base hand sizes (stack 6, bulk 2) rather than the engine's deliberately conservative 5/1. The engine under-credits on purpose because it's sizing; the meter is measuring, and under-crediting would make it measure something the game doesn't do.

## What does NOT work — the finding

**The model does not reproduce #448.** With a *smooth* boundary supply at exactly aggregate demand and bounded consumer buffers, a 6-consumer express row delivers `[7.50, 7.50, 7.50, 7.50, 7.50, 7.50]`. No tail starvation. Conservation just works out.

And a margin sweep is **non-monotonic** (`cargo run -p spaghettio_meter --example row_probe`):

```
 margin  supply/s  consumption/s (head->tail)      starved ticks
   1.00      45.0  7.50 7.50 7.50 7.50 7.50 7.50              0
   1.02      45.9  7.50 7.50 7.50 7.50 5.50 6.20           3300
   1.05      47.2  7.50 7.50 7.50 7.12 5.25 7.13           3000
   1.10      49.5  7.50 7.50 7.50 7.50 7.50 6.00           1500
   1.25      56.2  7.50 7.50 7.50 7.50 7.50 7.50              0
   1.50      67.5  7.50 7.50 7.50 7.50 7.50 7.50              0
```

Margin 1.02 starves where 1.00 does not, recovering by 1.25. In a fully deterministic simulator with periodic sources and periodic inserter swings, that is the signature of **phase aliasing** between the two cadences — not a physical effect.

### Why I landed this instead of fixing it

The fixture idealizes both ends. A real row-input belt is fed by a producer cell's output **inserters** — discrete, bursty drops — and real consumers draw in craft batches, not a smooth trickle. Adding burstiness would quite plausibly produce the starvation.

That is exactly why it must not be added *here*. Choosing mechanisms until the answer matches the expected one is how an instrument acquires the quirks it was built to detect, and this RFC's entire integrity argument is about not doing that. The anchor against real Factorio is PR 2; that's where the question gets settled with evidence rather than with my expectations.

The negative result is pinned by `smooth_supply_at_zero_margin_does_not_starve_the_row`, so a later change that makes the row starve can't land silently — it fails there and forces a decision-log entry.

### Consequence for PR 2

Its first question changes. It is no longer "what is the margin number" but **"does real Factorio starve this configuration at all"**:

- If it does → the belt model is missing something, and the sweep attributes it.
- If it does not → #448's zero-margin attribution needs revisiting, which connects directly to #453's finding that three of the four failing fixtures starve **with margin available** and remain unattributed.

Either answer is worth more than a green suite here would have been.

## Two modelling bugs caught by the crate's own tests

Both found by derivation tests rather than by inspection, which is mild evidence the "derive, don't tabulate" discipline pays:

1. **Inserter cycle timing.** Lost a tick to the grab and `round()`ed its half-cycles (12.5 → 13, doubling to 26 instead of 25), under-crediting a fast inserter by ~8% — 2.222/s against I8's 2.40. A model that mis-times inserters cannot measure a defect *about* inserter timing. Fixed with a single fractional cycle timer.
2. **Unbounded consumers.** The first fixture let a row's head pull **16.2/s against a 7.5/s demand**, which both overstated head-hogging and made added margin actively *worse* (the head just hogged harder). `Chest` gained a buffer cap and a demand rate — a machine's input side minus the crafting. #448's dumps show head machines holding 42/34/20, i.e. buffered to a cap, so this was a fidelity gap, not a convenience.

A third, smaller one: the belt throughput test initially read 6.98/s against B5's 7.5 — the shortfall was exactly the run's 32 slots, i.e. the fill transient. Fixed with a warmup rather than a looser tolerance. Same "buffer fill reads as convergence" class `sim-harness-forensics.md` already documents.

## Verification

- [x] `cargo test -p spaghettio_meter` — **22 pass, 0 fail** (15 unit, 2 KC4, 5 row)
- [x] `cargo clippy -p spaghettio_meter --all-targets` — clean
- [x] `cargo build -p spaghettio_core` — unaffected
- [ ] WASM rebuild + browser eyeball — **N/A**: the meter is a native crate and deliberately does not enter the WASM build
- [ ] Snapshot inspection — **N/A**: no layout-engine change; nothing in `crates/core` is touched

## Deviations from intent

- **Blueprint ingestion moved from PR 1 to PR 3.** The tracking issue listed it here, but ingestion is only end-to-end testable once machines exist — without them there is nothing to simulate from a real blueprint. The KC4 boundary it was meant to establish is instead established by the guard test, which is the part that actually mattered.
- `BUFFER_CAP = 40` is a stated approximation of Factorio's per-recipe insertion limit, chosen to sit in the range #448's dumps show (42/34/20). It is **not** a measured constant and is flagged inline as a candidate `meter-divergence.md` entry; PR 3 replaces it with the real per-recipe rule.
- Update order is sources → inserters → belts, an approximation of Factorio's entity update order, stated in the `World::tick` docs as a candidate divergence.

## Models / contracts touched

None. No change to `crates/core`, the validators, the layout engine, or any golden. New crate only; workspace picks it up via the existing `crates/*` glob.

RFC-054's decision log records acceptance and the full negative result above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7WofziF3m6nsoQeGawEFj)_