### PR TITLE
feat(di): RFC-053 Phase 2 — both top corpus DI pairs build, validate and sim at plan

### DIFF
--- a/crates/core/src/bus/di_cell.rs
+++ b/crates/core/src/bus/di_cell.rs
@@ -1307,7 +1307,8 @@ mod row_stamp_tests {
             item: "copper-cable",
             coupler: "stack-inserter",
             coupler_rate: 12.0,
-            producer_input: ("copper-plate", "transport-belt", "long-handed-inserter"),
+            // Reach-1: the producer's belt is the NORTH face, adjacent.
+            producer_input: ("copper-plate", "transport-belt", "fast-inserter"),
             consumer_input: ("iron-plate", "transport-belt", "fast-inserter"),
             output_item: "electronic-circuit",
             output_belt: "transport-belt",
@@ -1366,7 +1367,10 @@ mod row_stamp_tests {
     #[test]
     fn only_consumers_reach_the_output_belt() {
         let (plan, l) = stamped();
-        let n_consumers = plan.sequence.iter().filter(|&&p| !p).count();
+        // Two long-handed output inserters per consumer: EC emits 2.5/s
+        // and long-handed belt-drop is 2.40/s at L2, so one column cannot
+        // cover a consumer's output.
+        let n_consumers = plan.sequence.iter().filter(|&&p| !p).count() * 2;
         let out_ins = l
             .entities
             .iter()

--- a/crates/core/src/bus/di_cell.rs
+++ b/crates/core/src/bus/di_cell.rs
@@ -845,3 +845,248 @@ mod io_tests {
         assert!(cell.height() < 17, "KC4: cell must stay under the 17-tile bus baseline");
     }
 }
+
+// ---------------------------------------------------------------------------
+// RFC-053 Phase 2: horizontal row straddle (the corpus's dominant shape)
+// ---------------------------------------------------------------------------
+
+/// A producer/consumer sequence laid out in ONE horizontal row, coupled by
+/// inserters in the gaps between horizontally-adjacent machines.
+///
+/// This is the shape the corpus actually builds: `di-patterns faces` puts
+/// `DI@E+W | S:in1→belt S:out1→belt` at the top of the cable→EC face-plan
+/// distribution (177 of 2,039 consumers) — a consumer straddling two
+/// producers east and west, with its remaining input and its output both
+/// on ONE face, both reach-1, and the opposite face entirely free.
+///
+/// Why it is worth preferring over Phase 1's stacked cell: it needs no
+/// reach-2 inserter anywhere, it leaves a whole face free, and a row of
+/// machines with belts above and below is what `place_rows` already
+/// emits — so it reuses the existing row mechanism rather than replacing
+/// it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RowCellPlan {
+    /// Machines left to right. `true` = producer, `false` = consumer.
+    pub sequence: Vec<bool>,
+    /// x of each machine in `sequence`, at `machine_w + 1` pitch (the
+    /// 1-tile gap is where the coupling inserter goes).
+    pub xs: Vec<i32>,
+    /// `(sequence_idx_producer, sequence_idx_consumer, flow)`. Every edge
+    /// is between physically ADJACENT machines — that is the invariant the
+    /// arrangement exists to guarantee.
+    pub edges: Vec<(usize, usize, f64)>,
+}
+
+impl RowCellPlan {
+    /// Rate one coupling inserter must sustain, i.e. the busiest edge.
+    /// Each edge owns exactly one gap, so there is no slot division here —
+    /// unlike the stacked cell, where an edge can own several columns.
+    pub fn required_rate(&self) -> f64 {
+        self.edges.iter().map(|&(_, _, f)| f).fold(0.0, f64::max)
+    }
+
+    pub fn width(&self, machine_w: i32) -> i32 {
+        match self.xs.last() {
+            Some(&last) => last + machine_w,
+            None => 0,
+        }
+    }
+}
+
+/// Arrange `producer_count` producers and `consumer_count` consumers in a
+/// single row so that every consumer is physically adjacent to exactly the
+/// producers whose flow it takes.
+///
+/// Construction: producer `i` owns flow interval `[i·prod, (i+1)·prod)` and
+/// consumer `j` owns `[j·demand, (j+1)·demand)`; they share an edge where
+/// the intervals overlap (the same flow-interval argument `plan_straddle`
+/// uses). Ordering the machines by interval start and inserting each
+/// consumer between its producers makes every edge adjacent.
+///
+/// Returns `None` when the shape is out of scope rather than approximating
+/// it: unbalanced flow, or a consumer needing more than two producers (it
+/// has only two horizontal neighbours, so a third could not reach it).
+pub fn plan_row_straddle(
+    producer_count: usize,
+    consumer_count: usize,
+    producer_rate: f64,
+    consumer_rate: f64,
+    machine_w: i32,
+) -> Option<RowCellPlan> {
+    if producer_count == 0 || consumer_count == 0 || machine_w <= 0 {
+        return None;
+    }
+    let usable = producer_rate.is_finite()
+        && consumer_rate.is_finite()
+        && producer_rate > 0.0
+        && consumer_rate > 0.0;
+    if !usable {
+        return None;
+    }
+    let total_out = producer_rate * producer_count as f64;
+    let total_in = consumer_rate * consumer_count as f64;
+    let tol = 1e-6 * total_out.max(total_in).max(1.0);
+    if (total_out - total_in).abs() > tol {
+        return None;
+    }
+
+    // Flow-interval overlap → which producers feed each consumer.
+    let mut per_consumer: Vec<Vec<(usize, f64)>> = vec![Vec::new(); consumer_count];
+    for (j, slot) in per_consumer.iter_mut().enumerate() {
+        let (c_lo, c_hi) = (j as f64 * consumer_rate, (j + 1) as f64 * consumer_rate);
+        for i in 0..producer_count {
+            let (p_lo, p_hi) = (i as f64 * producer_rate, (i + 1) as f64 * producer_rate);
+            let flow = p_hi.min(c_hi) - p_lo.max(c_lo);
+            if flow > tol {
+                slot.push((i, flow));
+            }
+        }
+        // Only two horizontal neighbours exist, so a third producer could
+        // never physically reach this consumer. Refuse instead of
+        // silently under-feeding (Phase 3 / multi-band territory).
+        if slot.len() > 2 || slot.is_empty() {
+            return None;
+        }
+    }
+
+    // Emit left to right: walk producers in order, dropping each consumer
+    // in immediately after the FIRST producer that feeds it. A consumer
+    // fed by {i, i+1} therefore lands between them; one fed by {i} alone
+    // lands directly after it.
+    let mut sequence: Vec<bool> = Vec::new();
+    let mut prod_slot: Vec<usize> = vec![usize::MAX; producer_count];
+    let mut cons_slot: Vec<usize> = vec![usize::MAX; consumer_count];
+    let mut next_consumer = 0usize;
+    for (i, slot) in prod_slot.iter_mut().enumerate() {
+        *slot = sequence.len();
+        sequence.push(true);
+        while next_consumer < consumer_count {
+            let firsts = per_consumer[next_consumer][0].0;
+            let lasts = per_consumer[next_consumer].last().unwrap().0;
+            if firsts != i {
+                break;
+            }
+            // A consumer straddling {i, i+1} must wait until i+1 exists to
+            // its right; emitting it here places it between them, which is
+            // exactly what we want, so only the single-producer case needs
+            // the last-producer check.
+            if lasts > i + 1 {
+                return None;
+            }
+            cons_slot[next_consumer] = sequence.len();
+            sequence.push(false);
+            next_consumer += 1;
+        }
+    }
+    if next_consumer != consumer_count {
+        return None;
+    }
+
+    let pitch = machine_w + 1;
+    let xs: Vec<i32> = (0..sequence.len()).map(|k| k as i32 * pitch).collect();
+
+    let mut edges = Vec::new();
+    for (j, feeders) in per_consumer.iter().enumerate() {
+        let cs = cons_slot[j];
+        for &(i, flow) in feeders {
+            let ps = prod_slot[i];
+            // The invariant this whole construction exists to hold.
+            if cs.abs_diff(ps) != 1 {
+                return None;
+            }
+            edges.push((ps, cs, flow));
+        }
+    }
+    Some(RowCellPlan { sequence, xs, edges })
+}
+
+#[cfg(test)]
+mod row_straddle_tests {
+    use super::*;
+
+    /// The canonical cable→EC ratio, hand-derived independently in the RFC
+    /// as `P0 C0 P1 C1 P2 P3 C2 P4 C3 P5`. If the construction reproduces
+    /// that without being fitted to it, the flow-interval argument holds
+    /// in 1-D the same way it does for the stacked cell.
+    #[test]
+    fn canonical_cable_to_ec_row_matches_the_hand_derivation() {
+        let p = plan_row_straddle(6, 4, 5.0, 7.5, 3).expect("6:4 must arrange");
+        let seq: String = p
+            .sequence
+            .iter()
+            .map(|&is_p| if is_p { 'P' } else { 'C' })
+            .collect();
+        assert_eq!(seq, "PCPCPPCPCP", "sequence must match the hand derivation");
+        assert_eq!(p.sequence.len(), 10);
+        // Pitch 4 = 3-wide machine + the 1-tile coupling gap.
+        assert_eq!(p.xs, vec![0, 4, 8, 12, 16, 20, 24, 28, 32, 36]);
+        assert_eq!(p.width(3), 39);
+    }
+
+    /// The defining property: every coupling is between physically
+    /// ADJACENT machines. Without it the plan is unbuildable, since an
+    /// inserter only spans one gap.
+    #[test]
+    fn every_edge_couples_adjacent_machines() {
+        for (pc, cc, pr, cr) in [(6, 4, 5.0, 7.5), (4, 4, 2.5, 2.5), (2, 1, 3.0, 6.0)] {
+            let p = plan_row_straddle(pc, cc, pr, cr, 3).expect("must arrange");
+            for &(ps, cs, _) in &p.edges {
+                assert_eq!(ps.abs_diff(cs), 1, "edge {ps}->{cs} is not adjacent in {p:?}");
+                assert!(p.sequence[ps], "edge source must be a producer");
+                assert!(!p.sequence[cs], "edge target must be a consumer");
+            }
+        }
+    }
+
+    /// Conservation: every consumer receives exactly its demand, and every
+    /// producer's output is fully consumed.
+    #[test]
+    fn flow_is_conserved_per_machine() {
+        let (pr, cr) = (5.0, 7.5);
+        let p = plan_row_straddle(6, 4, pr, cr, 3).unwrap();
+        for (slot, &is_p) in p.sequence.iter().enumerate() {
+            let moved: f64 = p
+                .edges
+                .iter()
+                .filter(|&&(ps, cs, _)| if is_p { ps == slot } else { cs == slot })
+                .map(|&(_, _, f)| f)
+                .sum();
+            let want = if is_p { pr } else { cr };
+            assert!(
+                (moved - want).abs() < 1e-9,
+                "slot {slot} moves {moved}, wants {want}"
+            );
+        }
+    }
+
+    /// No reach-2 anywhere: each edge owns exactly one gap, so the busiest
+    /// edge IS the per-inserter rate. For cable→EC that is 5.0/s, which a
+    /// stack inserter covers at zero research (12.0/s).
+    #[test]
+    fn required_rate_is_the_busiest_single_edge() {
+        let p = plan_row_straddle(6, 4, 5.0, 7.5, 3).unwrap();
+        assert_eq!(p.required_rate(), 5.0);
+    }
+
+    /// Out-of-scope shapes refuse rather than approximate.
+    #[test]
+    fn out_of_scope_shapes_are_refused() {
+        // Unbalanced flow.
+        assert!(plan_row_straddle(6, 4, 5.0, 9.0, 3).is_none());
+        // A consumer needing three producers has only two neighbours.
+        assert!(plan_row_straddle(9, 3, 1.0, 3.0, 3).is_none());
+        // Degenerate inputs.
+        assert!(plan_row_straddle(0, 4, 5.0, 7.5, 3).is_none());
+        assert!(plan_row_straddle(6, 4, f64::NAN, 7.5, 3).is_none());
+        assert!(plan_row_straddle(6, 4, 5.0, 7.5, 0).is_none());
+    }
+
+    /// 1:1 pairing (the furnace→furnace shape) interleaves strictly.
+    #[test]
+    fn one_to_one_interleaves() {
+        let p = plan_row_straddle(4, 4, 2.5, 2.5, 3).unwrap();
+        let seq: String = p.sequence.iter().map(|&x| if x { 'P' } else { 'C' }).collect();
+        assert_eq!(seq, "PCPCPCPC");
+        assert_eq!(p.edges.len(), 4, "1:1 needs exactly one edge per pair");
+    }
+}

--- a/crates/core/src/bus/di_cell.rs
+++ b/crates/core/src/bus/di_cell.rs
@@ -1097,6 +1097,12 @@ pub struct RowCellLayout {
     pub entities: Vec<PlacedEntity>,
     /// Input belt rows, parallel to the caller's solid-input order.
     pub input_belt_ys: Vec<i32>,
+    /// Rows carrying a fluid tap point, for `RowSpan.fluid_port_ys`.
+    pub fluid_port_ys: Vec<i32>,
+    /// `(item, x, y)` of each real fluid input port, for
+    /// `RowSpan.fluid_port_pipes`. The lane planner taps fluids through
+    /// these, NOT through `input_belt_y`.
+    pub fluid_port_pipes: Vec<(String, i32, i32)>,
     pub machine_y: i32,
     pub output_belt_y: i32,
     pub x_min: i32,
@@ -1118,7 +1124,16 @@ pub struct RowCellSpec<'a> {
     /// input, then the consumer's. The producer's belt is the OUTER row
     /// (reached by a reach-2 inserter stepping over the inner belt), the
     /// consumer's is the inner row at reach 1.
+    /// `(item, belt, feed_inserter)` for a SOLID-fed producer. Ignored
+    /// when `producer_fluid` is set.
     pub producer_input: (&'a str, &'a str, &'a str),
+    /// `Some((fluid_item, pipe_entity))` when the producer's inputs are
+    /// ALL fluid — `casting-copper-cable` (molten-copper → copper-cable),
+    /// `casting-iron`, `solid-fuel-from-light-oil`. Such a producer has no
+    /// solid input at all, so the north face that would carry a feed belt
+    /// and inserters is free, and the pipe run goes exactly there. That is
+    /// also why the corpus shows no canonical pipe face: no contention.
+    pub producer_fluid: Option<(&'a str, &'a str)>,
     pub consumer_input: (&'a str, &'a str, &'a str),
     /// Inserters per machine face. The output face needs reach-2 (it steps
     /// over the consumer's input belt), and long-handed is the only
@@ -1184,6 +1199,7 @@ pub fn stamp_row_cell(
     let x_max = x0 + plan.width(machine_w) - 1;
     let seg = format!("di-row:{}:{}", spec.item, spec.consumer_recipe);
     let mut ents = Vec::new();
+    let mut fluid_ports: Vec<(String, i32, i32)> = Vec::new();
 
     let belt_run = |ents: &mut Vec<PlacedEntity>, y: i32, name: &str, carries: &str| {
         for x in x_min..=x_max {
@@ -1198,7 +1214,9 @@ pub fn stamp_row_cell(
             });
         }
     };
-    belt_run(&mut ents, p_belt_y, spec.producer_input.1, spec.producer_input.0);
+    if spec.producer_fluid.is_none() {
+        belt_run(&mut ents, p_belt_y, spec.producer_input.1, spec.producer_input.0);
+    }
     belt_run(&mut ents, c_belt_y, spec.consumer_input.1, spec.consumer_input.0);
     belt_run(&mut ents, output_belt_y, spec.output_belt, spec.output_item);
 
@@ -1208,11 +1226,21 @@ pub fn stamp_row_cell(
 
     for (k, &is_producer) in plan.sequence.iter().enumerate() {
         let mx = x0 + plan.xs[k];
+        // A fluid-fed producer must be placed at the orientation whose
+        // fluid INPUT port faces north, or the pipe row below lands on a
+        // tile that merely looks adjacent and carries nothing. Ports are
+        // prototype-fixed per direction, so this is read from the shared
+        // table rather than assumed.
+        let (m_mirror, m_dir) = match (is_producer, spec.producer_fluid) {
+            (true, Some(_)) => crate::fluid_ports::north_input_orientation(spec.producer_entity),
+            _ => (false, EntityDirection::North),
+        };
         ents.push(PlacedEntity {
             name: if is_producer { spec.producer_entity } else { spec.consumer_entity }.to_string(),
             x: mx,
             y: machine_y,
-            direction: EntityDirection::North,
+            direction: m_dir,
+            mirror: m_mirror,
             recipe: Some(
                 if is_producer { spec.producer_recipe } else { spec.consumer_recipe }.to_string(),
             ),
@@ -1220,17 +1248,25 @@ pub fn stamp_row_cell(
             ..Default::default()
         });
         if is_producer {
-            // North face, reach-1: picks the belt above, drops into the machine.
-            for dx in cols(spec.producer_feed_count.max(1)) {
-                ents.push(PlacedEntity {
-                    name: spec.producer_input.2.to_string(),
-                    x: mx + dx,
-                    y: p_feed_y,
-                    direction: EntityDirection::South,
-                    carries: Some(spec.producer_input.0.to_string()),
-                    segment_id: Some(seg.clone()),
-                    ..Default::default()
-                });
+            if let Some((fluid_item, _pipe)) = spec.producer_fluid {
+                // Record the machine's REAL north input ports as tap points.
+                for dx in crate::fluid_ports::north_input_dxs(spec.producer_entity, m_mirror, m_dir)
+                {
+                    fluid_ports.push((fluid_item.to_string(), mx + dx, p_feed_y));
+                }
+            } else {
+                // North face, reach-1: picks the belt above, drops into the machine.
+                for dx in cols(spec.producer_feed_count.max(1)) {
+                    ents.push(PlacedEntity {
+                        name: spec.producer_input.2.to_string(),
+                        x: mx + dx,
+                        y: p_feed_y,
+                        direction: EntityDirection::South,
+                        carries: Some(spec.producer_input.0.to_string()),
+                        segment_id: Some(seg.clone()),
+                        ..Default::default()
+                    });
+                }
             }
         } else {
             // South face shares one row: reach-1 feeds from the inner belt,
@@ -1266,6 +1302,24 @@ pub fn stamp_row_cell(
         }
     }
 
+    // Continuous pipe run on the row ADJACENT to the machines, so it meets
+    // the north input ports recorded above. Consumers sharing the row are
+    // unaffected: they have no fluid box, so the run forms no connection
+    // over their columns.
+    if let Some((fluid_item, pipe)) = spec.producer_fluid {
+        for x in x_min..=x_max {
+            ents.push(PlacedEntity {
+                name: pipe.to_string(),
+                x,
+                y: p_feed_y,
+                direction: EntityDirection::North,
+                carries: Some(fluid_item.to_string()),
+                segment_id: Some(seg.clone()),
+                ..Default::default()
+            });
+        }
+    }
+
     for &(ps, cs, _) in &plan.edges {
         let (gap_x, dir) = if cs == ps + 1 {
             (x0 + plan.xs[ps] + machine_w, EntityDirection::East)
@@ -1283,9 +1337,16 @@ pub fn stamp_row_cell(
         });
     }
 
+    let fluid_port_ys = if spec.producer_fluid.is_some() { vec![p_feed_y] } else { Vec::new() };
     Some(RowCellLayout {
         entities: ents,
-        input_belt_ys: vec![p_belt_y, c_belt_y],
+        input_belt_ys: if spec.producer_fluid.is_some() {
+            vec![c_belt_y]
+        } else {
+            vec![p_belt_y, c_belt_y]
+        },
+        fluid_port_ys,
+        fluid_port_pipes: fluid_ports,
         machine_y,
         output_belt_y,
         x_min,
@@ -1309,6 +1370,7 @@ mod row_stamp_tests {
             coupler_rate: 12.0,
             // Reach-1: the producer's belt is the NORTH face, adjacent.
             producer_input: ("copper-plate", "transport-belt", "fast-inserter"),
+            producer_fluid: None,
             consumer_input: ("iron-plate", "transport-belt", "fast-inserter"),
             output_item: "electronic-circuit",
             output_belt: "transport-belt",
@@ -1425,6 +1487,51 @@ mod row_stamp_tests {
                 }
             }
         }
+    }
+
+    /// The fluid-producer path: an all-fluid producer's north face carries
+    /// a PIPE RUN instead of a belt + feed inserters, and the machines are
+    /// placed at the orientation whose fluid input port faces north so the
+    /// run lands on real ports.
+    ///
+    /// NOTE: no corpus pair reaches this path yet — see the RFC decision
+    /// log. It is unit-tested here so the geometry is pinned for whoever
+    /// lands the prerequisites (heterogeneous machine footprints, and
+    /// fluid-on-both-sides).
+    #[test]
+    fn fluid_producer_gets_a_pipe_run_on_a_free_north_face() {
+        let plan = plan_row_straddle(4, 4, 2.5, 2.5, 3).unwrap();
+        let mut sp = spec();
+        sp.producer_recipe = "casting-copper-cable";
+        sp.producer_fluid = Some(("molten-copper", "pipe"));
+        let l = stamp_row_cell(&plan, &sp, 0, 0, 3, 3).expect("fluid cell must stamp");
+
+        // No belt for the producer's input, and no feed inserters for it.
+        assert!(
+            !l.entities.iter().any(|e| e.carries.as_deref() == Some("copper-plate")),
+            "an all-fluid producer must have no solid feed at all"
+        );
+        // A contiguous pipe run sits on the row ADJACENT to the machines.
+        let pipe_y = l.machine_y - 1;
+        let pipes: Vec<_> = l
+            .entities
+            .iter()
+            .filter(|e| e.name == "pipe" && e.y == pipe_y)
+            .collect();
+        assert_eq!(
+            pipes.len() as i32,
+            l.x_max - l.x_min + 1,
+            "pipe run must span the cell on the row adjacent to the machines"
+        );
+        // Every recorded port is on that run and carries the fluid.
+        assert!(!l.fluid_port_pipes.is_empty(), "ports must be registered for the lane planner");
+        for (item, _px, py) in &l.fluid_port_pipes {
+            assert_eq!(item, "molten-copper");
+            assert_eq!(*py, pipe_y, "a port off the pipe row would never connect");
+        }
+        assert_eq!(l.fluid_port_ys, vec![pipe_y]);
+        // The fluid never displaces the consumer's belt-fed input.
+        assert_eq!(l.input_belt_ys.len(), 1, "only the consumer's belt remains");
     }
 
     /// Under-rate couplers refuse rather than under-feed.

--- a/crates/core/src/bus/di_cell.rs
+++ b/crates/core/src/bus/di_cell.rs
@@ -1145,7 +1145,18 @@ pub struct RowCellSpec<'a> {
     /// and inserters is free, and the pipe run goes exactly there. That is
     /// also why the corpus shows no canonical pipe face: no contention.
     pub producer_fluid: Option<(&'a str, &'a str)>,
-    pub consumer_input: (&'a str, &'a str, &'a str),
+    /// `(item, belt, feed_inserter)` for the consumer's belt-fed input, or
+    /// `None` when the coupled item is its ONLY solid ingredient
+    /// (`solid-fuel-from-light-oil → rocket-fuel`). Then its south face
+    /// carries the output alone and no inner belt is stamped.
+    pub consumer_input: Option<(&'a str, &'a str, &'a str)>,
+    /// `Some((fluid_item, pipe_entity))` when the CONSUMER also draws a
+    /// fluid. Only ever the same fluid the producer is piped: the cell
+    /// declares one set of tap points on one row and the lane planner
+    /// routes a single run to them, so both roles' north input ports are
+    /// registered against that one run. A second, different fluid would
+    /// need a second run on a face the cell does not have.
+    pub consumer_fluid: Option<(&'a str, &'a str)>,
     /// Inserters per machine face. The output face needs reach-2 (it steps
     /// over the consumer's input belt), and long-handed is the only
     /// reach-2 inserter (I8a) at 2.40/s at L2 — under the 2.5/s an EC
@@ -1216,7 +1227,12 @@ pub fn stamp_row_cell(
     // Row-relative top of each role once bottom-aligned.
     let top_of = |is_p: bool| machine_y + (max_h - if is_p { producer_h } else { consumer_h });
     let c_belt_y = face_y + 1;
-    let output_belt_y = face_y + 2;
+    // With no belt-fed consumer input that inner row is empty, so the
+    // output belt moves up into it. Worth doing rather than leaving a gap:
+    // it drops a row from the cell AND puts the output inserter at reach-1,
+    // off long-handed's 2.40/s ceiling — the constraint that forces two
+    // output columns in the ordinary shape.
+    let output_belt_y = if spec.consumer_input.is_some() { face_y + 2 } else { face_y + 1 };
     let x_min = x0;
     let x_max = x0 + plan.width(producer_w, consumer_w) - 1;
     let seg = format!("di-row:{}:{}", spec.item, spec.consumer_recipe);
@@ -1239,7 +1255,9 @@ pub fn stamp_row_cell(
     if spec.producer_fluid.is_none() {
         belt_run(&mut ents, p_belt_y, spec.producer_input.1, spec.producer_input.0);
     }
-    belt_run(&mut ents, c_belt_y, spec.consumer_input.1, spec.consumer_input.0);
+    if let Some((item, belt, _)) = spec.consumer_input {
+        belt_run(&mut ents, c_belt_y, belt, item);
+    }
     belt_run(&mut ents, output_belt_y, spec.output_belt, spec.output_item);
 
     // Columns available on a face, innermost first so single-inserter
@@ -1253,8 +1271,13 @@ pub fn stamp_row_cell(
         // tile that merely looks adjacent and carries nothing. Ports are
         // prototype-fixed per direction, so this is read from the shared
         // table rather than assumed.
-        let (m_mirror, m_dir) = match (is_producer, spec.producer_fluid) {
-            (true, Some(_)) => crate::fluid_ports::north_input_orientation(spec.producer_entity),
+        let (m_mirror, m_dir) = match is_producer {
+            true if spec.producer_fluid.is_some() => {
+                crate::fluid_ports::north_input_orientation(spec.producer_entity)
+            }
+            false if spec.consumer_fluid.is_some() => {
+                crate::fluid_ports::north_input_orientation(spec.consumer_entity)
+            }
             _ => (false, EntityDirection::North),
         };
         let my = top_of(is_producer);
@@ -1292,21 +1315,35 @@ pub fn stamp_row_cell(
                 }
             }
         } else {
+            // NOTE: a fluid-drawing consumer registers NO tap points of its
+            // own. Tested, not assumed: adding them changes nothing. The
+            // pipe run below is stamped across the whole cell width from
+            // the producer's side, so it is one connected network and the
+            // consumer's north ports are adjacent to it either way;
+            // `fluid_port_pipes` only tells the lane planner where to tap
+            // the bus INTO the cell, which the producer's ports already do.
+            // What IS load-bearing is the consumer's ORIENTATION above —
+            // eligibility admits it on the strength of having a north input
+            // port, so the stamp has to actually put it there.
+            //
             // South face shares one row: reach-1 feeds from the inner belt,
             // reach-2 outputs over it. Feed takes the low columns, output
-            // the high ones, so they never contend for a tile.
-            let nf = spec.consumer_feed_count.max(1);
+            // the high ones, so they never contend for a tile. A consumer
+            // whose only solid ingredient is the coupled one has no feed at
+            // all and gives the whole face to its output.
+            let nf = if spec.consumer_input.is_some() { spec.consumer_feed_count.max(1) } else { 0 };
             let no = spec.out_count.max(1);
             if nf + no > consumer_w as usize {
                 return None;
             }
             for dx in 0..nf as i32 {
+                let (item, _, inserter) = spec.consumer_input.expect("nf > 0 implies Some");
                 ents.push(PlacedEntity {
-                    name: spec.consumer_input.2.to_string(),
+                    name: inserter.to_string(),
                     x: mx + dx,
                     y: face_y,
                     direction: EntityDirection::North,
-                    carries: Some(spec.consumer_input.0.to_string()),
+                    carries: Some(item.to_string()),
                     segment_id: Some(seg.clone()),
                     ..Default::default()
                 });
@@ -1326,9 +1363,12 @@ pub fn stamp_row_cell(
     }
 
     // Continuous pipe run on the row ADJACENT to the machines, so it meets
-    // the north input ports recorded above. Consumers sharing the row are
-    // unaffected: they have no fluid box, so the run forms no connection
-    // over their columns.
+    // the north input ports recorded above. A consumer sharing the row
+    // either has no fluid box — the run forms no connection over its
+    // columns — or draws the SAME fluid, which is the only case
+    // `row_cell_eligible` admits, so joining that one network is exactly
+    // the intent. Different fluids on one run would cross-contaminate,
+    // which is why the gate is same-fluid rather than any-fluid.
     if let Some((fluid_item, pipe)) = spec.producer_fluid {
         let pipe_y = top_of(true) - 1;
         for x in x_min..=x_max {
@@ -1363,15 +1403,26 @@ pub fn stamp_row_cell(
         });
     }
 
-    let fluid_port_ys =
-        if spec.producer_fluid.is_some() { vec![top_of(true) - 1] } else { Vec::new() };
+    // Derived from the ports actually recorded, not from which role has a
+    // fluid: the two can only agree by accident, and a port declared on a
+    // row the lane planner is not told about would never be piped.
+    let mut fluid_port_ys: Vec<i32> = fluid_ports.iter().map(|&(_, _, y)| y).collect();
+    fluid_port_ys.sort_unstable();
+    fluid_port_ys.dedup();
+    // Parallel to the fused spec's solid-input order: producer's belt
+    // first when it has one, then the consumer's. Either may be absent,
+    // and both are when the producer is piped and the coupled item is the
+    // consumer's only solid ingredient.
+    let mut input_belt_ys = Vec::new();
+    if spec.producer_fluid.is_none() {
+        input_belt_ys.push(p_belt_y);
+    }
+    if spec.consumer_input.is_some() {
+        input_belt_ys.push(c_belt_y);
+    }
     Some(RowCellLayout {
         entities: ents,
-        input_belt_ys: if spec.producer_fluid.is_some() {
-            vec![c_belt_y]
-        } else {
-            vec![p_belt_y, c_belt_y]
-        },
+        input_belt_ys,
         fluid_port_ys,
         fluid_port_pipes: fluid_ports,
         machine_y,
@@ -1398,7 +1449,8 @@ mod row_stamp_tests {
             // Reach-1: the producer's belt is the NORTH face, adjacent.
             producer_input: ("copper-plate", "transport-belt", "fast-inserter"),
             producer_fluid: None,
-            consumer_input: ("iron-plate", "transport-belt", "fast-inserter"),
+            consumer_input: Some(("iron-plate", "transport-belt", "fast-inserter")),
+            consumer_fluid: None,
             output_item: "electronic-circuit",
             output_belt: "transport-belt",
             out_inserter: "long-handed-inserter",
@@ -1412,6 +1464,102 @@ mod row_stamp_tests {
         let plan = plan_row_straddle(6, 4, 5.0, 7.5, 3, 3).unwrap();
         let l = stamp_row_cell(&plan, &spec(), 0, 0, 3, 3, 3, 3).unwrap();
         (plan, l)
+    }
+
+    /// The shared-fluid shape: a piped producer whose consumer draws the
+    /// SAME fluid and takes no belt-fed solid at all
+    /// (`solid-fuel-from-light-oil → rocket-fuel`).
+    ///
+    /// Pinned as a unit test rather than end-to-end because the shape is
+    /// currently UNREACHABLE: the only corpus pair with it resolves to a
+    /// `biochamber`, which `cell_machines_are_powerable` refuses (burner,
+    /// fuel category `nutrients`, and nothing in the engine delivers
+    /// burner fuel). `chemical-plant` on both sides here stands in for the
+    /// geometry, which is what this test is about.
+    fn shared_fluid_spec() -> RowCellSpec<'static> {
+        RowCellSpec {
+            producer_entity: "chemical-plant",
+            consumer_entity: "chemical-plant",
+            producer_recipe: "solid-fuel-from-light-oil",
+            consumer_recipe: "rocket-fuel",
+            item: "solid-fuel",
+            coupler: "inserter",
+            coupler_rate: 12.0,
+            producer_input: ("", "transport-belt", "inserter"),
+            producer_fluid: Some(("light-oil", "pipe")),
+            // The coupling supplies every solid the consumer needs.
+            consumer_input: None,
+            consumer_fluid: Some(("light-oil", "pipe")),
+            output_item: "rocket-fuel",
+            output_belt: "transport-belt",
+            out_inserter: "inserter",
+            producer_feed_count: 0,
+            consumer_feed_count: 0,
+            out_count: 1,
+        }
+    }
+
+    /// With no belt-fed consumer input the inner row is empty, so the
+    /// output belt moves up into it and its inserter drops at reach-1.
+    /// Leaving the gap would cost a row AND pin the output to long-handed's
+    /// 2.40/s ceiling.
+    #[test]
+    fn coupling_fed_consumer_drops_the_inner_belt_row() {
+        let plan = plan_row_straddle(4, 4, 1.0, 1.0, 3, 3).unwrap();
+        let l = stamp_row_cell(&plan, &shared_fluid_spec(), 0, 0, 3, 3, 3, 3).unwrap();
+
+        // Face row is directly above the output belt: nothing between.
+        let face_y = l.machine_y + 3;
+        assert_eq!(l.output_belt_y, face_y + 1, "output belt sits against the face");
+        assert!(
+            l.input_belt_ys.is_empty(),
+            "a piped producer and a coupling-fed consumer tap no belt at all, got {:?}",
+            l.input_belt_ys
+        );
+        // Exactly one belt run — the output.
+        let belt_ys: std::collections::BTreeSet<i32> = l
+            .entities
+            .iter()
+            .filter(|e| e.name.ends_with("transport-belt"))
+            .map(|e| e.y)
+            .collect();
+        assert_eq!(
+            belt_ys.iter().copied().collect::<Vec<_>>(),
+            vec![l.output_belt_y],
+            "the only belt should be the output"
+        );
+    }
+
+    /// Equal heights are an eligibility precondition precisely so that
+    /// bottom-alignment lands BOTH roles' north faces on the pipe row the
+    /// producer's run occupies. Checked against real port geometry, not by
+    /// assuming the run's extent is enough.
+    #[test]
+    fn shared_fluid_run_reaches_both_roles_north_ports() {
+        let plan = plan_row_straddle(4, 4, 1.0, 1.0, 3, 3).unwrap();
+        let l = stamp_row_cell(&plan, &shared_fluid_spec(), 0, 0, 3, 3, 3, 3).unwrap();
+        let pipes: std::collections::HashSet<(i32, i32)> = l
+            .entities
+            .iter()
+            .filter(|e| e.name == "pipe")
+            .map(|e| (e.x, e.y))
+            .collect();
+        assert!(!pipes.is_empty(), "a piped producer must get a run");
+
+        let machines: Vec<_> =
+            l.entities.iter().filter(|e| e.name == "chemical-plant").collect();
+        assert_eq!(machines.len(), 8, "4 producers + 4 consumers");
+        let (mirror, dir) = crate::fluid_ports::north_input_orientation("chemical-plant");
+        let dxs = crate::fluid_ports::north_input_dxs("chemical-plant", mirror, dir);
+        assert!(!dxs.is_empty(), "chemical-plant must expose a north input port");
+        for m in &machines {
+            assert!(
+                dxs.iter().any(|dx| pipes.contains(&(m.x + dx, m.y - 1))),
+                "machine at ({},{}) has no pipe on any north port (dxs {dxs:?})",
+                m.x,
+                m.y
+            );
+        }
     }
 
     /// THE defining DI property, the same predicate `classify.rs` applies

--- a/crates/core/src/bus/di_cell.rs
+++ b/crates/core/src/bus/di_cell.rs
@@ -885,10 +885,13 @@ impl RowCellPlan {
         self.edges.iter().map(|&(_, _, f)| f).fold(0.0, f64::max)
     }
 
-    pub fn width(&self, machine_w: i32) -> i32 {
-        match self.xs.last() {
-            Some(&last) => last + machine_w,
-            None => 0,
+    /// Total x-extent. Takes BOTH widths because a cell may mix machine
+    /// footprints (a foundry is 5x5 against an assembler's 3x3), so the
+    /// last machine's width depends on its role.
+    pub fn width(&self, producer_w: i32, consumer_w: i32) -> i32 {
+        match (self.xs.last(), self.sequence.last()) {
+            (Some(&last), Some(&is_p)) => last + if is_p { producer_w } else { consumer_w },
+            _ => 0,
         }
     }
 }
@@ -911,9 +914,10 @@ pub fn plan_row_straddle(
     consumer_count: usize,
     producer_rate: f64,
     consumer_rate: f64,
-    machine_w: i32,
+    producer_w: i32,
+    consumer_w: i32,
 ) -> Option<RowCellPlan> {
-    if producer_count == 0 || consumer_count == 0 || machine_w <= 0 {
+    if producer_count == 0 || consumer_count == 0 || producer_w <= 0 || consumer_w <= 0 {
         return None;
     }
     let usable = producer_rate.is_finite()
@@ -982,8 +986,15 @@ pub fn plan_row_straddle(
         return None;
     }
 
-    let pitch = machine_w + 1;
-    let xs: Vec<i32> = (0..sequence.len()).map(|k| k as i32 * pitch).collect();
+    // Per-machine pitch: each machine's own width plus the 1-tile gap that
+    // holds its coupling inserter. A uniform pitch would overlap machines
+    // whenever the two roles have different footprints.
+    let mut xs: Vec<i32> = Vec::with_capacity(sequence.len());
+    let mut cursor = 0i32;
+    for &is_p in &sequence {
+        xs.push(cursor);
+        cursor += if is_p { producer_w } else { consumer_w } + 1;
+    }
 
     let mut edges = Vec::new();
     for (j, feeders) in per_consumer.iter().enumerate() {
@@ -1010,7 +1021,7 @@ mod row_straddle_tests {
     /// in 1-D the same way it does for the stacked cell.
     #[test]
     fn canonical_cable_to_ec_row_matches_the_hand_derivation() {
-        let p = plan_row_straddle(6, 4, 5.0, 7.5, 3).expect("6:4 must arrange");
+        let p = plan_row_straddle(6, 4, 5.0, 7.5, 3, 3).expect("6:4 must arrange");
         let seq: String = p
             .sequence
             .iter()
@@ -1020,7 +1031,7 @@ mod row_straddle_tests {
         assert_eq!(p.sequence.len(), 10);
         // Pitch 4 = 3-wide machine + the 1-tile coupling gap.
         assert_eq!(p.xs, vec![0, 4, 8, 12, 16, 20, 24, 28, 32, 36]);
-        assert_eq!(p.width(3), 39);
+        assert_eq!(p.width(3, 3), 39);
     }
 
     /// The defining property: every coupling is between physically
@@ -1029,7 +1040,7 @@ mod row_straddle_tests {
     #[test]
     fn every_edge_couples_adjacent_machines() {
         for (pc, cc, pr, cr) in [(6, 4, 5.0, 7.5), (4, 4, 2.5, 2.5), (2, 1, 3.0, 6.0)] {
-            let p = plan_row_straddle(pc, cc, pr, cr, 3).expect("must arrange");
+            let p = plan_row_straddle(pc, cc, pr, cr, 3, 3).expect("must arrange");
             for &(ps, cs, _) in &p.edges {
                 assert_eq!(ps.abs_diff(cs), 1, "edge {ps}->{cs} is not adjacent in {p:?}");
                 assert!(p.sequence[ps], "edge source must be a producer");
@@ -1043,7 +1054,7 @@ mod row_straddle_tests {
     #[test]
     fn flow_is_conserved_per_machine() {
         let (pr, cr) = (5.0, 7.5);
-        let p = plan_row_straddle(6, 4, pr, cr, 3).unwrap();
+        let p = plan_row_straddle(6, 4, pr, cr, 3, 3).unwrap();
         for (slot, &is_p) in p.sequence.iter().enumerate() {
             let moved: f64 = p
                 .edges
@@ -1064,7 +1075,7 @@ mod row_straddle_tests {
     /// stack inserter covers at zero research (12.0/s).
     #[test]
     fn required_rate_is_the_busiest_single_edge() {
-        let p = plan_row_straddle(6, 4, 5.0, 7.5, 3).unwrap();
+        let p = plan_row_straddle(6, 4, 5.0, 7.5, 3, 3).unwrap();
         assert_eq!(p.required_rate(), 5.0);
     }
 
@@ -1072,19 +1083,19 @@ mod row_straddle_tests {
     #[test]
     fn out_of_scope_shapes_are_refused() {
         // Unbalanced flow.
-        assert!(plan_row_straddle(6, 4, 5.0, 9.0, 3).is_none());
+        assert!(plan_row_straddle(6, 4, 5.0, 9.0, 3, 3).is_none());
         // A consumer needing three producers has only two neighbours.
-        assert!(plan_row_straddle(9, 3, 1.0, 3.0, 3).is_none());
+        assert!(plan_row_straddle(9, 3, 1.0, 3.0, 3, 3).is_none());
         // Degenerate inputs.
-        assert!(plan_row_straddle(0, 4, 5.0, 7.5, 3).is_none());
-        assert!(plan_row_straddle(6, 4, f64::NAN, 7.5, 3).is_none());
-        assert!(plan_row_straddle(6, 4, 5.0, 7.5, 0).is_none());
+        assert!(plan_row_straddle(0, 4, 5.0, 7.5, 3, 3).is_none());
+        assert!(plan_row_straddle(6, 4, f64::NAN, 7.5, 3, 3).is_none());
+        assert!(plan_row_straddle(6, 4, 5.0, 7.5, 0, 0).is_none());
     }
 
     /// 1:1 pairing (the furnace→furnace shape) interleaves strictly.
     #[test]
     fn one_to_one_interleaves() {
-        let p = plan_row_straddle(4, 4, 2.5, 2.5, 3).unwrap();
+        let p = plan_row_straddle(4, 4, 2.5, 2.5, 3, 3).unwrap();
         let seq: String = p.sequence.iter().map(|&x| if x { 'P' } else { 'C' }).collect();
         assert_eq!(seq, "PCPCPCPC");
         assert_eq!(p.edges.len(), 4, "1:1 needs exactly one edge per pair");
@@ -1162,17 +1173,26 @@ pub struct RowCellSpec<'a> {
 /// Couplers sit in the gap columns BETWEEN machines, at reach 1 — the
 /// property that makes this DI at all. Returns `None` if the coupler
 /// cannot carry the busiest edge, rather than emitting an under-fed row.
+#[allow(clippy::too_many_arguments)]
 pub fn stamp_row_cell(
     plan: &RowCellPlan,
     spec: &RowCellSpec<'_>,
     x0: i32,
     y0: i32,
-    machine_w: i32,
-    machine_h: i32,
+    producer_w: i32,
+    producer_h: i32,
+    consumer_w: i32,
+    consumer_h: i32,
 ) -> Option<RowCellLayout> {
-    if machine_w <= 0 || machine_h <= 0 {
+    if producer_w <= 0 || producer_h <= 0 || consumer_w <= 0 || consumer_h <= 0 {
         return None;
     }
+    // Machines are BOTTOM-ALIGNED so both roles share one south face row.
+    // Top-aligning them would leave a shorter machine's south face two
+    // tiles above the face row, unreachable by its own feed and output
+    // inserters. Bottom-alignment also guarantees the roles overlap on
+    // the bottom row, which is where the coupling inserters sit.
+    let max_h = producer_h.max(consumer_h);
     if plan.required_rate() > spec.coupler_rate + 1e-9 {
         return None;
     }
@@ -1192,11 +1212,13 @@ pub fn stamp_row_cell(
     let p_belt_y = y0;
     let p_feed_y = y0 + 1;
     let machine_y = y0 + 2;
-    let face_y = machine_y + machine_h;
+    let face_y = machine_y + max_h;
+    // Row-relative top of each role once bottom-aligned.
+    let top_of = |is_p: bool| machine_y + (max_h - if is_p { producer_h } else { consumer_h });
     let c_belt_y = face_y + 1;
     let output_belt_y = face_y + 2;
     let x_min = x0;
-    let x_max = x0 + plan.width(machine_w) - 1;
+    let x_max = x0 + plan.width(producer_w, consumer_w) - 1;
     let seg = format!("di-row:{}:{}", spec.item, spec.consumer_recipe);
     let mut ents = Vec::new();
     let mut fluid_ports: Vec<(String, i32, i32)> = Vec::new();
@@ -1222,7 +1244,7 @@ pub fn stamp_row_cell(
 
     // Columns available on a face, innermost first so single-inserter
     // faces keep the natural centre-ish position.
-    let cols = |n: usize| -> Vec<i32> { (0..machine_w).take(n).collect() };
+    let cols = |w: i32, n: usize| -> Vec<i32> { (0..w).take(n).collect() };
 
     for (k, &is_producer) in plan.sequence.iter().enumerate() {
         let mx = x0 + plan.xs[k];
@@ -1235,10 +1257,11 @@ pub fn stamp_row_cell(
             (true, Some(_)) => crate::fluid_ports::north_input_orientation(spec.producer_entity),
             _ => (false, EntityDirection::North),
         };
+        let my = top_of(is_producer);
         ents.push(PlacedEntity {
             name: if is_producer { spec.producer_entity } else { spec.consumer_entity }.to_string(),
             x: mx,
-            y: machine_y,
+            y: my,
             direction: m_dir,
             mirror: m_mirror,
             recipe: Some(
@@ -1252,11 +1275,11 @@ pub fn stamp_row_cell(
                 // Record the machine's REAL north input ports as tap points.
                 for dx in crate::fluid_ports::north_input_dxs(spec.producer_entity, m_mirror, m_dir)
                 {
-                    fluid_ports.push((fluid_item.to_string(), mx + dx, p_feed_y));
+                    fluid_ports.push((fluid_item.to_string(), mx + dx, my - 1));
                 }
             } else {
                 // North face, reach-1: picks the belt above, drops into the machine.
-                for dx in cols(spec.producer_feed_count.max(1)) {
+                for dx in cols(producer_w, spec.producer_feed_count.max(1)) {
                     ents.push(PlacedEntity {
                         name: spec.producer_input.2.to_string(),
                         x: mx + dx,
@@ -1274,7 +1297,7 @@ pub fn stamp_row_cell(
             // the high ones, so they never contend for a tile.
             let nf = spec.consumer_feed_count.max(1);
             let no = spec.out_count.max(1);
-            if nf + no > machine_w as usize {
+            if nf + no > consumer_w as usize {
                 return None;
             }
             for dx in 0..nf as i32 {
@@ -1307,11 +1330,12 @@ pub fn stamp_row_cell(
     // unaffected: they have no fluid box, so the run forms no connection
     // over their columns.
     if let Some((fluid_item, pipe)) = spec.producer_fluid {
+        let pipe_y = top_of(true) - 1;
         for x in x_min..=x_max {
             ents.push(PlacedEntity {
                 name: pipe.to_string(),
                 x,
-                y: p_feed_y,
+                y: pipe_y,
                 direction: EntityDirection::North,
                 carries: Some(fluid_item.to_string()),
                 segment_id: Some(seg.clone()),
@@ -1322,14 +1346,16 @@ pub fn stamp_row_cell(
 
     for &(ps, cs, _) in &plan.edges {
         let (gap_x, dir) = if cs == ps + 1 {
-            (x0 + plan.xs[ps] + machine_w, EntityDirection::East)
+            (x0 + plan.xs[ps] + producer_w, EntityDirection::East)
         } else {
-            (x0 + plan.xs[cs] + machine_w, EntityDirection::West)
+            (x0 + plan.xs[cs] + consumer_w, EntityDirection::West)
         };
         ents.push(PlacedEntity {
             name: spec.coupler.to_string(),
+            // Bottom row: the only row both roles are guaranteed to occupy
+            // once bottom-aligned, so the coupler reaches both.
+            y: face_y - 1,
             x: gap_x,
-            y: machine_y + machine_h / 2,
             direction: dir,
             carries: Some(spec.item.to_string()),
             segment_id: Some(seg.clone()),
@@ -1337,7 +1363,8 @@ pub fn stamp_row_cell(
         });
     }
 
-    let fluid_port_ys = if spec.producer_fluid.is_some() { vec![p_feed_y] } else { Vec::new() };
+    let fluid_port_ys =
+        if spec.producer_fluid.is_some() { vec![top_of(true) - 1] } else { Vec::new() };
     Some(RowCellLayout {
         entities: ents,
         input_belt_ys: if spec.producer_fluid.is_some() {
@@ -1382,8 +1409,8 @@ mod row_stamp_tests {
     }
 
     fn stamped() -> (RowCellPlan, RowCellLayout) {
-        let plan = plan_row_straddle(6, 4, 5.0, 7.5, 3).unwrap();
-        let l = stamp_row_cell(&plan, &spec(), 0, 0, 3, 3).unwrap();
+        let plan = plan_row_straddle(6, 4, 5.0, 7.5, 3, 3).unwrap();
+        let l = stamp_row_cell(&plan, &spec(), 0, 0, 3, 3, 3, 3).unwrap();
         (plan, l)
     }
 
@@ -1500,11 +1527,12 @@ mod row_stamp_tests {
     /// fluid-on-both-sides).
     #[test]
     fn fluid_producer_gets_a_pipe_run_on_a_free_north_face() {
-        let plan = plan_row_straddle(4, 4, 2.5, 2.5, 3).unwrap();
+        let plan = plan_row_straddle(4, 4, 2.5, 2.5, 5, 3).unwrap();
         let mut sp = spec();
         sp.producer_recipe = "casting-copper-cable";
+        sp.producer_entity = "foundry";
         sp.producer_fluid = Some(("molten-copper", "pipe"));
-        let l = stamp_row_cell(&plan, &sp, 0, 0, 3, 3).expect("fluid cell must stamp");
+        let l = stamp_row_cell(&plan, &sp, 0, 0, 5, 5, 3, 3).expect("fluid cell must stamp");
 
         // No belt for the producer's input, and no feed inserters for it.
         assert!(
@@ -1537,10 +1565,10 @@ mod row_stamp_tests {
     /// Under-rate couplers refuse rather than under-feed.
     #[test]
     fn under_rate_coupler_refuses() {
-        let plan = plan_row_straddle(6, 4, 5.0, 7.5, 3).unwrap();
+        let plan = plan_row_straddle(6, 4, 5.0, 7.5, 3, 3).unwrap();
         let mut s = spec();
         s.coupler = "inserter";
         s.coupler_rate = 0.84;
-        assert!(stamp_row_cell(&plan, &s, 0, 0, 3, 3).is_none());
+        assert!(stamp_row_cell(&plan, &s, 0, 0, 3, 3, 3, 3).is_none());
     }
 }

--- a/crates/core/src/bus/di_cell.rs
+++ b/crates/core/src/bus/di_cell.rs
@@ -1090,3 +1090,346 @@ mod row_straddle_tests {
         assert_eq!(p.edges.len(), 4, "1:1 needs exactly one edge per pair");
     }
 }
+
+/// Entities and row geometry for a stamped [`RowCellPlan`].
+#[derive(Debug, Clone)]
+pub struct RowCellLayout {
+    pub entities: Vec<PlacedEntity>,
+    /// Input belt rows, parallel to the caller's solid-input order.
+    pub input_belt_ys: Vec<i32>,
+    pub machine_y: i32,
+    pub output_belt_y: i32,
+    pub x_min: i32,
+    pub x_max: i32,
+}
+
+/// Everything the row stamper needs beyond the plan.
+pub struct RowCellSpec<'a> {
+    pub producer_entity: &'a str,
+    pub consumer_entity: &'a str,
+    pub producer_recipe: &'a str,
+    pub consumer_recipe: &'a str,
+    /// The directly-inserted item.
+    pub item: &'a str,
+    /// Coupling inserter — reach-1, sits in the 1-tile gap.
+    pub coupler: &'a str,
+    pub coupler_rate: f64,
+    /// `(item, belt_entity, feed_inserter)` for the producer's belt-fed
+    /// input, then the consumer's. The producer's belt is the OUTER row
+    /// (reached by a reach-2 inserter stepping over the inner belt), the
+    /// consumer's is the inner row at reach 1.
+    pub producer_input: (&'a str, &'a str, &'a str),
+    pub consumer_input: (&'a str, &'a str, &'a str),
+    /// Inserters per machine face. The output face needs reach-2 (it steps
+    /// over the consumer's input belt), and long-handed is the only
+    /// reach-2 inserter (I8a) at 2.40/s at L2 — under the 2.5/s an EC
+    /// machine emits — so more than one column is the NORMAL case here,
+    /// not an edge case. Ignoring these counts silently under-feeds.
+    pub producer_feed_count: usize,
+    pub consumer_feed_count: usize,
+    pub out_count: usize,
+    pub output_item: &'a str,
+    pub output_belt: &'a str,
+    pub out_inserter: &'a str,
+}
+
+/// Stamp a horizontal row cell with its belts.
+///
+/// ```text
+///   y0                  producer input belt   (outer, reach-2 feed)
+///   y1                  consumer input belt   (inner, reach-1 feed)
+///   y2                  feed inserters
+///   y3 .. y3+h-1        machines, interleaved P/C at plan.xs
+///   y3+h                output inserters
+///   y3+h+1              output belt
+/// ```
+///
+/// Couplers sit in the gap columns BETWEEN machines, at reach 1 — the
+/// property that makes this DI at all. Returns `None` if the coupler
+/// cannot carry the busiest edge, rather than emitting an under-fed row.
+pub fn stamp_row_cell(
+    plan: &RowCellPlan,
+    spec: &RowCellSpec<'_>,
+    x0: i32,
+    y0: i32,
+    machine_w: i32,
+    machine_h: i32,
+) -> Option<RowCellLayout> {
+    if machine_w <= 0 || machine_h <= 0 {
+        return None;
+    }
+    if plan.required_rate() > spec.coupler_rate + 1e-9 {
+        return None;
+    }
+    // The producer's belt is NORTH at reach-1; both consumer flows go
+    // SOUTH. Putting the producer's feed on a reach-2 hop instead would
+    // reintroduce the long-handed 2.40/s ceiling the row shape exists to
+    // avoid, and it is the arrangement the corpus shows
+    // (`DI@E+W | S:in1 S:out1`, the top cable->EC face plan).
+    //
+    //   y0                  producer input belt   (north)
+    //   y1                  producer feed         reach-1
+    //   y2 .. y2+h-1        machines, interleaved
+    //   y2+h                face row: consumer feed (reach-1, picks the
+    //                       belt below) + output (reach-2, steps over it)
+    //   y2+h+1              consumer input belt
+    //   y2+h+2              output belt
+    let p_belt_y = y0;
+    let p_feed_y = y0 + 1;
+    let machine_y = y0 + 2;
+    let face_y = machine_y + machine_h;
+    let c_belt_y = face_y + 1;
+    let output_belt_y = face_y + 2;
+    let x_min = x0;
+    let x_max = x0 + plan.width(machine_w) - 1;
+    let seg = format!("di-row:{}:{}", spec.item, spec.consumer_recipe);
+    let mut ents = Vec::new();
+
+    let belt_run = |ents: &mut Vec<PlacedEntity>, y: i32, name: &str, carries: &str| {
+        for x in x_min..=x_max {
+            ents.push(PlacedEntity {
+                name: name.to_string(),
+                x,
+                y,
+                direction: EntityDirection::East,
+                carries: Some(carries.to_string()),
+                segment_id: Some(seg.clone()),
+                ..Default::default()
+            });
+        }
+    };
+    belt_run(&mut ents, p_belt_y, spec.producer_input.1, spec.producer_input.0);
+    belt_run(&mut ents, c_belt_y, spec.consumer_input.1, spec.consumer_input.0);
+    belt_run(&mut ents, output_belt_y, spec.output_belt, spec.output_item);
+
+    // Columns available on a face, innermost first so single-inserter
+    // faces keep the natural centre-ish position.
+    let cols = |n: usize| -> Vec<i32> { (0..machine_w).take(n).collect() };
+
+    for (k, &is_producer) in plan.sequence.iter().enumerate() {
+        let mx = x0 + plan.xs[k];
+        ents.push(PlacedEntity {
+            name: if is_producer { spec.producer_entity } else { spec.consumer_entity }.to_string(),
+            x: mx,
+            y: machine_y,
+            direction: EntityDirection::North,
+            recipe: Some(
+                if is_producer { spec.producer_recipe } else { spec.consumer_recipe }.to_string(),
+            ),
+            segment_id: Some(seg.clone()),
+            ..Default::default()
+        });
+        if is_producer {
+            // North face, reach-1: picks the belt above, drops into the machine.
+            for dx in cols(spec.producer_feed_count.max(1)) {
+                ents.push(PlacedEntity {
+                    name: spec.producer_input.2.to_string(),
+                    x: mx + dx,
+                    y: p_feed_y,
+                    direction: EntityDirection::South,
+                    carries: Some(spec.producer_input.0.to_string()),
+                    segment_id: Some(seg.clone()),
+                    ..Default::default()
+                });
+            }
+        } else {
+            // South face shares one row: reach-1 feeds from the inner belt,
+            // reach-2 outputs over it. Feed takes the low columns, output
+            // the high ones, so they never contend for a tile.
+            let nf = spec.consumer_feed_count.max(1);
+            let no = spec.out_count.max(1);
+            if nf + no > machine_w as usize {
+                return None;
+            }
+            for dx in 0..nf as i32 {
+                ents.push(PlacedEntity {
+                    name: spec.consumer_input.2.to_string(),
+                    x: mx + dx,
+                    y: face_y,
+                    direction: EntityDirection::North,
+                    carries: Some(spec.consumer_input.0.to_string()),
+                    segment_id: Some(seg.clone()),
+                    ..Default::default()
+                });
+            }
+            for j in 0..no as i32 {
+                ents.push(PlacedEntity {
+                    name: spec.out_inserter.to_string(),
+                    x: mx + nf as i32 + j,
+                    y: face_y,
+                    direction: EntityDirection::South,
+                    carries: Some(spec.output_item.to_string()),
+                    segment_id: Some(seg.clone()),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    for &(ps, cs, _) in &plan.edges {
+        let (gap_x, dir) = if cs == ps + 1 {
+            (x0 + plan.xs[ps] + machine_w, EntityDirection::East)
+        } else {
+            (x0 + plan.xs[cs] + machine_w, EntityDirection::West)
+        };
+        ents.push(PlacedEntity {
+            name: spec.coupler.to_string(),
+            x: gap_x,
+            y: machine_y + machine_h / 2,
+            direction: dir,
+            carries: Some(spec.item.to_string()),
+            segment_id: Some(seg.clone()),
+            ..Default::default()
+        });
+    }
+
+    Some(RowCellLayout {
+        entities: ents,
+        input_belt_ys: vec![p_belt_y, c_belt_y],
+        machine_y,
+        output_belt_y,
+        x_min,
+        x_max,
+    })
+}
+
+#[cfg(test)]
+mod row_stamp_tests {
+    use super::*;
+    use crate::common::{dir_to_vec, inserter_reach};
+
+    fn spec() -> RowCellSpec<'static> {
+        RowCellSpec {
+            producer_entity: "assembling-machine-3",
+            consumer_entity: "assembling-machine-3",
+            producer_recipe: "copper-cable",
+            consumer_recipe: "electronic-circuit",
+            item: "copper-cable",
+            coupler: "stack-inserter",
+            coupler_rate: 12.0,
+            producer_input: ("copper-plate", "transport-belt", "long-handed-inserter"),
+            consumer_input: ("iron-plate", "transport-belt", "fast-inserter"),
+            output_item: "electronic-circuit",
+            output_belt: "transport-belt",
+            out_inserter: "long-handed-inserter",
+            producer_feed_count: 1,
+            consumer_feed_count: 1,
+            out_count: 2,
+        }
+    }
+
+    fn stamped() -> (RowCellPlan, RowCellLayout) {
+        let plan = plan_row_straddle(6, 4, 5.0, 7.5, 3).unwrap();
+        let l = stamp_row_cell(&plan, &spec(), 0, 0, 3, 3).unwrap();
+        (plan, l)
+    }
+
+    /// THE defining DI property, the same predicate `classify.rs` applies
+    /// to community blueprints: every coupler picks from a machine tile
+    /// and drops into a machine tile, at reach 1, and no belt anywhere
+    /// carries the coupled item.
+    #[test]
+    fn couplers_are_machine_to_machine_and_the_item_never_hits_a_belt() {
+        let (_, l) = stamped();
+        let mtiles: std::collections::HashSet<(i32, i32)> = l
+            .entities
+            .iter()
+            .filter(|e| e.name.starts_with("assembling-machine"))
+            .flat_map(|e| {
+                (0..3).flat_map(move |dx| (0..3).map(move |dy| (e.x + dx, e.y + dy)))
+            })
+            .collect();
+        let couplers: Vec<_> = l
+            .entities
+            .iter()
+            .filter(|e| e.carries.as_deref() == Some("copper-cable"))
+            .collect();
+        assert_eq!(couplers.len(), 8, "6:4 straddle has 8 edges");
+        for c in &couplers {
+            assert!(c.name.contains("inserter"), "coupled item must move by inserter");
+            let r = inserter_reach(&c.name);
+            assert_eq!(r, 1, "coupler must be reach-1 (it sits in a 1-tile gap)");
+            let (dx, dy) = dir_to_vec(c.direction);
+            let pick = (c.x - dx * r, c.y - dy * r);
+            let drop = (c.x + dx * r, c.y + dy * r);
+            assert!(mtiles.contains(&pick), "coupler {:?} picks off a machine", (c.x, c.y));
+            assert!(mtiles.contains(&drop), "coupler {:?} drops into a machine", (c.x, c.y));
+        }
+        assert!(
+            !l.entities.iter().any(|e| e.name.contains("transport-belt")
+                && e.carries.as_deref() == Some("copper-cable")),
+            "no belt may carry the DI'd item"
+        );
+    }
+
+    /// Producers put nothing on the output belt; only consumers do.
+    #[test]
+    fn only_consumers_reach_the_output_belt() {
+        let (plan, l) = stamped();
+        let n_consumers = plan.sequence.iter().filter(|&&p| !p).count();
+        let out_ins = l
+            .entities
+            .iter()
+            .filter(|e| e.carries.as_deref() == Some("electronic-circuit") && e.name.contains("inserter"))
+            .count();
+        assert_eq!(out_ins, n_consumers);
+    }
+
+    /// Feed inserters must actually reach their belts: the consumer's is
+    /// reach-1 off the inner belt, the producer's reach-2 over it.
+    #[test]
+    fn feed_inserters_reach_their_belts() {
+        let (_, l) = stamped();
+        let belt_at: std::collections::HashMap<(i32, i32), String> = l
+            .entities
+            .iter()
+            .filter(|e| e.name.contains("transport-belt"))
+            .map(|e| ((e.x, e.y), e.carries.clone().unwrap_or_default()))
+            .collect();
+        for e in l.entities.iter().filter(|e| {
+            e.name.contains("inserter")
+                && matches!(e.carries.as_deref(), Some("copper-plate") | Some("iron-plate"))
+        }) {
+            let r = inserter_reach(&e.name);
+            let (dx, dy) = dir_to_vec(e.direction);
+            let pick = (e.x - dx * r, e.y - dy * r);
+            let carried = e.carries.as_deref().unwrap();
+            assert_eq!(
+                belt_at.get(&pick).map(String::as_str),
+                Some(carried),
+                "feed inserter at {:?} must pick {carried} off its belt",
+                (e.x, e.y)
+            );
+        }
+    }
+
+    /// No two entities may share a tile.
+    #[test]
+    fn row_cell_has_no_overlaps() {
+        let (_, l) = stamped();
+        let mut seen = std::collections::HashSet::new();
+        for e in &l.entities {
+            let (w, h) = if e.name.starts_with("assembling-machine") { (3, 3) } else { (1, 1) };
+            for dx in 0..w {
+                for dy in 0..h {
+                    assert!(
+                        seen.insert((e.x + dx, e.y + dy)),
+                        "overlap at {:?} from {}",
+                        (e.x + dx, e.y + dy),
+                        e.name
+                    );
+                }
+            }
+        }
+    }
+
+    /// Under-rate couplers refuse rather than under-feed.
+    #[test]
+    fn under_rate_coupler_refuses() {
+        let plan = plan_row_straddle(6, 4, 5.0, 7.5, 3).unwrap();
+        let mut s = spec();
+        s.coupler = "inserter";
+        s.coupler_rate = 0.84;
+        assert!(stamp_row_cell(&plan, &s, 0, 0, 3, 3).is_none());
+    }
+}

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3406,11 +3406,19 @@ pub fn route_bus_ghost(
     // ones) so south columns never clip a wider foreign row, and record
     // placed column x-positions so later items' east extension runs can
     // UG-hop across them.
-    let mut merge_x_cursor: i32 = if output_items.len() > 1 {
-        row_spans.iter().map(|rs| rs.row_width).max().unwrap_or(0) + 1
-    } else {
-        0
-    };
+    // The widest row, ALWAYS — not only when several items merge. The
+    // single-item path used to start at 0 and let `merge_output_rows`
+    // derive its start from the participating rows alone, which is only
+    // safe while the output-producing row is also the widest. That holds
+    // for ordinary layouts (the final row sits at the end of the chain
+    // and is typically largest) but not for an RFC-053 row cell, which
+    // fuses two recipes into one comparatively narrow row: at EC@10/s the
+    // cell is `bus+39` wide against the iron-plate row's `bus+48`, and
+    // the merger drove a column straight through it (7 entity-overlap
+    // errors). The comment above already stated this invariant; only the
+    // multi-item branch implemented it.
+    let mut merge_x_cursor: i32 =
+        row_spans.iter().map(|rs| rs.row_width).max().unwrap_or(0) + 1;
     let mut blocked_columns: Vec<i32> = Vec::new();
     // Tail tiles of every merge cascade stamped below (target items AND
     // solid surplus, Step 7b) — the LAST entity `merge_output_rows`

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3393,16 +3393,6 @@ pub fn route_bus_ghost(
     // Deterministic Vec order (not a set): with multiple output items the
     // iteration order decides merge-column positions, and FxHashSet order
     // is arbitrary. Dedup by seen-set, first occurrence wins.
-    // A fused RFC-053 cell row is present when any already-placed entity
-    // carries a cell segment id. Cell rows can be NARROWER than an
-    // ordinary row (they fuse two recipes into one), which breaks the
-    // merger's implicit assumption that the output-producing row is the
-    // widest — see the cursor comment below.
-    let cell_rows_present = entities.iter().any(|e| {
-        e.segment_id
-            .as_deref()
-            .is_some_and(|s| s.starts_with("di-cell:") || s.starts_with("di-row:"))
-    });
     let mut seen_output_items: FxHashSet<&str> = FxHashSet::default();
     let output_items: Vec<String> = solver_result
         .external_outputs
@@ -3427,17 +3417,7 @@ pub fn route_bus_ghost(
     // the merger drove a column straight through it (7 entity-overlap
     // errors). The comment above already stated this invariant; only the
     // multi-item branch implemented it.
-    //
-    // NARROWED DELIBERATELY: applied only when a fused DI cell row is
-    // present. Applying it unconditionally is the more principled reading
-    // of the invariant, but it regressed `mega_chain_ac_from_raw_zero_issues`
-    // (a previously zero-issue layout gained issues), and diagnosing why
-    // mega chains depend on the old cursor is out of scope here. Scoping
-    // it to cell layouts fixes the case that needs it and leaves every
-    // pre-existing layout bit-identical. The unconditional form is the
-    // right long-term fix once the mega-chain interaction is understood —
-    // tracked as a followup, NOT silently dropped.
-    let mut merge_x_cursor: i32 = if output_items.len() > 1 || cell_rows_present {
+    let mut merge_x_cursor: i32 = if output_items.len() > 1 {
         row_spans.iter().map(|rs| rs.row_width).max().unwrap_or(0) + 1
     } else {
         0

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3393,6 +3393,16 @@ pub fn route_bus_ghost(
     // Deterministic Vec order (not a set): with multiple output items the
     // iteration order decides merge-column positions, and FxHashSet order
     // is arbitrary. Dedup by seen-set, first occurrence wins.
+    // A fused RFC-053 cell row is present when any already-placed entity
+    // carries a cell segment id. Cell rows can be NARROWER than an
+    // ordinary row (they fuse two recipes into one), which breaks the
+    // merger's implicit assumption that the output-producing row is the
+    // widest — see the cursor comment below.
+    let cell_rows_present = entities.iter().any(|e| {
+        e.segment_id
+            .as_deref()
+            .is_some_and(|s| s.starts_with("di-cell:") || s.starts_with("di-row:"))
+    });
     let mut seen_output_items: FxHashSet<&str> = FxHashSet::default();
     let output_items: Vec<String> = solver_result
         .external_outputs
@@ -3417,8 +3427,21 @@ pub fn route_bus_ghost(
     // the merger drove a column straight through it (7 entity-overlap
     // errors). The comment above already stated this invariant; only the
     // multi-item branch implemented it.
-    let mut merge_x_cursor: i32 =
-        row_spans.iter().map(|rs| rs.row_width).max().unwrap_or(0) + 1;
+    //
+    // NARROWED DELIBERATELY: applied only when a fused DI cell row is
+    // present. Applying it unconditionally is the more principled reading
+    // of the invariant, but it regressed `mega_chain_ac_from_raw_zero_issues`
+    // (a previously zero-issue layout gained issues), and diagnosing why
+    // mega chains depend on the old cursor is out of scope here. Scoping
+    // it to cell layouts fixes the case that needs it and leaves every
+    // pre-existing layout bit-identical. The unconditional form is the
+    // right long-term fix once the mega-chain interaction is understood —
+    // tracked as a followup, NOT silently dropped.
+    let mut merge_x_cursor: i32 = if output_items.len() > 1 || cell_rows_present {
+        row_spans.iter().map(|rs| rs.row_width).max().unwrap_or(0) + 1
+    } else {
+        0
+    };
     let mut blocked_columns: Vec<i32> = Vec::new();
     // Tail tiles of every merge cascade stamped below (target items AND
     // solid surplus, Step 7b) — the LAST entity `merge_output_rows`

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -2877,12 +2877,17 @@ mod tests {
             .iter()
             .filter(|e| {
                 e.carries.as_deref() == Some("copper-cable")
-                    && e.segment_id.as_deref().map_or(false, |s| s.starts_with("di-bridge:"))
+                    && e.segment_id.as_deref().map_or(false, |s| {
+                        // Phase 2 serves this pair with a row cell; the
+                        // bridge remains the fallback for pairs a cell
+                        // cannot arrange.
+                        s.starts_with("di-bridge:") || s.starts_with("di-row:")
+                    })
             })
             .collect();
         assert!(
             !di_inserters.is_empty(),
-            "layout should contain DI bridge inserters carrying copper-cable"
+            "layout should contain DI inserters carrying copper-cable"
         );
         // Two bridge inserters per EC machine (4 machines = 8). The bridge
         // spans a 2-tile gap so it must be long-handed — the only reach-2
@@ -2893,16 +2898,21 @@ mod tests {
         assert_eq!(
             di_inserters.len(),
             8,
-            "expected 8 DI bridge inserters (two per EC machine), got {}",
+            "expected 8 DI inserters carrying copper-cable, got {}",
             di_inserters.len()
         );
-        // All facing south (pick from producer belt north, drop to consumer belt south).
+        // Orientation depends on which DI shape served the pair. #432's
+        // bridge is vertical — south-facing, picking off the producer's
+        // output belt and dropping onto the consumer's input belt. RFC-053
+        // Phase 2's row cell couples HORIZONTALLY, producer beside
+        // consumer, so its couplers face east or west. Both are valid DI;
+        // what must never appear is any other orientation.
         for ins in &di_inserters {
-            assert_eq!(
-                ins.direction,
-                crate::models::EntityDirection::South,
-                "DI bridge inserter at ({},{}) should face south",
-                ins.x, ins.y
+            use crate::models::EntityDirection as D;
+            assert!(
+                matches!(ins.direction, D::South | D::East | D::West),
+                "DI inserter at ({},{}) has orientation {:?}, expected south (bridge) or east/west (row cell)",
+                ins.x, ins.y, ins.direction
             );
         }
 
@@ -2920,23 +2930,54 @@ mod tests {
                 .filter(|e| crate::common::is_belt_entity(&e.name))
                 .filter_map(|e| e.carries.as_deref().map(|c| ((e.x, e.y), c)))
                 .collect();
+            let machine_tiles: std::collections::HashSet<(i32, i32)> = layout
+                .entities
+                .iter()
+                .filter(|e| crate::common::is_machine_entity(&e.name))
+                .flat_map(|e| {
+                    let (w, h) = crate::common::machine_dims(&e.name);
+                    (0..w as i32)
+                        .flat_map(move |dx| (0..h as i32).map(move |dy| (e.x + dx, e.y + dy)))
+                })
+                .collect();
             for ins in &di_inserters {
                 let (dx, dy) = dir_to_vec(ins.direction);
                 let r = inserter_reach(&ins.name);
                 let pick = (ins.x - dx * r, ins.y - dy * r);
                 let drop = (ins.x + dx * r, ins.y + dy * r);
-                assert_eq!(
-                    belt_item.get(&pick).copied(),
-                    Some("copper-cable"),
-                    "bridge at ({},{}) must PICK from a copper-cable belt, got {:?}",
-                    ins.x, ins.y, belt_item.get(&pick)
-                );
-                assert_eq!(
-                    belt_item.get(&drop).copied(),
-                    Some("copper-cable"),
-                    "bridge at ({},{}) must DROP onto a copper-cable belt, got {:?}",
-                    ins.x, ins.y, belt_item.get(&drop)
-                );
+                let is_row_cell = ins
+                    .segment_id
+                    .as_deref()
+                    .is_some_and(|s| s.starts_with("di-row:"));
+                if is_row_cell {
+                    // TRUE direct insertion: machine to machine, with NO
+                    // belt for the coupled item anywhere. This is the same
+                    // predicate `classify.rs` uses to count DI in community
+                    // blueprints, and it is the property #432's bridge
+                    // could not achieve.
+                    assert!(
+                        machine_tiles.contains(&pick) && machine_tiles.contains(&drop),
+                        "row-cell coupler at ({},{}) must couple machine->machine, got pick={:?} drop={:?}",
+                        ins.x, ins.y, belt_item.get(&pick), belt_item.get(&drop)
+                    );
+                } else {
+                    // #432's bridge is belt-to-belt, and ITEM-KEYED at both
+                    // ends: EC is a DualInput consumer, so a positional
+                    // lookup is a coin flip that happens to land right for
+                    // this recipe order.
+                    assert_eq!(
+                        belt_item.get(&pick).copied(),
+                        Some("copper-cable"),
+                        "bridge at ({},{}) must PICK from a copper-cable belt, got {:?}",
+                        ins.x, ins.y, belt_item.get(&pick)
+                    );
+                    assert_eq!(
+                        belt_item.get(&drop).copied(),
+                        Some("copper-cable"),
+                        "bridge at ({},{}) must DROP onto a copper-cable belt, got {:?}",
+                        ins.x, ins.y, belt_item.get(&drop)
+                    );
+                }
             }
         }
 
@@ -2995,16 +3036,24 @@ mod tests {
                 },
             )
             .expect("layout should succeed");
-            // The bridge must actually exist — otherwise "no delivery
-            // warnings" would just mean DI silently fell back to the bus.
-            let bridges = layout
+            // DI must actually happen — otherwise "no delivery warnings"
+            // would just mean it silently fell back to the bus. Since
+            // RFC-053 Phase 2 this pair is served by a ROW CELL rather
+            // than #432's belt-to-belt bridge: the cell couples the
+            // machines directly at reach 1, so a stack inserter (12.0/s at
+            // zero research) carries it instead of a long-handed bridge
+            // capped at 2.4/s. That is why the delivery result below is now
+            // research-INDEPENDENT for cable, where the bridge needed L7.
+            let di = layout
                 .entities
                 .iter()
                 .filter(|e| {
-                    e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-bridge:"))
+                    e.segment_id.as_deref().is_some_and(|s| {
+                        s.starts_with("di-bridge:") || s.starts_with("di-row:")
+                    })
                 })
                 .count();
-            assert_eq!(bridges, 8, "L{level}: DI bridge must be stamped (got {bridges})");
+            assert!(di > 0, "L{level}: DI must be stamped (got {di})");
             crate::validate::belt_flow::check_input_rate_delivery(&layout, Some(&sr))
                 .iter()
                 .filter(|i| i.message.contains("copper-cable"))

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -1820,6 +1820,9 @@ fn cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str) -> 
     if producer.voider || consumer.voider {
         return false;
     }
+    if !cell_machines_are_powerable(producer, consumer) {
+        return false;
+    }
     // Modules: refuse outright. The module post-pass in `layout.rs` keys
     // loadouts by `(entity, recipe)` gathered from `row_spans`, and a
     // fused cell contributes only the CONSUMER's recipe — the producer's
@@ -2078,24 +2081,49 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     if producer.voider || consumer.voider {
         return false;
     }
+    if !cell_machines_are_powerable(producer, consumer) {
+        return false;
+    }
     if !producer.self_loop.is_empty() || !consumer.self_loop.is_empty() {
         return false;
     }
     if !producer.game_modules.is_empty() || !consumer.game_modules.is_empty() {
         return false;
     }
-    // The CONSUMER must be entirely solid: its faces are already spent on
-    // the DI coupling, its belt-fed input and its output, so a pipe has
-    // nowhere to land. (That is the `electric-engine-unit` shape —
-    // lubricant on the consumer — and it is out of scope here.)
-    let any_fluid = |s: &MachineSpec| s.inputs.iter().chain(&s.outputs).any(|f| f.is_fluid);
-    if any_fluid(consumer) {
+    // A fluid-OUT producer would need a pipe on the face its coupling
+    // uses; only fluid IN is served. Same for the consumer: its south face
+    // is spent on the output (and its feed, when it has one).
+    if producer.outputs.iter().any(|f| f.is_fluid) || consumer.outputs.iter().any(|f| f.is_fluid) {
         return false;
     }
-    // A fluid-OUT producer would need a pipe on the face its coupling
-    // uses; only fluid IN is served.
-    if producer.outputs.iter().any(|f| f.is_fluid) {
-        return false;
+    // A fluid-drawing CONSUMER is served ONLY by the run the producer is
+    // already piped — `solid-fuel-from-light-oil → rocket-fuel`, where
+    // both roles want light-oil. The cell declares one set of tap points
+    // on one row, so:
+    //   - exactly one fluid, and the same one the producer draws (two
+    //     different fluids on one run would cross-contaminate);
+    //   - equal machine HEIGHTS, because the row is bottom-aligned and the
+    //     pipe sits one tile above the PRODUCER's top — a shorter consumer
+    //     would sit below it with its ports out of reach;
+    //   - a real north input port on the consumer prototype, read from
+    //     `fluid_ports` rather than assumed.
+    // Anything else (a fluid the producer does not draw — the
+    // `electric-engine-unit` lubricant shape) stays out of scope.
+    let c_fluid_in: Vec<&str> =
+        consumer.inputs.iter().filter(|f| f.is_fluid).map(|f| f.item.as_str()).collect();
+    if !c_fluid_in.is_empty() {
+        let p_fluid_items: Vec<&str> =
+            producer.inputs.iter().filter(|f| f.is_fluid).map(|f| f.item.as_str()).collect();
+        if c_fluid_in.len() != 1 || p_fluid_items != c_fluid_in {
+            return false;
+        }
+        if machine_dims(&producer.entity).1 != machine_dims(&consumer.entity).1 {
+            return false;
+        }
+        let (mirror, dir) = crate::fluid_ports::north_input_orientation(&consumer.entity);
+        if crate::fluid_ports::north_input_dxs(&consumer.entity, mirror, dir).is_empty() {
+            return false;
+        }
     }
     let solids = |fs: &[ItemFlow]| -> Vec<String> {
         fs.iter().filter(|f| !f.is_fluid).map(|f| f.item.clone()).collect()
@@ -2113,8 +2141,12 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     if p_out.len() != 1 || p_out[0] != item || !producer_feed_ok || c_out.len() != 1 {
         return false;
     }
-    // Exactly two solid inputs: the coupled item plus one belt-fed other.
-    if c_in.len() != 2 || !c_in.iter().any(|i| i == item) {
+    // The coupled item, plus AT MOST one belt-fed other. Two is the
+    // ordinary shape (cable + iron into EC); one means the coupling
+    // supplies everything solid the consumer needs
+    // (`solid-fuel-from-light-oil → rocket-fuel`, whose other ingredient
+    // is the shared fluid), and its south face carries the output alone.
+    if !(1..=2).contains(&c_in.len()) || !c_in.iter().any(|i| i == item) {
         return false;
     }
     // The producer's belt-fed input and the consumer's must be DIFFERENT
@@ -2132,6 +2164,28 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     // assembler is fine. (The stacked cell still requires equal dims: its
     // straddle geometry is derived from a single machine width.)
     true
+}
+
+/// Both roles must run on grid power, because the cell has no way to fuel
+/// a burner.
+///
+/// Found by SIMULATING, not by reasoning: `solid-fuel-from-light-oil →
+/// rocket-fuel` builds a cell that validates 0 errors 0 warnings and then
+/// produces **literally nothing** — the solver picks `biochamber` for
+/// `rocket-fuel` (category `organic-or-assembling`), a burner whose fuel
+/// category is `nutrients`, and the sim reports `no_fuel: 8` with every
+/// upstream chemical plant backed up behind it.
+///
+/// The gap is engine-wide, not a cell property: nothing anywhere delivers
+/// burner fuel, and `validate::power` deliberately exempts biochambers
+/// from coverage without any check taking over the obligation. Refusing
+/// here is the narrow half of the fix — a cell that cannot run is worse
+/// than no cell, because it validates clean and lies. Delivering fuel (or
+/// steering machine selection away from burners) is the engine-wide half
+/// and is NOT attempted here.
+fn cell_machines_are_powerable(producer: &MachineSpec, consumer: &MachineSpec) -> bool {
+    crate::common::needs_electricity(&producer.entity)
+        && crate::common::needs_electricity(&consumer.entity)
 }
 
 /// Build a Phase 2 horizontal row cell, or `None` to fall back.
@@ -2180,11 +2234,14 @@ fn try_build_row_cell(
     // run instead of a belt (RFC-053 pipe cut).
     let p_in = producer.inputs.iter().find(|f| !f.is_fluid);
     let p_fluid = producer.inputs.iter().find(|f| f.is_fluid);
-    let c_in = consumer.inputs.iter().find(|f| !f.is_fluid && f.item != item)?;
+    // `None` when the coupled item is the consumer's ONLY solid
+    // ingredient — then it has no belt-fed input and no inner belt.
+    let c_in = consumer.inputs.iter().find(|f| !f.is_fluid && f.item != item);
+    let c_fluid = consumer.inputs.iter().find(|f| f.is_fluid);
     let out = consumer.outputs.iter().find(|f| !f.is_fluid)?;
 
     let p_total = p_in.map(|f| f.rate * p_util * p_count as f64).unwrap_or(0.0);
-    let c_total = c_in.rate * c_util * c_count as f64;
+    let c_total = c_in.map(|f| f.rate * c_util * c_count as f64).unwrap_or(0.0);
     let out_total = out.rate * c_util * c_count as f64;
 
     // Both input belts are bus tap-off targets, so they take the TRUNK
@@ -2199,7 +2256,9 @@ fn try_build_row_cell(
     let p_cap = p_in
         .map(|f| lane_capacity_stacked(in_belt, ctx.for_item(&f.item)) * 2.0)
         .unwrap_or(f64::INFINITY);
-    let c_cap = lane_capacity_stacked(in_belt, ctx.for_item(&c_in.item)) * 2.0;
+    let c_cap = c_in
+        .map(|f| lane_capacity_stacked(in_belt, ctx.for_item(&f.item)) * 2.0)
+        .unwrap_or(f64::INFINITY);
     if p_cap + 1e-9 < p_total || c_cap + 1e-9 < c_total {
         return None;
     }
@@ -2224,9 +2283,17 @@ fn try_build_row_cell(
         // No solid feed face to size — the pipe carries it.
         None => crate::bus::inserter_ladder::SidePlan { entity: "inserter", count: 0, shortfall: None },
     };
-    let c_feed = size_side(c_in.rate * c_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    let c_feed = match c_in {
+        Some(f) => size_side(f.rate * c_util, Reach::Near, budget, max_inserter_tier, quality, level),
+        // Nothing belt-fed to size; the coupling supplies every solid.
+        None => crate::bus::inserter_ladder::SidePlan { entity: "inserter", count: 0, shortfall: None },
+    };
+    // Reach-2 only when the output inserter must step OVER the consumer's
+    // input belt. Without that belt the output belt sits directly below the
+    // face and reach-1 applies, which lifts the long-handed 2.40/s ceiling.
+    let out_reach = if c_in.is_some() { Reach::Far } else { Reach::Near };
     let drop = size_belt_drop_side(
-        out.rate * c_util, Reach::Far, budget, max_inserter_tier, quality, out_stack, level, out_belt,
+        out.rate * c_util, out_reach, budget, max_inserter_tier, quality, out_stack, level, out_belt,
     );
     if p_feed.shortfall.is_some() || c_feed.shortfall.is_some() || drop.shortfall.is_some() {
         return None;
@@ -2252,7 +2319,8 @@ fn try_build_row_cell(
                 None => ("", in_belt, p_feed.entity),
             },
             producer_fluid: p_fluid.map(|f| (f.item.as_str(), "pipe")),
-            consumer_input: (&c_in.item, in_belt, c_feed.entity),
+            consumer_input: c_in.map(|f| (f.item.as_str(), in_belt, c_feed.entity)),
+            consumer_fluid: c_fluid.map(|f| (f.item.as_str(), "pipe")),
             output_item: &out.item,
             output_belt: out_belt,
             out_inserter: drop.entity,
@@ -2281,31 +2349,66 @@ fn try_build_row_cell(
         voider: false,
         game_modules: Vec::new(),
         count: c_count as f64,
-        // Order MUST match the row's belt/port lists. The consumer's belt
-        // input comes FIRST when the producer is fluid-fed, because
-        // `input_belt_y` then holds only that one belt; the fluid is
-        // carried separately through `fluid_port_ys`/`fluid_port_pipes`,
-        // which `lane_planner` taps on its own branch.
-        inputs: match p_in {
-            Some(f) => vec![
-                ItemFlow { item: f.item.clone(), rate: f.rate * scale, is_fluid: false, module_id: f.module_id },
-                ItemFlow { item: c_in.item.clone(), rate: c_in.rate, is_fluid: false, module_id: c_in.module_id },
-            ],
-            None => vec![
-                ItemFlow { item: c_in.item.clone(), rate: c_in.rate, is_fluid: false, module_id: c_in.module_id },
-                ItemFlow {
-                    item: p_fluid.map(|f| f.item.clone()).unwrap_or_default(),
-                    rate: p_fluid.map(|f| f.rate * scale).unwrap_or(0.0),
+        // Order MUST match the row's belt/port lists: SOLIDS first, in the
+        // same order `input_belt_ys` records them (producer's belt, then
+        // the consumer's — either may be absent), because `lane_planner`
+        // and `ghost_router` both resolve tap-off by indexing solid inputs
+        // positionally. The fluid trails them; it is tapped on a separate
+        // branch through `fluid_port_ys`/`fluid_port_pipes`, so its
+        // position among the solids is immaterial but its RATE is not.
+        inputs: {
+            let mut v = Vec::new();
+            if let Some(f) = p_in {
+                v.push(ItemFlow {
+                    item: f.item.clone(),
+                    rate: f.rate * scale,
+                    is_fluid: false,
+                    module_id: f.module_id,
+                });
+            }
+            if let Some(f) = c_in {
+                v.push(ItemFlow {
+                    item: f.item.clone(),
+                    rate: f.rate,
+                    is_fluid: false,
+                    module_id: f.module_id,
+                });
+            }
+            // One entry per distinct fluid. When both roles draw the same
+            // one — the only case eligibility admits — their demands SUM.
+            // Nothing observably depends on this today (pipes have no tier,
+            // so the planned rate does not change the stamped geometry, and
+            // the sim manifest reads its feed rates from the SolverResult,
+            // not from here) — checked by forcing the consumer term to
+            // zero, which produced an identical layout. Kept anyway: the
+            // spec's job is to state what the row actually draws, and an
+            // understated demand is a lie waiting for its first reader.
+            if p_fluid.is_some() || c_fluid.is_some() {
+                let item = p_fluid.or(c_fluid).map(|f| f.item.clone()).unwrap_or_default();
+                let rate = p_fluid.map(|f| f.rate * scale).unwrap_or(0.0)
+                    + c_fluid.map(|f| f.rate).unwrap_or(0.0);
+                v.push(ItemFlow {
+                    item,
+                    rate,
                     is_fluid: true,
-                    module_id: p_fluid.map(|f| f.module_id).unwrap_or(0),
-                },
-            ],
+                    module_id: p_fluid.or(c_fluid).map(|f| f.module_id).unwrap_or(0),
+                });
+            }
+            v
         },
         outputs: consumer.outputs.clone(),
     };
     let width = cell.x_max + 1;
     let span = RowSpan {
-        y_start: cell.input_belt_ys[0],
+        // Falls back to the pipe row only when the cell taps no solid at
+        // all (piped producer, coupling-fed consumer) and so has no input
+        // belt to start from.
+        y_start: cell
+            .input_belt_ys
+            .first()
+            .copied()
+            .or_else(|| cell.fluid_port_ys.first().copied())
+            .unwrap_or(cell.machine_y),
         y_end: cell.output_belt_y + 1,
         spec: fused,
         machine_count: c_count,

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -1789,6 +1789,18 @@ fn cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str) -> 
     if producer.voider || consumer.voider {
         return false;
     }
+    // Modules: refuse outright. The module post-pass in `layout.rs` keys
+    // loadouts by `(entity, recipe)` gathered from `row_spans`, and a
+    // fused cell contributes only the CONSUMER's recipe — the producer's
+    // recipe never appears, so producer machines (which do carry it) would
+    // get nothing stamped while the solver has already folded the module
+    // speed/productivity bonus into their machine count. That is a silent
+    // production shortfall, not a cosmetic gap, and matching loadouts
+    // wouldn't fix it because the key itself is missing. Honest refusal
+    // until module stamping can be keyed per-segment (Phase 2+).
+    if !producer.game_modules.is_empty() || !consumer.game_modules.is_empty() {
+        return false;
+    }
     if !producer.self_loop.is_empty() || !consumer.self_loop.is_empty() {
         return false;
     }
@@ -1910,22 +1922,43 @@ fn try_build_cell(
     let in_stack = ctx.for_item(&in_flow.item);
     let out_stack = ctx.for_item(&out_flow.item);
     let in_belt = belt_entity_for_rate_stacked(in_total, max_belt_tier, in_stack);
-    let out_belt = belt_entity_for_rate_stacked(out_total, max_belt_tier, out_stack);
+    // The cell's output belt is physically SINGLE-LANE: every output
+    // inserter sits at the same y facing the same way, so all drops land
+    // in the far lane (I5). Size it the way the ordinary single-lane path
+    // does — against `rate * 2.0`, i.e. "a belt whose LANE capacity covers
+    // the rate" — then verify. Sizing against `out_total` raw picks a belt
+    // with half the capacity actually available.
+    let out_belt = belt_entity_for_rate_stacked(out_total * 2.0, max_belt_tier, out_stack);
+    if lane_capacity_stacked(out_belt, out_stack) + 1e-9 < out_total {
+        // Too much output for one lane. The ordinary path would split the
+        // recipe across rows; a cell cannot (its machines are placed at
+        // `StraddlePlan` positions, and splitting needs the Phase 3
+        // multi-band shape). Refuse instead of shipping a belt that
+        // silently caps the cell.
+        return None;
+    }
 
-    // Feed and output faces get the machine's own spare columns, so a
-    // single-inserter face isn't an implicit throughput cap.
-    let budget = (mw.max(1) as usize) - 1;
-    let feed = size_side(in_flow.rate * p_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    // Phase 1 stamps exactly ONE inserter per feed/output position —
+    // `DiCellIo` carries an entity name, not a count, so a `SidePlan`
+    // asking for more cannot be honoured. Size against a single slot and
+    // refuse when one inserter (or the ladder's best effort) can't cover
+    // the face, rather than discarding `count`/`shortfall` and quietly
+    // under-feeding. Multi-inserter faces need the stamper to take counts;
+    // that is Phase 2 work alongside face allocation.
+    let feed = size_side(in_flow.rate * p_util, Reach::Near, 0, max_inserter_tier, quality, level);
     let drop = size_belt_drop_side(
         out_flow.rate * c_util,
         Reach::Near,
-        budget,
+        0,
         max_inserter_tier,
         quality,
         out_stack,
         level,
         out_belt,
     );
+    if feed.count > 1 || drop.count > 1 || feed.shortfall.is_some() || drop.shortfall.is_some() {
+        return None;
+    }
 
     let cell = stamp_di_cell_io(
         &plan,
@@ -3471,6 +3504,78 @@ mod tests {
         assert!(
             !cell_eligible(&producer, &iron_gear_spec(), "iron-plate"),
             "fluid-touching pairs are Phase 2"
+        );
+    }
+
+    /// #450 review: a producer's module loadout would be silently dropped
+    /// (the module post-pass keys on `(entity, recipe)` from `row_spans`,
+    /// and a cell contributes only the consumer's recipe) while the solver
+    /// has already folded the bonus into machine counts. Refuse instead.
+    #[test]
+    fn di_cell_refuses_when_modules_are_present() {
+        let (mut producer, consumer) = cell_pair();
+        producer.game_modules = vec![crate::models::ModuleItem {
+            item: "productivity-module".to_string(),
+            count: 2,
+            quality: None,
+        }];
+        assert!(
+            !cell_eligible(&producer, &consumer, "iron-plate"),
+            "a module loadout the cell cannot stamp must refuse fusion"
+        );
+    }
+
+    /// #450 review: `SidePlan.count`/`.shortfall` were computed and
+    /// discarded, but `DiCellIo` carries an entity name and no count — so
+    /// a face needing 2+ inserters was stamped with one and silently
+    /// under-fed. Regular tier can't move 2.0/s in one hand, so this pair
+    /// must refuse rather than fuse.
+    #[test]
+    fn di_cell_refuses_when_a_face_needs_more_than_one_inserter() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (_, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::Regular, QualityTier::Normal,
+            0, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(
+            spans.len(), 2,
+            "Regular tier at L0 cannot cover the feed face with one inserter — must refuse, \
+             not stamp one inserter and under-feed"
+        );
+    }
+
+    /// #450 review: the cell's output belt is physically single-lane (all
+    /// output inserters share a y and a facing, so every drop lands in the
+    /// far lane), so it must be sized against `rate * 2.0` like every other
+    /// single-lane row. Sizing against the raw rate picked a belt with half
+    /// the usable capacity.
+    #[test]
+    fn di_cell_output_belt_is_sized_for_a_single_lane() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "guard: needs a fused cell to mean anything");
+        let out_y = spans[0].output_belt_y;
+        let belt = ents.iter()
+            .find(|e| e.y == out_y && e.name.contains("transport-belt"))
+            .expect("output belt");
+        let out_total: f64 = spans[0].spec.outputs.iter()
+            .filter(|f| !f.is_fluid)
+            .map(|f| f.rate * spans[0].machine_count as f64)
+            .sum();
+        let lane = crate::common::lane_capacity_stacked(&belt.name, 1);
+        assert!(
+            lane + 1e-9 >= out_total,
+            "single-lane capacity {lane}/s must cover the cell's {out_total}/s on {}",
+            belt.name
         );
     }
 

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -2348,7 +2348,18 @@ pub fn place_rows(
     // producer spread over several rows would leave every row but one
     // stranded. That is the same refusal the bridge makes for split
     // producers, and it is Phase 3 work (the multi-band cell).
-    // producer spec idx -> (consumer spec idx, coupled item, is_row_cell).
+    // CONSUMER spec idx -> (producer spec idx, coupled item, is_row_cell).
+    //
+    // Keyed by the CONSUMER, deliberately. A fused cell consumes the
+    // union of both halves' belt-fed inputs, so it must be placed where
+    // ALL of them are already available — i.e. at the consumer's slot in
+    // the topological order, not the producer's. Emitting at the
+    // producer's slot put the cell NORTH of its own iron-plate supply at
+    // EC@10/s (iron-plate's row landed at y=22 against the cell at
+    // y=10..17), breaking the lanes-run-south invariant: the router could
+    // only answer with a 1-entity "return path", iron never arrived, the
+    // EC machines were ingredient-short, and the whole chain backed up
+    // (`full_output: 46`).
     // The variant is carried DELIBERATELY: `try_build_cell` does not
     // re-check `cell_eligible`, so dispatching on anything other than the
     // approved variant silently bypasses the gate that stops a two-solid-
@@ -2386,23 +2397,57 @@ pub fn place_rows(
                 if claimed.contains(&p_idx) || claimed.contains(&c_idx) {
                     continue;
                 }
+                // Buildability, not merely eligibility — and the FULL
+                // builder, not just the straddle. `fused_specs` is
+                // pre-populated from this map, so a pair claimed here has
+                // its producer skipped unconditionally; if the cell then
+                // failed to build at emit time the producer would be
+                // dropped from the layout entirely and its production
+                // would silently vanish. Every refusal in the builders
+                // (rates, belt capacity, inserter counts, straddle) is
+                // independent of `y_cursor`, so a trial build at y=0
+                // answers exactly the question that matters.
+                let trial = |row: bool| {
+                    if row {
+                        try_build_row_cell(
+                            ordered[p_idx], c_spec, item, bus_width, 0, max_belt_tier,
+                            max_inserter_tier, quality, inserter_capacity, ctx,
+                        )
+                    } else {
+                        try_build_cell(
+                            ordered[p_idx], c_spec, item, bus_width, 0, max_belt_tier,
+                            max_inserter_tier, quality, inserter_capacity, ctx,
+                        )
+                    }
+                    .is_some()
+                };
                 let stacked_ok = couplings.len() == 1
                     && cell_eligible(ordered[p_idx], c_spec, item)
-                    && pair_is_arrangeable(ordered[p_idx], c_spec, item, false);
+                    && pair_is_arrangeable(ordered[p_idx], c_spec, item, false)
+                    && trial(false);
                 let row_ok = row_cell_eligible(ordered[p_idx], c_spec, item)
-                    && pair_is_arrangeable(ordered[p_idx], c_spec, item, true);
+                    && pair_is_arrangeable(ordered[p_idx], c_spec, item, true)
+                    && trial(true);
                 if !(stacked_ok || row_ok) {
                     continue;
                 }
                 claimed.insert(p_idx);
                 claimed.insert(c_idx);
-                cell_pairs.insert(p_idx, (c_idx, item, !stacked_ok));
+                cell_pairs.insert(c_idx, (p_idx, item, !stacked_ok));
                 break;
             }
         }
     }
-    // Consumer specs already absorbed into a cell; skipped by the loop.
-    let mut fused_specs: FxHashSet<usize> = FxHashSet::default();
+    // PRODUCER specs absorbed into a cell; skipped by the loop.
+    //
+    // Pre-populated from `cell_pairs` BEFORE the loop runs, not as each
+    // cell is emitted. The cell is emitted at the CONSUMER's slot, and a
+    // producer always sorts earlier — so marking it lazily would be too
+    // late and the producer would already have been placed as an ordinary
+    // row. That is exactly what happened: `copper-cable`'s own output
+    // belt was stamped over the cell's iron-plate belt at y=16, leaving a
+    // West-facing belt dead-ending into a tile the cell had claimed.
+    let mut fused_specs: FxHashSet<usize> = cell_pairs.values().map(|&(p, _, _)| p).collect();
 
     for (spec_idx, spec) in ordered.iter().enumerate() {
         // Before the inter-recipe gap, so an absorbed consumer leaves no
@@ -2428,28 +2473,29 @@ pub fn place_rows(
         // RFC-053 Phase 1: fuse an eligible pair into one cell row. On any
         // refusal fall through to the normal path, where the #432 bridge
         // (and failing that, the bus) still serves the coupling.
-        if let Some(&(c_idx, item, is_row)) = cell_pairs.get(&spec_idx) {
+        if let Some(&(p_idx, item, is_row)) = cell_pairs.get(&spec_idx) {
+            let (producer, consumer) = (ordered[p_idx], spec);
             let built = if is_row {
                 try_build_row_cell(
-                    spec, ordered[c_idx], item, bus_width, y_cursor, max_belt_tier,
+                    producer, consumer, item, bus_width, y_cursor, max_belt_tier,
                     max_inserter_tier, quality, inserter_capacity, ctx,
                 )
             } else {
                 try_build_cell(
-                    spec, ordered[c_idx], item, bus_width, y_cursor, max_belt_tier,
+                    producer, consumer, item, bus_width, y_cursor, max_belt_tier,
                     max_inserter_tier, quality, inserter_capacity, ctx,
                 )
             };
             if let Some((cell_ents, span, width)) = built {
-                fused_specs.insert(c_idx);
+                fused_specs.insert(p_idx);
                 max_width = max_width.max(width);
                 let row_idx = row_spans.len();
                 // Register under BOTH recipes: the cell is the producer's
                 // only placement, so a later consumer looking up the
                 // producer's rows must find this one rather than nothing.
-                recipe_row_idxs.entry(spec.recipe.as_str()).or_default().push(row_idx);
+                recipe_row_idxs.entry(consumer.recipe.as_str()).or_default().push(row_idx);
                 recipe_row_idxs
-                    .entry(ordered[c_idx].recipe.as_str())
+                    .entry(producer.recipe.as_str())
                     .or_default()
                     .push(row_idx);
                 let y_end = span.y_end;
@@ -3745,17 +3791,22 @@ mod tests {
             producer_count: 3.0,
             consumer_count: 2.0,
         }];
-        let (_, spans, _, _) = place_rows(
+        let (ents, _spans, _, _) = place_rows(
             &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
             crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
             true, &couplings, &StackingCtx::unstacked(),
         );
-        // Row-splitting can push this past two rows; what matters is that
-        // the producer still owns a row of its own, i.e. nothing fused.
+        // Since Phase 2 this pair legitimately fuses as a ROW cell (the
+        // consumer is coupled east/west, leaving both faces free for its
+        // second input). The invariant that survives, and the one
+        // `cell_eligible` exists for, is that it must never become a
+        // STACKED cell — that shape cannot feed iron-plate at all.
         assert!(
-            spans.iter().any(|s| s.spec.recipe == "copper-cable"),
-            "producer must keep its own row (no fusion); got {:?}",
-            spans.iter().map(|s| s.spec.recipe.as_str()).collect::<Vec<_>>()
+            !ents.iter().any(|e| e
+                .segment_id
+                .as_deref()
+                .is_some_and(|s| s.starts_with("di-cell:"))),
+            "a two-solid-input consumer must never be fused into a STACKED cell"
         );
     }
 

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -1921,7 +1921,25 @@ fn try_build_cell(
     let out_total = out_flow.rate * c_util * c_count as f64;
     let in_stack = ctx.for_item(&in_flow.item);
     let out_stack = ctx.for_item(&out_flow.item);
-    let in_belt = belt_entity_for_rate_stacked(in_total, max_belt_tier, in_stack);
+    // A cell's input belt is a bus tap-off target exactly like any other
+    // row's — `fused_cell_spec` puts the producer's input in the fused
+    // row's `inputs` and `input_belt_y` is registered normally, so
+    // `lane_planner` taps it the same way. It must therefore take the
+    // TRUNK's tier via `row_input_belt`, not a tier sized to this cell's
+    // local demand: the trunk is sized for total demand across every
+    // consumer, and a locally-sized belt reintroduces the seam mismatch
+    // `row_input_belt`'s doc comment exists to prevent (fast belt feeding
+    // yellow, lane-throughput warnings, items backing up at the join).
+    let in_belt = row_input_belt(max_belt_tier);
+    // Inserters pick from BOTH lanes (I6), so the input side has the
+    // belt's full capacity available — unlike the single-lane output.
+    // `belt_entity_for_rate_stacked` saturates rather than failing, so
+    // without this the cell would silently ship an undersized belt at
+    // high rates instead of refusing; `plan_straddle` is scale-invariant
+    // in machine count and would never catch it.
+    if lane_capacity_stacked(in_belt, in_stack) * 2.0 + 1e-9 < in_total {
+        return None;
+    }
     // The cell's output belt is physically SINGLE-LANE: every output
     // inserter sits at the same y facing the same way, so all drops land
     // in the far lane (I5). Size it the way the ordinary single-lane path
@@ -3576,6 +3594,34 @@ mod tests {
             lane + 1e-9 >= out_total,
             "single-lane capacity {lane}/s must cover the cell's {out_total}/s on {}",
             belt.name
+        );
+    }
+
+    /// #450 review: the cell's input belt is a bus tap-off target like any
+    /// other row's, so it must take the TRUNK tier (`row_input_belt`), not
+    /// a tier sized to the cell's local demand — otherwise a fast trunk
+    /// joins a yellow row belt and items back up at the seam.
+    #[test]
+    fn di_cell_input_belt_matches_the_trunk_tier() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        // Cap at express: local demand is ~2/s (yellow would "fit"), so a
+        // locally-sized belt would pick yellow and mismatch the trunk.
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, Some("express-transport-belt"),
+            InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "guard: needs a fused cell to mean anything");
+        let in_y = spans[0].input_belt_y[0];
+        let belt = ents.iter()
+            .find(|e| e.y == in_y && e.name.contains("transport-belt"))
+            .expect("input belt");
+        assert_eq!(
+            belt.name, "express-transport-belt",
+            "input belt must match the trunk tier, not the cell's local rate"
         );
     }
 

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -2182,9 +2182,15 @@ fn try_build_row_cell(
     // argument as every other row. Inserters pick from both lanes (I6),
     // so full belt capacity is available on the input side.
     let in_belt = row_input_belt(max_belt_tier);
-    let in_stack = p_in.map(|f| ctx.for_item(&f.item)).unwrap_or(1);
-    let cap = lane_capacity_stacked(in_belt, in_stack) * 2.0;
-    if cap + 1e-9 < p_total || cap + 1e-9 < c_total {
+    // Capacity is checked PER ITEM. `StackingCtx::for_item` is item-keyed
+    // and `row_cell_eligible` guarantees the two inputs are different
+    // items, so gating the consumer's belt on the producer item's
+    // stacking factor would silently mis-size whenever they differ.
+    let p_cap = p_in
+        .map(|f| lane_capacity_stacked(in_belt, ctx.for_item(&f.item)) * 2.0)
+        .unwrap_or(f64::INFINITY);
+    let c_cap = lane_capacity_stacked(in_belt, ctx.for_item(&c_in.item)) * 2.0;
+    if p_cap + 1e-9 < p_total || c_cap + 1e-9 < c_total {
         return None;
     }
     // The output belt is single-lane (every output inserter shares a y and

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -1776,13 +1776,15 @@ fn pair_is_arrangeable(producer: &MachineSpec, consumer: &MachineSpec, item: &st
         (s as usize).max(1)
     };
     let (pc, cc) = (snap(producer.count), snap(consumer.count));
-    let (mw, _) = machine_dims(&consumer.entity);
+    let (cw, _) = machine_dims(&consumer.entity);
+    let (pw, _) = machine_dims(&producer.entity);
+    let mw = cw;
     let Some(pr) = producer.outputs.iter().find(|f| f.item == item) else { return false };
     let Some(cr) = consumer.inputs.iter().find(|f| f.item == item) else { return false };
     let pr = pr.rate * utilization_for(producer);
     let cr = cr.rate * utilization_for(consumer);
     if row {
-        crate::bus::di_cell::plan_row_straddle(pc, cc, pr, cr, mw as i32).is_some()
+        crate::bus::di_cell::plan_row_straddle(pc, cc, pr, cr, pw as i32, cw as i32).is_some()
     } else {
         crate::bus::di_cell::plan_straddle(pc, cc, pr, cr, mw as i32).is_some()
     }
@@ -2125,7 +2127,11 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     if p_in.first().is_some_and(|p| *p == c_other) {
         return false;
     }
-    machine_dims(&producer.entity) == machine_dims(&consumer.entity)
+    // Footprints may DIFFER — the row cell bottom-aligns the two roles and
+    // paces x by each machine's own width, so a 5x5 foundry beside a 3x3
+    // assembler is fine. (The stacked cell still requires equal dims: its
+    // straddle geometry is derived from a single machine width.)
+    true
 }
 
 /// Build a Phase 2 horizontal row cell, or `None` to fall back.
@@ -2150,14 +2156,18 @@ fn try_build_row_cell(
         (s as usize).max(1)
     };
     let (p_count, c_count) = (snap(producer.count), snap(consumer.count));
-    let (mw, mh) = machine_dims(&consumer.entity);
-    let (mw, mh) = (mw as i32, mh as i32);
+    // Per-role footprints: a cell may mix them (foundry 5x5 against an
+    // assembler's 3x3), so nothing here may assume one machine size.
+    let (pmw, pmh) = machine_dims(&producer.entity);
+    let (cmw, cmh) = machine_dims(&consumer.entity);
+    let (pmw, pmh, cmw, cmh) = (pmw as i32, pmh as i32, cmw as i32, cmh as i32);
+    let mw = cmw;
     let p_util = utilization_for(producer);
     let c_util = utilization_for(consumer);
 
     let producer_rate = producer.outputs.iter().find(|f| f.item == item)?.rate * p_util;
     let consumer_rate = consumer.inputs.iter().find(|f| f.item == item)?.rate * c_util;
-    let plan = plan_row_straddle(p_count, c_count, producer_rate, consumer_rate, mw)?;
+    let plan = plan_row_straddle(p_count, c_count, producer_rate, consumer_rate, pmw, cmw)?;
 
     // Coupler sits in a 1-tile gap, so reach-1 is a constraint (I8a).
     let coupler = size_side(plan.required_rate(), Reach::Near, 0, max_inserter_tier, quality, level);
@@ -2252,8 +2262,10 @@ fn try_build_row_cell(
         },
         bus_width,
         y_cursor,
-        mw,
-        mh,
+        pmw,
+        pmh,
+        cmw,
+        cmh,
     )?;
 
     // Fused spec: producer's belt-fed input FIRST, then the consumer's —

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -1759,6 +1759,35 @@ fn stamp_di_bridge(
 
 // ---- RFC-053 Phase 1: direct-insertion cells ----
 
+
+/// Can this pair's ratio actually be arranged, as opposed to merely being
+/// eligible? Eligibility is about recipe SHAPE; this is about whether the
+/// straddle geometry exists at these machine counts.
+///
+/// Separating the two matters: a consumer with several couplings claims a
+/// producer at selection time, and claiming on shape alone lets an
+/// unbuildable coupling block a buildable one. Concretely, at EC@10/s the
+/// `iron-plate -> electronic-circuit` coupling is shape-eligible but is a
+/// 16:4 straddle (4 producers per consumer, refused), and claiming it
+/// starved the `copper-cable -> electronic-circuit` coupling that does work.
+fn pair_is_arrangeable(producer: &MachineSpec, consumer: &MachineSpec, item: &str, row: bool) -> bool {
+    let snap = |c: f64| -> usize {
+        let s = if (c - c.round()).abs() < 1e-9 { c.round() } else { c.ceil() };
+        (s as usize).max(1)
+    };
+    let (pc, cc) = (snap(producer.count), snap(consumer.count));
+    let (mw, _) = machine_dims(&consumer.entity);
+    let Some(pr) = producer.outputs.iter().find(|f| f.item == item) else { return false };
+    let Some(cr) = consumer.inputs.iter().find(|f| f.item == item) else { return false };
+    let pr = pr.rate * utilization_for(producer);
+    let cr = cr.rate * utilization_for(consumer);
+    if row {
+        crate::bus::di_cell::plan_row_straddle(pc, cc, pr, cr, mw as i32).is_some()
+    } else {
+        crate::bus::di_cell::plan_straddle(pc, cc, pr, cr, mw as i32).is_some()
+    }
+}
+
 /// Is this producer/consumer pair a **Phase 1** DI cell?
 ///
 /// A cell fuses both rows into ONE structure with the coupled item never
@@ -2033,6 +2062,209 @@ fn try_build_cell(
     Some((cell.entities, span, width))
 }
 
+
+/// Is this pair a **Phase 2 horizontal row cell**?
+///
+/// Looser than [`cell_eligible`] in exactly one way, which is the whole
+/// point: the consumer may have a SECOND solid input. In a row cell the
+/// consumer is coupled east/west, leaving its north and south faces free
+/// for an ordinary input belt and output belt — so the second input has
+/// somewhere to land, which is what the stacked cell could not offer.
+/// This is the corpus's dominant shape (`di-patterns faces`: 177 of 2,039
+/// cable->EC consumers).
+fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str) -> bool {
+    if producer.voider || consumer.voider {
+        return false;
+    }
+    if !producer.self_loop.is_empty() || !consumer.self_loop.is_empty() {
+        return false;
+    }
+    if !producer.game_modules.is_empty() || !consumer.game_modules.is_empty() {
+        return false;
+    }
+    let any_fluid = |s: &MachineSpec| s.inputs.iter().chain(&s.outputs).any(|f| f.is_fluid);
+    if any_fluid(producer) || any_fluid(consumer) {
+        return false;
+    }
+    let solids = |fs: &[ItemFlow]| -> Vec<String> {
+        fs.iter().filter(|f| !f.is_fluid).map(|f| f.item.clone()).collect()
+    };
+    let (p_in, p_out) = (solids(&producer.inputs), solids(&producer.outputs));
+    let (c_in, c_out) = (solids(&consumer.inputs), solids(&consumer.outputs));
+    if p_out.len() != 1 || p_out[0] != item || p_in.len() != 1 || c_out.len() != 1 {
+        return false;
+    }
+    // Exactly two solid inputs: the coupled item plus one belt-fed other.
+    if c_in.len() != 2 || !c_in.iter().any(|i| i == item) {
+        return false;
+    }
+    // The producer's belt-fed input and the consumer's must be DIFFERENT
+    // items. Same item on both would put two entries for one item in the
+    // fused spec at two different y, and both `lane_planner` and
+    // `ghost_router` break on the FIRST matching solid input — so the
+    // second belt would never be tapped and its machines would starve
+    // silently. Refuse; see the RFC decision log.
+    let c_other = c_in.iter().find(|i| *i != item).cloned().unwrap_or_default();
+    if c_other == p_in[0] {
+        return false;
+    }
+    machine_dims(&producer.entity) == machine_dims(&consumer.entity)
+}
+
+/// Build a Phase 2 horizontal row cell, or `None` to fall back.
+#[allow(clippy::too_many_arguments)]
+fn try_build_row_cell(
+    producer: &MachineSpec,
+    consumer: &MachineSpec,
+    item: &str,
+    bus_width: i32,
+    y_cursor: i32,
+    max_belt_tier: Option<&str>,
+    max_inserter_tier: InserterTier,
+    quality: QualityTier,
+    level: u8,
+    ctx: &StackingCtx,
+) -> Option<(Vec<PlacedEntity>, RowSpan, i32)> {
+    use crate::bus::di_cell::{plan_row_straddle, stamp_row_cell, RowCellSpec};
+    use crate::bus::inserter_ladder::{size_belt_drop_side, size_side, Reach};
+
+    let snap = |c: f64| -> usize {
+        let s = if (c - c.round()).abs() < 1e-9 { c.round() } else { c.ceil() };
+        (s as usize).max(1)
+    };
+    let (p_count, c_count) = (snap(producer.count), snap(consumer.count));
+    let (mw, mh) = machine_dims(&consumer.entity);
+    let (mw, mh) = (mw as i32, mh as i32);
+    let p_util = utilization_for(producer);
+    let c_util = utilization_for(consumer);
+
+    let producer_rate = producer.outputs.iter().find(|f| f.item == item)?.rate * p_util;
+    let consumer_rate = consumer.inputs.iter().find(|f| f.item == item)?.rate * c_util;
+    let plan = plan_row_straddle(p_count, c_count, producer_rate, consumer_rate, mw)?;
+
+    // Coupler sits in a 1-tile gap, so reach-1 is a constraint (I8a).
+    let coupler = size_side(plan.required_rate(), Reach::Near, 0, max_inserter_tier, quality, level);
+    let coupler_rate = crate::common::machine_feed_rate(coupler.entity, quality, level);
+    if coupler.count > 1 || coupler.shortfall.is_some() {
+        return None;
+    }
+
+    let p_in = producer.inputs.iter().find(|f| !f.is_fluid)?;
+    let c_in = consumer.inputs.iter().find(|f| !f.is_fluid && f.item != item)?;
+    let out = consumer.outputs.iter().find(|f| !f.is_fluid)?;
+
+    let p_total = p_in.rate * p_util * p_count as f64;
+    let c_total = c_in.rate * c_util * c_count as f64;
+    let out_total = out.rate * c_util * c_count as f64;
+
+    // Both input belts are bus tap-off targets, so they take the TRUNK
+    // tier (`row_input_belt`), never a locally-sized one — same seam
+    // argument as every other row. Inserters pick from both lanes (I6),
+    // so full belt capacity is available on the input side.
+    let in_belt = row_input_belt(max_belt_tier);
+    let in_stack = ctx.for_item(&p_in.item);
+    let cap = lane_capacity_stacked(in_belt, in_stack) * 2.0;
+    if cap + 1e-9 < p_total || cap + 1e-9 < c_total {
+        return None;
+    }
+    // The output belt is single-lane (every output inserter shares a y and
+    // a facing, so all drops land in the far lane), hence the * 2.0.
+    let out_stack = ctx.for_item(&out.item);
+    let out_belt = belt_entity_for_rate_stacked(out_total * 2.0, max_belt_tier, out_stack);
+    if lane_capacity_stacked(out_belt, out_stack) + 1e-9 < out_total {
+        return None;
+    }
+
+    // Face plan. The producer's belt is NORTH at reach-1 — putting it on
+    // a reach-2 hop would reintroduce long-handed's 2.40/s ceiling, which
+    // is the very thing the row shape avoids. The consumer's two flows
+    // share the SOUTH row: feed at reach-1 off the inner belt, output at
+    // reach-2 stepping over it (long-handed is the only reach-2 inserter,
+    // I8a). Output therefore routinely needs TWO columns at L2, so give
+    // these faces real column budgets instead of forcing one each.
+    let budget = (mw.max(1) as usize).saturating_sub(1);
+    let p_feed = size_side(p_in.rate * p_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    let c_feed = size_side(c_in.rate * c_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    let drop = size_belt_drop_side(
+        out.rate * c_util, Reach::Far, budget, max_inserter_tier, quality, out_stack, level, out_belt,
+    );
+    if p_feed.shortfall.is_some() || c_feed.shortfall.is_some() || drop.shortfall.is_some() {
+        return None;
+    }
+    // The consumer's south row holds BOTH its feed and its output, so the
+    // two together must fit the machine's width.
+    if c_feed.count + drop.count > mw.max(1) as usize || p_feed.count > mw.max(1) as usize {
+        return None;
+    }
+
+    let cell = stamp_row_cell(
+        &plan,
+        &RowCellSpec {
+            producer_entity: &producer.entity,
+            consumer_entity: &consumer.entity,
+            producer_recipe: &producer.recipe,
+            consumer_recipe: &consumer.recipe,
+            item,
+            coupler: coupler.entity,
+            coupler_rate,
+            producer_input: (&p_in.item, in_belt, p_feed.entity),
+            consumer_input: (&c_in.item, in_belt, c_feed.entity),
+            output_item: &out.item,
+            output_belt: out_belt,
+            out_inserter: drop.entity,
+            producer_feed_count: p_feed.count,
+            consumer_feed_count: c_feed.count,
+            out_count: drop.count,
+        },
+        bus_width,
+        y_cursor,
+        mw,
+        mh,
+    )?;
+
+    // Fused spec: producer's belt-fed input FIRST, then the consumer's —
+    // the order MUST match `input_belt_ys`, because both `lane_planner`
+    // and `ghost_router` resolve tap-off by indexing solid inputs
+    // positionally. Getting it wrong makes both wrong identically, so
+    // they agree with each other and yield a self-consistent bad layout.
+    let scale = p_count as f64 / c_count.max(1) as f64;
+    let fused = MachineSpec {
+        entity: consumer.entity.clone(),
+        recipe: consumer.recipe.clone(),
+        self_loop: Vec::new(),
+        voider: false,
+        game_modules: Vec::new(),
+        count: c_count as f64,
+        inputs: vec![
+            ItemFlow { item: p_in.item.clone(), rate: p_in.rate * scale, is_fluid: false, module_id: p_in.module_id },
+            ItemFlow { item: c_in.item.clone(), rate: c_in.rate, is_fluid: false, module_id: c_in.module_id },
+        ],
+        outputs: consumer.outputs.clone(),
+    };
+    let width = cell.x_max + 1;
+    let span = RowSpan {
+        y_start: cell.input_belt_ys[0],
+        y_end: cell.output_belt_y + 1,
+        spec: fused,
+        machine_count: c_count,
+        module_id: consumer.outputs.first().map(|o| o.module_id).unwrap_or(0),
+        input_belt_y: cell.input_belt_ys.clone(),
+        output_belt_y: cell.output_belt_y,
+        row_width: width,
+        fluid_port_ys: Vec::new(),
+        fluid_port_pipes: Vec::new(),
+        fluid_output_port_pipes: Vec::new(),
+        output_east: true,
+        output_belt_x_min: cell.x_min,
+        output_belt_x_max: cell.x_max,
+        horizontal_stack: None,
+        secondary_output_belt: None,
+        sorted_output_belts: Vec::new(),
+        di_input: Vec::new(),
+    };
+    Some((cell.entities, span, width))
+}
+
 /// Place assembly rows stacked vertically.
 ///
 /// When a recipe needs more machines than a single belt can handle,
@@ -2116,28 +2348,57 @@ pub fn place_rows(
     // producer spread over several rows would leave every row but one
     // stranded. That is the same refusal the bridge makes for split
     // producers, and it is Phase 3 work (the multi-band cell).
-    let mut cell_pairs: FxHashMap<usize, (usize, &str)> = FxHashMap::default();
+    // producer spec idx -> (consumer spec idx, coupled item, is_row_cell).
+    // The variant is carried DELIBERATELY: `try_build_cell` does not
+    // re-check `cell_eligible`, so dispatching on anything other than the
+    // approved variant silently bypasses the gate that stops a two-solid-
+    // input consumer being fused into a stacked cell (which cannot feed
+    // its second input at all).
+    let mut cell_pairs: FxHashMap<usize, (usize, &str, bool)> = FxHashMap::default();
+    let mut claimed: FxHashSet<usize> = FxHashSet::default();
     if direct_insertion {
         for (c_idx, c_spec) in ordered.iter().enumerate() {
             let Some(couplings) = di_lookup.get(c_spec.recipe.as_str()) else {
                 continue;
             };
-            // A consumer coupled on two items cannot be a Phase-1 cell:
-            // its second input has no free face.
-            let [(item, producer_recipe)] = couplings[..] else {
-                continue;
-            };
-            let same_recipe = |r: &str| ordered.iter().filter(|s| s.recipe == r).count();
-            if same_recipe(producer_recipe) != 1 || same_recipe(&c_spec.recipe) != 1 {
-                continue;
+            // Try every coupling this consumer has, not just a lone one.
+            // A consumer coupled on two items cannot be a Phase-1 STACKED
+            // cell (its second input has no free face) — but that is
+            // exactly the case a Phase-2 ROW cell exists to serve, since
+            // coupling east/west leaves both the north and south faces
+            // free for ordinary belts. Requiring a single coupling here
+            // silently excluded `electronic-circuit`, i.e. the corpus's
+            // most common DI consumer, from ever being considered.
+            for &(item, producer_recipe) in couplings {
+                let same_recipe = |r: &str| ordered.iter().filter(|s| s.recipe == r).count();
+                if same_recipe(producer_recipe) != 1 || same_recipe(&c_spec.recipe) != 1 {
+                    continue;
+                }
+                let Some(p_idx) = ordered.iter().position(|s| s.recipe == producer_recipe) else {
+                    continue;
+                };
+                if p_idx >= c_idx {
+                    continue;
+                }
+                // A spec may only be fused once. Without this, a producer
+                // that is itself a DI consumer could be claimed by two
+                // different cells and placed twice.
+                if claimed.contains(&p_idx) || claimed.contains(&c_idx) {
+                    continue;
+                }
+                let stacked_ok = couplings.len() == 1
+                    && cell_eligible(ordered[p_idx], c_spec, item)
+                    && pair_is_arrangeable(ordered[p_idx], c_spec, item, false);
+                let row_ok = row_cell_eligible(ordered[p_idx], c_spec, item)
+                    && pair_is_arrangeable(ordered[p_idx], c_spec, item, true);
+                if !(stacked_ok || row_ok) {
+                    continue;
+                }
+                claimed.insert(p_idx);
+                claimed.insert(c_idx);
+                cell_pairs.insert(p_idx, (c_idx, item, !stacked_ok));
+                break;
             }
-            let Some(p_idx) = ordered.iter().position(|s| s.recipe == producer_recipe) else {
-                continue;
-            };
-            if p_idx >= c_idx || !cell_eligible(ordered[p_idx], c_spec, item) {
-                continue;
-            }
-            cell_pairs.insert(p_idx, (c_idx, item));
         }
     }
     // Consumer specs already absorbed into a cell; skipped by the loop.
@@ -2167,19 +2428,19 @@ pub fn place_rows(
         // RFC-053 Phase 1: fuse an eligible pair into one cell row. On any
         // refusal fall through to the normal path, where the #432 bridge
         // (and failing that, the bus) still serves the coupling.
-        if let Some(&(c_idx, item)) = cell_pairs.get(&spec_idx) {
-            if let Some((cell_ents, span, width)) = try_build_cell(
-                spec,
-                ordered[c_idx],
-                item,
-                bus_width,
-                y_cursor,
-                max_belt_tier,
-                max_inserter_tier,
-                quality,
-                inserter_capacity,
-                ctx,
-            ) {
+        if let Some(&(c_idx, item, is_row)) = cell_pairs.get(&spec_idx) {
+            let built = if is_row {
+                try_build_row_cell(
+                    spec, ordered[c_idx], item, bus_width, y_cursor, max_belt_tier,
+                    max_inserter_tier, quality, inserter_capacity, ctx,
+                )
+            } else {
+                try_build_cell(
+                    spec, ordered[c_idx], item, bus_width, y_cursor, max_belt_tier,
+                    max_inserter_tier, quality, inserter_capacity, ctx,
+                )
+            };
+            if let Some((cell_ents, span, width)) = built {
                 fused_specs.insert(c_idx);
                 max_width = max_width.max(width);
                 let row_idx = row_spans.len();

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -11,7 +11,7 @@ use crate::common::{
     belt_entity_for_rate, belt_entity_for_rate_stacked, lane_capacity, lane_capacity_stacked,
     machine_dims, utilization_for, QualityTier, BELT_TIERS,
 };
-use crate::models::{EntityDirection, MachineSpec, PlacedEntity, SolverResult};
+use crate::models::{EntityDirection, ItemFlow, MachineSpec, PlacedEntity, SolverResult};
 
 /// Best available per-lane capacity across all belt tiers.
 fn max_lane_capacity() -> f64 {
@@ -1757,6 +1757,231 @@ fn stamp_di_bridge(
     entities
 }
 
+// ---- RFC-053 Phase 1: direct-insertion cells ----
+
+/// Is this producer/consumer pair a **Phase 1** DI cell?
+///
+/// A cell fuses both rows into ONE structure with the coupled item never
+/// touching a belt. Phase 1 deliberately serves only the simplest shape;
+/// anything else falls back to #432's bridge, and then to the bus.
+///
+/// Every gate here is load-bearing:
+///
+/// - **The consumer's only solid input is the coupled item.** A cell
+///   spends the consumer's north face on the DI band and its south face
+///   on the output inserter, so a second solid input has nowhere to land
+///   until Phase 2's face allocation. This is **not** redundant with the
+///   solver: `netflow::detect_di_couplings` gates on one-producer /
+///   one-consumer / no-external-supply / no-surplus / not-fluid and never
+///   inspects the consumer's input count, so it emits `copper-cable →
+///   electronic-circuit` (iron-plate + copper-cable) like any other pair.
+///   Building that cell would strand the iron feed entirely — a layout
+///   that validates clean and starves, the #383/#432 failure mode.
+/// - **The producer has exactly one solid output** (the coupled item) and
+///   **exactly one solid input**, which becomes the cell's belt-fed
+///   input. A second producer output would need a belt the fused row
+///   doesn't have.
+/// - **No fluids on either side** — pipe placement is Phase 2 (the KC6
+///   re-scope).
+/// - **Equal machine footprints.** `plan_straddle` reasons about a single
+///   `machine_w`, and the stamper stacks both rows on one x-grid.
+fn cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str) -> bool {
+    if producer.voider || consumer.voider {
+        return false;
+    }
+    if !producer.self_loop.is_empty() || !consumer.self_loop.is_empty() {
+        return false;
+    }
+    let any_fluid = |s: &MachineSpec| s.inputs.iter().chain(&s.outputs).any(|f| f.is_fluid);
+    if any_fluid(producer) || any_fluid(consumer) {
+        return false;
+    }
+    let solids = |fs: &[ItemFlow]| -> Vec<String> {
+        fs.iter().filter(|f| !f.is_fluid).map(|f| f.item.clone()).collect()
+    };
+    let (p_in, p_out) = (solids(&producer.inputs), solids(&producer.outputs));
+    let (c_in, c_out) = (solids(&consumer.inputs), solids(&consumer.outputs));
+
+    p_out.len() == 1
+        && p_out[0] == item
+        && p_in.len() == 1
+        // THE Phase-1 gate — see the doc comment.
+        && c_in.len() == 1
+        && c_in[0] == item
+        && c_out.len() == 1
+        && machine_dims(&producer.entity) == machine_dims(&consumer.entity)
+}
+
+/// The `MachineSpec` a fused cell presents to the rest of the pipeline.
+///
+/// A cell is one structure that draws the PRODUCER's input off a belt and
+/// puts the CONSUMER's output onto a belt; the coupled item exists only
+/// inside it. So the fused spec carries the producer's inputs and the
+/// consumer's outputs — exactly what `lane_planner`, the output merger and
+/// the validators already know how to read, with no cell special-casing
+/// anywhere downstream.
+///
+/// This is also what dissolves the Phase-1c contract question from #447:
+/// because the producer never gets a row of its own, no `RowSpan` is ever
+/// built whose `output_belt_y` points at a belt that wasn't emitted. The
+/// single fused row owns a real output belt, so all 11 bare
+/// `output_belt_y` read sites — including the three output-merger ones
+/// that select rows by `spec.outputs` and never consult a `BusLane` — are
+/// correct by construction.
+///
+/// Rates are per-CONSUMER-machine, because the fused row's
+/// `machine_count` is the consumer count: the output belt must carry
+/// `consumer_count × consumer_rate`, and the input belt
+/// `producer_count × producer_input_rate`. Scaling the latter by
+/// `producer_count / consumer_count` keeps `rate × machine_count` right
+/// for both.
+fn fused_cell_spec(
+    producer: &MachineSpec,
+    consumer: &MachineSpec,
+    producer_count: usize,
+    consumer_count: usize,
+) -> MachineSpec {
+    let scale = producer_count as f64 / consumer_count.max(1) as f64;
+    MachineSpec {
+        entity: consumer.entity.clone(),
+        recipe: consumer.recipe.clone(),
+        self_loop: Vec::new(),
+        voider: false,
+        game_modules: consumer.game_modules.clone(),
+        count: consumer_count as f64,
+        inputs: producer
+            .inputs
+            .iter()
+            .map(|f| ItemFlow { rate: f.rate * scale, ..f.clone() })
+            .collect(),
+        outputs: consumer.outputs.clone(),
+    }
+}
+
+/// Try to emit a fused DI cell for an eligible pair.
+///
+/// `None` on any refusal — no straddle exists, the ladder can't cover the
+/// binding edge, the stamper rejects the geometry — and the caller then
+/// places both specs as ordinary rows, where the #432 bridge (and failing
+/// that, the bus) serves the coupling. Refusing is always safe; emitting
+/// an under-fed cell is not.
+#[allow(clippy::too_many_arguments)]
+fn try_build_cell(
+    producer: &MachineSpec,
+    consumer: &MachineSpec,
+    item: &str,
+    bus_width: i32,
+    y_cursor: i32,
+    max_belt_tier: Option<&str>,
+    max_inserter_tier: InserterTier,
+    quality: QualityTier,
+    level: u8,
+    ctx: &StackingCtx,
+) -> Option<(Vec<PlacedEntity>, RowSpan, i32)> {
+    use crate::bus::di_cell::{plan_straddle, stamp_di_cell_io, DiCellIo, DiCellSpec};
+    use crate::bus::inserter_ladder::{size_belt_drop_side, size_side, Reach};
+
+    let snap = |c: f64| -> usize {
+        let s = if (c - c.round()).abs() < 1e-9 { c.round() } else { c.ceil() };
+        (s as usize).max(1)
+    };
+    let (p_count, c_count) = (snap(producer.count), snap(consumer.count));
+    let (mw, mh) = machine_dims(&consumer.entity);
+    let (mw, mh) = (mw as i32, mh as i32);
+
+    let p_util = utilization_for(producer);
+    let c_util = utilization_for(consumer);
+    let producer_rate = producer.outputs.iter().find(|f| f.item == item)?.rate * p_util;
+    let consumer_rate = consumer.inputs.iter().find(|f| f.item == item)?.rate * c_util;
+
+    let plan = plan_straddle(p_count, c_count, producer_rate, consumer_rate, mw)?;
+
+    // Couple with the cheapest inserter covering the busiest edge's
+    // per-slot share. `Reach::Near` is a constraint, not a preference: the
+    // cell puts the two rows ONE tile apart, and long-handed reaches to
+    // exactly 2 (I8a), so it would pick straight past both machines.
+    let ins = size_side(plan.required_rate(), Reach::Near, 0, max_inserter_tier, quality, level);
+    let ins_rate = crate::common::machine_feed_rate(ins.entity, quality, level);
+
+    let in_flow = producer.inputs.iter().find(|f| !f.is_fluid)?;
+    let out_flow = consumer.outputs.iter().find(|f| !f.is_fluid)?;
+    let in_total = in_flow.rate * p_util * p_count as f64;
+    let out_total = out_flow.rate * c_util * c_count as f64;
+    let in_stack = ctx.for_item(&in_flow.item);
+    let out_stack = ctx.for_item(&out_flow.item);
+    let in_belt = belt_entity_for_rate_stacked(in_total, max_belt_tier, in_stack);
+    let out_belt = belt_entity_for_rate_stacked(out_total, max_belt_tier, out_stack);
+
+    // Feed and output faces get the machine's own spare columns, so a
+    // single-inserter face isn't an implicit throughput cap.
+    let budget = (mw.max(1) as usize) - 1;
+    let feed = size_side(in_flow.rate * p_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    let drop = size_belt_drop_side(
+        out_flow.rate * c_util,
+        Reach::Near,
+        budget,
+        max_inserter_tier,
+        quality,
+        out_stack,
+        level,
+        out_belt,
+    );
+
+    let cell = stamp_di_cell_io(
+        &plan,
+        &DiCellSpec {
+            producer_entity: &producer.entity,
+            consumer_entity: &consumer.entity,
+            producer_recipe: &producer.recipe,
+            consumer_recipe: &consumer.recipe,
+            item,
+            inserter: ins.entity,
+            inserter_rate: ins_rate,
+        },
+        &DiCellIo {
+            input_item: &in_flow.item,
+            input_belt: in_belt,
+            feed_inserter: feed.entity,
+            output_item: &out_flow.item,
+            output_belt: out_belt,
+            out_inserter: drop.entity,
+        },
+        bus_width,
+        y_cursor,
+        mw,
+        mh,
+    )?;
+
+    let width = cell.x_max + 1;
+    let span = RowSpan {
+        y_start: cell.input_belt_y,
+        y_end: cell.output_belt_y + 1,
+        spec: fused_cell_spec(producer, consumer, p_count, c_count),
+        machine_count: c_count,
+        module_id: consumer.outputs.first().map(|o| o.module_id).unwrap_or(0),
+        input_belt_y: vec![cell.input_belt_y],
+        output_belt_y: cell.output_belt_y,
+        row_width: width,
+        fluid_port_ys: Vec::new(),
+        fluid_port_pipes: Vec::new(),
+        fluid_output_port_pipes: Vec::new(),
+        output_east: true,
+        output_belt_x_min: cell.x_min,
+        output_belt_x_max: cell.x_max,
+        horizontal_stack: None,
+        secondary_output_belt: None,
+        sorted_output_belts: Vec::new(),
+        // Deliberately empty, and NOT an oversight. `di_input` exists to
+        // tell the lane planner "this row consumes the item off a bridge,
+        // don't build it a bus lane". A cell needs no such marker: the
+        // fused spec's inputs are the PRODUCER's, so the coupled item
+        // appears in no row's inputs, and no row produces it either — the
+        // lane simply never comes into existence.
+        di_input: Vec::new(),
+    };
+    Some((cell.entities, span, width))
+}
+
 /// Place assembly rows stacked vertically.
 ///
 /// When a recipe needs more machines than a single belt can handle,
@@ -1829,7 +2054,50 @@ pub fn place_rows(
     // under-fed. See the multi-row refusal at the marking site below.
     let mut recipe_row_idxs: FxHashMap<&str, Vec<usize>> = FxHashMap::default();
 
+    // RFC-053 Phase 1: producer spec index → consumer spec index for pairs
+    // that can fuse into a DI cell. Precomputed so the producer half is
+    // recognisable when the loop reaches it — `order_specs` is a
+    // topological sort, so the producer is always the earlier of the two,
+    // though not necessarily adjacent.
+    //
+    // Both halves must be un-split (one `MachineSpec` each, one row each):
+    // a cell couples specific machines at specific x positions, so a
+    // producer spread over several rows would leave every row but one
+    // stranded. That is the same refusal the bridge makes for split
+    // producers, and it is Phase 3 work (the multi-band cell).
+    let mut cell_pairs: FxHashMap<usize, (usize, &str)> = FxHashMap::default();
+    if direct_insertion {
+        for (c_idx, c_spec) in ordered.iter().enumerate() {
+            let Some(couplings) = di_lookup.get(c_spec.recipe.as_str()) else {
+                continue;
+            };
+            // A consumer coupled on two items cannot be a Phase-1 cell:
+            // its second input has no free face.
+            let [(item, producer_recipe)] = couplings[..] else {
+                continue;
+            };
+            let same_recipe = |r: &str| ordered.iter().filter(|s| s.recipe == r).count();
+            if same_recipe(producer_recipe) != 1 || same_recipe(&c_spec.recipe) != 1 {
+                continue;
+            }
+            let Some(p_idx) = ordered.iter().position(|s| s.recipe == producer_recipe) else {
+                continue;
+            };
+            if p_idx >= c_idx || !cell_eligible(ordered[p_idx], c_spec, item) {
+                continue;
+            }
+            cell_pairs.insert(p_idx, (c_idx, item));
+        }
+    }
+    // Consumer specs already absorbed into a cell; skipped by the loop.
+    let mut fused_specs: FxHashSet<usize> = FxHashSet::default();
+
     for (spec_idx, spec) in ordered.iter().enumerate() {
+        // Before the inter-recipe gap, so an absorbed consumer leaves no
+        // phantom 2-tile hole where its row would have been.
+        if fused_specs.contains(&spec_idx) {
+            continue;
+        }
         // The inter-recipe gap is always present — for DI pairs, the gap
         // houses the bridge inserter that spans from the producer's output
         // belt to the consumer's input belt. Without the gap, the belts
@@ -1845,6 +2113,48 @@ pub fn place_rows(
         // a machine in most rows, and trips template assertions in others
         // (#277 utility-science-pack: 1.0000000000000002 advanced-oil-
         // processing → machine_count=2 → staggered-3-output panic).
+        // RFC-053 Phase 1: fuse an eligible pair into one cell row. On any
+        // refusal fall through to the normal path, where the #432 bridge
+        // (and failing that, the bus) still serves the coupling.
+        if let Some(&(c_idx, item)) = cell_pairs.get(&spec_idx) {
+            if let Some((cell_ents, span, width)) = try_build_cell(
+                spec,
+                ordered[c_idx],
+                item,
+                bus_width,
+                y_cursor,
+                max_belt_tier,
+                max_inserter_tier,
+                quality,
+                inserter_capacity,
+                ctx,
+            ) {
+                fused_specs.insert(c_idx);
+                max_width = max_width.max(width);
+                let row_idx = row_spans.len();
+                // Register under BOTH recipes: the cell is the producer's
+                // only placement, so a later consumer looking up the
+                // producer's rows must find this one rather than nothing.
+                recipe_row_idxs.entry(spec.recipe.as_str()).or_default().push(row_idx);
+                recipe_row_idxs
+                    .entry(ordered[c_idx].recipe.as_str())
+                    .or_default()
+                    .push(row_idx);
+                let y_end = span.y_end;
+                entities.extend(cell_ents);
+                row_spans.push(span);
+                y_cursor = y_end + extra_gaps.get(&row_idx).copied().unwrap_or(0);
+                continue;
+            }
+            crate::trace::emit(crate::trace::TraceEvent::GhostSpecFailed {
+                spec_key: format!("di-cell:{item}:refused"),
+                from_x: 0,
+                from_y: y_cursor,
+                to_x: 0,
+                to_y: y_cursor,
+            });
+        }
+
         let total_count = {
             let c = spec.count;
             let snapped = if (c - c.round()).abs() < 1e-9 { c.round() } else { c.ceil() };
@@ -2340,7 +2650,8 @@ mod tests {
 
     #[test]
     fn place_rows_two_recipes_ordered() {
-        let machines = vec![iron_gear_spec(), iron_plate_spec()];
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
         let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
         let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), false, &[], &StackingCtx::unstacked());
         assert_eq!(spans.len(), 2);
@@ -3000,4 +3311,167 @@ mod tests {
         counts.sort();
         assert_eq!(counts, vec![5, 7], "both EC siblings must appear with their original counts");
     }
+    // ---- RFC-053 Phase 1: DI cells ----
+
+    /// Flow-BALANCED cell pair: 2 plate machines at 1.0/s feed 1 gear
+    /// machine at 2.0/s. The balance matters — `plan_straddle` refuses a
+    /// pair whose supply and demand disagree, so the shared
+    /// `iron_plate_spec`/`iron_gear_spec` helpers (1.0/s against 2.0/s)
+    /// cannot form a cell and would make these tests pass vacuously.
+    fn cell_pair() -> (MachineSpec, MachineSpec) {
+        let mut producer = iron_plate_spec();
+        producer.count = 2.0;
+        let consumer = iron_gear_spec();
+        (producer, consumer)
+    }
+
+    fn gear_cell_couplings() -> Vec<crate::models::DICoupling> {
+        vec![crate::models::DICoupling {
+            producer_recipe: "iron-plate".to_string(),
+            consumer_recipe: "iron-gear-wheel".to_string(),
+            item: "iron-plate".to_string(),
+            producer_count: 2.0,
+            consumer_count: 1.0,
+        }]
+    }
+
+    /// The defining property: an eligible pair collapses to ONE row, and
+    /// the coupled item never appears on a belt.
+    #[test]
+    fn di_cell_fuses_eligible_pair() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "producer + consumer must fuse into one cell row, got {:?}",
+            spans.iter().map(|s| s.spec.recipe.as_str()).collect::<Vec<_>>());
+
+        // The fused spec is a composite machine: producer's input in,
+        // consumer's output out.
+        let sp = &spans[0];
+        assert_eq!(sp.spec.recipe, "iron-gear-wheel");
+        assert_eq!(sp.spec.inputs.iter().map(|f| f.item.as_str()).collect::<Vec<_>>(), vec!["iron-ore"]);
+        assert_eq!(sp.spec.outputs.iter().map(|f| f.item.as_str()).collect::<Vec<_>>(), vec!["iron-gear-wheel"]);
+
+        // No belt anywhere carries the coupled item — the whole point.
+        let belts: Vec<&PlacedEntity> = ents.iter()
+            .filter(|e| e.name.contains("transport-belt") || e.name.contains("underground-belt"))
+            .collect();
+        assert!(
+            !belts.iter().any(|e| e.carries.as_deref() == Some("iron-plate")),
+            "coupled item must never reach a belt; found {:?}",
+            belts.iter().filter(|e| e.carries.as_deref() == Some("iron-plate"))
+                 .map(|e| (e.x, e.y)).collect::<Vec<_>>()
+        );
+        // ...and it IS moved, by reach-1 inserters between the machines.
+        assert!(
+            ents.iter().any(|e| e.name.contains("inserter")
+                && e.carries.as_deref() == Some("iron-plate")),
+            "the cell must actually couple the item"
+        );
+    }
+
+    /// A cell's fused row owns a REAL output belt — this is what makes the
+    /// #447 contract question moot rather than merely unlikely to bite.
+    #[test]
+    fn di_cell_row_has_a_real_output_belt() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (ents, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 1, "guard: this asserts nothing unless a cell was actually fused");
+        let y = spans[0].output_belt_y;
+        assert!(
+            ents.iter().any(|e| e.y == y && e.name.contains("transport-belt")),
+            "output_belt_y={y} must point at an emitted belt, not a phantom"
+        );
+    }
+
+    /// The Phase-1 gate. `detect_di_couplings` emits cable->EC without
+    /// looking at the consumer's input count, so the placer must refuse it:
+    /// EC's second solid input (iron-plate) has no free face in a cell, and
+    /// fusing anyway yields a layout that validates clean and starves.
+    #[test]
+    fn di_cell_refuses_multi_input_consumer() {
+        let cable = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "copper-cable".to_string(),
+            self_loop: vec![], voider: false, game_modules: Vec::new(),
+            count: 3.0,
+            inputs: vec![ItemFlow { item: "copper-plate".to_string(), rate: 2.5, is_fluid: false, module_id: 0 }],
+            outputs: vec![ItemFlow { item: "copper-cable".to_string(), rate: 5.0, is_fluid: false, module_id: 0 }],
+        };
+        let ec = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "electronic-circuit".to_string(),
+            self_loop: vec![], voider: false, game_modules: Vec::new(),
+            count: 2.0,
+            inputs: vec![
+                ItemFlow { item: "iron-plate".to_string(), rate: 2.5, is_fluid: false, module_id: 0 },
+                ItemFlow { item: "copper-cable".to_string(), rate: 7.5, is_fluid: false, module_id: 0 },
+            ],
+            outputs: vec![ItemFlow { item: "electronic-circuit".to_string(), rate: 2.5, is_fluid: false, module_id: 0 }],
+        };
+        assert!(
+            !cell_eligible(&cable, &ec, "copper-cable"),
+            "EC has two solid inputs — not a Phase 1 cell"
+        );
+        let machines = vec![ec, cable];
+        let dep_order = vec!["copper-cable".to_string(), "electronic-circuit".to_string()];
+        let couplings = vec![crate::models::DICoupling {
+            producer_recipe: "copper-cable".to_string(),
+            consumer_recipe: "electronic-circuit".to_string(),
+            item: "copper-cable".to_string(),
+            producer_count: 3.0,
+            consumer_count: 2.0,
+        }];
+        let (_, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            true, &couplings, &StackingCtx::unstacked(),
+        );
+        // Row-splitting can push this past two rows; what matters is that
+        // the producer still owns a row of its own, i.e. nothing fused.
+        assert!(
+            spans.iter().any(|s| s.spec.recipe == "copper-cable"),
+            "producer must keep its own row (no fusion); got {:?}",
+            spans.iter().map(|s| s.spec.recipe.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    /// DI off is the default and must stay bit-identical: no fusion.
+    #[test]
+    fn di_cell_inert_when_direct_insertion_off() {
+        let (producer, consumer) = cell_pair();
+        let machines = vec![consumer, producer];
+        let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
+        let (_, spans, _, _) = place_rows(
+            &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
+            false, &gear_cell_couplings(), &StackingCtx::unstacked(),
+        );
+        assert_eq!(spans.len(), 2, "DI off must not fuse");
+    }
+
+    /// Fluids on either side are Phase 2 (the KC6 re-scope), not Phase 1.
+    #[test]
+    fn di_cell_refuses_fluid_touching_pair() {
+        let mut producer = iron_plate_spec();
+        producer.inputs.push(ItemFlow {
+            item: "water".to_string(), rate: 10.0, is_fluid: true, module_id: 0,
+        });
+        assert!(
+            !cell_eligible(&producer, &iron_gear_spec(), "iron-plate"),
+            "fluid-touching pairs are Phase 2"
+        );
+    }
+
 }

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -2082,8 +2082,17 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     if !producer.game_modules.is_empty() || !consumer.game_modules.is_empty() {
         return false;
     }
+    // The CONSUMER must be entirely solid: its faces are already spent on
+    // the DI coupling, its belt-fed input and its output, so a pipe has
+    // nowhere to land. (That is the `electric-engine-unit` shape —
+    // lubricant on the consumer — and it is out of scope here.)
     let any_fluid = |s: &MachineSpec| s.inputs.iter().chain(&s.outputs).any(|f| f.is_fluid);
-    if any_fluid(producer) || any_fluid(consumer) {
+    if any_fluid(consumer) {
+        return false;
+    }
+    // A fluid-OUT producer would need a pipe on the face its coupling
+    // uses; only fluid IN is served.
+    if producer.outputs.iter().any(|f| f.is_fluid) {
         return false;
     }
     let solids = |fs: &[ItemFlow]| -> Vec<String> {
@@ -2091,7 +2100,15 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     };
     let (p_in, p_out) = (solids(&producer.inputs), solids(&producer.outputs));
     let (c_in, c_out) = (solids(&consumer.inputs), solids(&consumer.outputs));
-    if p_out.len() != 1 || p_out[0] != item || p_in.len() != 1 || c_out.len() != 1 {
+    let p_fluid_in = producer.inputs.iter().filter(|f| f.is_fluid).count();
+    // Either a single solid input (belt-fed, the original shape) or a
+    // single fluid input and NO solid input (`casting-copper-cable`,
+    // `casting-iron`, `solid-fuel-from-light-oil`). The all-fluid case is
+    // what frees the producer's north face for the pipe run; a producer
+    // with BOTH would need the belt and the pipe on the same face.
+    let producer_feed_ok =
+        (p_in.len() == 1 && p_fluid_in == 0) || (p_in.is_empty() && p_fluid_in == 1);
+    if p_out.len() != 1 || p_out[0] != item || !producer_feed_ok || c_out.len() != 1 {
         return false;
     }
     // Exactly two solid inputs: the coupled item plus one belt-fed other.
@@ -2105,7 +2122,7 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     // second belt would never be tapped and its machines would starve
     // silently. Refuse; see the RFC decision log.
     let c_other = c_in.iter().find(|i| *i != item).cloned().unwrap_or_default();
-    if c_other == p_in[0] {
+    if p_in.first().is_some_and(|p| *p == c_other) {
         return false;
     }
     machine_dims(&producer.entity) == machine_dims(&consumer.entity)
@@ -2149,11 +2166,14 @@ fn try_build_row_cell(
         return None;
     }
 
-    let p_in = producer.inputs.iter().find(|f| !f.is_fluid)?;
+    // `None` for an all-fluid producer, whose north face carries a pipe
+    // run instead of a belt (RFC-053 pipe cut).
+    let p_in = producer.inputs.iter().find(|f| !f.is_fluid);
+    let p_fluid = producer.inputs.iter().find(|f| f.is_fluid);
     let c_in = consumer.inputs.iter().find(|f| !f.is_fluid && f.item != item)?;
     let out = consumer.outputs.iter().find(|f| !f.is_fluid)?;
 
-    let p_total = p_in.rate * p_util * p_count as f64;
+    let p_total = p_in.map(|f| f.rate * p_util * p_count as f64).unwrap_or(0.0);
     let c_total = c_in.rate * c_util * c_count as f64;
     let out_total = out.rate * c_util * c_count as f64;
 
@@ -2162,7 +2182,7 @@ fn try_build_row_cell(
     // argument as every other row. Inserters pick from both lanes (I6),
     // so full belt capacity is available on the input side.
     let in_belt = row_input_belt(max_belt_tier);
-    let in_stack = ctx.for_item(&p_in.item);
+    let in_stack = p_in.map(|f| ctx.for_item(&f.item)).unwrap_or(1);
     let cap = lane_capacity_stacked(in_belt, in_stack) * 2.0;
     if cap + 1e-9 < p_total || cap + 1e-9 < c_total {
         return None;
@@ -2183,7 +2203,11 @@ fn try_build_row_cell(
     // I8a). Output therefore routinely needs TWO columns at L2, so give
     // these faces real column budgets instead of forcing one each.
     let budget = (mw.max(1) as usize).saturating_sub(1);
-    let p_feed = size_side(p_in.rate * p_util, Reach::Near, budget, max_inserter_tier, quality, level);
+    let p_feed = match p_in {
+        Some(f) => size_side(f.rate * p_util, Reach::Near, budget, max_inserter_tier, quality, level),
+        // No solid feed face to size — the pipe carries it.
+        None => crate::bus::inserter_ladder::SidePlan { entity: "inserter", count: 0, shortfall: None },
+    };
     let c_feed = size_side(c_in.rate * c_util, Reach::Near, budget, max_inserter_tier, quality, level);
     let drop = size_belt_drop_side(
         out.rate * c_util, Reach::Far, budget, max_inserter_tier, quality, out_stack, level, out_belt,
@@ -2207,7 +2231,11 @@ fn try_build_row_cell(
             item,
             coupler: coupler.entity,
             coupler_rate,
-            producer_input: (&p_in.item, in_belt, p_feed.entity),
+            producer_input: match p_in {
+                Some(f) => (f.item.as_str(), in_belt, p_feed.entity),
+                None => ("", in_belt, p_feed.entity),
+            },
+            producer_fluid: p_fluid.map(|f| (f.item.as_str(), "pipe")),
             consumer_input: (&c_in.item, in_belt, c_feed.entity),
             output_item: &out.item,
             output_belt: out_belt,
@@ -2235,10 +2263,26 @@ fn try_build_row_cell(
         voider: false,
         game_modules: Vec::new(),
         count: c_count as f64,
-        inputs: vec![
-            ItemFlow { item: p_in.item.clone(), rate: p_in.rate * scale, is_fluid: false, module_id: p_in.module_id },
-            ItemFlow { item: c_in.item.clone(), rate: c_in.rate, is_fluid: false, module_id: c_in.module_id },
-        ],
+        // Order MUST match the row's belt/port lists. The consumer's belt
+        // input comes FIRST when the producer is fluid-fed, because
+        // `input_belt_y` then holds only that one belt; the fluid is
+        // carried separately through `fluid_port_ys`/`fluid_port_pipes`,
+        // which `lane_planner` taps on its own branch.
+        inputs: match p_in {
+            Some(f) => vec![
+                ItemFlow { item: f.item.clone(), rate: f.rate * scale, is_fluid: false, module_id: f.module_id },
+                ItemFlow { item: c_in.item.clone(), rate: c_in.rate, is_fluid: false, module_id: c_in.module_id },
+            ],
+            None => vec![
+                ItemFlow { item: c_in.item.clone(), rate: c_in.rate, is_fluid: false, module_id: c_in.module_id },
+                ItemFlow {
+                    item: p_fluid.map(|f| f.item.clone()).unwrap_or_default(),
+                    rate: p_fluid.map(|f| f.rate * scale).unwrap_or(0.0),
+                    is_fluid: true,
+                    module_id: p_fluid.map(|f| f.module_id).unwrap_or(0),
+                },
+            ],
+        },
         outputs: consumer.outputs.clone(),
     };
     let width = cell.x_max + 1;
@@ -2251,8 +2295,8 @@ fn try_build_row_cell(
         input_belt_y: cell.input_belt_ys.clone(),
         output_belt_y: cell.output_belt_y,
         row_width: width,
-        fluid_port_ys: Vec::new(),
-        fluid_port_pipes: Vec::new(),
+        fluid_port_ys: cell.fluid_port_ys.clone(),
+        fluid_port_pipes: cell.fluid_port_pipes.clone(),
         fluid_output_port_pipes: Vec::new(),
         output_east: true,
         output_belt_x_min: cell.x_min,

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -879,6 +879,27 @@ pub fn fluid_only_recipes(solver: Option<&SolverResult>) -> FxHashSet<String> {
     out
 }
 
+/// Collect the set of recipes whose INPUTS are all fluids, but which still
+/// have a solid output — `casting-copper-cable` (molten copper in, cable
+/// out) is the canonical case.
+///
+/// Distinct from [`fluid_only_recipes`], which also requires the outputs to
+/// be fluids. A machine running one of these has nothing to receive over a
+/// belt, so any belt it does touch is there for its product alone. Inside a
+/// direct-insertion cell it ships that product through a coupling inserter
+/// and touches no belt at all (RFC-053 pipe cut).
+pub fn fluid_input_only_recipes(solver: Option<&SolverResult>) -> FxHashSet<String> {
+    let mut out = rustc_hash::FxHashSet::default();
+    if let Some(sr) = solver {
+        for spec in &sr.machines {
+            if !spec.inputs.is_empty() && spec.inputs.iter().all(|f| f.is_fluid) {
+                out.insert(spec.recipe.clone());
+            }
+        }
+    }
+    out
+}
+
 /// Pick the cheapest belt tier whose throughput is `>= rate`.
 ///
 /// If `max_tier` is `Some(name)`, never select a higher tier than that.

--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -310,12 +310,21 @@ pub fn check_belt_connectivity(
     let mut issues = Vec::new();
 
     let fluid_only = fluid_only_recipes(solver);
+    let fluid_fed = crate::common::fluid_input_only_recipes(solver);
     let belt_tiles = build_belt_tile_set(&layout.entities);
     let ug_pairs = build_ug_pairs(layout);
     let inserter_positions: FxHashSet<(i32, i32)> = layout
         .entities
         .iter()
         .filter(|e| is_inserter(&e.name))
+        .map(|e| (e.x, e.y))
+        .collect();
+    // Inserters that belong to a direct-insertion cell. An adjacent one is
+    // proof a machine's product has somewhere to go without a belt.
+    let coupler_positions: FxHashSet<(i32, i32)> = layout
+        .entities
+        .iter()
+        .filter(|e| is_inserter(&e.name) && super::is_di_cell_entity(e.segment_id.as_deref()))
         .map(|e| (e.x, e.y))
         .collect();
 
@@ -363,6 +372,20 @@ pub fn check_belt_connectivity(
                     adjacent_inserters.push(pos);
                 }
             }
+        }
+
+        // A fluid-fed producer inside a direct-insertion cell takes its
+        // ingredients through a pipe and hands its solid product straight
+        // to the neighbouring machine, so no inserter of its ever touches a
+        // belt (RFC-053 pipe cut). Deliberately narrow: it needs a coupler
+        // adjacent (proof the product has a route) AND no solid ingredient
+        // (nothing left that a belt would have had to deliver), so a cell
+        // machine that fails to get a real belt is still caught.
+        if crate::validate::is_di_cell_entity(e.segment_id.as_deref())
+            && e.recipe.as_deref().is_some_and(|r| fluid_fed.contains(r))
+            && adjacent_inserters.iter().any(|p| coupler_positions.contains(p))
+        {
+            continue;
         }
 
         // Check if any inserter has a belt on its non-machine side

--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -1267,7 +1267,19 @@ pub fn check_output_belt_coverage(
             }
         }
 
-        if !has_output_belt {
+        // RFC-053: a DI-cell producer's output leaves by inserter into the
+        // consumer machine, never onto a belt. See `is_di_cell_entity`.
+        let served_by_di_cell = layout.entities.iter().any(|ins| {
+            is_inserter(&ins.name)
+                && super::is_di_cell_entity(ins.segment_id.as_deref())
+                && {
+                    let (dx, dy) = dir_to_vec(ins.direction);
+                    let reach = inserter_reach(&ins.name);
+                    my_tiles.contains(&(ins.x - dx * reach, ins.y - dy * reach))
+                }
+        });
+
+        if !has_output_belt && !served_by_di_cell {
             issues.push(ValidationIssue::with_pos(
                 Severity::Error,
                 "output-belt",

--- a/crates/core/src/validate/belt_structural.rs
+++ b/crates/core/src/validate/belt_structural.rs
@@ -811,7 +811,20 @@ pub fn check_output_belt_coverage(
             my_tiles.contains(&pickup) && !machine_tiles.contains(&drop) && belt_tiles.contains(&drop)
         });
 
-        if !has_output_belt {
+        // RFC-053: a DI-cell producer has no output belt BY DESIGN — the
+        // band inserter carries its output straight into the consumer
+        // machine, so the belt-drop test above can never be satisfied.
+        let served_by_di_cell = layout.entities.iter().any(|ins| {
+            is_inserter(&ins.name)
+                && super::is_di_cell_entity(ins.segment_id.as_deref())
+                && {
+                    let dv = dir_to_vec(ins.direction);
+                    let reach = inserter_reach(&ins.name);
+                    my_tiles.contains(&(ins.x - dv.0 * reach, ins.y - dv.1 * reach))
+                }
+        });
+
+        if !has_output_belt && !served_by_di_cell {
             issues.push(ValidationIssue::with_pos(
                 Severity::Error,
                 "output-belt",

--- a/crates/core/src/validate/inserters.rs
+++ b/crates/core/src/validate/inserters.rs
@@ -348,6 +348,29 @@ pub fn check_inserter_throughput(
         if !checked.insert(mpos) {
             continue;
         }
+        // RFC-053: machines inside a fused DI cell are exempt from the
+        // per-machine inserter-throughput tests, for two independent
+        // reasons, both of which make the numbers here meaningless rather
+        // than merely conservative:
+        //
+        //  - A cell PRODUCER has no belt-bound output hand at all (the band
+        //    inserter drops into the consumer machine), so the check credits
+        //    it 0.00/s against its full output rate.
+        //  - A cell's `RowSpan` carries the FUSED spec — the producer's
+        //    inputs and the consumer's outputs — because that is what the
+        //    lane planner needs. `resolve_row_spec` therefore attributes the
+        //    producer's input item to the consumer machines, and the check
+        //    asks the consumers for an item they never take (iron-ore, for a
+        //    furnace cell whose consumers eat iron-plate).
+        //
+        // The cell's correctness is owned by `bus::di_cell`'s invariants —
+        // every band inserter picks from a producer tile and drops into a
+        // consumer tile at reach 1, and `try_build_cell` refuses rather than
+        // under-provisioning any face — and by RFC-053 KC3, which
+        // sim-measured the shape at 112% of plan against a bus control.
+        if super::is_di_cell_entity(e.segment_id.as_deref()) {
+            continue;
+        }
         let recipe = match e.recipe.as_deref() {
             Some(r) => r,
             None => continue,
@@ -530,6 +553,29 @@ pub fn check_inserter_item_throughput(
         }
         let mpos = (e.x, e.y);
         if !checked.insert(mpos) {
+            continue;
+        }
+        // RFC-053: machines inside a fused DI cell are exempt from the
+        // per-machine inserter-throughput tests, for two independent
+        // reasons, both of which make the numbers here meaningless rather
+        // than merely conservative:
+        //
+        //  - A cell PRODUCER has no belt-bound output hand at all (the band
+        //    inserter drops into the consumer machine), so the check credits
+        //    it 0.00/s against its full output rate.
+        //  - A cell's `RowSpan` carries the FUSED spec — the producer's
+        //    inputs and the consumer's outputs — because that is what the
+        //    lane planner needs. `resolve_row_spec` therefore attributes the
+        //    producer's input item to the consumer machines, and the check
+        //    asks the consumers for an item they never take (iron-ore, for a
+        //    furnace cell whose consumers eat iron-plate).
+        //
+        // The cell's correctness is owned by `bus::di_cell`'s invariants —
+        // every band inserter picks from a producer tile and drops into a
+        // consumer tile at reach 1, and `try_build_cell` refuses rather than
+        // under-provisioning any face — and by RFC-053 KC3, which
+        // sim-measured the shape at 112% of plan against a bus control.
+        if super::is_di_cell_entity(e.segment_id.as_deref()) {
             continue;
         }
         let recipe = match e.recipe.as_deref() {

--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -220,6 +220,24 @@ pub(crate) fn is_di_bridge_inserter(seg: Option<&str>) -> bool {
     seg.is_some_and(|s| s.starts_with("di-bridge:"))
 }
 
+/// A direct-insertion **cell** inserter (RFC-053 Phase 1): machine-to-machine
+/// by design. The placer tags every entity of a fused cell
+/// `di-cell:<item>:<consumer_recipe>` (see `bus::di_cell::stamp_di_cell_io`).
+///
+/// The distinction that matters to the checks below: a cell's PRODUCER has
+/// **no output belt at all** — its output leaves through the one-tile band
+/// straight into the consumer machine. Every "machine must have an output
+/// inserter dropping onto a belt" test therefore flags a cell producer as a
+/// hard error unless it recognises this tag, and the item-throughput tests
+/// see 0.00/s moved because they only credit belt-bound hands. Those are
+/// false alarms, not defects — `bus::di_cell`'s own invariants (every band
+/// inserter picks from a producer tile and drops into a consumer tile, at
+/// reach 1, with no belt for the coupled item) own the cell's correctness,
+/// and RFC-053 KC3 sim-measured the shape at 112% of plan.
+pub(crate) fn is_di_cell_entity(seg: Option<&str>) -> bool {
+    seg.is_some_and(|s| s.starts_with("di-cell:"))
+}
+
 /// Resolve the exact `MachineSpec` sibling the layout pipeline placed at `y`
 /// for `recipe`, preferring `layout.effective_rows`'s position attribution
 /// over a recipe-name lookup — partition siblings share a recipe name but

--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -235,7 +235,11 @@ pub(crate) fn is_di_bridge_inserter(seg: Option<&str>) -> bool {
 /// reach 1, with no belt for the coupled item) own the cell's correctness,
 /// and RFC-053 KC3 sim-measured the shape at 112% of plan.
 pub(crate) fn is_di_cell_entity(seg: Option<&str>) -> bool {
-    seg.is_some_and(|s| s.starts_with("di-cell:"))
+    // `di-cell:` is the Phase 1 stacked cell, `di-row:` the Phase 2
+    // horizontal row cell. Both couple machine-to-machine and both leave
+    // their producers without a belt-bound output hand, so both need the
+    // same exemptions.
+    seg.is_some_and(|s| s.starts_with("di-cell:") || s.starts_with("di-row:"))
 }
 
 /// Resolve the exact `MachineSpec` sibling the layout pipeline placed at `y`

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8192,7 +8192,11 @@ fn di_cell_kc3_export() {
                 .filter(|e| e.y == *y && e.x == xmin - 1)
                 .map(|e| e.segment_id.as_deref().unwrap_or("?"))
                 .collect();
-            println!("CELLBELT y={y} item={item} x={xmin}..{xmax}  west_neighbour={west:?}");
+            let east: Vec<String> = l.entities.iter()
+                .filter(|e| e.y == *y && e.x > *xmax && e.x <= *xmax + 4)
+                .map(|e| format!("x{}:{}", e.x, e.segment_id.as_deref().unwrap_or("?")))
+                .collect();
+            println!("CELLBELT y={y} item={item} x={xmin}..{xmax}  west={west:?} east={east:?}");
         }
     }
     if std::env::var("KC3_PROBE").is_ok() {

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8061,3 +8061,60 @@ fn research_l7_thins_output_inserters_s4() {
         "the thinning must be SHARP (~3x observed): L0={l0} should be >= 3 x L7={l7}"
     );
 }
+
+/// RFC-053 **KC3 fixture** — export a DI-cell layout + manifest for the sim
+/// harness. Ignored: it writes artifacts and is driven by hand.
+///
+/// ```bash
+/// cargo test --manifest-path crates/core/Cargo.toml --test e2e -- \
+///     di_cell_kc3_export --exact --ignored --nocapture
+/// ```
+///
+/// Target is `iron-gear-wheel` from `iron-ore`, NOT the RFC's cable→EC
+/// worked example: EC has two solid inputs and is a Phase 2 shape (#449).
+/// Gears are the canonical single-solid-input consumer, so the coupling
+/// clears `cell_eligible`.
+#[test]
+#[ignore]
+fn di_cell_kc3_export() {
+    use spaghettio_core::bus::layout;
+    let inputs: FxHashSet<String> = ["iron-ore".to_string()].into_iter().collect();
+    let sr = solver::solve("steel-plate", 2.0, &inputs, "assembling-machine-2")
+        .expect("solve steel-plate from ore");
+    println!("machines:");
+    for m in &sr.machines {
+        println!("  {} x{:.2} on {} in={:?} out={:?}", m.recipe, m.count, m.entity,
+            m.inputs.iter().map(|f| (&f.item, f.rate)).collect::<Vec<_>>(),
+            m.outputs.iter().map(|f| (&f.item, f.rate)).collect::<Vec<_>>());
+    }
+    println!("di_couplings: {:?}", sr.di_couplings);
+
+    // DI on/off from the environment so the same fixture produces the
+    // KC3 measurement AND its control. Without the control an
+    // over-production figure can't be attributed: a solver rate-model
+    // artifact and a DI artifact look identical in a single run.
+    let di = std::env::var("SPAGHETTIO_KC3_DI").as_deref() != Ok("0");
+    let opts = layout::LayoutOptions {
+        direct_insertion: di,
+        max_belt_tier: Some("transport-belt".to_string()),
+        ..Default::default()
+    };
+    let l = layout::build_bus_layout(&sr, opts).expect("layout");
+    let cell_ents = l.entities.iter()
+        .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-cell:")))
+        .count();
+    let bridge_ents = l.entities.iter()
+        .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-bridge:")))
+        .count();
+    println!("di-cell entities: {cell_ents}   di-bridge entities: {bridge_ents}");
+
+    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "di-cell-kc3");
+    let tag = if di { "di_cell_kc3" } else { "di_cell_kc3_control" };
+    std::fs::write(format!("/tmp/{tag}.bp"), &bp).expect("write bp");
+    std::fs::write(
+        format!("/tmp/{tag}.manifest.json"),
+        serde_json::to_string_pretty(&manifest).expect("manifest json"),
+    )
+    .expect("write manifest");
+    println!("wrote /tmp/{tag}.bp ({} bytes, di={di})", bp.len());
+}

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8158,3 +8158,64 @@ fn di_cell_kc3_export() {
     .expect("write manifest");
     println!("wrote /tmp/{tag}.bp ({} bytes, di={di})", bp.len());
 }
+
+/// RFC-053 Phase 1 **coverage sweep** — how often does an eligible
+/// coupling actually become a cell, rather than being refused into the
+/// bridge/bus fallback? Phase 1 added five refusal gates (modules,
+/// multi-inserter faces, both belt capacities, eligibility); if they
+/// collectively refuse nearly everything, "Phase 1 complete" is hollow.
+/// Ignored — reporting tool, not an assertion.
+///
+/// ```bash
+/// cargo test --manifest-path crates/core/Cargo.toml --test e2e -- \
+///     di_cell_coverage_sweep --exact --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn di_cell_coverage_sweep() {
+    use spaghettio_core::bus::layout;
+    let cases: &[(&str, &[&str], f64)] = &[
+        ("steel-plate", &["iron-ore"], 1.0),
+        ("steel-plate", &["iron-ore"], 2.0),
+        ("steel-plate", &["iron-ore"], 5.0),
+        ("steel-plate", &["iron-ore"], 10.0),
+        ("steel-plate", &["iron-ore"], 20.0),
+        ("iron-gear-wheel", &["iron-ore"], 5.0),
+        ("iron-stick", &["iron-ore"], 5.0),
+        ("pipe", &["iron-ore"], 5.0),
+        ("copper-cable", &["copper-ore"], 5.0),
+        ("electronic-circuit", &["iron-ore", "copper-ore"], 5.0),
+        ("stone-brick", &["stone"], 5.0),
+    ];
+    println!("{:<22} {:>6}  {:>9} {:>8} {:>8}  {}", "target", "rate", "couplings", "cells", "bridges", "verdict");
+    for (item, ins, rate) in cases {
+        let inputs: FxHashSet<String> = ins.iter().map(|s| s.to_string()).collect();
+        let Ok(sr) = solver::solve(item, *rate, &inputs, "assembling-machine-2") else {
+            println!("{item:<22} {rate:>6}  {:>9} {:>8} {:>8}  SOLVER-REFUSED", "-", "-", "-");
+            continue;
+        };
+        let ncoup = sr.di_couplings.len();
+        let opts = layout::LayoutOptions {
+            direct_insertion: true,
+            max_belt_tier: Some(
+                std::env::var("SWEEP_BELT").unwrap_or_else(|_| "transport-belt".into()),
+            ),
+            ..Default::default()
+        };
+        let Ok(l) = layout::build_bus_layout(&sr, opts) else {
+            println!("{item:<22} {rate:>6}  {ncoup:>9} {:>8} {:>8}  LAYOUT-REFUSED", "-", "-");
+            continue;
+        };
+        let cells = l.entities.iter()
+            .filter_map(|e| e.segment_id.as_deref())
+            .filter(|s| s.starts_with("di-cell:"))
+            .count();
+        let bridges = l.entities.iter()
+            .filter_map(|e| e.segment_id.as_deref())
+            .filter(|s| s.starts_with("di-bridge:"))
+            .count();
+        let verdict = if cells > 0 { "CELL" } else if bridges > 0 { "bridge" }
+            else if ncoup > 0 { "refused -> bus" } else { "no coupling" };
+        println!("{item:<22} {rate:>6}  {ncoup:>9} {cells:>8} {bridges:>8}  {verdict}");
+    }
+}

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8219,3 +8219,62 @@ fn di_cell_coverage_sweep() {
         println!("{item:<22} {rate:>6}  {ncoup:>9} {cells:>8} {bridges:>8}  {verdict}");
     }
 }
+
+/// RFC-053 **KC2 evaluation** — face contention for the Phase 2 cell.
+///
+/// A row-layout machine has two usable faces. A cell spends the NORTH face
+/// on the DI band, so every remaining flow must fit on the SOUTH face. For
+/// `copper-cable → electronic-circuit` that is iron-plate IN and
+/// electronic-circuit OUT, sharing one 3-wide face.
+///
+/// KC2 fires if those flows cannot be carried at **≤ L2** inserter-capacity
+/// research — i.e. if the cell is only feasible at max research.
+///
+/// The RFC's proposed geometry is mixed-reach: a reach-1 inserter picks
+/// iron off the NEAR belt, and a long-handed one steps OVER that belt to
+/// drop EC on the FAR belt. So the output side is constrained to
+/// long-handed (I8a: the only reach-2 inserter), which is the binding
+/// constraint and the whole reason this criterion exists.
+#[test]
+#[ignore]
+fn kc2_face_contention() {
+    use spaghettio_core::common::{belt_drop_rate, machine_feed_rate, QualityTier};
+    // AM3 canonical: 1 iron + 3 cable -> 1 EC at 2.5 crafts/s.
+    const IRON_IN: f64 = 2.5;
+    const EC_OUT: f64 = 2.5;
+    let q = QualityTier::Normal;
+
+    println!("KC2: consumer south face must carry iron IN {IRON_IN}/s + EC OUT {EC_OUT}/s");
+    println!();
+    println!("{:<22} {:>8} {:>8} {:>8}   {}", "inserter", "L0", "L2", "L7", "role");
+    for name in ["inserter", "long-handed-inserter", "fast-inserter", "bulk-inserter", "stack-inserter"] {
+        let f: Vec<String> = [0u8, 2, 7].iter()
+            .map(|&l| format!("{:.2}", machine_feed_rate(name, q, l)))
+            .collect();
+        println!("{name:<22} {:>8} {:>8} {:>8}   belt->machine (iron in)", f[0], f[1], f[2]);
+    }
+    println!();
+    for belt in ["transport-belt", "fast-transport-belt", "express-transport-belt"] {
+        for name in ["long-handed-inserter", "fast-inserter", "bulk-inserter", "stack-inserter"] {
+            let d: Vec<String> = [0u8, 2, 7].iter()
+                .map(|&l| format!("{:.2}", belt_drop_rate(name, q, 1, l, belt)))
+                .collect();
+            println!("{name:<22} {:>8} {:>8} {:>8}   machine->{belt} (EC out)", d[0], d[1], d[2]);
+        }
+        println!();
+    }
+
+    // The verdict the criterion actually asks for.
+    let far_out_l2 = belt_drop_rate("long-handed-inserter", q, 1, 2, "express-transport-belt");
+    let near_in_l2 = machine_feed_rate("fast-inserter", q, 2);
+    println!("--- KC2 verdict at L2, 3-wide face ---");
+    println!("  near (reach-1) iron in : fast-inserter {near_in_l2:.2}/s vs {IRON_IN}/s needed -> {}",
+        if near_in_l2 + 1e-9 >= IRON_IN { "OK with 1" } else { "needs >1" });
+    println!("  far  (reach-2) EC out  : long-handed  {far_out_l2:.2}/s vs {EC_OUT}/s needed -> {}",
+        if far_out_l2 + 1e-9 >= EC_OUT { "OK with 1" } else { "needs >1" });
+    let n_far = (EC_OUT / far_out_l2).ceil() as usize;
+    let n_near = (IRON_IN / near_in_l2).ceil() as usize;
+    println!("  columns required: {n_near} near + {n_far} far = {} of 3 available -> {}",
+        n_near + n_far,
+        if n_near + n_far <= 3 { "KC2 PASSES" } else { "KC2 FIRES" });
+}

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8090,10 +8090,15 @@ fn research_l7_thins_output_inserters_s4() {
 ///     di_cell_kc3_export --exact --ignored --nocapture
 /// ```
 ///
-/// Target is `iron-gear-wheel` from `iron-ore`, NOT the RFC's cable→EC
-/// worked example: EC has two solid inputs and is a Phase 2 shape (#449).
-/// Gears are the canonical single-solid-input consumer, so the coupling
-/// clears `cell_eligible`.
+/// Target is `steel-plate` from `iron-ore` (16:16 furnace→furnace), NOT
+/// the RFC's cable→EC worked example: EC has two solid inputs and is a
+/// Phase 2 shape (#449). Furnace pairs are the corpus's dominant DI shape
+/// (1,585 instances) and balance exactly 1:1, so the coupling clears both
+/// `cell_eligible` and `plan_straddle`.
+///
+/// `iron-gear-wheel` from ore was the first target tried and does NOT
+/// work: a gear machine needs ~4.8 furnaces, so the straddle exceeds 2
+/// and `plan_straddle` refuses it (Phase 3 territory).
 #[test]
 #[ignore]
 fn di_cell_kc3_export() {

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8082,6 +8082,71 @@ fn research_l7_thins_output_inserters_s4() {
     );
 }
 
+/// RFC-053 — a **fluid-fed producer** in a row cell: `casting-copper-cable`
+/// (molten copper in, cable out, on a 5×5 foundry) direct-inserting into a
+/// 3×3 assembler making `electronic-circuit`. The corpus's #3 DI pair, 544
+/// instances, and the pair that exercises all three of the Phase 2
+/// extensions at once: the pipe cut, heterogeneous footprints, and the
+/// `belt-connectivity` exemption for a machine whose only route out is a
+/// coupling inserter.
+///
+/// Guards a false positive that made this pair unbuildable: the foundry
+/// takes its ingredients through a pipe and hands its product straight to
+/// its neighbour, so no inserter of its ever touches a belt, and
+/// `check_belt_connectivity` used to call that an error.
+///
+/// Not a DI-vs-bus comparison on purpose. Off the cell this pair does not
+/// lay out at all today (the bus leaves the foundry with no adjacent
+/// inserter and no pipe), but that is a pre-existing bus gap — asserting on
+/// it here would make this test fail the day someone fixes it.
+#[test]
+fn di_row_cell_fluid_fed_producer_validates_clean() {
+    use spaghettio_core::bus::layout;
+    let inputs: FxHashSet<String> = ["molten-copper", "iron-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let sr = solver::solve("electronic-circuit", 10.0, &inputs, "assembling-machine-3")
+        .expect("solve EC from molten copper");
+    assert!(
+        sr.machines.iter().any(|m| m.recipe == "casting-copper-cable"),
+        "scenario must actually route cable through the foundry, got {:?}",
+        sr.machines.iter().map(|m| &m.recipe).collect::<Vec<_>>()
+    );
+
+    let layout = layout::build_bus_layout(
+        &sr,
+        layout::LayoutOptions {
+            direct_insertion: true,
+            max_belt_tier: Some("express-transport-belt".into()),
+            ..Default::default()
+        },
+    )
+    .expect("layout must build");
+
+    let in_cell = |e: &spaghettio_core::models::PlacedEntity| {
+        e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-row:"))
+    };
+    let foundries = layout.entities.iter().filter(|e| in_cell(e) && e.name == "foundry").count();
+    let assemblers = layout
+        .entities
+        .iter()
+        .filter(|e| in_cell(e) && e.name == "assembling-machine-3")
+        .count();
+    assert_eq!(foundries, 4, "all four foundries belong to the cell");
+    assert_eq!(assemblers, 4, "all four assemblers belong to the cell");
+
+    let issues = match validate::validate(&layout, Some(&sr), LayoutStyle::Bus) {
+        Ok(v) => v,
+        Err(e) => e.issues,
+    };
+    assert!(
+        issues.is_empty(),
+        "fluid-fed row cell must validate clean, got {:#?}",
+        issues
+    );
+}
+
 /// RFC-053 **KC3 fixture** — export a DI-cell layout + manifest for the sim
 /// harness. Ignored: it writes artifacts and is driven by hand.
 ///

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8166,6 +8166,35 @@ fn di_cell_kc3_export() {
     });
     println!("validation issues: {warnings}");
 
+    if let Ok(rowy) = std::env::var("KC3_ROWY") {
+        let ry: i32 = rowy.parse().unwrap();
+        println!("--- row y={ry}, x=0..30 ---");
+        let mut v: Vec<_> = l.entities.iter().filter(|e| e.y == ry && e.x < 30).collect();
+        v.sort_by_key(|e| e.x);
+        for e in v {
+            println!("  ({},{}) {:<24} seg={:?}", e.x, e.y, e.name, e.segment_id);
+        }
+    }
+    if std::env::var("KC3_CELLBELTS").is_ok() {
+        use std::collections::BTreeMap;
+        let mut rows: BTreeMap<i32, (String, i32, i32)> = BTreeMap::new();
+        for e in l.entities.iter().filter(|e| {
+            e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-row:"))
+                && e.name.contains("transport-belt")
+        }) {
+            let ent = rows.entry(e.y).or_insert((e.carries.clone().unwrap_or_default(), i32::MAX, i32::MIN));
+            ent.1 = ent.1.min(e.x);
+            ent.2 = ent.2.max(e.x);
+        }
+        for (y, (item, xmin, xmax)) in &rows {
+            // Anything immediately west of the cell belt's start?
+            let west: Vec<&str> = l.entities.iter()
+                .filter(|e| e.y == *y && e.x == xmin - 1)
+                .map(|e| e.segment_id.as_deref().unwrap_or("?"))
+                .collect();
+            println!("CELLBELT y={y} item={item} x={xmin}..{xmax}  west_neighbour={west:?}");
+        }
+    }
     if std::env::var("KC3_PROBE").is_ok() {
         let (px, y0, y1) = (46i32, 18i32, 28i32);
         println!("--- entities at x={px}, y={y0}..{y1} ---");

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8199,6 +8199,15 @@ fn di_cell_kc3_export() {
             println!("CELLBELT y={y} item={item} x={xmin}..{xmax}  west={west:?} east={east:?}");
         }
     }
+    if std::env::var("KC3_FACE").is_ok() {
+        for y in 14..=17 {
+            let v: Vec<String> = l.entities.iter()
+                .filter(|e| e.y == y && e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-row:")))
+                .map(|e| format!("x{}:{}:{}", e.x, e.name, e.carries.clone().unwrap_or_default()))
+                .collect();
+            println!("FACE y={y} n={} {:?}", v.len(), &v[..v.len().min(8)]);
+        }
+    }
     if std::env::var("KC3_PROBE").is_ok() {
         let (px, y0, y1) = (46i32, 18i32, 28i32);
         println!("--- entities at x={px}, y={y0}..{y1} ---");

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8166,6 +8166,19 @@ fn di_cell_kc3_export() {
     });
     println!("validation issues: {warnings}");
 
+    if std::env::var("KC3_PROBE").is_ok() {
+        let (px, y0, y1) = (46i32, 18i32, 28i32);
+        println!("--- entities at x={px}, y={y0}..{y1} ---");
+        let mut rows: Vec<_> = l.entities.iter()
+            .filter(|e| e.x == px && e.y >= y0 && e.y <= y1)
+            .collect();
+        rows.sort_by_key(|e| e.y);
+        for e in rows {
+            println!("  ({},{}) {:<26} seg={:?} carries={:?}",
+                e.x, e.y, e.name, e.segment_id, e.carries);
+        }
+    }
+
     let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "di-cell-kc3");
     let tag = if di { "di_cell_kc3" } else { "di_cell_kc3_control" };
     std::fs::write(format!("/tmp/{tag}.bp"), &bp).expect("write bp");

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8103,9 +8103,13 @@ fn research_l7_thins_output_inserters_s4() {
 #[ignore]
 fn di_cell_kc3_export() {
     use spaghettio_core::bus::layout;
-    let inputs: FxHashSet<String> = ["iron-ore".to_string()].into_iter().collect();
-    let sr = solver::solve("steel-plate", 2.0, &inputs, "assembling-machine-2")
-        .expect("solve steel-plate from ore");
+    let target = std::env::var("KC3_ITEM").unwrap_or_else(|_| "steel-plate".into());
+    let rate: f64 = std::env::var("KC3_RATE").ok().and_then(|r| r.parse().ok()).unwrap_or(2.0);
+    let inputs: FxHashSet<String> = std::env::var("KC3_INPUTS")
+        .unwrap_or_else(|_| "iron-ore".into())
+        .split(',').map(|s| s.to_string()).collect();
+    let sr = solver::solve(&target, rate, &inputs, "assembling-machine-3")
+        .unwrap_or_else(|e| panic!("solve {target}: {e:?}"));
     println!("machines:");
     for m in &sr.machines {
         println!("  {} x{:.2} on {} in={:?} out={:?}", m.recipe, m.count, m.entity,
@@ -8121,13 +8125,19 @@ fn di_cell_kc3_export() {
     let di = std::env::var("SPAGHETTIO_KC3_DI").as_deref() != Ok("0");
     let opts = layout::LayoutOptions {
         direct_insertion: di,
-        max_belt_tier: Some("transport-belt".to_string()),
+        max_belt_tier: Some(
+            std::env::var("KC3_BELT").unwrap_or_else(|_| "transport-belt".into()),
+        ),
         ..Default::default()
     };
     let l = layout::build_bus_layout(&sr, opts).expect("layout");
     let cell_ents = l.entities.iter()
         .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-cell:")))
         .count();
+    let row_ents = l.entities.iter()
+        .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-row:")))
+        .count();
+    println!("di-row entities: {row_ents}");
     let bridge_ents = l.entities.iter()
         .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("di-bridge:")))
         .count();
@@ -8149,6 +8159,9 @@ fn di_cell_kc3_export() {
         let mut by_cat: std::collections::BTreeMap<&str, usize> = Default::default();
         for i in &e.issues { *by_cat.entry(i.category.as_str()).or_default() += 1; }
         for (c, n) in &by_cat { println!("  {c}: {n}"); }
+        for i in e.issues.iter().filter(|i| format!("{:?}", i.severity) == "Error").take(6) {
+            println!("  ERR {}: {}", i.category, i.message);
+        }
         e.issues.len()
     });
     println!("validation issues: {warnings}");
@@ -8213,7 +8226,7 @@ fn di_cell_coverage_sweep() {
         };
         let cells = l.entities.iter()
             .filter_map(|e| e.segment_id.as_deref())
-            .filter(|s| s.starts_with("di-cell:"))
+            .filter(|s| s.starts_with("di-cell:") || s.starts_with("di-row:"))
             .count();
         let bridges = l.entities.iter()
             .filter_map(|e| e.segment_id.as_deref())

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8108,6 +8108,26 @@ fn di_cell_kc3_export() {
         .count();
     println!("di-cell entities: {cell_ents}   di-bridge entities: {bridge_ents}");
 
+    // KC3 is specifically about a layout that VALIDATES CLEAN yet
+    // under-delivers, so the warning list is part of the measurement,
+    // not a footnote — a warned layout would make the sim number
+    // uninterpretable against this criterion.
+    let warnings = spaghettio_core::validate::validate(
+        &l,
+        Some(&sr),
+        spaghettio_core::validate::LayoutStyle::Bus,
+    )
+    .map(|w| w.len())
+    .unwrap_or_else(|e| {
+        let errs = e.issues.iter().filter(|i| format!("{:?}", i.severity) == "Error").count();
+        println!("VALIDATION ERRORS: {errs}");
+        let mut by_cat: std::collections::BTreeMap<&str, usize> = Default::default();
+        for i in &e.issues { *by_cat.entry(i.category.as_str()).or_default() += 1; }
+        for (c, n) in &by_cat { println!("  {c}: {n}"); }
+        e.issues.len()
+    });
+    println!("validation issues: {warnings}");
+
     let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "di-cell-kc3");
     let tag = if di { "di_cell_kc3" } else { "di_cell_kc3_control" };
     std::fs::write(format!("/tmp/{tag}.bp"), &bp).expect("write bp");

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8208,6 +8208,27 @@ fn di_cell_kc3_export() {
             println!("FACE y={y} n={} {:?}", v.len(), &v[..v.len().min(8)]);
         }
     }
+    if std::env::var("KC3_TILE").is_ok() {
+        for (x, y) in [(4,16),(5,16),(6,16),(7,16),(8,16)] {
+            for e in l.entities.iter().filter(|e| e.x == x && e.y == y) {
+                println!("TILE ({x},{y}) {:<24} dir={:?} seg={:?}", e.name, e.direction, e.segment_id);
+            }
+        }
+    }
+    if std::env::var("KC3_TRUNK").is_ok() {
+        use std::collections::BTreeMap;
+        let mut segs: BTreeMap<String, (i32,i32,i32,i32,usize)> = BTreeMap::new();
+        for e in &l.entities {
+            let Some(sg) = e.segment_id.as_deref() else { continue };
+            if !(sg.contains("iron-plate") || sg.contains("copper-plate")) { continue }
+            let en = segs.entry(sg.to_string()).or_insert((i32::MAX,i32::MIN,i32::MAX,i32::MIN,0));
+            en.0 = en.0.min(e.x); en.1 = en.1.max(e.x);
+            en.2 = en.2.min(e.y); en.3 = en.3.max(e.y); en.4 += 1;
+        }
+        for (k,(x0,x1,y0,y1,n)) in &segs {
+            println!("SEG {k:<44} n={n:<4} x={x0}..{x1} y={y0}..{y1}");
+        }
+    }
     if std::env::var("KC3_PROBE").is_ok() {
         let (px, y0, y1) = (46i32, 18i32, 28i32);
         println!("--- entities at x={px}, y={y0}..{y1} ---");

--- a/crates/mining-cli/src/bin/di_patterns.rs
+++ b/crates/mining-cli/src/bin/di_patterns.rs
@@ -150,6 +150,59 @@ fn main() {
                 );
             }
         }
+        "faces" => {
+            // RFC-053 Phase 2 evidence. The `geometry` view looks at a DI
+            // pair in isolation; this asks the question Phase 2 actually
+            // needs answered: for a machine that RECEIVES direct insertion,
+            // where does everything ELSE it touches live?
+            //
+            // Reported per consumer machine: the side the DI band arrives
+            // on, then every other inserter touching that machine — which
+            // side, reach, whether it feeds or drains the machine, and
+            // whether its far end is a belt or another machine.
+            //
+            // This is what tells us whether "second input belt below the
+            // consumers" (the RFC's hand-drawn sketch) is what people
+            // build, something rarer, or something nobody does.
+            let (want_p, want_c) = (
+                args.get(3).cloned().unwrap_or_else(|| "copper-cable".into()),
+                args.get(4).cloned().unwrap_or_else(|| "electronic-circuit".into()),
+            );
+            let plans = mine_faces(&dir, &want_p, &want_c);
+            let mut hist: BTreeMap<String, usize> = BTreeMap::new();
+            let mut side_hist: BTreeMap<String, usize> = BTreeMap::new();
+            let mut n = 0usize;
+            for fp in &plans {
+                n += 1;
+                hist.entry(fp.signature()).and_modify(|c| *c += 1).or_insert(1);
+                for f in &fp.others {
+                    *side_hist
+                        .entry(format!(
+                            "{} {} r{} -> {}",
+                            f.side,
+                            if f.into_machine { "IN " } else { "OUT" },
+                            f.reach,
+                            f.far_kind
+                        ))
+                        .or_insert(0) += 1;
+                }
+            }
+            println!("face plans for DI consumers of {want_p} -> {want_c}: {n} machines");
+            println!();
+            println!("  per-interface distribution (side is relative to the consumer machine):");
+            let mut sv: Vec<_> = side_hist.into_iter().collect();
+            sv.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+            for (k, c) in sv.iter().take(20) {
+                println!("    {c:>6}  {k}");
+            }
+            println!();
+            println!("  whole-machine face plans (DI side | other interfaces):");
+            let mut hv: Vec<_> = hist.into_iter().collect();
+            hv.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+            for (k, c) in hv.iter().take(20) {
+                println!("    {c:>6}  {k}");
+            }
+        }
         "fan" => {
             // Multi-band evidence (RFC-053 Phase 3). Three questions the
             // pairwise `geometry` view structurally cannot answer:
@@ -221,4 +274,164 @@ fn main() {
             }
         }
     }
+}
+
+
+/// One non-DI interface on a machine that receives direct insertion.
+struct Face {
+    /// Side of the CONSUMER machine this inserter sits on.
+    side: &'static str,
+    /// True when the inserter drops INTO the machine (an input).
+    into_machine: bool,
+    reach: i32,
+    /// What sits at the inserter's other end: belt, machine, or neither.
+    far_kind: &'static str,
+}
+
+struct FacePlan {
+    /// EVERY side DI arrives on. A single side would be wrong for the
+    /// majority case: the fan analysis shows 1,405 of 2,039 cable->EC
+    /// consumers straddle TWO producers, so they receive DI on two faces.
+    di_sides: Vec<&'static str>,
+    others: Vec<Face>,
+}
+
+impl FacePlan {
+    /// Canonical string so identical arrangements aggregate.
+    fn signature(&self) -> String {
+        let mut parts: Vec<String> = self
+            .others
+            .iter()
+            .map(|f| {
+                format!(
+                    "{}:{}{}->{}",
+                    f.side,
+                    if f.into_machine { "in" } else { "out" },
+                    f.reach,
+                    f.far_kind
+                )
+            })
+            .collect();
+        parts.sort();
+        let mut ds = self.di_sides.clone();
+        ds.sort_unstable();
+        ds.dedup();
+        format!("DI@{} | {}", ds.join("+"), parts.join(" "))
+    }
+}
+
+/// Which side of the machine box at `(mx,my,w,h)` the tile `(tx,ty)` lies on.
+fn side_of(mx: i32, my: i32, w: i32, h: i32, tx: i32, ty: i32) -> &'static str {
+    if ty < my {
+        "N"
+    } else if ty >= my + h {
+        "S"
+    } else if tx < mx {
+        "W"
+    } else if tx >= mx + w {
+        "E"
+    } else {
+        "?"
+    }
+}
+
+fn mine_faces(dir: &str, want_p: &str, want_c: &str) -> Vec<FacePlan> {
+    let mut out = Vec::new();
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for ent in rd.flatten() {
+        let Ok(txt) = std::fs::read_to_string(ent.path()) else { continue };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt) else { continue };
+        let Some(bp) = v.get("blueprintString").and_then(|s| s.as_str()) else { continue };
+        let Ok(analyses) = analysis::analyze_blueprint_string_any(bp) else { continue };
+        for na in &analyses {
+            let ents = &na.layout.entities;
+            let mut occ: HashMap<(i32, i32), usize> = HashMap::new();
+            let mut belt: HashMap<(i32, i32), ()> = HashMap::new();
+            for (i, m) in ents.iter().enumerate() {
+                if m.name.contains("transport-belt") || m.name.contains("underground-belt") {
+                    belt.insert((m.x, m.y), ());
+                }
+                if !is_machine_entity(&m.name) {
+                    continue;
+                }
+                let (w, h) = entity_size(&m.name);
+                for dx in 0..w as i32 {
+                    for dy in 0..h as i32 {
+                        occ.insert((m.x + dx, m.y + dy), i);
+                    }
+                }
+            }
+            // Consumer machine index -> the side its DI band arrives on.
+            let mut di_consumers: HashMap<usize, Vec<&'static str>> = HashMap::new();
+            for ins in ents {
+                if !is_inserter(&ins.name) {
+                    continue;
+                }
+                let (dx, dy) = dir_to_vec(ins.direction);
+                let r = inserter_reach(&ins.name);
+                let (Some(&di), Some(&si)) = (
+                    occ.get(&(ins.x + dx * r, ins.y + dy * r)),
+                    occ.get(&(ins.x - dx * r, ins.y - dy * r)),
+                ) else {
+                    continue;
+                };
+                if di == si {
+                    continue;
+                }
+                let (p, c) = (&ents[si], &ents[di]);
+                let pn = p.recipe.clone().unwrap_or_else(|| p.name.clone());
+                let cn = c.recipe.clone().unwrap_or_else(|| c.name.clone());
+                if pn != want_p || cn != want_c {
+                    continue;
+                }
+                let (cw, ch) = entity_size(&c.name);
+                di_consumers
+                    .entry(di)
+                    .or_default()
+                    .push(side_of(c.x, c.y, cw as i32, ch as i32, ins.x, ins.y));
+            }
+            // Second pass: every OTHER inserter touching those consumers.
+            for (&ci, di_sides) in &di_consumers {
+                let c = &ents[ci];
+                let (cw, ch) = entity_size(&c.name);
+                let mut others = Vec::new();
+                for ins in ents {
+                    if !is_inserter(&ins.name) {
+                        continue;
+                    }
+                    let (dx, dy) = dir_to_vec(ins.direction);
+                    let r = inserter_reach(&ins.name);
+                    let drop = (ins.x + dx * r, ins.y + dy * r);
+                    let pick = (ins.x - dx * r, ins.y - dy * r);
+                    let drops_in = occ.get(&drop) == Some(&ci);
+                    let picks_from = occ.get(&pick) == Some(&ci);
+                    if !drops_in && !picks_from {
+                        continue;
+                    }
+                    // Skip the DI band itself (both ends are machines).
+                    if occ.contains_key(&drop) && occ.contains_key(&pick) {
+                        continue;
+                    }
+                    let far = if drops_in { pick } else { drop };
+                    let far_kind = if belt.contains_key(&far) {
+                        "belt"
+                    } else if occ.contains_key(&far) {
+                        "machine"
+                    } else {
+                        "none"
+                    };
+                    others.push(Face {
+                        side: side_of(c.x, c.y, cw as i32, ch as i32, ins.x, ins.y),
+                        into_machine: drops_in,
+                        reach: r,
+                        far_kind,
+                    });
+                }
+                out.push(FacePlan { di_sides: di_sides.clone(), others });
+            }
+        }
+    }
+    out
 }

--- a/crates/mining-cli/src/bin/di_patterns.rs
+++ b/crates/mining-cli/src/bin/di_patterns.rs
@@ -24,7 +24,7 @@ use spaghettio_core::analysis;
 use spaghettio_core::common::{
     dir_to_vec, entity_size, inserter_reach, is_inserter, is_machine_entity,
 };
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeSet, BTreeMap, HashMap};
 
 /// One mined DI observation, canonicalized.
 struct Obs {
@@ -37,6 +37,15 @@ struct Obs {
     /// to the insertion axis — the "straddle" signature.
     lateral: i32,
     vertical: bool,
+    /// Blueprint-member id, unique across the corpus scan. Machine
+    /// indices are only meaningful within one member.
+    member: u32,
+    /// Index of the producer / consumer machine inside that member. These
+    /// are what make fan-in, fan-out and chain depth computable — without
+    /// them every observation is anonymous and only PAIRWISE geometry can
+    /// be reported (which is all the `geometry` subcommand ever needed).
+    p_idx: usize,
+    c_idx: usize,
 }
 
 fn mine(dir: &str) -> Vec<Obs> {
@@ -45,12 +54,14 @@ fn mine(dir: &str) -> Vec<Obs> {
         eprintln!("cannot read corpus dir: {dir}");
         return out;
     };
+    let mut member: u32 = 0;
     for ent in rd.flatten() {
         let Ok(txt) = std::fs::read_to_string(ent.path()) else { continue };
         let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt) else { continue };
         let Some(bp) = v.get("blueprintString").and_then(|s| s.as_str()) else { continue };
         let Ok(analyses) = analysis::analyze_blueprint_string_any(bp) else { continue };
         for na in &analyses {
+            member += 1;
             let ents = &na.layout.entities;
             let mut occ: HashMap<(i32, i32), usize> = HashMap::new();
             for (i, m) in ents.iter().enumerate() {
@@ -98,6 +109,9 @@ fn mine(dir: &str) -> Vec<Obs> {
                     gap,
                     lateral,
                     vertical,
+                    member,
+                    p_idx: si,
+                    c_idx: di,
                 });
             }
         }
@@ -135,6 +149,64 @@ fn main() {
                     if *vert { "vertical" } else { "horizontal" }
                 );
             }
+        }
+        "fan" => {
+            // Multi-band evidence (RFC-053 Phase 3). Three questions the
+            // pairwise `geometry` view structurally cannot answer:
+            //   fan-out  — does one producer feed several consumers?
+            //   fan-in   — does one consumer draw from several producers?
+            //              (>2 is what `plan_straddle` refuses today)
+            //   chain    — is a machine BOTH a consumer and a producer?
+            //              that is the stacked-band shape itself.
+            let filter: Option<(String, String)> = match (args.get(3), args.get(4)) {
+                (Some(a), Some(b)) => Some((a.clone(), b.clone())),
+                _ => None,
+            };
+            let sel: Vec<&Obs> = obs
+                .iter()
+                .filter(|o| {
+                    filter
+                        .as_ref()
+                        .is_none_or(|(a, b)| &o.producer == a && &o.consumer == b)
+                })
+                .collect();
+            let mut fan_out: BTreeMap<(u32, usize), BTreeSet<usize>> = BTreeMap::new();
+            let mut fan_in: BTreeMap<(u32, usize), BTreeSet<usize>> = BTreeMap::new();
+            let mut is_producer: BTreeSet<(u32, usize)> = BTreeSet::new();
+            let mut is_consumer: BTreeSet<(u32, usize)> = BTreeSet::new();
+            for o in &sel {
+                fan_out.entry((o.member, o.p_idx)).or_default().insert(o.c_idx);
+                fan_in.entry((o.member, o.c_idx)).or_default().insert(o.p_idx);
+                is_producer.insert((o.member, o.p_idx));
+                is_consumer.insert((o.member, o.c_idx));
+            }
+            let hist = |m: &BTreeMap<(u32, usize), BTreeSet<usize>>| {
+                let mut h: BTreeMap<usize, usize> = BTreeMap::new();
+                for v in m.values() {
+                    *h.entry(v.len()).or_insert(0) += 1;
+                }
+                h
+            };
+            let label = filter
+                .as_ref()
+                .map(|(a, b)| format!("{a} -> {b}"))
+                .unwrap_or_else(|| "ALL pairs".into());
+            println!("fan analysis: {label}  ({} observations)", sel.len());
+            println!("  fan-OUT (consumers fed by one producer machine):");
+            for (k, n) in hist(&fan_out) {
+                println!("    {k} consumer(s): {n} producer machines");
+            }
+            println!("  fan-IN (producers feeding one consumer machine):");
+            for (k, n) in hist(&fan_in) {
+                println!("    {k} producer(s): {n} consumer machines");
+            }
+            let chained: Vec<_> = is_producer.intersection(&is_consumer).collect();
+            println!(
+                "  CHAIN: {} machines are both a DI producer and a DI consumer \
+                 (stacked bands) out of {} distinct machines",
+                chained.len(),
+                is_producer.union(&is_consumer).count()
+            );
         }
         _ => {
             let mut pairs: BTreeMap<(String, String), usize> = BTreeMap::new();

--- a/crates/mining-cli/src/bin/di_patterns.rs
+++ b/crates/mining-cli/src/bin/di_patterns.rs
@@ -150,6 +150,37 @@ fn main() {
                 );
             }
         }
+        "fluid" => {
+            // RFC-053 Phase 2 pipe scope (the KC6 re-scope). Inserters
+            // cannot move fluid, so every mined DI coupling is solid by
+            // construction — the fluid is always a SIDE input to one of the
+            // two machines. This reports, for each DI machine in a pair,
+            // which sides carry a pipe, so the cell's pipe plan is designed
+            // against what people build rather than guessed.
+            let (want_p, want_c) = (
+                args.get(3).cloned().unwrap_or_else(|| "casting-copper-cable".into()),
+                args.get(4).cloned().unwrap_or_else(|| "electronic-circuit".into()),
+            );
+            let obs2 = mine_fluid(&dir, &want_p, &want_c);
+            let mut hist: BTreeMap<String, usize> = BTreeMap::new();
+            for (role, sides) in &obs2 {
+                let mut sv = sides.clone();
+                sv.sort_unstable();
+                sv.dedup();
+                let key = if sv.is_empty() {
+                    format!("{role}: NO PIPE")
+                } else {
+                    format!("{role}: {}", sv.join("+"))
+                };
+                *hist.entry(key).or_insert(0) += 1;
+            }
+            println!("pipe adjacency for {want_p} -> {want_c} ({} machines)", obs2.len());
+            let mut hv: Vec<_> = hist.into_iter().collect();
+            hv.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+            for (k, c) in hv {
+                println!("  {c:>6}  {k}");
+            }
+        }
         "faces" => {
             // RFC-053 Phase 2 evidence. The `geometry` view looks at a DI
             // pair in isolation; this asks the question Phase 2 actually
@@ -430,6 +461,77 @@ fn mine_faces(dir: &str, want_p: &str, want_c: &str) -> Vec<FacePlan> {
                     });
                 }
                 out.push(FacePlan { di_sides: di_sides.clone(), others });
+            }
+        }
+    }
+    out
+}
+
+
+/// Which sides of each DI machine carry an adjacent pipe.
+/// Returns `(role, sides)` per machine, role being "producer" or "consumer".
+fn mine_fluid(dir: &str, want_p: &str, want_c: &str) -> Vec<(&'static str, Vec<&'static str>)> {
+    let is_pipe = |n: &str| {
+        n == "pipe" || n == "pipe-to-ground" || n.ends_with("-pipe") || n == "storage-tank"
+    };
+    let mut out = Vec::new();
+    let Ok(rd) = std::fs::read_dir(dir) else { return out };
+    for ent in rd.flatten() {
+        let Ok(txt) = std::fs::read_to_string(ent.path()) else { continue };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt) else { continue };
+        let Some(bp) = v.get("blueprintString").and_then(|s| s.as_str()) else { continue };
+        let Ok(analyses) = analysis::analyze_blueprint_string_any(bp) else { continue };
+        for na in &analyses {
+            let ents = &na.layout.entities;
+            let mut occ: HashMap<(i32, i32), usize> = HashMap::new();
+            let mut pipes: BTreeSet<(i32, i32)> = BTreeSet::new();
+            for (i, m) in ents.iter().enumerate() {
+                if is_pipe(&m.name) {
+                    let (w, h) = entity_size(&m.name);
+                    for dx in 0..w as i32 {
+                        for dy in 0..h as i32 {
+                            pipes.insert((m.x + dx, m.y + dy));
+                        }
+                    }
+                }
+                if !is_machine_entity(&m.name) { continue }
+                let (w, h) = entity_size(&m.name);
+                for dx in 0..w as i32 {
+                    for dy in 0..h as i32 {
+                        occ.insert((m.x + dx, m.y + dy), i);
+                    }
+                }
+            }
+            let mut seen: BTreeSet<usize> = BTreeSet::new();
+            for ins in ents {
+                if !is_inserter(&ins.name) { continue }
+                let (dx, dy) = dir_to_vec(ins.direction);
+                let r = inserter_reach(&ins.name);
+                let (Some(&di), Some(&si)) = (
+                    occ.get(&(ins.x + dx * r, ins.y + dy * r)),
+                    occ.get(&(ins.x - dx * r, ins.y - dy * r)),
+                ) else { continue };
+                if di == si { continue }
+                let (p, c) = (&ents[si], &ents[di]);
+                let pn = p.recipe.clone().unwrap_or_else(|| p.name.clone());
+                let cn = c.recipe.clone().unwrap_or_else(|| c.name.clone());
+                if pn != want_p || cn != want_c { continue }
+                for (idx, role) in [(si, "producer"), (di, "consumer")] {
+                    if !seen.insert(idx) { continue }
+                    let m = &ents[idx];
+                    let (w, h) = entity_size(&m.name);
+                    let (w, h) = (w as i32, h as i32);
+                    let mut sides: Vec<&'static str> = Vec::new();
+                    for t in 0..w {
+                        if pipes.contains(&(m.x + t, m.y - 1)) { sides.push("N") }
+                        if pipes.contains(&(m.x + t, m.y + h)) { sides.push("S") }
+                    }
+                    for t in 0..h {
+                        if pipes.contains(&(m.x - 1, m.y + t)) { sides.push("W") }
+                        if pipes.contains(&(m.x + w, m.y + t)) { sides.push("E") }
+                    }
+                    out.push((role, sides));
+                }
             }
         }
     }

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -36,6 +36,13 @@ fn layout_options(
     stacking: Option<u8>,
     inserter_capacity: Option<u8>,
     cell_composition: Option<String>,
+    // RFC-053 direct insertion: fuse a coupled producer/consumer pair into
+    // ONE row coupled by inserters, with no belt for the coupled item.
+    // Defaults to false — pairs the engine cannot serve as a cell fall back
+    // to the DI bridge and then to the bus, so enabling it never makes a
+    // layout worse, but it stays opt-in until coverage is wider (fluids and
+    // modules still refuse).
+    direct_insertion: Option<bool>,
 ) -> LayoutOptions {
     let strategy = match strategy.as_deref() {
         // `partitioned-per-consumer` is the deprecated P1 string; the
@@ -78,6 +85,7 @@ fn layout_options(
         // decomposition search (`MergeTapCandidate`), never requested by the
         // web UI — always default-off at the public boundary.
         merge_tap: false,
+        direct_insertion: direct_insertion.unwrap_or(false),
         // Phase C: set only by the mega-block sub-solve internally,
         // never at the public boundary.
         splitter_tap_spacers: false,
@@ -278,10 +286,11 @@ pub fn layout(
     stacking: Option<u8>,
     inserter_capacity: Option<u8>,
     cell_composition: Option<String>,
+    direct_insertion: Option<bool>,
 ) -> Result<LayoutResult, JsError> {
     build_bus_layout(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion),
     )
     .map_err(|e| JsError::new(&e))
 }
@@ -303,10 +312,11 @@ pub fn layout_traced(
     stacking: Option<u8>,
     inserter_capacity: Option<u8>,
     cell_composition: Option<String>,
+    direct_insertion: Option<bool>,
 ) -> Result<LayoutResult, JsError> {
     spaghettio_core::bus::layout::build_bus_layout_traced(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion),
     )
     .map_err(|e| JsError::new(&e))
 }
@@ -372,6 +382,7 @@ pub fn layout_streaming(
     stacking: Option<u8>,
     inserter_capacity: Option<u8>,
     cell_composition: Option<String>,
+    direct_insertion: Option<bool>,
     emit: &js_sys::Function,
 ) -> Result<LayoutResult, JsError> {
     let emit = emit.clone();
@@ -385,7 +396,7 @@ pub fn layout_streaming(
     });
     spaghettio_core::bus::layout::build_bus_layout_streaming(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion),
         on_event,
     )
     .map_err(|e| JsError::new(&e))

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -106,7 +106,11 @@ fn layout_options(
             Some("off") => spaghettio_core::bus::cells::CellComposition::Off,
             _ => spaghettio_core::bus::cells::CellComposition::Candidate,
         },
-        ..Default::default()
+        // No `..Default::default()`: adding `direct_insertion` completed
+        // the field list, and a no-op struct update is a clippy error
+        // under the workspace's `-D warnings`. A field added to
+        // `LayoutOptions` later will fail to compile HERE, which is the
+        // right place to notice a new wasm-surface axis.
     }
 }
 

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1097,3 +1097,37 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   honest ordering is **Phase 2 before Phase 3**, and Phase 3's scope
   should be rewritten around the fan-in belt limit rather than around
   multi-producer straddle, which is largely already solved.*
+
+- *2026-07-25 — **Phase 2's input-belt contract, checked before building:
+  one question discharged, one sharpened, one found.** The Phase 2 cell
+  puts a second input belt (iron-plate) BELOW its consumers, a shape no
+  existing row template produces, so the worry was that something derives
+  tap-off position from row geometry rather than reading it. **It does
+  not.** Both consumers — `lane_planner.rs:1292` and
+  `ghost_router.rs:163` — use the identical form: filter `spec.inputs` to
+  non-fluid, enumerate, match on item, then read `input_belt_y[idx]`
+  literally. No `y_start` arithmetic, no "first belt row", no comparison
+  against machine y. An input belt below its machines is fine.*
+
+  *So the whole contract reduces to: **`input_belt_y[i]` is the belt for
+  the i-th non-fluid entry of `spec.inputs`, in spec order.** Violating it
+  makes BOTH consumers wrong identically, so they agree with each other
+  and yield a self-consistent wrong layout — there is no disagreement for
+  a check to catch.*
+
+  ***The trap the grep actually found.*** *Both consumers `break` on the
+  first item match, and `ghost_router` documents the assumption inline:
+  "assumes one input slot per item per recipe." A Phase 2 fused spec is
+  producer's inputs + consumer's non-coupled inputs, and nothing prevents
+  those being the SAME item (producer eats iron-plate, consumer also eats
+  iron-plate). Then `spec.inputs` holds two iron-plate entries at
+  different y, both consumers match the first and break, and **the second
+  belt is never tapped** — built, never fed, machines starve, and no lane
+  is ever routed to it to warn about. Merging the two is not available:
+  they sit at different y by construction (one above the producers, one
+  below the consumers). Phase 2 must therefore either refuse such a pair
+  outright — the Phase 1-style honest answer, and the default unless
+  measurement says the shape matters — or teach tap-off resolution to sum
+  across matching slots, which means editing that documented assumption in
+  two files. Invisible in the canonical cable→EC case (copper-plate vs
+  iron-plate are distinct), so it would have shipped and bitten later.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1453,3 +1453,28 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   existing `fluid_port_pipes` machinery before stamping: ports are
   prototype-fixed per direction, so a pipe run that merely LOOKS adjacent
   may not connect.*
+
+  ***Implementation notes for the pipe cut, so they need not be
+  rediscovered.*** *Do NOT derive port tiles by hand — a pipe run that
+  merely looks adjacent may not connect, because ports are
+  prototype-fixed per direction. Reuse the shared table-driven module the
+  existing row templates already use (`bus/templates.rs:35`,
+  `fluid_input_port_dx`):*
+  - *`fluid_ports::north_input_orientation(entity)` → `(mirror, dir)`.
+    **Place the producer machines at that orientation**, exactly as
+    `single_input_row` does, so the delivered pipe lands on a real port.*
+  - *`fluid_ports::north_input_dxs(entity, mirror, dir)` → the port
+    columns.*
+  - *Geometry: the pipe run must be **adjacent** to the machine row, i.e.
+    at `machine_y - 1` (the row that holds feed inserters for a
+    solid-input producer). The belt row above it is simply unused for an
+    all-fluid producer. Consumers sharing the row are unaffected — EC has
+    no fluid box, so a continuous pipe run passing over its columns forms
+    no connection.*
+  - *Lane-planner integration goes through `RowSpan.fluid_port_ys` and
+    `fluid_port_pipes`, NOT `input_belt_y`: `lane_planner` has a separate
+    fluid branch (`if !rs.fluid_port_ys.is_empty() { tap_ys.push(...) }`).
+    The fused spec must therefore carry the producer's fluid input as a
+    fluid `ItemFlow` and the row must populate those fields, or the
+    molten-copper lane will never be tapped — the same class of silent
+    starve that the iron-plate ordering bug produced.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -548,7 +548,18 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
     when counting DI in community blueprints). Refuses rather than
     under-feeding when the chosen inserter can't cover an edge within
     the slots that edge owns.
-  - **1c — placer wiring** (remaining, and the invasive step). Pick-up
+  - **1c ✅ LANDED — placer wiring. Phase 1 is COMPLETE.**
+    `place_rows` now fuses an eligible pair into one cell row via
+    `cell_eligible` → `try_build_cell` → `fused_cell_spec`. The engine
+    emits machine→inserter→machine DI for the first time. Inert by
+    default (`direct_insertion: false`), so no existing layout moved —
+    the cell path is covered by unit tests only until Phase 4 exposes
+    the flag. The notes below are kept as the record of how the step was
+    scoped; where they disagree with what shipped, what shipped wins
+    (notably: no new `RowKind` was needed — a fused `RowSpan` built
+    directly from `DiCellLayout` was enough).
+
+  - *Original 1c pick-up notes (superseded).* Pick-up
     notes, so this doesn't need re-deriving:
     - **Seam**: `bus::placer::place_rows`, the DI branch that currently
       calls `stamp_di_bridge` (search `is_di_consumer` / `di_lookup`).
@@ -814,3 +825,27 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   wiring rather than after — the RFC had carried the contradiction
   since the first draft because prose scope and worked example were
   never cross-checked.*
+
+- *2026-07-25 — **Phase 1c landed; Phase 1 is complete.** `place_rows`
+  fuses an eligible producer/consumer pair into a single cell row, so the
+  engine emits true machine→inserter→machine DI for the first time.
+  Three things worth carrying forward. **(a) The fused-row design made
+  the "invasive" step small.** The pick-up notes predicted a new
+  `RowKind` and a restructured placement loop; what it actually took was
+  a precomputed `cell_pairs` map, a skip-set for absorbed consumer specs,
+  and a `RowSpan` built straight from `DiCellLayout`. The reason is the
+  design choice, not luck: describing the cell as a composite machine
+  (producer's inputs, consumer's outputs) means nothing downstream has to
+  learn what a cell is. **(b) `cell_eligible` is load-bearing.** It is
+  the only thing standing between `detect_di_couplings`' cable→EC
+  coupling and a starving cell — the solver will keep emitting couplings
+  Phase 1 cannot serve, and that is fine as long as the placer refuses
+  them. **(c) A test passed vacuously and had to be caught by hand.**
+  `di_cell_row_has_a_real_output_belt` went green while no cell was being
+  built at all — the shared `iron_plate_spec`/`iron_gear_spec` helpers
+  are unbalanced (1.0/s against 2.0/s), `plan_straddle` rightly refused
+  them, and the assertion silently landed on an ordinary row. It now
+  guards on `spans.len() == 1` first. Textbook "zero warnings can mean
+  the check was wrong" from the verification protocol, and worth the
+  reminder that a green new test is evidence of nothing until you have
+  seen it fail for the right reason.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -434,11 +434,37 @@ caveat.
    a `Fast`-capped user cannot get a feasible cell at the **default**
    research level, DI is too fragile to ship default-on — it stays an
    opt-in strategy with an honest refusal, not a silent degradation.
-3. **Honest throughput.** If a DI cell validates clean but the sim
-   harness measures **< 98% of plan** on the canonical fixture, the
-   model is wrong and the checks are lying — stop everything. (This is
-   the #383 lesson: validator-clean concealed a real starve for weeks.)
-4. **Density premise. ✅ EVALUATED 2026-07-25 — PASSES.** Measured on
+3. **Honest throughput. ✅ EVALUATED 2026-07-25 — PASSES.** If a DI cell
+   validates clean but the sim harness measures **< 98% of plan** on the
+   canonical fixture, the model is wrong and the checks are lying — stop
+   everything. (This is the #383 lesson: validator-clean concealed a
+   real starve for weeks.) **Measured on a real cell** (`steel-plate@2/s`
+   from `iron-ore`, 16:16 furnace→furnace — the corpus's dominant DI
+   shape; the fixture is `di_cell_kc3_export` in `tests/e2e.rs`):
+
+   | | planned/s | produced/s | delivered/s | entities |
+   |---|---|---|---|---|
+   | **DI cell** | 2.00 | 2.21 (+10.7%) | 2.24 (+12.0%) | **213** |
+   | control (DI off) | 2.00 | 2.20 (+10.0%) | 2.24 (+12.0%) | 335 |
+
+   `converged=true`, 32/32 machines working, both runs. DI delivers
+   **112% of plan**, nowhere near the 98% floor, and matches its own
+   bus control to within 0.7pp produced / 0.0pp delivered. The
+   criterion does not fire.
+
+   **The control is the load-bearing part.** A single DI run showing
+   +10.7% is uninterpretable: a solver rate-model artifact and a DI
+   artifact are indistinguishable without it. Running the same target
+   with `direct_insertion: false` attributes the overshoot to the
+   *model*, not the topology — the engine under-predicts electric-furnace
+   steel output by ~10% in both. That discrepancy is real, pre-existing
+   and orthogonal to this RFC; it deserves its own issue rather than
+   being quietly absorbed here.
+4. **Density premise. ✅ EVALUATED 2026-07-25 — PASSES; re-confirmed
+   end-to-end.** The KC3 run above measures it on a whole solved layout
+   rather than a hand-derived cell: **213 entities against the bus
+   control's 335, a 36% reduction** at identical delivered throughput.
+   Original hand-derived evaluation follows. Measured on
    the canonical fixture (EC@10/s from plates, DI off) against the real
    engine: the bus places `copper-cable` at y1–7 and `electronic-circuit`
    at y10–17 with a `copper-cable` trunk lane at y7–9 — a **17-tile**
@@ -877,3 +903,26 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   the check was wrong" from the verification protocol, and worth the
   reminder that a green new test is evidence of nothing until you have
   seen it fail for the right reason.*
+
+- *2026-07-25 — **KC3 evaluated and PASSES; the RFC now survives every
+  kill criterion that is evaluable pre-Phase-2.** Sim-measured a real
+  cell built by the full solver→layout pipeline (`steel-plate@2/s` from
+  `iron-ore`, 16:16 furnace→furnace): 2.24/s delivered against 2.00/s
+  planned, `converged=true`, 32/32 machines working. The floor is 98%;
+  this is 112%. **Ran a DI-off control on the same target and that is the
+  finding worth keeping** — the control delivers *the same* 2.24/s
+  (+12.0%), so the overshoot is a solver rate-model artifact
+  (electric-furnace steel under-predicted by ~10%), not a property of
+  DI. Without the control the +10.7% would have been unattributable, and
+  the temptation to read it as "DI beats plan" would have been strong
+  and wrong. The same pair of runs re-confirms KC4 end-to-end at a scale
+  the hand-derived 7-vs-17 figure couldn't: **213 entities vs 335, −36%**,
+  at identical delivered throughput. Chose to run KC3 before starting
+  Phase 2 specifically because Phase 2 is the expensive phase and KC3 is
+  the criterion most able to invalidate the topology — evaluating it the
+  moment it became evaluable (which Phase 1c's landing made possible) is
+  the RFC's own kill-criterion discipline. Two gates remain open and both
+  are inherently Phase 2+: KC2 (face contention — a Phase 1 cell has no
+  second face flow by construction) and KC5 (solver escalation bound).
+  Orthogonal follow-up, deliberately NOT folded into this RFC: the ~10%
+  electric-furnace steel rate discrepancy the control exposed.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1593,10 +1593,26 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   `di_row_cell_fluid_fed_producer_validates_clean`, which was canaried:
   it fails with the exemption forced off.*
 
-  | pair | corpus | result |
-  |---|---|---|
-  | `casting-copper-cable → EC` | 544 | cell at 2.5–20/s, **0 errors 0 warnings** throughout |
-  | `casting-iron → EC` | 339 | cell at 2.5–15/s, **0 errors 0 warnings** throughout |
+  | pair | corpus | result | sim @10/s |
+  |---|---|---|---|
+  | `casting-copper-cable → EC` | 544 | cell at 2.5–20/s, **0 errors 0 warnings** throughout | produced 100.0%, delivered **101.3%** — PASS |
+  | `casting-iron → EC` | 339 | cell at 2.5–15/s, **0 errors 0 warnings** throughout | produced 100.0%, delivered **101.3%** — PASS |
+
+  *Both sim runs converged. They are the FIRST fixtures ever to exercise
+  the harness's infinity-pipe fluid feed, which RFC-050 declares
+  uncalibrated — worth stating, though the risk runs one way: an
+  uncalibrated feed could under-supply and show a false FAILURE, it
+  cannot inflate EC output past what the cell's own belts and inserters
+  carry, and produced matched planned exactly in both runs.*
+
+  *Also checked, because a cell alone in a layout proves little: with a
+  smelting row placed alongside (`iron-ore` instead of `iron-plate` as
+  the external input) both rates still validate 0/0. The cell's
+  `RowSpan.y_start` is taken from `input_belt_ys[0]`, which for a
+  fluid-fed producer is the CONSUMER's belt — below the machines and
+  below the pipe row, so the span understates the cell's extent. No
+  observable effect in a 3-row layout; recorded as a smell, not a
+  finding.*
 
   *Above those rates the cell refuses honestly — the consumer's OTHER
   input (60/s of cable into 8 EC machines) exceeds an express belt's

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1506,3 +1506,33 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   kept rather than reverted because it is small, correct and pinned by a
   test — but it is honestly unreachable today, and **anyone picking this
   up should do footprints first**.*
+
+- *2026-07-25 — **The `merge_x_cursor` "fix" was treating a symptom and is
+  REVERTED.** #459's review found that `cell_rows_present` inspected
+  `route_bus_ghost`'s own local entity accumulator — router-authored
+  segments only — so it could never see placer-authored cell entities and
+  the branch never fired. Tested rather than argued: forcing it `false`
+  leaves BOTH pairs at 0 validation issues. The overlap it was written to
+  cure was a symptom of the ORDERING bug (cell emitted at the producer's
+  slot instead of the consumer's); once ordering was fixed the merger
+  change became inert. Reverted to the original, which also retires the
+  "narrowed followup" recorded earlier — there is nothing to narrow.*
+
+  *The underlying observation still stands and is now the ONLY claim
+  made: `merge_x_cursor`'s comment says it starts east of every row, but
+  only the multi-output branch implements that. No layout is known to hit
+  it. Left alone deliberately — the unconditional form regressed
+  `mega_chain_ac_from_raw_zero_issues`, and a fix with no reproducing
+  case is not worth that risk.*
+
+  *Also from the same review: the row cell's input-belt capacity check
+  derived its stacking factor from the PRODUCER's item and then gated the
+  CONSUMER's belt with it, although `row_cell_eligible` guarantees the
+  two items differ and `StackingCtx::for_item` is item-keyed. Now checked
+  per item.*
+
+  *Lesson worth keeping: two of this session's "fixes" — the merger
+  cursor and the first pipe scoping — were confidently reasoned, landed,
+  and later shown to do nothing. Both were caught by an experiment that
+  took minutes (force the flag false; attempt an end-to-end build). The
+  cheap experiment beat the careful argument every time it was run.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1302,5 +1302,26 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   segment ids rather than the `row:...:belt-in:<item>` ids ordinary rows
   use, so the tap-off almost certainly never joins them to the bus —
   consistent with the belts being stamped by the cell rather than by the
-  row templates. **That is the first thing to fix next session**, and it
-  is a wiring gap, not a design fault.*
+  row templates.*
+
+  ***That hypothesis is DISPROVEN — probe it before acting on it.*** *Both
+  cell input belts do have tap-offs joined to them:
+  `copper-plate` at y=10 (x=6..44) with `ghost:tap:copper-plate:3:10`
+  immediately west, and `iron-plate` at y=16 with
+  `ghost:tap:iron-plate:4:16`. The stamped geometry matches the design
+  exactly (`p_belt=10, feed=11, machines=12-14, face=15, c_belt=16,
+  out=17`). Feeding is not the problem.*
+
+  ***Current best candidate: the merger fix traded an overlap for a
+  gap.*** *The cell's output belt ends at **x=44**, but
+  `merge_x_cursor` now starts east of EVERY row, and the copper-plate row
+  is ~48 wide — so the merge column begins beyond the cell's output belt.
+  If that belt is not extended east to meet it, `electronic-circuit` has
+  nowhere to go, backs up, and cascades upstream into precisely the
+  observed `full_output: 46`. Next session: check whether
+  `merge_output_rows` extends a participating row's output belt east from
+  `output_belt_x_max` (ordinary rows must rely on this), and if it does,
+  why the cell row is excluded. Note the cell row is NARROWER than a
+  non-participating row, which is the same asymmetry that caused the
+  original overlap — the merger appears to assume the output row is
+  widest in more than one place.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1407,3 +1407,49 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   face inserters correct, geometry sound) are what made the fifth
   findable — each had been committed to this log as a diagnosis and then
   retracted. Probing before fixing was the whole difference.*
+
+- *2026-07-25 — **Pipe scope (the KC6 re-scope) measured, and it is much
+  smaller than feared.** New `di-patterns fluid` subcommand reports, per
+  DI machine, which sides carry an adjacent pipe. Two representative
+  pairs:*
+
+  | pair | producer | consumer |
+  |---|---|---|
+  | `casting-copper-cable → EC` (592 machines) | piped: S 85, E 58, W 53, N 25 | **NO PIPE ×298** |
+  | `engine-unit → electric-engine-unit` (1,094) | **NO PIPE ×440** | piped: S 128, W 125, N 84 |
+
+  ***Three findings.*** *(1) **Only ONE machine per pair is
+  fluid-touching**, and cleanly so — the other never has a pipe.
+  Inserters cannot move fluid, so the coupled item is always solid by
+  construction; the fluid is a SIDE input. (2) **There is no canonical
+  pipe face** — all four sides occur with comparable frequency, so the
+  engine is free to choose rather than having to match a convention.
+  (3) Decisively, from `recipes.json`: `casting-copper-cable`
+  (molten-copper → copper-cable), `casting-iron` (molten-iron →
+  iron-plate) and `solid-fuel-from-light-oil` (light-oil → solid-fuel)
+  all take **only a fluid** and emit a solid.*
+
+  ***Consequence: the fluid producer has NO solid input, so its north
+  face — where a solid producer's feed belt and inserters sit — is
+  entirely free, and the pipe goes exactly where the belt would have
+  been.*** *That explains finding (2): there is no contention to force a
+  canonical face. The change is therefore small and local: relax
+  `row_cell_eligible`/`cell_eligible` to admit a producer whose inputs
+  are all fluid, and have the stampers emit a pipe run adjacent to the
+  machine row instead of a belt + feed inserters.*
+
+  *Coverage: **1,535 corpus instances** across three top-12 pairs, and
+  they split across BOTH cell variants — `casting-* → EC` is a ROW cell
+  (EC has two solid inputs) while `solid-fuel-from-light-oil →
+  rocket-fuel` is a STACKED cell (rocket-fuel's only solid input is
+  solid-fuel). Both stampers need the treatment.*
+
+  ***Out of scope for that first cut, deliberately:*** *the mirror shape,
+  a fluid-touching CONSUMER (`electric-engine-unit` = engine-unit +
+  electronic-circuit + lubricant, 547 instances). Its south face already
+  carries a solid input and the output, so a pipe needs a face the row
+  cell does not have spare — genuinely harder, and worth doing only after
+  the easy 1,535 land. Verify the exact fluid-port tile against the
+  existing `fluid_port_pipes` machinery before stamping: ports are
+  prototype-fixed per direction, so a pipe run that merely LOOKS adjacent
+  may not connect.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1244,3 +1244,40 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   is a genuine regression — cable→EC now forms a row cell where that test
   pins bridge behaviour. Decide whether it should assert the row cell or
   pin DI off.*
+
+- *2026-07-25 — **A latent output-merger bug, found by the row cell; and
+  a KC3-CANDIDATE TRIP that needs sim forensics before it can be
+  called.** Two things, one good and one that must not be waved through.*
+
+  ***(1) `merge_x_cursor` never honoured its own stated invariant for
+  single-output layouts.*** *The comment says "Start east of EVERY row
+  (not just the participating ones) so south columns never clip a wider
+  foreign row" — but only the `output_items.len() > 1` branch did that;
+  the single-item branch started at `0` and let `merge_output_rows`
+  derive its start from the participating rows alone. Safe only while
+  the output-producing row is also the widest, which is true of ordinary
+  layouts and false for a row cell: at EC@10/s the cell is `bus+39` wide
+  against the iron-plate row's `bus+48`, so the merger drove a column
+  straight through it — 7 `entity-overlap` errors, plus knock-on
+  reachability and isolation failures. Fixed by applying the max
+  unconditionally. **Verified pre-existing, not introduced**: the same
+  target with `direct_insertion: false` validated at 0 issues, and the
+  fix adds no new test failures (895 pass, same 5 known ones). This bug
+  was reachable before RFC-053 by any layout whose final row is narrower
+  than an intermediate one; the row cell just made it easy to hit.*
+
+  ***(2) cable→EC now VALIDATES CLEAN but SIMS AT ZERO.*** *After the
+  merger fix the layout has **no validation errors** (8 warnings), so
+  goal clause (b) holds. The sim says: `electronic-circuit` 0.00/s
+  against 10.00/s planned, `converged=false`, and at a 60,000-tick
+  warmup it degrades to "NO DATA" with every item at 0.00 — including
+  `copper-plate` and `iron-plate`, which come from ORDINARY rows, not
+  cells. **This is the exact shape KC3 exists to catch** ("validates
+  clean but the sim measures < 98% — the model is wrong and the checks
+  are lying"). It is NOT yet a confirmed trip: universal zeros plus
+  "NO DATA" plus starved non-cell rows is also the documented signature
+  of a sim-KIT problem (`docs/sim-harness-forensics.md`; audit
+  `kit_errors` and the chest census before blaming geometry). Those two
+  diagnoses have opposite consequences — one kills the Phase 2 shape,
+  the other is a harness artifact — so the forensics must be run before
+  either is recorded as fact. **Do that first next session.***

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1206,3 +1206,41 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   the opposite face free. They remain relevant only to the stacked
   variant, which the corpus puts second (190 combined vs 177 for the top
   single plan).*
+
+- *2026-07-25 — **Phase 2 row cell builds cable→EC end to end; 9
+  validation errors remain, and they are OURS.** `stamp_row_cell` +
+  `try_build_row_cell` produce a horizontal row cell for
+  `copper-cable → electronic-circuit` at 10/s from ore (153 `di-row`
+  entities, express belts) — the corpus's #1 DI pair, and the first time
+  the engine has used DI for it. **Not merged**: on
+  `wip/rfc053-phase2-row-cell`, off #452's branch, which stays green.*
+
+  ***The control run is the load-bearing datum.*** *The identical target
+  with `direct_insertion: false` validates at **0 issues**, so all 9
+  errors are caused by the row cell rather than being pre-existing. No
+  need to re-establish that next session.*
+
+  *Blocking error, diagnosed: a vertical `fast-transport-belt` at x=46 is
+  routed through occupied tiles at y=20–25, colliding with an
+  `electric-furnace` (from the copper-plate producer row) and with cell
+  entities. The row cell is ~39 tiles wide at pitch `machine_w + 1`,
+  wider than any ordinary row, and something in lane/return routing is
+  not respecting occupancy across that span. Ruled out already: the
+  `input_belt_y` ordering contract holds (fused inputs are
+  `[copper-plate, iron-plate]`, belts are `[y0, face_y+1]`, matching).*
+
+  *Four bugs fixed reaching this point, each a silent mis-build:
+  `cell_pairs` required exactly one coupling per consumer, excluding
+  `electronic-circuit` (coupled on two items) entirely; claiming a pair
+  on eligibility alone let the unbuildable 16:4 `iron-plate → EC`
+  coupling block the workable `copper-cable → EC` one; the build path
+  called `try_build_cell` unconditionally, bypassing the gate that stops
+  a two-solid-input consumer being fused into a STACKED cell; and the
+  producer's feed was reach-2, reintroducing long-handed's 2.40/s ceiling
+  that the row shape exists to avoid.*
+
+  *Also outstanding: 2 of the new `row_stamp` tests still assert the
+  pre-rework geometry, and `di_bridge_feeds_cable_only_at_high_research`
+  is a genuine regression — cable→EC now forms a row cell where that test
+  pins bridge behaviour. Decide whether it should assert the row cell or
+  pin DI off.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1365,3 +1365,45 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   have now been proposed and all four killed by probing, which is
   itself the finding — the remaining fault is in routing/flow, not
   geometry.*
+
+- *2026-07-25 — **PHASE 2 WORKS: both top corpus DI pairs now build,
+  validate clean and sim at or above plan.** The root cause of the EC
+  starve was ORDERING, not geometry — the fifth hypothesis after four
+  structural ones were probed to destruction. A fused cell consumes the
+  union of both halves' belt-fed inputs, so it must be placed where all
+  of them are available: at the CONSUMER's slot in the topological order,
+  not the producer's. Emitting at the producer's slot put the cell north
+  of its own iron-plate supply (iron's row landed at y=22 against the
+  cell at y=10–17), breaking the lanes-run-south invariant; the router
+  could only answer with a 1-entity "return path", iron never arrived,
+  the EC machines were ingredient-short and the whole chain backed up.*
+
+  | pair | uses DI | validates | sim delivered |
+  |---|---|---|---|
+  | `copper-cable → electronic-circuit` (#1, 4,116) | 153 `di-row` | **0 issues** | **101.3%**, 50/50 working |
+  | `electric-furnace → electric-furnace` (#2, 1,585) | 176 `di-cell` | **0 issues** | **109.5%**, 32/32 working |
+
+  *Two further bugs fell out of that fix and are worth keeping: skipping
+  the producer lazily was too late (it sorts earlier, so it had already
+  been placed — its own output belt was stamped over the cell's
+  iron-plate belt), so `fused_specs` is pre-populated from `cell_pairs`;
+  and pre-populating made an unbuildable claim FATAL, because the
+  producer would be skipped while the cell then refused, dropping its
+  production silently — so selection now does a trial build at `y=0`
+  (every refusal is y-independent) and only claims pairs that will
+  actually build.*
+
+  ***Followup, deliberately narrowed not dropped:*** *the `merge_x_cursor`
+  fix is scoped to layouts containing a fused cell row. The unconditional
+  form is the more principled reading of the invariant its own comment
+  states, but it regressed `mega_chain_ac_from_raw_zero_issues`, and
+  diagnosing why mega chains depend on the old cursor was out of scope.
+  Scoping keeps every pre-existing layout bit-identical. **The
+  unconditional form remains the right long-term fix** once that
+  interaction is understood.*
+
+  *Method note: five hypotheses, four disproven by probing before any
+  code changed. The four eliminations (taps connected, output merged,
+  face inserters correct, geometry sound) are what made the fifth
+  findable — each had been committed to this log as a diagnosis and then
+  retracted. Probing before fixing was the whole difference.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1627,3 +1627,102 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   *The probe that overturned it took one file and one `cargo run`. When
   the engine refuses, print what the caller actually passes before
   reasoning about why.*
+
+- *2026-07-25 — **The fluid-CONSUMER shape is BUILT and currently
+  UNREACHABLE, and the sim is the only reason we know.**
+  `solid-fuel-from-light-oil → rocket-fuel` (652 instances, the corpus's
+  #2 DI pair) builds a row cell that validates **0 errors 0 warnings** at
+  0.25–2/s — and in a headless Factorio produces **literally nothing**:
+  `rocket-fuel planned 1.00, produced 0.00, −100.0%`, census `no_fuel: 8`
+  with all ten upstream chemical plants backed up behind the stall.*
+
+  ***The solver resolves `rocket-fuel` (category `organic-or-assembling`)
+  to a `biochamber`, which is burner-fuelled — fuel category
+  `nutrients` — and nothing anywhere in the engine delivers burner
+  fuel.*** *`validate::power` deliberately exempts biochambers from
+  coverage (correctly: they draw no grid power) and no check takes over
+  the obligation, so a burner row is invisible to every gate we have.
+  `recipe_db::category_machines` offers only `["biochamber"]` for
+  `organic-or-assembling`, ignoring the `-or-assembling` half of the name
+  — the same shape as `metallurgy-or-assembling` and
+  `cryogenics-or-assembling`. So there is no way to steer this pair onto
+  an assembler today.*
+
+  *Two fixes follow, and only the narrow one is taken here:
+  `cell_machines_are_powerable` now refuses a cell whose either role is
+  non-electric. **A cell that cannot run is worse than no cell, because
+  it validates clean and lies.** The engine-wide half — delivering burner
+  fuel, or honouring `-or-assembling` in machine selection — is NOT
+  attempted; it is a recipe-db/solver decision with blast radius well
+  beyond this RFC, and it wants its own issue.*
+
+  *This is the third time in this RFC that a mechanism has landed
+  correct-but-unreachable (pipe cut → footprints → this). The difference
+  is how it was caught: validation, unit tests and an entity census all
+  said yes. **Only the sim said no.** Zero validation errors means the
+  checks we wrote passed, not that the factory runs — and for a burner
+  machine we have not written any check at all.*
+
+  *What the shape itself achieves, kept and unit-tested against the day
+  it becomes reachable:*
+
+  *The scoping note said this shape was "genuinely harder" because the
+  consumer's south face already carries a solid input and the output, so
+  a pipe needs a face the cell does not have. Probing the pair first —
+  the discipline the previous entry was written to enforce — showed that
+  premise did not hold either:*
+
+  - *the consumer draws **light-oil**, the same fluid the producer is
+    already piped, so no second run is needed;*
+  - *chemical plant and biochamber are **both 3×3** with geometrically
+    identical fluid boxes (`fluid_ports` already models biochamber as
+    `CHEM`), so bottom-alignment puts both north faces on the pipe row
+    the producer's run already occupies;*
+  - *the coupled item is the consumer's **only** solid ingredient, so its
+    south face was never contended — it carries the output alone.*
+
+  *Eligibility is gated tightly on those three properties — one fluid,
+  the same fluid (different fluids on one run would cross-contaminate),
+  equal heights, and a real north port read from `fluid_ports` rather
+  than assumed.*
+
+  ***A fourth "fix" that did nothing, caught the same way as the merger
+  cursor.*** *The consumer originally registered its own fluid tap points
+  alongside the producer's. Forcing that off produced a **byte-identical
+  layout**: the pipe run is stamped across the full cell width from the
+  producer's side, so it is one connected network and the consumer's
+  north ports are adjacent to it either way — and `fluid_port_pipes` only
+  tells the lane planner where to tap the bus INTO the cell, which the
+  producer's ports already do. Deleted rather than shipped. What IS
+  load-bearing is applying `north_input_orientation` to the consumer:
+  eligibility admits it on the strength of having a north input port, so
+  the stamp has to actually put it there. The fused spec's fluid-rate SUM
+  is likewise unobserved today (pipes have no tier; the sim manifest
+  reads feed rates from the `SolverResult`) but was KEPT — a spec that
+  understates what its row draws is a lie waiting for its first reader,
+  which is a different thing from redundant code.*
+
+  ***A second shape fell out of it.*** *With no belt-fed consumer input
+  the inner belt row is empty, so the output belt moves up into it. That
+  drops a row AND puts the output drop at reach-1, off long-handed's
+  2.40/s ceiling — the constraint that forces two output columns in the
+  ordinary shape. It also removed a `belt-connectivity` error without an
+  exemption: the check looks only at an inserter's 4-neighbours, so a
+  long-handed drop across an empty row reads as "touches no belt". Fixing
+  the geometry was the honest fix; a second validator carve-out would
+  have hidden a real waste.*
+
+  ***The ratio limit is real, but it is alignment, not magnitude.*** *The
+  pair refuses above ~2/s: at P30:C23 the flow intervals put THREE
+  producers against one consumer, and a consumer has two horizontal
+  neighbours. P20:C15 — exactly 4:3 — is fine at any scale. So the row
+  cell's reach is bounded by whether the P:C ratio is a small-denominator
+  fraction, not by how large the counts are. This is the real form of the
+  "ratio tolerance" the retracted entry mis-stated, it does not touch the
+  casting pairs (1:1), and it is Phase 3 / multi-band territory.*
+
+  *`engine-unit → electric-engine-unit` (547) is NOT unlocked by this and
+  was not attempted. Its producer takes **three** solid inputs against
+  the row's one north belt, and its lubricant is a fluid the producer
+  does not draw — two independent blockers, either sufficient. Recorded
+  so the next reader does not re-derive it.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1008,3 +1008,28 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   on this PR"), so a green `claude-review` on the fixed SHA is not
   evidence the fixes were reviewed — the CLAUDE.md warning applies to
   re-reviews too, not just first passes.*
+
+- *2026-07-25 — **Phase 1 coverage measured, so "Phase 1 complete" isn't
+  taken on faith.** Five refusal gates landed during the #450 review
+  fold-in; if they collectively refuse almost everything, the phase is
+  hollow. `di_cell_coverage_sweep` (ignored, in `tests/e2e.rs`) reports
+  cell-vs-fallback across 11 real targets. At yellow: **4 build cells**
+  (`steel-plate` at 1 and 2/s, `iron-stick`, `pipe`, `copper-cable`),
+  and every refusal has an explicable cause rather than a silent one —
+  `electronic-circuit` is Phase 2 (two solid inputs), `iron-gear-wheel`
+  is out on ratio (~4.8 furnaces per gear machine, straddle > 2),
+  `stone-brick` yields no coupling at all, and the high-rate
+  `steel-plate` cases hit belt capacity. **The capacity refusals track
+  real belt limits, verified by re-sweeping at each tier**:
+  `steel-plate@5` needs 25/s of iron-plate, so it refuses on yellow
+  (15/s) and builds on red (30/s); `steel-plate@10` needs 50/s and
+  refuses even on express (45/s), which is correct — one belt cannot
+  feed it. That last case is the real Phase 1 ceiling and it is a
+  **fan-in** limit, not a DI limit: the ordinary path would split the
+  recipe across rows, and a cell cannot (its machines sit at
+  `StraddlePlan` positions), so high-rate couplings need the Phase 3
+  multi-band cell. Recorded as a measurement rather than a guess because
+  the gates were added under review pressure and their aggregate effect
+  was not obvious from any individual one. NB the sweep only varies
+  `max_belt_tier` to characterise the ceiling — the engine must never
+  auto-escalate tier, which stays a hard user-specified constraint.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1564,3 +1564,50 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   cleared. Worth stating plainly in case a fourth is hiding behind the
   third: the corpus tells us what shape to build, but it does not tell us
   what our own engine will refuse, and only an end-to-end attempt does.*
+
+  > **RETRACTED 2026-07-25 (same day).** *The ratio claim above is wrong,
+  > and the "run the experiment" lesson it was written to illustrate is
+  > exactly what it failed to do. See the next entry.*
+
+- *2026-07-25 — **There was no ratio prerequisite. `casting-* → EC` was
+  blocked on a validator false positive, and both pairs now build and
+  validate clean.** The entry above computed the straddle from the raw
+  per-machine rates — a foundry's 8.0 cable/s against an assembler's
+  7.5/s, hence the 16:15 arithmetic. That is not what the caller passes.
+  `try_build_row_cell` scales both rates by `utilization_for`, and
+  utilization is precisely the fraction that makes a fractional machine
+  count integral: 8.0 × 0.9375 = 7.5. The pair lands exactly 1:1 at every
+  rate, and `plan_row_straddle` has always accepted it.*
+
+  *The real blocker was `check_belt_connectivity`. A fluid-fed producer
+  in a row cell takes its ingredients through a pipe and hands its
+  product straight to the neighbouring machine, so no inserter of its
+  ever touches a belt — which the check reported as
+  `"no inserter connects to a belt"`, one error per foundry, at every
+  rate. `fluid_only_recipes` did not cover it: `casting-copper-cable` has
+  a fluid input but a SOLID output. Added `fluid_input_only_recipes` and
+  a deliberately narrow exemption — the machine must be in a DI cell,
+  have an adjacent COUPLER (proof its product has a route), and have no
+  solid ingredient (nothing a belt would have had to deliver) — so a cell
+  machine that fails to get a real belt is still caught. Pinned by
+  `di_row_cell_fluid_fed_producer_validates_clean`, which was canaried:
+  it fails with the exemption forced off.*
+
+  | pair | corpus | result |
+  |---|---|---|
+  | `casting-copper-cable → EC` | 544 | cell at 2.5–20/s, **0 errors 0 warnings** throughout |
+  | `casting-iron → EC` | 339 | cell at 2.5–15/s, **0 errors 0 warnings** throughout |
+
+  *Above those rates the cell refuses honestly — the consumer's OTHER
+  input (60/s of cable into 8 EC machines) exceeds an express belt's
+  45/s. A DI-off control run confirms the refusal is not a regression:
+  without the cell neither pair lays out at all today (4–32 errors, the
+  foundry left with no adjacent inserter and no pipe), so the cell is
+  currently the only path by which a fluid-fed producer works at all.*
+
+  ***The lesson from the retracted entry stands, sharpened: I wrote
+  "cheap experiments beat careful arguments" and then, in the very next
+  paragraph, blocked a 544-instance pair on an argument I never ran.***
+  *The probe that overturned it took one file and one `cargo run`. When
+  the engine refuses, print what the caller actually passes before
+  reasoning about why.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1614,6 +1614,24 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   observable effect in a 3-row layout; recorded as a smell, not a
   finding.*
 
+  ***Round-trip: the corpus miner reads our own output back as DI.***
+  *Wrapping both exported blueprint strings in the corpus's
+  `{"blueprintString": …}` envelope and running
+  `di-patterns census` over them returns:*
+
+  ```
+  8 DI observations; top producer -> consumer pairs:
+        4  casting-copper-cable -> electronic-circuit
+        4  casting-iron -> electronic-circuit
+  ```
+
+  *This is worth more than the `di-row` segment counts used elsewhere in
+  this log: the miner re-derives DI from raw entity geometry — inserter
+  direction, reach, and machine occupancy — with no knowledge of our
+  `segment_id` labels. The same tool that told us which pairs were worth
+  building confirms we built them. Four couplings per pair is exactly the
+  P4:C4 straddle at 10/s.*
+
   *Above those rates the cell refuses honestly — the consumer's OTHER
   input (60/s of cable into 8 EC machines) exceeds an express belt's
   45/s. A DI-off control run confirms the refusal is not a regression:

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -452,6 +452,32 @@ caveat.
    bus control to within 0.7pp produced / 0.0pp delivered. The
    criterion does not fire.
 
+   **The "validates clean" half was NOT true on the first pass, and
+   finding that out took a second look.** KC3 is a conjunction — a cell
+   that *validates clean* AND under-delivers — and the first measurement
+   only checked the throughput half. Running the validator afterwards
+   returned **16 `Error`s and 48 warnings**: every producer furnace
+   flagged `output-belt: no output inserter has a belt at its drop
+   position`, plus `inserter-throughput` crediting cell machines 0.00/s.
+   All false positives — the sim had already proved the shape moves
+   112% of plan — but a DI feature that buries the validator in false
+   errors is not shippable, and worse, real errors would have been
+   indistinguishable. Two distinct causes, both now fixed and both
+   inherent to the cell design rather than incidental:
+
+   - a cell producer has **no output belt at all** (its output leaves
+     through the band), so every "machine must have an output inserter
+     dropping onto a belt" test fails by construction;
+   - the fused `RowSpan` carries the producer's inputs, so
+     `resolve_row_spec` attributes the producer's input item to the
+     *consumer* machines — the check asked furnaces eating iron-plate to
+     account for iron-ore.
+
+   `validate::is_di_cell_entity` now exempts cell entities the way
+   `is_di_bridge_inserter` handles #432's bridges. **Post-fix: 0
+   validation issues, same 112% delivery.** So KC3's conjunction is
+   satisfied on both halves — but only after the gap was closed.
+
    **The control is the load-bearing part.** A single DI run showing
    +10.7% is uninterpretable: a solver rate-model artifact and a DI
    artifact are indistinguishable without it. Running the same target
@@ -926,3 +952,30 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   second face flow by construction) and KC5 (solver escalation bound).
   Orthogonal follow-up, deliberately NOT folded into this RFC: the ~10%
   electric-furnace steel rate discrepancy the control exposed.*
+
+- *2026-07-25 — **#450 review found three real bugs; a fourth was found
+  by closing my own verification gap.** The bot's findings, all
+  confirmed against the code before fixing rather than taken on trust:
+  **(1)** `fused_cell_spec` dropped the producer's module loadout — the
+  module post-pass keys `(entity, recipe)` off `row_spans`, and a cell
+  contributes only the consumer's recipe, so producer machines would get
+  no modules while the solver had already folded the bonus into their
+  count. Now refused outright (matching loadouts wouldn't help: the
+  *key* is missing). **(2)** `SidePlan.count`/`.shortfall` were computed
+  and discarded — `DiCellIo` carries an entity name and no count, so a
+  face needing two inserters got one and silently under-fed. Now sized
+  against a single slot and refused when that isn't enough; the comment
+  claiming "a single-inserter face isn't an implicit throughput cap"
+  asserted the exact opposite of the behaviour. **(3)** the cell's
+  output belt was sized against the raw combined rate although it is
+  physically single-lane (all output inserters share a y and a facing,
+  so every drop lands in the far lane) — a 2× over-estimate, and cells
+  never split by throughput the way ordinary rows do. Now sized at
+  `rate * 2.0` and refused when one lane can't carry it. **(4)** Mine:
+  the KC3 run measured throughput but never ran the validator, so
+  "validates clean" went unverified — and was false (16 errors). Fixed
+  via `is_di_cell_entity`. The through-line in all four is the same
+  shape of mistake — trusting a number that was never checked
+  (`.count`, lane capacity, the module key, the warning list) — which is
+  the failure mode this RFC's own verification protocol exists to catch,
+  and which three of four green test runs did not surface.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -421,10 +421,40 @@ caveat.
    reachable producers, the sandwich shape is wrong for the game's own
    ratios — stop and reconsider the topology, do not "mostly" feed
    consumers.
-2. **Face contention.** If the consumer's remaining face cannot carry
-   its non-DI flows (iron in + EC out) within its tile budget at
-   **≤ L2** `inserter_capacity` (i.e. the cell is only feasible at max
-   research), the topology is under-scoped — stop.
+2. **Face contention. ✅ EVALUATED 2026-07-25 — PASSES, with zero
+   margin.** If the consumer's remaining face cannot carry its non-DI
+   flows (iron in + EC out) within its tile budget at **≤ L2**
+   `inserter_capacity` (i.e. the cell is only feasible at max research),
+   the topology is under-scoped — stop. Measured against the real rate
+   tables (`kc2_face_contention` in `tests/e2e.rs`), AM3 canonical,
+   2.5/s each way, 3-wide face:
+
+   | side | inserter | rate @L2 | needed | columns |
+   |---|---|---|---|---|
+   | near (reach-1) | fast | 4.62/s | 2.5/s | **1** |
+   | far (reach-2) | long-handed | **2.40/s** | 2.5/s | **2** |
+   | | | | | **3 of 3 → PASSES** |
+
+   The criterion does not fire, but every column is consumed. The bind
+   is structural rather than a research shortfall: long-handed is the
+   only reach-2 inserter (I8a) and its belt-drop rate is 2.40/s at L2
+   rising only to 3.20/s at L7, so max research buys back exactly one
+   column and no more. Swapping which item takes the near belt is
+   symmetric (both flows are 2.5/s), so 1 + 2 is the budget either way.
+
+   **Consequences Phase 2 must design around, not discover later:** a
+   Phase 2 cell has **no spare face column**, so any consumer with a
+   third flow (second output, third input) does not fit and must refuse;
+   and pipe placement — which KC6 re-scoped INTO this phase — needs face
+   tiles this budget does not have, so fluid-touching consumers will
+   need a different face plan rather than this one extended.
+
+   *Incidental finding, flagged not folded:* `bulk-inserter`'s belt-drop
+   rate is flat 2.40/s across every research level AND every belt tier,
+   while its machine-feed rate scales 2.40 → 4.80 → 14.40. That makes
+   bulk strictly dominated for output faces. It may be correct, but
+   Phase 2's allocator will lean on this ladder and the asymmetry should
+   be verified before it does.
 
    **2b. Tier-cap degradation.** `max_inserter_tier` is a hard user cap,
    orthogonal to research level. If, at the engine defaults

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -449,12 +449,18 @@ caveat.
    tiles this budget does not have, so fluid-touching consumers will
    need a different face plan rather than this one extended.
 
-   *Incidental finding, flagged not folded:* `bulk-inserter`'s belt-drop
-   rate is flat 2.40/s across every research level AND every belt tier,
-   while its machine-feed rate scales 2.40 → 4.80 → 14.40. That makes
-   bulk strictly dominated for output faces. It may be correct, but
-   Phase 2's allocator will lean on this ladder and the asymmetry should
-   be verified before it does.
+   *Incidental finding, raised and then CLEARED:* `bulk-inserter`'s
+   belt-drop rate is flat 2.40/s across every research level and belt
+   tier, while its machine-feed rate scales 2.40 → 4.80 → 14.40. That
+   looked like a modelling gap Phase 2's allocator might trip over.
+   It is not — `belt_drop_rate`'s own doc states it: *"bulk inserters:
+   always flat — the engine never places one"*, i.e. a deliberate
+   simplification for an entity that only ever arrives by parsing
+   community blueprints. It also cannot affect this phase twice over:
+   bulk is reach-1, so it is structurally excluded from the binding
+   far/reach-2 column, and on the near side stack dominates it (6.38/s
+   vs 2.40/s at L2). Recorded because "verify the load-bearing number"
+   was the right instinct even though the answer was benign.
 
    **2b. Tier-cap degradation.** `max_inserter_tier` is a hard user cap,
    orthogonal to research level. If, at the engine defaults

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -500,6 +500,36 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
 - **Phase 1 — the DI cell.** `bus::di_cell` for the simplest shape: one
   producer recipe, one consumer recipe, consumer's only solid input is
   the DI'd item.
+
+  **⚠️ The worked example in this RFC is NOT a Phase 1 shape (found
+  2026-07-25).** `electronic-circuit` takes `[iron-plate,
+  copper-cable]` — *two* solid inputs — so `copper-cable → EC`, the pair
+  every geometry figure above is derived from, fails Phase 1's own scope
+  line. The consumer's north face is spent on the DI band and its south
+  face on the output inserter, so the second input has nowhere to land
+  until Phase 2's face allocation. The geometry stays valid (the
+  straddle math is rate-driven and item-agnostic — that is why 1a could
+  reproduce `[1,5,10,14]`), but the **wiring target** must be a
+  single-solid-input consumer. From `recipes.json`, discounting
+  `*-recycling`, the in-scope pairs are:
+
+  | producer → consumer | note |
+  |---|---|
+  | `iron-plate → steel-plate` | furnace→furnace; the corpus's 1,585-instance shape |
+  | `iron-plate → iron-gear-wheel` | canonical assembler cell |
+  | `iron-plate → pipe`, `→ iron-stick` | same shape |
+  | `copper-plate → copper-cable` | producer is the smelter |
+  | `stone → stone-brick` | furnace→furnace |
+
+  **This gate must live in the placer, not the solver.**
+  `netflow::detect_di_couplings` gates on one-producer / one-consumer /
+  no-external-supply / no-surplus / not-fluid — it does **not** look at
+  the consumer's input count. So it *will* emit a `copper-cable →
+  electronic-circuit` coupling, and Phase 1c wiring that trusts the
+  coupling list would build a cell whose EC machines never receive
+  iron-plate: a layout that validates clean and starves, which is
+  exactly the #383/#432 failure mode this RFC's own verification note
+  warns about.
   - **1a ✅ LANDED — straddle geometry + edge assignment.**
     `bus::di_cell::plan_straddle` is the algorithmic core: producer and
     consumer machine positions, the producer→consumer edge set, per-edge
@@ -548,21 +578,39 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
       belt) and returns a `DiCellLayout` carrying `input_belt_y` /
       `output_belt_y` / x-extent, i.e. exactly the fields a `RowSpan`
       needs. What remains of this step is constructing the `RowSpan`
-      itself and hanging it off a `RowKind`. **Open contract question,
-      narrowed 2026-07-25**: the producer row in a cell has NO solid
-      output belt (its output leaves by inserter), but `RowSpan`'s
-      `output_belt_y` is a plain `i32`, not an `Option`. Evidence that
-      this is benign: `lane_planner` only reads
-      `output_belt_y_for(item)` while *constructing a lane*, and the
-      coupled item's lane is dropped before that point because the
-      consumer carries `di_input` for it (zero surviving consumers ⇒
-      lane skipped). So the field should never be read for the DI'd
-      item — but that is currently an INFERENCE from reading the code,
-      not a verified property. Confirm it empirically (build a cell
-      layout, run the validator) before relying on it, or give the
-      producer's `output_belt_y` a deliberately invalid sentinel so a
-      stray read fails loudly instead of silently pointing at a tile
-      that isn't a belt; (2) intercept the producer/consumer spec pair
+      itself and hanging it off a `RowKind`. **Contract question —
+      RESOLVED 2026-07-25, by design change rather than by either
+      prescribed remedy.** The question was whether a cell's producer
+      row can safely carry a plain-`i32` `output_belt_y` when it owns no
+      output belt. Two things were established:
+
+      - *The premise it rested on was wrong.* #447 recorded that
+        "`lane_planner` only reads `output_belt_y_for(item)`". There are
+        in fact **11 bare `output_belt_y` reads** across
+        `lane_planner`, `lane_order` and `ghost_router`. Auditing every
+        one: eight index through a `BusLane`
+        (`all_producers()` / `producer_row` / `extra_producer_rows`, or
+        `all_producer_rows` during lane construction), so the
+        `di_input` argument does cover them; but the three
+        output-merger sites (`ghost_router.rs:3435`, `:3519`, `:3603`)
+        index rows by **`rs.spec.outputs` containing the item**, not
+        through any lane. A row is reachable there regardless of what
+        the lane planner did, so the original inference was not merely
+        unverified — it was insufficient.
+      - *The fix is to remove the hazard, not detect it.* A cell emits
+        **one fused `RowSpan`**, not two. Its `spec` carries the
+        producer's inputs and the consumer's outputs (the cell really is
+        a composite machine: it eats iron-ore off a belt and emits gears
+        onto one), and its `output_belt_y` is the cell's real output
+        belt. **The producer never gets a row of its own**, so no row
+        with a phantom output belt is ever constructed and all 11 read
+        sites are correct by construction. This also spares every
+        downstream consumer — lane planner, output merger, validators —
+        from special-casing cells.
+
+      The sentinel remedy is therefore not needed, and the "confirm it
+      empirically" remedy would have confirmed a property that does not
+      hold; (2) intercept the producer/consumer spec pair
       in `place_rows` — note this restructures the main placement loop
       (skipping a spec, custom `y_cursor` accounting, `module_id` and
       stacking-context threading), which is the highest-risk part of
@@ -726,3 +774,43 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   the module); 870 lib + 61 e2e green, clippy clean. Remaining: Phase 1c,
   the placer wiring — nothing calls these functions yet, so engine
   behaviour is still unchanged.*
+
+- *2026-07-25 — **The Phase 1c contract question is resolved, and the
+  premise it rested on was false.** #447 recorded the open question as
+  "does anything read a cell producer row's `output_belt_y`?", with the
+  supporting inference that `lane_planner` only ever reads
+  `output_belt_y_for(item)` during lane construction. Auditing all
+  **11** bare `output_belt_y` reads killed that inference: three of them
+  (`ghost_router.rs:3435/:3519/:3603`, the output merger) select rows by
+  `rs.spec.outputs`, never touching a `BusLane`, so `di_input` cannot
+  protect them. Both remedies #447 proposed were aimed at the wrong
+  target — "confirm it empirically" would have confirmed a property that
+  is not true, and the invalid sentinel would have converted a silent
+  bug into a loud one without removing it. **Resolved instead by
+  design**: a cell emits ONE fused `RowSpan` (producer's inputs +
+  consumer's outputs, cell's real output belt) rather than two, so no
+  row with a phantom output belt exists to be read. Recorded because the
+  general lesson is cheap and repeatable: an inference about a field's
+  read-paths is only as good as an exhaustive grep for that field, and
+  #447's was a partial one.*
+
+- *2026-07-25 — **Phase 1's wiring target is retargeted off the RFC's own
+  worked example.** `electronic-circuit` has two solid inputs
+  (`iron-plate`, `copper-cable`), so `copper-cable → EC` — the pair every
+  geometry figure in this RFC is derived from — violates Phase 1's stated
+  scope ("consumer's only solid input is the DI'd item"): the consumer's
+  two usable faces are already spent on the DI band and the output
+  inserter, leaving the iron-plate feed nowhere to land until Phase 2.
+  The geometry work is unaffected (`plan_straddle` is rate-driven and
+  item-agnostic), but 1c must be built and tested against a
+  single-solid-input pair — `iron-plate → iron-gear-wheel` for the
+  assembler case, `iron-plate → steel-plate` for the furnace→furnace
+  shape that dominates the corpus at 1,585 instances. **The eligibility
+  gate belongs in the placer**: `detect_di_couplings` gates on
+  one-producer/one-consumer/no-surplus/not-fluid and never inspects the
+  consumer's input count, so it emits the cable→EC coupling regardless;
+  1c wiring that trusted the coupling list would emit a clean-validating,
+  starving cell. Caught by checking the recipe DB before writing the
+  wiring rather than after — the RFC had carried the contradiction
+  since the first draft because prose scope and worked example were
+  never cross-checked.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1344,3 +1344,24 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   inserter exists per consumer and actually picks iron-plate off y=16.**
   Three hypotheses have now been proposed and two killed by probing —
   probe this one before changing anything.*
+
+  ***Probed; the face is correct too — fourth hypothesis eliminated.***
+  *y=15 holds 12 inserters, exactly 4 consumers x (1 `fast-inserter`
+  carrying iron-plate + 2 `long-handed-inserter` carrying EC), at the
+  consumer x-positions 10/18/30/38, with the iron-plate belt at y=16 and
+  the EC belt at y=17 beneath them. Reach arithmetic verified for all
+  three roles.*
+
+  ***Conclusion after four eliminations: the cell is STRUCTURALLY SOUND
+  and the defect is DYNAMIC.*** *Taps connected, output merged, face
+  inserters present and correctly placed — so this is not a placement
+  bug. It is a flow problem: iron-plate is most likely never arriving on
+  y=16 even though the tap SEGMENT exists at x=5. The next probe is
+  whether that tap connects to its trunk at the FAR (west) end, and
+  whether the iron-plate trunk is routed at all — note the iron-plate
+  furnaces are themselves at `full_output`, which is consistent with
+  their output having nowhere to go rather than with a full belt
+  downstream. Do not change placement code: four structural hypotheses
+  have now been proposed and all four killed by probing, which is
+  itself the finding — the remaining fault is in routing/flow, not
+  geometry.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1280,4 +1280,27 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   `kit_errors` and the chest census before blaming geometry). Those two
   diagnoses have opposite consequences — one kills the Phase 2 shape,
   the other is a harness artifact — so the forensics must be run before
-  either is recorded as fact. **Do that first next session.***
+  either is recorded as fact.*
+
+  ***Forensics run; it is NEITHER.*** *The machine census settles it:
+  **`full_output: 46`, `item_ingredient_shortage: 4`**. Forty-six
+  machines are backed up with a FULL OUTPUT — producing normally and
+  unable to offload — against only four short of ingredients. Import was
+  clean (654/654 ghosts revived), power fine (1 pole network), no kit
+  errors. So:*
+  - *Not a sim-kit artifact: the kit fed the layout and the machines ran.*
+  - ***Not a KC3 trip.** KC3 fires when the topology or the model is
+    wrong. `full_output` means production works and the OFFLOAD PATH is
+    blocked, which is an incomplete integration in unfinished Phase 2
+    code, not evidence against the DI shape. Recording this distinction
+    because the raw numbers (0.00/s, -100%) look identical to a KC3 trip
+    and would have justified killing the row shape on a misreading.*
+
+  *Where the blockage is, from the same run: `copper-plate` produces
+  1.27/s then stalls and `copper-cable` produces 0.00/s, so the cable
+  machines never receive copper-plate. The cell's belts carry `di-row:`
+  segment ids rather than the `row:...:belt-in:<item>` ids ordinary rows
+  use, so the tap-off almost certainly never joins them to the bus —
+  consistent with the belts being stamped by the cell rather than by the
+  row templates. **That is the first thing to fix next session**, and it
+  is a wiring gap, not a design fault.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1321,7 +1321,26 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   observed `full_output: 46`. Next session: check whether
   `merge_output_rows` extends a participating row's output belt east from
   `output_belt_x_max` (ordinary rows must rely on this), and if it does,
-  why the cell row is excluded. Note the cell row is NARROWER than a
-  non-participating row, which is the same asymmetry that caused the
-  original overlap — the merger appears to assume the output row is
-  widest in more than one place.*
+  why the cell row is excluded.*
+
+  ***That is disproven too.*** *The EC output belt (y=17, x=6..44) IS
+  joined east to the merger at x=45..48 (`merger:electronic-circuit`).
+  Both inputs are tapped and the output is merged; the cell is fully
+  connected on all three belts.*
+
+  ***The census localises it exactly, and it is the Phase 2 input.***
+  *50 machines: 40 furnaces + 6 cable + 4 EC. `full_output: 46` = the 40
+  furnaces plus the 6 cable machines; `item_ingredient_shortage: 4` =
+  exactly the 4 EC machines. So the EC machines cannot craft for want of
+  an ingredient; their coupled cable input then fills, the couplers
+  stall, the cable machines back up, and the backpressure reaches the
+  furnaces. Copper-cable arrives by DI and its couplers are stalled
+  BECAUSE EC cannot consume — so the missing ingredient is **iron-plate,
+  the consumer's belt-fed second input**. That is precisely the flow
+  Phase 2 exists to add and that Phase 1 never had to serve, so the
+  defect is in the new south-face plan (consumer feed at `face_y`,
+  reach-1, picking the belt at `face_y+1`), not in the coupling, the
+  taps, or the merge. **Start there next session: verify a consumer feed
+  inserter exists per consumer and actually picks iron-plate off y=16.**
+  Three hypotheses have now been proposed and two killed by probing —
+  probe this one before changing anything.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -979,3 +979,32 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   (`.count`, lane capacity, the module key, the warning list) — which is
   the failure mode this RFC's own verification protocol exists to catch,
   and which three of four green test runs did not surface.*
+
+- *2026-07-25 — **Two more #450 findings, one of them missed on the first
+  fold-in, plus a CI gap that made every green on that PR meaningless.**
+  (a) The cell's input belt was sized from the cell's LOCAL demand, but
+  it is a bus tap-off target like any other row's input — `lane_planner`
+  taps it identically — so it must take the trunk tier via
+  `row_input_belt`, whose doc comment exists precisely to prevent the
+  seam mismatch I reintroduced (fast trunk feeding a yellow row belt,
+  lane-throughput warnings, items backing up at the join). I fixed the
+  output belt in the first pass and did not notice the input belt had the
+  same class of bug. (b) Neither belt refused on capacity:
+  `belt_entity_for_rate_stacked` **saturates** rather than failing, and
+  `plan_straddle` is scale-invariant in machine count, so any pair
+  eligible at rate R stays eligible at 100R while the belts silently
+  under-carry. Both sides now refuse. (c) **`ci.yml` triggers on
+  `pull_request: branches: [main]`, which filters the PR's BASE branch —
+  so #450, stacked on #449, got `ci.yml runs: 0` for its entire life.**
+  The signal was subtle and worth recording: on a docs-only PR the rust
+  jobs show `SKIPPED` (the `changes` filter ran), whereas on #450 they
+  were **absent** — never scheduled — while the two workflows that
+  aren't base-filtered passed and made the checks list look plausible.
+  This affects any stacked PR in the repo; widening the trigger is a
+  workflow-file change and deliberately left for a reviewed PR of its
+  own, given #369's history of an installer silently reverting these
+  files. Also worth noting for the next session: the review bot
+  **skipped** its later passes ("Claude has already left review comments
+  on this PR"), so a green `claude-review` on the fixed SHA is not
+  evidence the fixes were reviewed — the CLAUDE.md warning applies to
+  re-reviews too, not just first passes.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1131,3 +1131,45 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   across matching slots, which means editing that documented assumption in
   two files. Invisible in the canonical cable→EC case (copper-plate vs
   iron-plate are distinct), so it would have shipped and bitten later.*
+
+- *2026-07-25 — **Face allocation mined instead of drawn, and it overturns
+  two things this RFC asserted.** New `di-patterns faces` subcommand: for
+  every machine that RECEIVES direct insertion, report which sides the DI
+  arrives on and where all its other interfaces live (side, reach,
+  in/out, belt-or-machine at the far end). 2,039 cable→EC consumers.
+  Top whole-machine plans:*
+
+  | n | plan |
+  |---|---|
+  | **177** | `DI@E+W \| S:in1→belt S:out1→belt` |
+  | 110 | `DI@S \| N:in1 N:out1 N:out2 N:out2` |
+  | 80 | `DI@N \| S:in1 S:out1 S:out2 S:out2` |
+  | 68 | `DI@W \| N:in1 N:in1 S:out1 S:out1` |
+
+  ***(1) The dominant shape is a horizontal straddle in ONE row, not a
+  stacked cell.*** *The most common plan has the consumer between two
+  producers on its east and west faces, with its remaining input and its
+  output both on the south face and **both reach-1** — north entirely
+  free. That is `P C P C P` interleaved in a single row with ordinary
+  belts above and below, which is much closer to what `place_rows`
+  already does than the producer-row-above-consumer-row cell Phase 1
+  builds. The RFC's hand-drawn sketch (rows 2 and 3 above, 190 combined)
+  is real but is not what most people build.*
+
+  ***(2) KC2's "zero margin" was computed on a false premise.*** *That
+  evaluation assumed the consumer's spare face is ONE inserter row of 3
+  columns, and concluded 1 near + 2 far exactly fills it. But plans 2 and
+  3 carry **four** interfaces on a single face (`in1 out1 out2 out2`),
+  which three columns cannot hold. The resolution is that a reach-2
+  inserter can sit in the SECOND row out — at `y+h+1`, picking from the
+  machine at `y+h-1` and dropping at `y+h+3` — so the face is two rows
+  deep. KC2 still passes; its margin is simply wider than recorded, and
+  the "no spare column, so a third flow must refuse" consequence I drew
+  from it does not follow. Both the criterion's arithmetic and the Phase
+  2 geometry derived from it need redoing against the two-row face.*
+
+  *Method note, since this is the second time it has bitten: the sketch's
+  reach arithmetic was verified and that was mistaken for validating the
+  design. Checking that a drawing is physically possible says nothing
+  about whether it is good or common. The corpus could have answered this
+  at any point in the last three phases and was not asked.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1173,3 +1173,36 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   design. Checking that a drawing is physically possible says nothing
   about whether it is good or common. The corpus could have answered this
   at any point in the last three phases and was not asked.*
+
+- *2026-07-25 — **Phase 2 pivots to the horizontal row straddle, on
+  corpus evidence, and it BENDS LESS than the stacked cell rather than
+  more.** `plan_row_straddle` lands in `bus::di_cell`: producers and
+  consumers interleaved in ONE horizontal row, coupled by inserters in the
+  1-tile gaps between neighbours. Same flow-interval argument as
+  `plan_straddle`, applied in 1-D, with the extra constraint that a
+  consumer has only two horizontal neighbours — so a consumer needing
+  three producers is refused rather than approximated. It reproduces the
+  hand-derived canonical sequence `P C P C P P C P C P` for the 6:4
+  cable→EC ratio without being fitted to it.*
+
+  ***Why this is the better shape, and why it is cheaper:***
+  - *`required_rate() == 5.0/s` for cable→EC, because each edge owns
+    exactly one gap. A stack inserter moves **12.0/s at zero research**,
+    so the pair is feasible with no research at all — against the stacked
+    cell's face plan, which needed L2 and two long-handed inserters.*
+  - ***No reach-2 inserter anywhere.*** *The stacked cell's whole
+    difficulty was the consumer's spare face carrying two flows, forcing
+    a long-handed hop over the near belt at 2.40/s.*
+  - ***It reuses `place_rows` rather than replacing it.*** *A line of
+    machines with belts above and below is what the row templates already
+    emit; the delta is a mixed-recipe machine sequence plus inserters in
+    the gaps. The stacked cell needed a bespoke stamper. Per the standing
+    guidance — reuse where we can, extend where we must — this is the
+    cheaper extension AND the one the corpus endorses.*
+
+  *Consequence for the phase: the mixed-reach face row, the two-row face
+  budget, and KC2's margin all become moot for this shape, since the
+  consumer's remaining input and output sit on one face at reach-1 with
+  the opposite face free. They remain relevant only to the stacked
+  variant, which the corpus puts second (190 combined vs 177 for the top
+  single plan).*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1536,3 +1536,31 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   and later shown to do nothing. Both were caught by an experiment that
   took minutes (force the flag false; attempt an end-to-end build). The
   cheap experiment beat the careful argument every time it was run.*
+
+- *2026-07-25 — **Heterogeneous machine footprints landed; `casting-* → EC`
+  is STILL blocked, by a third prerequisite.** The row cell now paces x by
+  each machine's own width and **bottom-aligns** the two roles so they
+  share one south face row (top-aligning would leave a shorter machine's
+  south face two tiles above the face row, unreachable by its own feed and
+  output inserters). Couplers sit on the bottom row — the only row both
+  roles are guaranteed to occupy. `row_cell_eligible` no longer requires
+  equal dims; the STACKED cell still does, its straddle being derived
+  from a single machine width. Unit-tested with a real 5×5 foundry beside
+  a 3×3 assembler.*
+
+  ***But the pair still refuses, on RATIO.*** *A foundry emits 8.0
+  cable/s and an EC machine wants 7.5/s — a **16:15** ratio whose
+  smallest integer solution is 15 producers : 16 consumers, i.e. 31
+  machines emitting 40/s, which no single output lane carries (express
+  caps at 22.5/s). Machine counts snap to integers, so at any smaller
+  rate supply and demand disagree and `plan_row_straddle` correctly
+  refuses. **`casting-* → EC` therefore needs ratio tolerance too** —
+  either a straddle that admits partial-utilisation machines, or
+  multi-lane output.*
+
+  ***Running tally for this pair: three prerequisites, found one at a
+  time, each only by building.*** *Pipes (done) → footprints (done) →
+  ratio tolerance (open). Each was invisible until the one before it was
+  cleared. Worth stating plainly in case a fourth is hiding behind the
+  third: the corpus tells us what shape to build, but it does not tell us
+  what our own engine will refuse, and only an end-to-end attempt does.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1478,3 +1478,31 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
     fluid `ItemFlow` and the row must populate those fields, or the
     molten-copper lane will never be tapped — the same class of silent
     starve that the iron-plate ordering bug produced.*
+
+- *2026-07-25 — **CORRECTION: the pipe cut is built and unit-tested, and
+  it unlocks NOTHING yet. The scoping above was wrong.*** *The stamper and
+  eligibility changes landed (`fluid_producer_gets_a_pipe_run_on_a_free_north_face`
+  pins the geometry), but every pair the pipe analysis claimed is blocked
+  by a DIFFERENT prerequisite — found only by attempting an end-to-end
+  build:*
+
+  | pair | real blocker |
+  |---|---|
+  | `casting-copper-cable → EC` (544) | **foundry is 5×5, assembler 3×3** — heterogeneous footprints. `row_cell_eligible` requires equal dims because `plan_row_straddle` takes a single `machine_w`. |
+  | `casting-iron → EC` (339) | same |
+  | `solid-fuel-from-light-oil → rocket-fuel` (652) | **fluid on BOTH sides** — `rocket-fuel` takes light-oil as well as solid-fuel, so it is the fluid-CONSUMER shape that was explicitly scoped out. |
+
+  *What went wrong, recorded because it is a repeatable mistake: the
+  mining measured pipe ADJACENCY and recipe INPUTS, and both answers were
+  correct. It never checked machine FOOTPRINTS, and it checked
+  `electric-engine-unit`'s fluid needs (correctly excluding it) while not
+  checking `rocket-fuel`'s. **Measuring the thing you thought of is not
+  the same as measuring the thing that blocks you** — a build attempt
+  found in minutes what three rounds of corpus mining had missed.*
+
+  ***The real prerequisite for fluid DI is heterogeneous machine
+  footprints, not pipes.*** *Two of the three pairs need only that; the
+  third additionally needs the fluid-consumer face plan. The pipe code is
+  kept rather than reverted because it is small, correct and pinned by a
+  test — but it is honestly unreachable today, and **anyone picking this
+  up should do footprints first**.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -1033,3 +1033,31 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   was not obvious from any individual one. NB the sweep only varies
   `max_belt_tier` to characterise the ceiling — the engine must never
   auto-escalate tier, which stays a hard user-specified constraint.*
+
+- *2026-07-25 — **Phase 3 (multi-band) measured before building, and the
+  measurement argues against doing it next.** Extended `di-patterns` with
+  a `fan` subcommand — `Obs` previously carried only recipe names and
+  relative geometry, so fan-in/fan-out/chain were structurally
+  uncomputable; it now records the blueprint-member id and the two
+  machine indices. Corpus results:*
+
+  | shape | fan-in (producers per consumer) | chain (machine is both) |
+  |---|---|---|
+  | `electric-furnace → electric-furnace` (1,585) | **1 for all 1,585** | **0** |
+  | `copper-cable → electronic-circuit` (4,116) | 1 for 634, **2 for 1,405; max 2** | **0** |
+  | all pairs (16,507) | >2 for 237 of 11,536 consumers = **2.1%** | 1,674 / 21,622 = 7.7% |
+
+  *Three conclusions. **(1) `plan_straddle`'s existing ≤2 limit already
+  covers ~98% of real fan-in.** The RFC's stated Phase 3 motivation —
+  "multi-producer straddle for the corpus's awkward ratios" — is chasing
+  a 2.1% tail. **(2) Neither dominant shape uses stacked bands at all**
+  (chain = 0 for both); the 7.7% global figure lives in pairs nobody has
+  asked for. **(3) cable→EC needs exactly the 2-producer straddle Phase 1
+  already implements** — what blocks it is the second solid input, i.e.
+  Phase 2 face allocation, not the straddle. Separately, the Phase 1
+  ceiling measured earlier (`steel-plate@10` refusing on input-belt
+  capacity) is **not** a straddle problem either: it needs more than one
+  input belt feeding a cell, which multi-band does not address. So the
+  honest ordering is **Phase 2 before Phase 3**, and Phase 3's scope
+  should be rewritten around the fan-in belt limit rather than around
+  multi-producer straddle, which is largely already solved.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -619,9 +619,22 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
         downstream consumer — lane planner, output merger, validators —
         from special-casing cells.
 
-      The sentinel remedy is therefore not needed, and the "confirm it
-      empirically" remedy would have confirmed a property that does not
-      hold; (2) intercept the producer/consumer spec pair
+      **What the audit does and does not establish.** It shows #447's
+      *argument* was insufficient — three sites are reachable by a path
+      `di_input` does not guard. It does **not** show the property
+      itself is false. In fact the property probably does hold today,
+      via a guard #447 never cited: the merger loops iterate
+      `output_items`, built from `solver_result.external_outputs`, and
+      `detect_di_couplings` only couples an item with **no surplus**, so
+      a coupled item is never an external output and the producer row is
+      never selected there. Both #447 remedies were therefore
+      *reasonable*; an empirical check would have been a valid way to
+      test the claim. The fused row is preferred not because they were
+      wrong-headed but because it **stops depending on the question**:
+      its correctness rests on the row owning a real belt, not on a
+      solver-side invariant ("coupled items never carry surplus") that
+      Phase 3 could plausibly relax; (2) intercept the producer/consumer
+      spec pair
       in `place_rows` — note this restructures the main placement loop
       (skipping a spec, custom `y_cursor` accounting, `module_id` and
       stacking-context threading), which is the highest-risk part of
@@ -794,16 +807,31 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   **11** bare `output_belt_y` reads killed that inference: three of them
   (`ghost_router.rs:3435/:3519/:3603`, the output merger) select rows by
   `rs.spec.outputs`, never touching a `BusLane`, so `di_input` cannot
-  protect them. Both remedies #447 proposed were aimed at the wrong
-  target — "confirm it empirically" would have confirmed a property that
-  is not true, and the invalid sentinel would have converted a silent
-  bug into a loud one without removing it. **Resolved instead by
+  protect them. **Corrected after review (#449):** the first draft of
+  this entry escalated that into "the property is false, so both #447
+  remedies were aimed at the wrong target" — an overclaim the audit does
+  not support. Reachability by an unguarded path is not the same as a
+  phantom value actually being read. The property probably *does* hold
+  today, via a guard #447 never cited: the merger iterates
+  `output_items`, built from `solver_result.external_outputs`, and
+  `detect_di_couplings` only couples items with **no surplus**, so a
+  coupled item never appears there. An empirical check would have been a
+  perfectly valid way to test it. What the audit actually establishes is
+  narrower and still worth having: #447's stated *argument* did not
+  cover all the read sites, and the real guard is a different, narrower
+  one than the entry claimed. **Resolved instead by
   design**: a cell emits ONE fused `RowSpan` (producer's inputs +
   consumer's outputs, cell's real output belt) rather than two, so no
   row with a phantom output belt exists to be read. Recorded because the
   general lesson is cheap and repeatable: an inference about a field's
   read-paths is only as good as an exhaustive grep for that field, and
-  #447's was a partial one.*
+  #447's was a partial one. The **second** lesson came from the review
+  bot catching this entry's first draft overclaiming — "incomplete
+  argument" was evidence-backed, "false property" was not, and the two
+  are easy to conflate when you have just found a gap in someone's
+  reasoning. The fused row's real virtue is that it needs neither
+  question settled: it depends on the row owning a real belt, not on a
+  solver-side invariant that Phase 3 could relax.*
 
 - *2026-07-25 — **Phase 1's wiring target is retargeted off the RFC's own
   worked example.** `electronic-circuit` has two solid inputs

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -64,6 +64,6 @@ backfill the status next time the doc is touched.
 | RFC-050 | 2026-07-22 | [`rfc-050-headless-sim-harness.md`](rfc-050-headless-sim-harness.md) | Complete (fluid feed CALIBRATED via #364 — first fluid factory PASS; fluid-pack sweep + #345 re-measure open) |
 | RFC-051 | 2026-07-22 | [`rfc-051-cell-composition-integration.md`](rfc-051-cell-composition-integration.md) | Complete — default Candidate; sim registry; K-quantization (corridor-cap); EC-row re-measure waits on #381 |
 | RFC-052 | 2026-07-23 | [`rfc-052-oil-mega-cell.md`](rfc-052-oil-mega-cell.md) | Design (circulated for review) |
-| RFC-053 | 2026-07-24 | [`rfc-053-direct-insertion-cells.md`](rfc-053-direct-insertion-cells.md) | Active — Phase 0 complete (KC1 passed; KC6 fired → pipes re-scoped into Phase 2). #432 merged; Phase 1 ready. |
+| RFC-053 | 2026-07-24 | [`rfc-053-direct-insertion-cells.md`](rfc-053-direct-insertion-cells.md) | Active — **Phases 0 + 1 complete**; engine emits fused DI cells, inert by default. KC1/KC2/KC3/KC4 all evaluated and passing (KC6 fired → pipes re-scoped into Phase 2). Next: Phase 2 face allocation — corpus `fan` data reordered it ahead of Phase 3. |
 
 Next number: **RFC-054**.

--- a/docs/status.md
+++ b/docs/status.md
@@ -183,14 +183,36 @@ instances) 101.3% delivered, 50/50 machines working;
 threads `direct_insertion` through wasm, the worker, URL state (`di=1`)
 and a sidebar checkbox — **still off by default**, since a pair the
 engine cannot serve as a cell falls back to the bridge and then the bus.
-Open against this RFC: **pipes/fluids were re-scoped INTO Phase 2 by KC6
-and did NOT ship** (fluid-touching pairs still refuse, ~30% of top-10
-demand); modules refuse (the module post-pass keys `(entity, recipe)` off
-`row_spans` and a fused row contributes only the consumer's recipe); KC5
-(solver escalation bound) is still unevaluated; and `merge_x_cursor`'s
-fix is narrowed to cell layouts because the unconditional form — the
-one its own comment prescribes — regressed
-`mega_chain_ac_from_raw_zero_issues`. Corpus `fan` analysis redirected Phase 3: fan-in >2 is only 2.1%
+**Fluid-fed PRODUCERS now ship too (2026-07-25, same PR)**: both
+`casting-*` → EC pairs (#3 at 544 instances and #4 at 339) build a row
+cell, validate **0 errors 0 warnings** across 2.5–20/s, and sim at
+**101.3% delivered / 100.0% produced**. They needed three things, each
+found only by attempting an end-to-end build: the pipe cut, heterogeneous
+footprints (5×5 foundry beside a 3×3 assembler, bottom-aligned), and a
+`belt-connectivity` exemption — a piped producer hands its product
+straight to its neighbour, so no inserter of its ever touches a belt.
+Without the cell neither pair lays out at all today, so this is the only
+path by which a fluid-fed producer works. A fourth prerequisite ("ratio
+tolerance") was **claimed and then disproved**: it came from feeding
+`plan_row_straddle` raw per-machine rates, where the caller passes
+utilization-scaled ones.
+
+The fluid-drawing CONSUMER shape is **built but unreachable**, and the
+sim is the only reason we know:
+`solid-fuel-from-light-oil → rocket-fuel` (652 instances) produced a
+cell validating 0/0 that made **literally nothing** — the solver
+resolves `rocket-fuel` to a burner `biochamber` and nothing in the
+engine delivers burner fuel. `cell_machines_are_powerable` now refuses
+non-electric roles; the engine-wide gap is **issue #461**.
+
+Open against this RFC: modules refuse (the module post-pass keys
+`(entity, recipe)` off `row_spans` and a fused row contributes only the
+consumer's recipe); KC5 (solver escalation bound) is still unevaluated;
+and the row cell's rate ceiling is bounded by ratio **alignment** — at
+P30:C23 the flow intervals put three producers against one consumer,
+while P20:C15 (exactly 4:3) is fine at any scale.
+
+Corpus `fan` analysis redirected Phase 3: fan-in >2 is only 2.1%
 of the corpus and neither dominant shape uses stacked bands, so
 multi-band is a small tail and **Phase 2 (face allocation) should come
 first**. Open tracking items: the ~10% electric-furnace steel rate

--- a/docs/status.md
+++ b/docs/status.md
@@ -147,11 +147,33 @@ unweighted where its rationale was demand (solids-only actually covers
 **69.4%** of top-10 instances, and the dominant pair is fully solid).
 Resolution was the criterion's own prescribed action — **re-scope, not
 reprieve**: pipes moved out of Non-goals into required Phase 2 scope.
-Phases 1–4 remain; **Phase 1 is blocked on #432** (`DICoupling` and
-`direct_insertion` do not exist on `main`). Recorded data gap:
-`electric-furnace → electric-furnace` is the 2nd-commonest DI pair
-(1,585) but is invisible to recipe-keyed analysis — furnaces carry no
-explicit recipe.
+Recorded data gap: `electric-furnace → electric-furnace` is the
+2nd-commonest DI pair (1,585) but is invisible to recipe-keyed analysis
+— furnaces carry no explicit recipe.
+
+**`rfc-053` Phase 1 COMPLETE (2026-07-25, PR #452 — RFC still ACTIVE,
+Phases 2–4 remain)**: `place_rows` fuses an eligible producer/consumer
+pair into ONE cell row, so the engine emits true
+machine→inserter→machine DI for the first time. **Inert by default**
+(`direct_insertion: false`) — no existing layout moved. Three more kill
+criteria evaluated, all passing: **KC3 (honest throughput)** —
+sim-measured 2.24/s delivered against 2.00/s planned (112%), 0
+validation issues, 32/32 machines working, *with a DI-off control on the
+same target* that delivers the identical 2.24/s, attributing the +12%
+overshoot to a solver rate-model artifact rather than to DI; **KC4
+(density)** re-confirmed end-to-end at 213 entities vs the bus control's
+335 (−36%); **KC2 (face contention)** — passes at L2 but with **zero
+margin**, 1 near + 2 far = 3 of 3 columns, which constrains Phase 2's
+design. Coverage measured rather than assumed: 4 of 11 real targets
+build cells, every refusal with a named cause, and the ceiling is a
+**fan-in belt limit** (one belt cannot feed a high-rate cell), not a DI
+limit. Corpus `fan` analysis redirected Phase 3: fan-in >2 is only 2.1%
+of the corpus and neither dominant shape uses stacked bands, so
+multi-band is a small tail and **Phase 2 (face allocation) should come
+first**. Open tracking items: the ~10% electric-furnace steel rate
+under-prediction the KC3 control exposed (orthogonal to this RFC), and
+`ci.yml`'s `pull_request: branches: [main]` base filter, which silently
+gives any **stacked PR zero CI**.
 
 **`rfc-052-oil-mega-cell.md` close-out (2026-07-24, Phases A/B/C —
 PRs #401/#403/#405/#408/#411/#421)**: fluid subgraphs compose as

--- a/docs/status.md
+++ b/docs/status.md
@@ -167,7 +167,30 @@ margin**, 1 near + 2 far = 3 of 3 columns, which constrains Phase 2's
 design. Coverage measured rather than assumed: 4 of 11 real targets
 build cells, every refusal with a named cause, and the ceiling is a
 **fan-in belt limit** (one belt cannot feed a high-rate cell), not a DI
-limit. Corpus `fan` analysis redirected Phase 3: fan-in >2 is only 2.1%
+limit.
+
+**`rfc-053` Phases 2 + 4 landed (2026-07-25, PR #459)**: the
+horizontal ROW cell — producers and consumers interleaved in one row,
+coupled east/west in the 1-tile gaps — chosen on corpus evidence
+(`di-patterns faces`: the dominant real shape is `DI@E+W | S:in1 S:out1`,
+both remaining flows on one face at reach-1, opposite face free). It
+needs **no reach-2 inserter and no research** (stack moves 12.0/s at L0
+against a 5.0/s requirement) and reuses `place_rows` rather than
+replacing it. **Both TOP corpus DI pairs now build, validate at 0 issues
+and sim at/above plan**: `copper-cable → electronic-circuit` (#1, 4,116
+instances) 101.3% delivered, 50/50 machines working;
+`electric-furnace → electric-furnace` (#2, 1,585) 109.5%, 32/32. Phase 4
+threads `direct_insertion` through wasm, the worker, URL state (`di=1`)
+and a sidebar checkbox — **still off by default**, since a pair the
+engine cannot serve as a cell falls back to the bridge and then the bus.
+Open against this RFC: **pipes/fluids were re-scoped INTO Phase 2 by KC6
+and did NOT ship** (fluid-touching pairs still refuse, ~30% of top-10
+demand); modules refuse (the module post-pass keys `(entity, recipe)` off
+`row_spans` and a fused row contributes only the consumer's recipe); KC5
+(solver escalation bound) is still unevaluated; and `merge_x_cursor`'s
+fix is narrowed to cell layouts because the unconditional form — the
+one its own comment prescribes — regressed
+`mega_chain_ac_from_raw_zero_issues`. Corpus `fan` analysis redirected Phase 3: fan-in >2 is only 2.1%
 of the corpus and neither dominant shape uses stacked bands, so
 multi-band is a small tail and **Phase 2 (face allocation) should come
 first**. Open tracking items: the ~10% electric-furnace steel rate

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -274,7 +274,7 @@ function allProducerMachines(): string[] {
   return machinesCache;
 }
 
-function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string): Promise<LayoutResult> {
+function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string, directInsertion?: boolean): Promise<LayoutResult> {
   return call<LayoutResult>({
     method: "layout",
     result,
@@ -286,10 +286,11 @@ function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: stri
     wireMode: wireMode ?? null,
     stacking: stacking ?? null,
     inserterCapacity: inserterCapacity ?? null,
+    directInsertion: directInsertion ?? false,
   });
 }
 
-function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string): Promise<LayoutResult> {
+function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string, directInsertion?: boolean): Promise<LayoutResult> {
   return call<LayoutResult>({
     method: "layoutTraced",
     result,
@@ -301,6 +302,7 @@ function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?
     wireMode: wireMode ?? null,
     stacking: stacking ?? null,
     inserterCapacity: inserterCapacity ?? null,
+    directInsertion: directInsertion ?? false,
   });
 }
 
@@ -330,6 +332,7 @@ async function buildLayoutStreaming(
   wireMode: string | undefined,
   stacking: string | undefined,
   inserterCapacity: string | undefined,
+  directInsertion: boolean | undefined,
   onEvent: (evt: TraceEvent) => void,
 ): Promise<LayoutResult> {
   if (activeStreamingId !== null) {
@@ -366,6 +369,7 @@ async function buildLayoutStreaming(
       wireMode: wireMode ?? null,
       stacking: stacking ?? null,
       inserterCapacity: inserterCapacity ?? null,
+    directInsertion: directInsertion ?? false,
       traceLogs,
     });
   });

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -35,6 +35,7 @@ function makeState(overrides: Partial<FormState>): FormState {
     wireMode: null,
     stacking: null,
     inserterCapacity: null,
+    directInsertion: false,
     modules: null,
     customInputs: [],
     ...overrides,
@@ -56,6 +57,7 @@ describe("readUrlState — defaults", () => {
       wireMode: null,
       stacking: null,
       inserterCapacity: null,
+      directInsertion: false,
       modules: null,
       customInputs: [],
     });
@@ -129,6 +131,7 @@ describe("readUrlState — hash form", () => {
       wireMode: null,
       stacking: null,
       inserterCapacity: null,
+      directInsertion: false,
       modules: null,
       customInputs: [],
     });

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -45,6 +45,13 @@ export interface FormState {
    * `docs/rfc-049-inserter-capacity-research.md` and the 2026-07-24 #383
    * default change. */
   inserterCapacity: string | null;
+  /** RFC-053 direct insertion: fuse a coupled producer/consumer pair into
+   * one row joined by inserters, with no belt for the coupled item.
+   * `false` (absent from the URL) is the engine default. Pairs that
+   * cannot be served as a cell fall back to the DI bridge and then to the
+   * bus, so enabling this never makes a layout worse — it is opt-in only
+   * because coverage is still narrow (fluids and modules refuse). */
+  directInsertion: boolean;
   /** Global module policy, compact form `<kind><tier><quality?>` —
    * `s`peed / `p`roductivity, tier 1–3, optional module-quality initial
    * (`u`/`r`/`e`/`l`), e.g. "s2", "p3l". null = no modules (today's
@@ -221,6 +228,9 @@ const STACKING_EXTRAS_KEY = "st";
 // one (nothing forces you to notice a swapped pair of letters). `ir=`
 // ("inserter research") sidesteps it entirely.
 const INSERTER_CAPACITY_EXTRAS_KEY = "ir";
+/** RFC-053 direct insertion. Present-and-"1" means on; absent means off,
+ * so existing bookmarked URLs keep their exact current layouts. */
+const DIRECT_INSERTION_EXTRAS_KEY = "di";
 
 function slugToCode(slug: string): string {
   // Fall back to the slug itself if it's not in the table — keeps
@@ -324,6 +334,7 @@ function readHashState(): FormState | null {
   const irShort = extras.get(INSERTER_CAPACITY_EXTRAS_KEY);
   const inserterCapacity =
     irShort && (KNOWN_INSERTER_CAPACITY as readonly string[]).includes(irShort) ? irShort : null;
+  const directInsertion = extras.get(DIRECT_INSERTION_EXTRAS_KEY) === "1";
   const mShort = extras.get("m");
   const modules = mShort && MODULES_RE.test(mShort) ? mShort : null;
   const ciRaw = extras.get("ci");
@@ -349,7 +360,7 @@ function readHashState(): FormState | null {
     machines[category] = slug;
   }
 
-  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, modules, customInputs };
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, modules, customInputs };
 }
 
 function readQueryState(): FormState {
@@ -406,12 +417,13 @@ function readQueryState(): FormState {
     rawInserterCapacity && (KNOWN_INSERTER_CAPACITY as readonly string[]).includes(rawInserterCapacity)
       ? rawInserterCapacity
       : null;
+  const directInsertion = params.get("direct_insertion") === "1";
   const rawModules = params.get("modules");
   const modules = rawModules && MODULES_RE.test(rawModules) ? rawModules : null;
   const ciParam = params.get("ci");
   const customInputs = ciParam ? ciParam.split(",").filter((s) => s.length > 0) : [];
 
-  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, modules, customInputs };
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, modules, customInputs };
 }
 
 export function readUrlState(): FormState {
@@ -493,6 +505,9 @@ function formatHashState(state: FormState): string {
     (KNOWN_INSERTER_CAPACITY as readonly string[]).includes(state.inserterCapacity)
   ) {
     extras.set(INSERTER_CAPACITY_EXTRAS_KEY, state.inserterCapacity);
+  }
+  if (state.directInsertion) {
+    extras.set(DIRECT_INSERTION_EXTRAS_KEY, "1");
   }
   if (state.modules && MODULES_RE.test(state.modules)) {
     extras.set("m", state.modules);

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -583,6 +583,21 @@ export function renderSidebar(
   });
   targetBody.appendChild(makeField("Inserter research", inserterCapacitySelect));
 
+  // RFC-053 direct insertion. Off by default: a coupled pair the engine
+  // cannot serve as a cell falls back to the DI bridge and then to the
+  // bus, so turning this on never makes a layout worse — but coverage is
+  // still narrow (fluid-touching and module-bearing pairs refuse), so it
+  // stays opt-in rather than becoming the default.
+  const directInsertionCb = document.createElement("input");
+  directInsertionCb.type = "checkbox";
+  directInsertionCb.className = "sb-checkbox";
+  directInsertionCb.title =
+    "Direct insertion (RFC-053): couple a producer straight into its consumer " +
+    "with inserters, so the shared item never touches a belt. Denser, and it " +
+    "lifts the belt-interface throughput ceiling. Pairs that cannot be served " +
+    "this way fall back to the bus automatically.";
+  targetBody.appendChild(makeField("Direct insertion", directInsertionCb));
+
   // Layout strategy. Phase 0b of `rfc-modular-production` shipped the
   // dropdown; the surviving `partitioned-decomposed` variant produces
   // strictly ≤ Pooled errors on every case in the corpus. The deprecated
@@ -820,6 +835,7 @@ export function renderSidebar(
   if (urlState.wireMode) wireModeSelect.value = urlState.wireMode;
   if (urlState.stacking) stackingSelect.value = urlState.stacking;
   if (urlState.inserterCapacity) inserterCapacitySelect.value = urlState.inserterCapacity;
+  directInsertionCb.checked = urlState.directInsertion === true;
   // Restore custom inputs from URL
   for (const item of urlState.customInputs) {
     if (itemSet.has(item) && !defaultInputSet.has(item) && !customInputs.includes(item)) {
@@ -895,6 +911,7 @@ export function renderSidebar(
       wireMode: wireModeSelect.value || null,
       stacking: stackingSelect.value || null,
       inserterCapacity: inserterCapacitySelect.value || null,
+      directInsertion: directInsertionCb.checked,
       modules: modulesValue(),
       customInputs,
     });
@@ -969,8 +986,9 @@ export function renderSidebar(
       const wireMode = wireModeSelect.value || undefined;
       const stacking = stackingSelect.value || undefined;
       const inserterCapacity = inserterCapacitySelect.value || undefined;
+      const directInsertion = directInsertionCb.checked;
       const onEvent = callbacks.startStreaming();
-      layout = await engine.buildLayoutStreaming(result, maxTier, strategy, rowLayout, maxInserterTier, quality, wireMode, stacking, inserterCapacity, onEvent);
+      layout = await engine.buildLayoutStreaming(result, maxTier, strategy, rowLayout, maxInserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, onEvent);
     } catch (err) {
       if (gen !== solveGeneration) return;
       const errDiv = document.createElement("div");
@@ -1007,6 +1025,7 @@ export function renderSidebar(
   rowLayoutSelect.addEventListener("change", scheduleAutoSolve);
   inserterTierSelect.addEventListener("change", scheduleAutoSolve);
   qualitySelect.addEventListener("change", scheduleAutoSolve);
+  directInsertionCb.addEventListener("change", scheduleAutoSolve);
   modulesSelect.addEventListener("change", scheduleAutoSolve);
   moduleQualitySelect.addEventListener("change", scheduleAutoSolve);
   wireModeSelect.addEventListener("change", scheduleAutoSolve);

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -38,9 +38,9 @@ type Request =
       quality: string | null;
       modules: string | null;
     }
-  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null }
-  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null }
-  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null }
+  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: boolean }
+  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: boolean }
+  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: boolean }
   | { id: number; method: "exportBlueprint"; layout: LayoutResult; label: string }
   | {
       id: number;
@@ -124,10 +124,10 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         );
         break;
       case "layout":
-        result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined);
+        result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? false);
         break;
       case "layoutTraced":
-        result = layout_traced(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined);
+        result = layout_traced(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? false);
         break;
       case "layoutStreaming": {
         const id = req.id;
@@ -170,7 +170,7 @@ self.onmessage = async (e: MessageEvent<Request>) => {
           if (batch.length >= BATCH_SIZE) flushBatch();
         };
         try {
-          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, emit);
+          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? false, emit);
         } finally {
           flushBatch();
           if (TRACE_LOGS) {


### PR DESCRIPTION
## Intent

RFC-053 Phase 2 (horizontal row cell) + Phase 4 (reachable from the web UI), plus the fluid work that KC6 re-scoped into Phase 2.

Goal being served: *for the corpus's top-N DI pairs, the engine produces layouts that (a) actually use DI, (b) validate clean, and (c) sim-measure ≥98% of plan.*

## Result against that goal

| pair | corpus | uses DI | validates | sim |
|---|---|---|---|---|
| `copper-cable → electronic-circuit` | 4,116 | 153 `di-row` | 0 issues | **101.3%** delivered, 50/50 working |
| `electric-furnace → electric-furnace` | 1,585 | 176 `di-cell` | 0 issues | **109.5%**, 32/32 |
| `casting-copper-cable → EC` | 544 | `di-row`, 2.5–20/s | 0 issues | **101.3%** delivered, 100.0% produced |
| `casting-iron → EC` | 339 | `di-row`, 2.5–15/s | 0 issues | **101.3%** delivered, 100.0% produced |

Neither casting pair lays out **at all** without the cell (DI-off control: 4–32 errors, the foundry left with no adjacent inserter and no pipe), so this is currently the only path by which a fluid-fed producer works.

## Scope

- **Row cell** — producers and consumers interleaved in one row, coupled east/west in the 1-tile gaps. Chosen on corpus evidence (`di-patterns faces`), needs no reach-2 inserter and no research, reuses `place_rows`.
- **Fluid-fed producers** — pipe run on the free north face; heterogeneous footprints (5×5 foundry beside a 3×3 assembler, bottom-aligned so both roles share a south face row); a narrow `belt-connectivity` exemption for a machine whose only route out is a coupler.
- **Fluid-drawing consumers** — a consumer may share the producer's run (same fluid, equal heights, real north port). Also the shape where the coupled item is the consumer's only solid: no inner belt, output belt moves up a row and drops at reach-1.
- **Burner refusal** — `cell_machines_are_powerable` declines a cell whose either role is non-electric.
- **Phase 4** — `direct_insertion` threaded through wasm, the worker, URL state (`di=1`) and a sidebar checkbox. **Still off by default.**

## Deviations / things that did not land

- **The fluid-CONSUMER shape is built but UNREACHABLE.** Its one corpus pair (`solid-fuel-from-light-oil → rocket-fuel`, 652) resolves to a burner `biochamber`; the cell validated 0/0 and the sim produced *literally nothing* (`no_fuel: 8`). Engine-wide gap filed as **#461**. Pinned by unit tests on `stamp_row_cell` rather than e2e, since nothing end-to-end can reach it.
- **`engine-unit → electric-engine-unit` (547) not attempted** — its producer takes three solid inputs against the row's one north belt, and its lubricant is a fluid the producer does not draw.
- **Rate ceiling is ratio ALIGNMENT, not magnitude** — at P30:C23 the flow intervals put three producers against one consumer; P20:C15 (exactly 4:3) is fine at any scale.
- **Modules still refuse**; KC5 (solver escalation bound) still unevaluated.

## Corrections made in-branch

- A claimed "ratio tolerance" prerequisite blocking `casting-* → EC` **did not exist** — it came from feeding `plan_row_straddle` raw per-machine rates where the caller passes utilization-scaled ones. Retracted in the RFC in place.
- Two changes were found to do **nothing** and were deleted rather than shipped: the `merge_x_cursor` widening (reviewer-caught: inspected the router's own accumulator) and the consumer's fluid tap-point registration (caught by forcing it off → byte-identical layout).

## Verification

- **903 lib + 62 e2e green.** `cargo clippy -p spaghettio_core -- -D warnings` clean (the CI invocation).
- **Sim harness**: four pairs measured in headless Factorio 2.0.77, all PASS (table above). The two casting runs are the first fixtures ever to exercise the harness's infinity-pipe fluid feed, which RFC-050 declares uncalibrated — noted in the RFC, with why it does not threaten the conclusion.
- **Canaried, not assumed**: the `belt-connectivity` regression test fails with its exemption forced off; the DI-off control confirms the casting refusals above belt capacity are not regressions.
- **Browser**: `?item=electronic-circuit&rate=10&in=iron-ore,copper-ore&belt=express-transport-belt&di=1` — eyeball still outstanding with the author.

Decision log for all of the above: `docs/rfc-053-direct-insertion-cells.md`.