### PR TITLE
fix(meter): the four review findings that landed after #460 merged

### DIFF
--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -110,7 +110,21 @@ pub struct Factory {
     /// Cumulative items reaching a sink.
     delivered: FxHashMap<u16, u64>,
     pub notes: Vec<String>,
+    /// `(tick, total delivered)` sampled every [`CHECKPOINT_TICKS`] since
+    /// the last counter reset. Feeds the convergence test in [`Self::report`].
+    checkpoints: Vec<(u64, u64)>,
 }
+
+/// Convergence sampling cadence, matching `spaghettio-sim`'s 3600-tick
+/// (one game-minute) checkpoints so the two instruments' `converged`
+/// flags answer the same question.
+const CHECKPOINT_TICKS: u64 = 3600;
+
+/// A run is converged when the last [`CONVERGENCE_WINDOWS`] checkpoint
+/// deltas differ from their mean by less than this. 2% is the sim
+/// harness's own steady-state tolerance.
+const CONVERGENCE_TOLERANCE: f64 = 0.02;
+const CONVERGENCE_WINDOWS: usize = 3;
 
 impl Factory {
     pub fn build(bp: &str, manifest: Manifest) -> Result<Self, String> {
@@ -189,6 +203,13 @@ impl Factory {
         let mut inserters = Vec::new();
         for e in entities {
             let Some(kind) = InserterKind::from_entity_name(&e.name) else {
+                // Not modelled, and it MUST be said. `footprint_checked`'s
+                // generic `*-inserter` arm lets names this constructor does
+                // not know (burner and filter variants) through `decode`'s
+                // otherwise-hard unknown-entity gate, so a silent `continue`
+                // here under-reports throughput with an empty `notes` — the
+                // one failure mode a meter must never have.
+                notes.push(format!("{} at ({},{}) not modelled", e.name, e.x, e.y));
                 continue;
             };
             let reach = kind.reach();
@@ -238,6 +259,7 @@ impl Factory {
         }
 
         Ok(Factory {
+            checkpoints: Vec::new(),
             net,
             machines,
             inserters,
@@ -270,7 +292,26 @@ impl Factory {
     pub fn run_for(&mut self, ticks: u64) {
         for _ in 0..ticks {
             self.tick();
+            if self.ticks.is_multiple_of(CHECKPOINT_TICKS) {
+                let total = self.delivered.values().sum();
+                self.checkpoints.push((self.ticks, total));
+            }
         }
+    }
+
+    /// Has throughput stopped moving?
+    ///
+    /// Compares the last [`CONVERGENCE_WINDOWS`] per-checkpoint deltas
+    /// against their mean. Deliberately measured on **delivered**, not on
+    /// buffer levels: a factory filling its buffers has rising deltas and
+    /// must not read as converged, which is the artifact class
+    /// `sim-harness-forensics.md` records the real harness learning the
+    /// hard way.
+    ///
+    /// Too few checkpoints to judge is reported as NOT converged — the
+    /// honest direction for a field a caller may gate on.
+    fn detect_converged(&self) -> bool {
+        converged_from(&self.checkpoints)
     }
 
     fn tick_feeds(&mut self) {
@@ -387,6 +428,9 @@ impl Factory {
     pub fn reset_counters(&mut self) {
         self.crafted.clear();
         self.delivered.clear();
+        // Checkpoints describe the window we just discarded; keeping them
+        // would let a pre-warmup transient decide `converged`.
+        self.checkpoints.clear();
         for m in &mut self.machines {
             m.crafts = 0;
         }
@@ -430,7 +474,7 @@ impl Factory {
             delivered_per_s: rate(&self.delivered),
             planned_per_s: self.manifest.planned_rates.clone().into_iter().collect(),
             machine_census: self.census(),
-            converged: true,
+            converged: self.detect_converged(),
             boundary_refusals: self.feeds.iter().map(|f| f.refused).sum(),
             notes: self.notes.clone(),
         }
@@ -442,5 +486,76 @@ impl Factory {
         self.reset_counters();
         self.run_for(window);
         self.report()
+    }
+}
+
+/// Steady-state test over `(tick, cumulative delivered)` checkpoints.
+///
+/// Split out from [`Factory::detect_converged`] so the decision rule is
+/// testable without standing up a whole factory — the rule is the part
+/// that can be subtly wrong.
+fn converged_from(checkpoints: &[(u64, u64)]) -> bool {
+    if checkpoints.len() < CONVERGENCE_WINDOWS + 1 {
+        return false;
+    }
+    let tail = &checkpoints[checkpoints.len() - (CONVERGENCE_WINDOWS + 1)..];
+    let deltas: Vec<f64> = tail
+        .windows(2)
+        .map(|w| (w[1].1.saturating_sub(w[0].1)) as f64)
+        .collect();
+    let mean = deltas.iter().sum::<f64>() / deltas.len() as f64;
+    if mean <= 0.0 {
+        // Nothing delivered at all. Stable, but not a steady state any
+        // caller should treat as a converged measurement.
+        return false;
+    }
+    deltas
+        .iter()
+        .all(|d| (d - mean).abs() / mean < CONVERGENCE_TOLERANCE)
+}
+
+#[cfg(test)]
+mod convergence_tests {
+    use super::*;
+
+    fn ticks(counts: &[u64]) -> Vec<(u64, u64)> {
+        counts
+            .iter()
+            .enumerate()
+            .map(|(i, &c)| (i as u64 * CHECKPOINT_TICKS, c))
+            .collect()
+    }
+
+    #[test]
+    fn flat_delivery_is_converged() {
+        // +180 every window, exactly the shape a steady factory shows.
+        assert!(converged_from(&ticks(&[0, 180, 360, 540, 720])));
+    }
+
+    #[test]
+    fn a_filling_buffer_is_not_converged() {
+        // Rising deltas: 100, 140, 180, 220. This is THE artifact class
+        // the harness records learning the hard way — a transient that
+        // reads as production. It must not pass.
+        assert!(!converged_from(&ticks(&[0, 100, 240, 420, 640])));
+    }
+
+    #[test]
+    fn producing_nothing_is_not_converged() {
+        // Perfectly stable at zero. Stable is not the question.
+        assert!(!converged_from(&ticks(&[0, 0, 0, 0, 0])));
+    }
+
+    #[test]
+    fn too_few_checkpoints_is_not_converged() {
+        // Under-report honestly: no evidence is not evidence of steadiness.
+        assert!(!converged_from(&ticks(&[0, 180, 360])));
+        assert!(!converged_from(&[]));
+    }
+
+    #[test]
+    fn small_jitter_is_still_converged() {
+        // 180/181/179/180 — within the 2% tolerance.
+        assert!(converged_from(&ticks(&[0, 180, 361, 540, 720])));
     }
 }

--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -202,13 +202,21 @@ impl Factory {
         let level = manifest.inserter_capacity;
         let mut inserters = Vec::new();
         for e in entities {
+            // Gate on the NAME first, mirroring the machine loop's
+            // `is_crafting_machine`. `entities` is every decoded entity —
+            // belts, poles, pipes, machines — so testing
+            // `from_entity_name` alone would note ~250 non-inserters on a
+            // 292-entity fixture and bury the signal below.
+            if !e.name.ends_with("inserter") {
+                continue;
+            }
             let Some(kind) = InserterKind::from_entity_name(&e.name) else {
-                // Not modelled, and it MUST be said. `footprint_checked`'s
-                // generic `*-inserter` arm lets names this constructor does
-                // not know (burner and filter variants) through `decode`'s
-                // otherwise-hard unknown-entity gate, so a silent `continue`
-                // here under-reports throughput with an empty `notes` — the
-                // one failure mode a meter must never have.
+                // A real inserter this constructor does not know. It MUST be
+                // said: `footprint_checked`'s generic `*-inserter` arm lets
+                // burner and filter variants through `decode`'s otherwise-hard
+                // unknown-entity gate, so a silent `continue` under-reports
+                // throughput with an empty `notes` — the one failure mode a
+                // meter must never have.
                 notes.push(format!("{} at ({},{}) not modelled", e.name, e.x, e.y));
                 continue;
             };
@@ -259,7 +267,7 @@ impl Factory {
         }
 
         Ok(Factory {
-            checkpoints: Vec::new(),
+            checkpoints: vec![(0, 0)],
             net,
             machines,
             inserters,
@@ -429,8 +437,12 @@ impl Factory {
         self.crafted.clear();
         self.delivered.clear();
         // Checkpoints describe the window we just discarded; keeping them
-        // would let a pre-warmup transient decide `converged`.
+        // would let a pre-warmup transient decide `converged`. The window's
+        // OWN start is a sample though — cumulative zero at tick zero — and
+        // seeding it is what makes an N-checkpoint window yield N deltas
+        // rather than N-1.
         self.checkpoints.clear();
+        self.checkpoints.push((0, 0));
         for m in &mut self.machines {
             m.crafts = 0;
         }
@@ -557,5 +569,101 @@ mod convergence_tests {
     fn small_jitter_is_still_converged() {
         // 180/181/179/180 — within the 2% tolerance.
         assert!(converged_from(&ticks(&[0, 180, 361, 540, 720])));
+    }
+
+    /// The detector must be able to fire under the window the callers
+    /// ACTUALLY ship, not merely under hand-built checkpoint arrays.
+    ///
+    /// The first version of this detector required 4 checkpoints while
+    /// `corpus_replay` and `examples/measure` both use a 3-game-minute
+    /// window, which produces exactly 3 — so `converged` was
+    /// unconditionally false, a hardcoded `true` swapped for an
+    /// effectively hardcoded `false`. Every unit test above still passed,
+    /// because they construct checkpoints directly and never exercise the
+    /// schedule `run_for` generates. Same lesson this RFC already learned
+    /// twice: a test that samples the rule is not testing the wiring.
+    #[test]
+    fn the_shipped_measurement_window_can_converge() {
+        const WINDOW: u64 = 60 * 60 * 3; // corpus_replay.rs / measure.rs
+        // Replay exactly what reset_counters + run_for record for a
+        // perfectly steady factory.
+        let mut cps = vec![(0u64, 0u64)];
+        let mut delivered = 0u64;
+        for t in 1..=WINDOW {
+            delivered += 3;
+            if t.is_multiple_of(CHECKPOINT_TICKS) {
+                cps.push((t, delivered));
+            }
+        }
+        assert!(
+            cps.len() > CONVERGENCE_WINDOWS,
+            "the shipped {WINDOW}-tick window yields {} checkpoints; the detector needs {}",
+            cps.len(),
+            CONVERGENCE_WINDOWS + 1
+        );
+        assert!(
+            converged_from(&cps),
+            "a perfectly steady factory must read as converged in the shipped window"
+        );
+    }
+}
+
+#[cfg(test)]
+mod note_tests {
+    use super::*;
+    use crate::blueprint_in::Dir;
+
+    fn ent(name: &str, x: i32, y: i32) -> RawEntity {
+        RawEntity {
+            name: name.into(),
+            x,
+            y,
+            direction: Dir::North,
+            recipe: None,
+            io_type: None,
+        }
+    }
+
+    /// Only genuine inserters may produce an "unmodelled inserter" note.
+    ///
+    /// The build loop walks EVERY decoded entity, so testing
+    /// `InserterKind::from_entity_name` without a name gate first noted
+    /// every belt, pole and pipe in the blueprint — roughly 250 spurious
+    /// notes on a 292-entity fixture, burying the one signal the note
+    /// exists to carry. A diagnostic that fires on everything is worse
+    /// than no diagnostic.
+    #[test]
+    fn ordinary_entities_do_not_produce_unmodelled_notes() {
+        let ents = vec![
+            ent("transport-belt", 0, 0),
+            ent("express-transport-belt", 1, 0),
+            ent("underground-belt", 2, 0),
+            ent("splitter", 3, 0),
+            ent("medium-electric-pole", 4, 0),
+            ent("inserter", 5, 0),
+            ent("long-handed-inserter", 6, 0),
+        ];
+        let f = Factory::from_entities(&ents, Manifest::default()).expect("builds");
+        let spurious: Vec<&String> =
+            f.notes.iter().filter(|n| n.contains("not modelled")).collect();
+        assert!(
+            spurious.is_empty(),
+            "no ordinary entity may be reported as an unmodelled inserter, got {spurious:?}"
+        );
+    }
+
+    /// ...but a real inserter this crate cannot model MUST be reported.
+    /// `burner-inserter` passes `decode`'s unknown-entity gate through
+    /// `footprint_checked`'s generic `*-inserter` arm, so without a note
+    /// its transfers vanish silently and throughput under-reports.
+    #[test]
+    fn an_unmodelled_inserter_is_reported() {
+        let ents = vec![ent("burner-inserter", 0, 0)];
+        let f = Factory::from_entities(&ents, Manifest::default()).expect("builds");
+        assert!(
+            f.notes.iter().any(|n| n.contains("burner-inserter") && n.contains("not modelled")),
+            "an inserter variant the meter cannot model must be noted, got {:?}",
+            f.notes
+        );
     }
 }

--- a/crates/meter/src/machine.rs
+++ b/crates/meter/src/machine.rs
@@ -267,7 +267,19 @@ impl Machine {
             for (id, amount) in &self.ingredients {
                 *self.input.get_mut(&id.0).unwrap() -= amount;
             }
-            self.progress = self.craft_ticks;
+            // ACCUMULATE, never assign. The previous craft ended with
+            // `progress` slightly below zero; that overshoot is the
+            // fractional part of the true period and must carry forward.
+            // Assigning discards it and quantises the effective period to
+            // `ceil(craft_ticks)` — a recipe at 4.5 ticks would run on a
+            // 5-tick cycle, −10% throughput, invisibly.
+            //
+            // Same discipline as `Lane::tick`, `Source::tick`,
+            // `Chest::tick` and `Inserter::cycle` — whose comment already
+            // named this rule. `Machine` was the one place not following
+            // it, which is exactly where a repeated-mistake audit should
+            // have looked and didn't.
+            self.progress += self.craft_ticks;
         }
         self.state = MachineState::Working;
         self.progress -= 1.0;

--- a/crates/meter/src/network.rs
+++ b/crates/meter/src/network.rs
@@ -566,7 +566,16 @@ impl NetworkBuilder {
             }
             let tdir = net.tiles[target].dir;
             let lanes = if is_back_feed(tdir, ahead, pos) {
+                // U6 / B-straight: a straight feed loads both lanes.
                 LaneMap::Straight
+            } else if net.tiles[target].kind == TileKind::UgInput {
+                // **U7**, and it is the opposite of B8: sideloading onto an
+                // underground INPUT fills only the **far** lane. There is no
+                // B11 curve exception here — U8 states that feeding straight
+                // from behind is the *only* way to load both lanes of a UG
+                // input, so a lone side-feeder does not render as a turn the
+                // way it would onto plain belt.
+                LaneMap::OntoLane(1 - near_lane_from(tdir, ahead, pos))
             } else {
                 let only_feeder = feeders.get(&target).map(|v| v.len() == 1).unwrap_or(false);
                 if only_feeder {
@@ -856,6 +865,57 @@ fn orphan_splitter_half_does_not_panic_when_stepped() {
             matches!(side.lanes, LaneMap::OntoLane(_)),
             "side feed must sideload, got {:?}",
             side.lanes
+        );
+    }
+
+    /// **U7**: sideloading onto an underground INPUT fills the **far**
+    /// lane, the opposite of B8's near-lane rule for plain belt.
+    ///
+    /// Both directions are asserted, because a single-side test passes
+    /// under the old near-lane code for whichever side happens to match:
+    /// the defect is a sign error, and a sign error is only visible from
+    /// both sides. Feeding from the west and from the east must land on
+    /// *different* lanes, and each must be the opposite of the plain-belt
+    /// answer for the same geometry.
+    #[test]
+    fn sideload_onto_ug_input_fills_the_far_lane() {
+        for (fx, fy, feeder_dir) in [(1, -1, Dir::South), (1, 1, Dir::North)] {
+            let ents = vec![
+                belt("transport-belt", 0, 0, Dir::East), // back feed into the UG input
+                belt("transport-belt", fx, fy, feeder_dir), // side feed into it
+                ug("underground-belt", 1, 0, Dir::East, "input"),
+                ug("underground-belt", 4, 0, Dir::East, "output"),
+            ];
+            let net = NetworkBuilder::build(&ents);
+            let side = net.tiles[net.tile_at((fx, fy)).unwrap()].downstream.unwrap();
+            let near = near_lane_from(Dir::East, (1, 0), (fx, fy));
+            assert_eq!(
+                side.lanes,
+                LaneMap::OntoLane(1 - near),
+                "U7: side feed from {:?} onto a UG input must fill the FAR lane \
+                 (near={near}), got {:?}",
+                (fx, fy),
+                side.lanes
+            );
+        }
+    }
+
+    /// U8: a *lone* side feeder onto a UG input is still a far-lane
+    /// sideload — the B11 curve rule does not apply, because feeding
+    /// straight from behind is the only way to load both lanes.
+    #[test]
+    fn lone_side_feed_onto_ug_input_is_not_a_curve() {
+        let ents = vec![
+            belt("transport-belt", 1, -1, Dir::South),
+            ug("underground-belt", 1, 0, Dir::East, "input"),
+            ug("underground-belt", 4, 0, Dir::East, "output"),
+        ];
+        let net = NetworkBuilder::build(&ents);
+        let side = net.tiles[net.tile_at((1, -1)).unwrap()].downstream.unwrap();
+        assert_eq!(
+            side.lanes,
+            LaneMap::OntoLane(1 - near_lane_from(Dir::East, (1, 0), (1, -1))),
+            "a lone side feed onto a UG input must NOT keep both lanes (U8)"
         );
     }
 

--- a/docs/rfc-054-fast-meter.md
+++ b/docs/rfc-054-fast-meter.md
@@ -992,3 +992,42 @@ the right thing moved.
   measurement, a dead branch and a loose allowlist. Different failure modes,
   and neither list is a subset of the other — which is a better argument for
   running both than for preferring either.*
+- *2026-07-25 — **Merged into a pending review check, and it cost four
+  findings.** The* `claude-review` *run on the final commit was still going at
+  25 minutes, past any signature in* `docs/review-bot.md` *(a completed review
+  is ~8 min). It was judged hung and PR #460 was merged with it pending. It
+  was not hung: it completed **success** and posted four inline findings
+  minutes later, against code that was by then on* `main`*.*
+
+  ***The reasoning was wrong in a specific way worth naming.*** *The evidence
+  said the run was **unusual** — longer than anything previously recorded. It
+  was read as saying the run was **dead**. Those are different claims, and the
+  supporting argument ("the delta since its last completed review is one
+  markdown file") was irrelevant: the bot reviews the **whole PR diff**, not
+  the incremental delta, so a fresh run always has all the code to look at.
+  The argument justified a conclusion it did not actually support.*
+
+  ***Finding 1, fixed here: `Machine::tick` assigned craft progress instead of
+  accumulating it.*** `self.progress = self.craft_ticks` *discards the
+  overshoot from the craft that just finished, quantising the effective period
+  to* `ceil(craft_ticks)` *— a 4.5-tick recipe runs a 5-tick cycle, −10%
+  throughput, silently.*
+
+  ***This is the same defect fixed in `inserter.rs` earlier in this same
+  RFC***, *whose comment already states the rule and names* `Lane::tick`,
+  `Source::tick` *and* `Chest::tick` *as following it.* `Machine` *was the one
+  place that did not. A repeated-mistake sweep after the inserter fix would
+  have found it; none was done. The lesson generalises past this instance:
+  **when a bug class is identified, grep for the class, not the instance.***
+
+  ***And the story does not hold.*** *Corpus is **byte-identical** after the
+  fix — every corpus recipe has integer* `craft_ticks` *(24/48/384/480 at AM3
+  speed 1.25; plates smelt at furnace speed 2.0 → 96), so the quantisation
+  never bites. It would have been convenient for this to be part of the KC1
+  gap. It is not. Fixed on merit; the explanation is tested and negative.*
+
+  *Remaining three from that run — U7 (sideload onto a UG **input** fills the
+  FAR lane, a documented "critical quirk", with no* `UgInput` *carve-out in*
+  `link_downstream`*), silently-dropped unrecognised inserters (no* `notes`
+  *entry, unlike every other skip path), and* `converged` *hardcoded true with
+  no detector — are open and tracked in this branch.*


### PR DESCRIPTION
## Intent

#460's `claude-review` run was still pending when the PR merged. It was not
hung — it completed successfully and posted **four findings** minutes later.
All four were valid; all four are fixed here against `main`.

Sequencing note: the first commit is cherry-picked from
`claude/factorio-direction-methods-pko2fv`, where it was authored after the
merge, so its original attribution is preserved rather than reworked.

## The findings

**1. Craft progress was assigned, not accumulated** (`machine.rs`) —
cherry-picked. `self.progress = self.craft_ticks` discards the overshoot
from the craft that just finished, quantising the effective period to
`ceil(craft_ticks)`. `inserter.rs` documents this exact rule and names
`Lane::tick`, `Source::tick` and `Chest::tick` as following it; `Machine`
was the one place that did not.

**Its impact claim does not hold for this corpus, and that is recorded
rather than glossed.** Every recipe in the military and EC chains has
integer craft ticks at AM3 speed 1.25 — grenade 384, MSP 480, PRM 288,
firearm-magazine 48, stone-wall 24 — so quantisation loss is **0.00%**. I
checked this specifically because the meter under-produces
piercing-rounds-magazine by 8.9% and a −10% craft-period bug looked like a
match. It is not the cause. Real latent bug, fixed on merit; the story was
tested separately and is unrelated to the KC1 gap.

**2. Sideloading onto a UG input filled the NEAR lane** (`network.rs`).
`link_downstream` routed every non-back-feed through `near_lane_from`,
which is B8's rule for plain belt. `factorio-mechanics.md` **U7** is
explicit that a UG input is the exception and fills only the **FAR** lane —
flagged in the doc as a critical quirk.

Two branches were wrong, not one: the `only_feeder` arm also treated a lone
side-feeder as a B11 curve and kept *both* lanes, which **U8** rules out
(feeding straight from behind is the only way to load both lanes). Both
rules were read in the mechanics doc before applying, not taken from the
finding's summary.

**3. Unrecognised inserters were dropped silently** (`factory.rs`).
`InserterKind::from_entity_name` knows five names, while
`footprint_checked`'s generic `*-inserter` arm lets burner and filter
variants through `decode`'s otherwise-hard unknown-entity gate. Such a
blueprint decoded cleanly, those inserters never moved an item, and `notes`
came back **empty** — throughput under-reported with no signal. Every other
skip path in that function pushes a note. A meter may be incomplete; it may
not be *quietly* incomplete.

**4. `converged` was hardcoded `true`** (`factory.rs`). No detector existed:
the identifier appeared exactly twice, this literal and the field
declaration. `MeterReport` derives `Serialize`, so a permanently-true flag
was being written into every exported report for a field the RFC contract
says means steady state was detected — and the decision log has no entry
deferring it.

Now real: `(tick, cumulative delivered)` sampled every 3600 ticks — the same
one-game-minute cadence `spaghettio-sim` checkpoints on, so both
instruments' flags answer the same question — with the last three deltas
required within 2% of their mean. Three deliberate choices, each the honest
direction:

- Measured on **delivered**, not buffer levels: a filling factory shows
  rising deltas and must not read as converged. That is the artifact class
  `sim-harness-forensics.md` records the real harness learning the hard way.
- **Zero throughput is not converged.** Stable at nothing is stable; stable
  is not the question.
- **Too few checkpoints is not converged.** No evidence is not evidence of
  steadiness.

`reset_counters` clears the history so a pre-warmup transient cannot decide
the flag for the window that follows.

## Verification

- [x] `cargo test -p spaghettio_meter` — 48 lib + corpus + ingestion + KC4 +
  row-starvation, **0 failures**.
- [x] `cargo clippy -p spaghettio_meter --all-targets` — **clean, zero
  warnings**.
- [x] **Both U7 regression tests verified against the old code** — they FAIL
  with the new arm disabled and pass with it. The far-lane test asserts from
  **both sides**, because the defect is a sign error and a single-sided test
  passes under the buggy code for whichever side happens to match. That is
  exactly how the original `near_lane_from` bug survived its own test
  earlier in this RFC.
- [x] Convergence rule split into a free `converged_from` so it is testable
  without standing up a factory — the rule is the part that can be subtly
  wrong. Five tests: flat, filling, zero, jitter, too-short.
- [ ] Corpus re-measurement — **deliberately deferred**. The corpus fixtures
  are themselves being fixed in #466 (they were exported at the wrong
  geometry), so measuring against them now would compare two different
  factories. Numbers land once #466 is in.
- [ ] WASM — N/A, the meter is native and outside the WASM build.

## Not included

The RFC-054 decision-log correction (KC1 was evaluated against
mis-generated fixtures; see #466) is deliberately **not** in this PR — it
depends on #466 landing and is a substantial record change that deserves
its own review.

Refs #457, #460, #466, RFC-054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ubh1F19DRQzy9Yce4DGf2