### PR TITLE
fix(corpus): re-band chain-mil5ore-d2 Fail → Pass, on oracle evidence

### DIFF
--- a/crates/meter/tests/corpus_replay.rs
+++ b/crates/meter/tests/corpus_replay.rs
@@ -156,29 +156,30 @@ const CORPUS: &[Entry] = &[
         source: "cell-sim-registry.json chem5 PASS (5.00/5.00 exact)",
         fluid_dependent: true,
     },
-    // KNOWN STALE, and deliberately not corrected here (2026-07-26).
+    // RE-BANDED 2026-07-26 Fail -> Pass, on oracle evidence only.
     //
-    // Re-measured in real Factorio at `--warmup 288000`: **+0.7%, 146/146
-    // machines working, PASS**. The recorded -28.7% was taken at the
+    // Recorded for months as -28.7% FAIL. Re-measured in real Factorio at
+    // `--warmup 288000`: **+0.7%, 146/146 machines working, PASS**,
+    // delivered 5.07/s against a 5.00 plan. The -28.7% was taken at the
     // harness's dim-scaled default warmup and is a buffer-fill transient,
-    // not a layout deficit — the same defect this file's own WARMUP
-    // constant just fixed on the meter side.
+    // not a layout deficit.
     //
-    // Left wrong on purpose. This entry is a BAND assignment that KC1's
-    // rank half grades against, and re-banding it in the same change that
-    // fixes the meter is precisely the tuning the "frozen and committed
-    // before this RFC" clause exists to prevent. The corpus should be
-    // re-measured as a unit, on measurement grounds alone, with #453
-    // (USP@2) and #437 (PU@4) — both also recorded at default warmup and
-    // both suspect for the same reason. Until then the gap column for this
-    // row is meaningless in both directions.
+    // The bar for touching a frozen corpus entry, and why it is cleared:
+    // the correction is justified by the ORACLE alone, never by agreement
+    // with the meter. It was also not taken in isolation — the same
+    // long-warmup re-measurement was run on the other two Fail-band
+    // entries, #453 (USP@2) and #437 (PU@4), and BOTH survived unchanged
+    // (-55.0% and -21.0%, the latter byte-identical across a 1.5x warmup
+    // increase). So this is a corpus re-measured as a unit that moved one
+    // row, not a row adjusted because it was inconvenient.
     Entry {
         label: "chain-mil5ore-d2",
         target: "military-science-pack",
-        measured: -0.287,
-        band: Band::Fail,
-        source: "status.md / RFC-051 close-out: mil5-from-ore FAIL -28.7% \
-                 (STALE: re-measures +0.7% PASS at --warmup 288000)",
+        measured: 0.007,
+        band: Band::Pass,
+        source: "spaghettio-sim chain-mil5ore-d2 --warmup 288000 (Factorio 2.0.77, \
+                 146/146 working, produced 5.03/s, delivered 5.07/s, PASS); \
+                 supersedes the -28.7% default-warmup measurement",
         fluid_dependent: false,
     },
     Entry {
@@ -312,21 +313,34 @@ fn corpus_replay_reports() {
     );
 }
 
-/// **KC1, rank half — solids only. CURRENTLY TRIPPED (2026-07-25).**
+/// **KC1, rank half — solids only. PASSES as of 2026-07-26.**
 ///
-/// `#[ignore]`d because it does not pass, not because it is unimportant.
-/// Leaving it red in the default suite would train people to ignore a red
-/// suite; deleting or loosening it would be rewriting a kill criterion
-/// after seeing it fire, which is the failure mode kill criteria exist to
-/// prevent. So it stays exact, stays runnable on demand
-/// (`cargo test -p spaghettio_meter --test corpus_replay -- --ignored`),
-/// and its trip is recorded in the RFC decision log.
+/// It tripped from 2026-07-25 and the trip was real, but neither cause was
+/// in the meter: the fixtures were built at the wrong geometry (#466, so
+/// meter and Factorio measured different factories) and the corpus warmed
+/// up for two game-minutes, reading buffer fill as throughput. With both
+/// fixed, every solid config lands within 4pp. Full account in the RFC's
+/// 2026-07-26 decision-log entry.
 ///
-/// The inversion: `chain-mil5plates-d0` is a real-measured **PASS**
-/// (−3.3%) that the meter reports at **−61.1%**, so it ranks below every
-/// Marginal EC config. It is a **solid** chain, so the fluid phase
-/// boundary does not excuse it — this is a genuine model defect awaiting
-/// attribution.
+/// **Still `#[ignore]`d, deliberately.** It passes when run on demand, but
+/// re-enabling it in the same change that corrects the corpus would be the
+/// most tuning-shaped edit available: a criterion that starts passing in
+/// the commit that edits the data it grades against invites exactly the
+/// suspicion kill criteria exist to earn against. The correction stands on
+/// oracle evidence alone; flipping the verdict is a separate decision,
+/// separately reviewed. Run it with
+/// `cargo test -p spaghettio_meter --test corpus_replay -- --ignored`.
+///
+/// **Known weakening, stated because it is a real reduction in coverage:**
+/// this now discriminates **Pass vs Marginal only**. Re-banding
+/// `chain-mil5ore-d2` (Fail → Pass, on oracle evidence — see its entry)
+/// removed the last solid Fail-band config, so nothing here exercises
+/// Fail-vs-anything. That is the *consequence of the correction being
+/// right*, not a scoping choice, and it is the weaker half of the
+/// criterion in any case: the RFC names the Marginal band as "the real
+/// test ... where a rate-shaped model will fail", because separating −5.3%
+/// from at-plan is the resolution an in-loop score actually needs. Adding
+/// a solid Fail fixture would restore full coverage.
 ///
 /// Scoped to solid chains because the meter does not model fluids yet
 /// (the RFC's Phase 3): a fluid-fed machine is deliberately held in
@@ -336,7 +350,7 @@ fn corpus_replay_reports() {
 /// reported by `corpus_replay_reports` above and by
 /// `kc1_full_corpus_status`, so nothing is hidden by the scoping.
 #[test]
-#[ignore = "KC1 tripped 2026-07-25 — see doc comment and the RFC-054 decision log"]
+#[ignore = "verdict re-enable is a separate decision; passes on demand as of 2026-07-26"]
 fn kc1_rank_ordering_on_solid_chains() {
     let results = replay();
     let solids: Vec<&Result_> = results.iter().filter(|r| !r.fluid).collect();
@@ -368,11 +382,13 @@ fn kc1_rank_ordering_on_solid_chains() {
     );
 }
 
-/// **KC1, magnitude half — solids only. CURRENTLY TRIPPED (2026-07-25).**
+/// **KC1, magnitude half — solids only. PASSES as of 2026-07-26**
+/// (5/5 solid configs within 10pp, against a 4/5 bar). See the rank gate
+/// above for why it tripped and what fixed it.
 /// Within ±10 percentage points; currently 3/5, needing 4/5.
 /// See the rank test above for why this is ignored rather than removed.
 #[test]
-#[ignore = "KC1 tripped 2026-07-25 — see doc comment and the RFC-054 decision log"]
+#[ignore = "verdict re-enable is a separate decision; passes on demand as of 2026-07-26"]
 fn kc1_magnitude_on_solid_chains() {
     let results = replay();
     let solids: Vec<&Result_> = results.iter().filter(|r| !r.fluid).collect();

--- a/docs/rfc-054-fast-meter.md
+++ b/docs/rfc-054-fast-meter.md
@@ -270,7 +270,26 @@ because they already exist. In three bands:
 |---|---|---|
 | **PASS** (at plan) | 10 | gear10, automation, logistic, military, chem5@5, AC@1, AC@2, mil5-from-plates, sulfur@2, plastic@2 |
 | **MARGINAL** (−5% to −8%) | 3 | chain-ec15 @d1 (13.8/15), chain-ec15 @d7 (14.2/15), chain-ec30 (27.7/30) |
-| **FAIL** | 4 | ec10 @L0 (−50%), PU@4 (−27.3%, [#437](https://github.com/storkme/spaghettio/issues/437)), USP@2 (−57.0%, [#453](https://github.com/storkme/spaghettio/issues/453)), mil5-from-ore (−28.7%) |
+| **FAIL** | 4 → **3** | ec10 @L0 (−50%), PU@4 (−27.3%, [#437](https://github.com/storkme/spaghettio/issues/437)), USP@2 (−57.0%, [#453](https://github.com/storkme/spaghettio/issues/453)), ~~mil5-from-ore (−28.7%)~~ |
+
+> **Corpus correction, 2026-07-26.** `mil5-from-ore` moves **FAIL → PASS**.
+> Re-measured in real Factorio at `--warmup 288000`: **+0.7%, 146/146
+> machines working**. The −28.7% was taken at the harness's default warmup
+> and is a buffer-fill transient, not a layout deficit.
+>
+> Recorded here, in the criterion's own band table, rather than only in the
+> decision log — this table is the specification KC1's rank half grades
+> against, and a spec that disagrees with the code is worse than either.
+> The correction rests on the **oracle alone** and was not taken in
+> isolation: the other two FAIL-band entries were re-measured the same way
+> and both survived unchanged (USP@2 −55.0%, PU@4 −21.0%). One row moved
+> out of three re-measured.
+>
+> **Consequence:** no **solid** FAIL-band config remains, so the rank half
+> now discriminates PASS-vs-MARGINAL only. That is a genuine loss of
+> coverage following from the correction being right, and it is the weaker
+> half — this RFC names MARGINAL as "the real test". Restoring full
+> coverage needs a new solid FAIL fixture.
 
 **KC1 — discrimination first, magnitude second.** Replay the meter over
 the corpus.

--- a/docs/status.md
+++ b/docs/status.md
@@ -479,7 +479,13 @@ sweep first, and it would move geometry everywhere.
 NOT caught: the `chain-mil5ore` and `mega-chain-pu4raw` tail-starvation
 instances — their belts sit at 5.5% and 27% utilization, so whatever
 starves those rows is a different binding constraint and is still
-unattributed.
+unattributed. **(2026-07-26: `chain-mil5ore` is struck from this list —
+it was never starving. Re-measured at `--warmup 288000` it runs at
+**+0.7%, 146/146 machines working**; the −28.7% was a buffer-fill
+transient. `mega-chain-pu4raw` stands, and was independently re-measured
+at the same long warmup: −21.0%, byte-identical to its default-warmup
+run, so it is genuinely bound by something. See §"Default warmup is too
+short for deep chains".)**
 
 **`rfc-047-lane-aware-tap-delivery.md` close-out (2026-07-22)**: made
 delivery **lane-aware** so belt stacking raises rate CEILINGS, not just


### PR DESCRIPTION
## Intent

`chain-mil5ore-d2` has been recorded across this repo as a **−28.7% FAIL**
for months. It is a **PASS**. Re-measured in real Factorio at
`--warmup 288000`:

```
military-science-pack   5.00 planned   5.03 produced +0.7%   5.07 delivered +1.3%   PASS
machine census: working: 146          OVERALL: PASS
```

146/146 machines working. The −28.7% was taken at the harness's dim-scaled
default warmup and is a buffer-fill transient, not a layout deficit — the
class documented in `docs/status.md` §"Default warmup is too short for deep
chains".

## Why this clears the bar for editing a frozen corpus entry

KC1's entire un-tunability argument is that the answers predate the
instrument. Moving one is the most suspicious edit available in this crate,
and it should be judged as such. Two things justify it:

1. **The correction is justified by the oracle alone.** It is a Factorio
   measurement that knows nothing about what the meter says, and it would
   stand if the meter did not exist.
2. **It was not taken in isolation.** The same long-warmup re-measurement
   ran on the *other two* Fail-band entries and **both survived unchanged**:

   | fixture | recorded | default warmup | `--warmup 288000` | outcome |
   |---|---|---|---|---|
   | #453 USP@2 | −57.0% | −62.0% | **−55.0%** | still FAIL |
   | #437 PU@4 | −27.3% | −21.0% | **−21.0%** | still FAIL, byte-identical |
   | mil5ore | −28.7% | −28.7% | **+0.7%** | **PASS** |

   A corpus re-measured as a unit that moved one row is a different thing
   from one row adjusted because it was inconvenient.

## The KC1 gates deliberately stay `#[ignore]`d

They **do** now pass — verified on demand, 5/5 solid configs within 4pp:

| config | band | real | meter | gap |
|---|---|---|---|---|
| chain-ec15-d1 | Marginal | −8.0% | −12.0% | 4.0pp |
| chain-ec15-d7 | Marginal | −5.3% | −5.6% | 0.3pp |
| chain-ec30-d2 | Marginal | −5.3% | −5.6% | 0.3pp |
| chain-mil5plates-d0 | Pass | −3.3% | +0.7% | 4.0pp |
| chain-mil5ore-d2 | Pass | +0.7% | −1.3% | 2.0pp |

**But re-enabling them here would be the single most tuning-shaped edit in
the change**: a criterion that starts passing in the same commit that edits
the data it grades against. So the verdict is left as a separate decision,
separately reviewed. Only the `#[ignore]` *reason strings* are updated, so
they stop claiming a trip that has been explained.

Run them with
`cargo test -p spaghettio_meter --test corpus_replay -- --ignored`.

## Deviations from intent

- **The gate re-enablement was split out mid-change.** The first version of
  this work removed both `#[ignore]`s. That bundles a data correction with
  a verdict flip, and the two deserve independent judgement — reverted, and
  the reasoning is now in the gate's doc comment rather than only in a PR
  description.

## Models / contracts touched

- **The KC1 calibration corpus** — one entry's `measured` and `band` move.
  This is the contract KC1 grades against, so it is the load-bearing change
  here and the reason the justification above is stated at length.
- **One honest consequence, in the gate doc rather than glossed:**
  re-banding removes the last **solid** Fail-band config, so the rank gate
  now discriminates **Pass-vs-Marginal only** — nothing exercises
  Fail-vs-anything on solids. That is a real reduction in coverage, and it
  follows from the correction being right rather than from a scoping
  choice. It is also the weaker half: the RFC names the Marginal band as
  *"the real test ... where a rate-shaped model will fail"*. Adding a solid
  Fail fixture would restore full coverage.
- No engine contract changes; `crates/core/src/` untouched.

## Verification

- [x] Default suite green with the gates ignored.
- [x] Both KC1 gates pass under `--include-ignored`.
- [x] `cargo clippy -p spaghettio_meter --all-targets` — zero warnings.
- [x] The re-measurement is real Factorio, geometry hash-gated by #466.
- [ ] WASM — N/A, native crate outside the WASM build.

Refs #437, #453, #457, RFC-054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ubh1F19DRQzy9Yce4DGf2