### PR TITLE
feat(di): three-solid-input row cells — capability built, premise falsified

### DIFF
--- a/crates/core/src/bus/di_cell.rs
+++ b/crates/core/src/bus/di_cell.rs
@@ -1295,12 +1295,10 @@ pub struct RowCellSpec<'a> {
     /// Coupling inserter — reach-1, sits in the 1-tile gap.
     pub coupler: &'a str,
     pub coupler_rate: f64,
-    /// `(item, belt_entity, feed_inserter)` for the producer's belt-fed
-    /// input, then the consumer's. The producer's belt is the OUTER row
-    /// (reached by a reach-2 inserter stepping over the inner belt), the
-    /// consumer's is the inner row at reach 1.
     /// `(item, belt, feed_inserter)` for a SOLID-fed producer. Ignored
-    /// when `producer_fluid` is set.
+    /// when `producer_fluid` is set. This belt is the producer's own, on
+    /// the NORTH face at reach-1 — see the sketch on `stamp_row_cell` for
+    /// the row assignments.
     pub producer_input: (&'a str, &'a str, &'a str),
     /// `Some((fluid_item, pipe_entity))` when the producer's inputs are
     /// ALL fluid — `casting-copper-cable` (molten-copper → copper-cable),
@@ -1321,6 +1319,18 @@ pub struct RowCellSpec<'a> {
     /// registered against that one run. A second, different fluid would
     /// need a second run on a face the cell does not have.
     pub consumer_fluid: Option<(&'a str, &'a str)>,
+    /// `(item, belt, feed_inserter)` for the consumer's SECOND belt-fed
+    /// input — the three-solid-input shape (`iron-stick -> rail`, whose
+    /// consumer wants stone AND steel-plate alongside the coupled stick).
+    ///
+    /// It lands on the NORTH face, one row ABOVE the producer's belt, fed
+    /// by a reach-2 inserter sharing the producer's feed row over the
+    /// CONSUMER's columns (the two roles' columns are disjoint, so they
+    /// never contend). North rather than south because the south face is
+    /// already full — feed plus output — and because moving the OUTPUT to
+    /// make room is not a stamping change but an `output_merger` rework:
+    /// that merger assumes a south-facing chain universally.
+    pub consumer_input_b: Option<(&'a str, &'a str, &'a str)>,
     /// Inserters per machine face. The output face needs reach-2 (it steps
     /// over the consumer's input belt), and long-handed is the only
     /// reach-2 inserter (I8a) at 2.40/s at L2 — under the 2.5/s an EC
@@ -1328,6 +1338,7 @@ pub struct RowCellSpec<'a> {
     /// not an edge case. Ignoring these counts silently under-feeds.
     pub producer_feed_count: usize,
     pub consumer_feed_count: usize,
+    pub consumer_feed_b_count: usize,
     pub out_count: usize,
     pub output_item: &'a str,
     pub output_belt: &'a str,
@@ -1337,9 +1348,13 @@ pub struct RowCellSpec<'a> {
 /// Stamp a horizontal row cell with its belts.
 ///
 /// ```text
+///   y0-1                consumer input belt B, only in the three-solid-
+///                       input shape (absent otherwise)
 ///   y0                  producer input belt, or the PIPE run when the
 ///                       producer is fluid-fed
-///   y1                  producer feed inserters, reach-1 (none when piped)
+///   y1                  producer feed inserters, reach-1 (none when piped),
+///                       sharing the row with B's reach-2 feed inserters
+///                       over the consumer's columns
 ///   y2 .. y2+h-1        machines, interleaved P/C at plan.xs,
 ///                       BOTTOM-aligned so both roles share a south face
 ///   y2+h                face row: consumer feed reach-1 + output reach-2
@@ -1391,6 +1406,41 @@ pub fn stamp_row_cell(
     //                       belt below) + output (reach-2, steps over it)
     //   y2+h+1              consumer input belt
     //   y2+h+2              output belt
+    // The consumer's SECOND belt-fed input, when it has one, goes one row
+    // ABOVE the producer's belt and is picked by a reach-2 inserter sharing
+    // the producer's feed row:
+    //
+    //   y0-1                consumer input belt B   (north, outer)
+    //   y0                  producer input belt     (north, inner)
+    //   y1                  producer feed reach-1 over PRODUCER columns,
+    //                       consumer feed B reach-2 over CONSUMER columns
+    //
+    // The reach-2 inserter passes OVER the producer's belt at y0 — an
+    // inserter interacts with its pick and drop tiles only, never with what
+    // it swings across — so no underground gap is needed, unlike
+    // `RowKind::QuadInput` where the inserter sits ON the belt row itself.
+    //
+    // Two constraints follow from the drop tile, and both are enforced
+    // rather than assumed. The inserter sits at `y1 = machine_y - 1` and
+    // drops at `y1 + 2 = machine_y + 1`, so:
+    //   - the CONSUMER must reach that row. Bottom-alignment puts its top
+    //     at `machine_y + (max_h - consumer_h)`, so a producer more than
+    //     ONE tile taller lifts the drop above the consumer's body and the
+    //     item lands on nothing. Foundry(5) over assembler(3) is exactly
+    //     this case, which is why the shipped fluid pairs are excluded.
+    //   - the consumer must be at least 2 tall, or `machine_y + 1` is past
+    //     its bottom.
+    let b_belt = spec.consumer_input_b;
+    if b_belt.is_some() {
+        // A piped producer puts its pipe run on the feed row (see the pipe
+        // stamp below), which is exactly where B's inserters would go.
+        if spec.producer_fluid.is_some() {
+            return None;
+        }
+        if producer_h - consumer_h > 1 || consumer_h < 2 {
+            return None;
+        }
+    }
     let p_belt_y = y0;
     let p_feed_y = y0 + 1;
     let machine_y = y0 + 2;
@@ -1425,6 +1475,9 @@ pub fn stamp_row_cell(
     };
     if spec.producer_fluid.is_none() {
         belt_run(&mut ents, p_belt_y, spec.producer_input.1, spec.producer_input.0);
+    }
+    if let Some((item, belt, _)) = b_belt {
+        belt_run(&mut ents, p_belt_y - 1, belt, item);
     }
     if let Some((item, belt, _)) = spec.consumer_input {
         belt_run(&mut ents, c_belt_y, belt, item);
@@ -1502,6 +1555,29 @@ pub fn stamp_row_cell(
             // the high ones, so they never contend for a tile. A consumer
             // whose only solid ingredient is the coupled one has no feed at
             // all and gives the whole face to its output.
+            // North face, reach-2: picks belt B two rows up, swinging over
+            // the producer's belt, and drops into this machine's second
+            // row. Shares `p_feed_y` with the producer's own feed
+            // inserters, which sit over the PRODUCER's columns — disjoint
+            // by construction, since each role's inserters are placed
+            // within its own footprint.
+            if let Some((item, _, inserter)) = b_belt {
+                let nb = spec.consumer_feed_b_count.max(1);
+                if nb > consumer_w as usize {
+                    return None;
+                }
+                for dx in cols(consumer_w, nb) {
+                    ents.push(PlacedEntity {
+                        name: inserter.to_string(),
+                        x: mx + dx,
+                        y: p_feed_y,
+                        direction: EntityDirection::South,
+                        carries: Some(item.to_string()),
+                        segment_id: Some(seg.clone()),
+                        ..Default::default()
+                    });
+                }
+            }
             let nf = if spec.consumer_input.is_some() { spec.consumer_feed_count.max(1) } else { 0 };
             let no = spec.out_count.max(1);
             if nf + no > consumer_w as usize {
@@ -1591,6 +1667,12 @@ pub fn stamp_row_cell(
     if spec.consumer_input.is_some() {
         input_belt_ys.push(c_belt_y);
     }
+    // B goes LAST, not in geometric order — the contract is that this list
+    // and the fused spec's solid inputs agree INDEX for INDEX, not that
+    // either is sorted by y. Appending keeps every existing index stable.
+    if b_belt.is_some() {
+        input_belt_ys.push(p_belt_y - 1);
+    }
     let y_top = ents.iter().map(|e| e.y).min().unwrap_or(y0);
     Some(RowCellLayout {
         entities: ents,
@@ -1629,6 +1711,8 @@ mod row_stamp_tests {
             out_inserter: "long-handed-inserter",
             producer_feed_count: 1,
             consumer_feed_count: 1,
+            consumer_input_b: None,
+            consumer_feed_b_count: 0,
             out_count: 2,
         }
     }
@@ -1668,6 +1752,8 @@ mod row_stamp_tests {
             out_inserter: "inserter",
             producer_feed_count: 0,
             consumer_feed_count: 0,
+            consumer_input_b: None,
+            consumer_feed_b_count: 0,
             out_count: 1,
         }
     }

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -2146,7 +2146,24 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     // supplies everything solid the consumer needs
     // (`solid-fuel-from-light-oil → rocket-fuel`, whose other ingredient
     // is the shared fluid), and its south face carries the output alone.
-    if !(1..=2).contains(&c_in.len()) || !c_in.iter().any(|i| i == item) {
+    // The coupled item, plus AT MOST two belt-fed others.
+    //   1 — the coupling supplies everything solid
+    //       (`solid-fuel-from-light-oil -> rocket-fuel`, whose other
+    //       ingredient is the shared fluid); south face carries the output
+    //       alone.
+    //   2 — the ordinary shape (cable + iron into EC).
+    //   3 — `iron-stick -> rail` (stone + steel-plate alongside the stick).
+    //       The third input lands on the north face ABOVE the producer's
+    //       belt; see `stamp_row_cell`, which enforces the geometry this
+    //       needs and refuses when it cannot hold.
+    if !(1..=3).contains(&c_in.len()) || !c_in.iter().any(|i| i == item) {
+        return false;
+    }
+    // A third solid input needs a free north face for its belt and a free
+    // feed row for its reach-2 inserters — both of which a piped producer
+    // has already spent (its pipe run occupies the feed row). No corpus
+    // pair wants both at once.
+    if c_in.len() == 3 && p_fluid_in > 0 {
         return false;
     }
     // Every solid input the fused spec carries must be a DISTINCT item.
@@ -2166,7 +2183,7 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     if c_others.iter().enumerate().any(|(i, a)| c_others[i + 1..].contains(a)) {
         return false;
     }
-    if p_in.first().is_some_and(|p| c_others.iter().any(|o| *o == p)) {
+    if p_in.first().is_some_and(|p| c_others.contains(&p)) {
         return false;
     }
     // WIDTHS may differ freely — the row paces x by each machine's own
@@ -2257,9 +2274,23 @@ fn try_build_row_cell(
     // run instead of a belt (RFC-053 pipe cut).
     let p_in = producer.inputs.iter().find(|f| !f.is_fluid);
     let p_fluid = producer.inputs.iter().find(|f| f.is_fluid);
-    // `None` when the coupled item is the consumer's ONLY solid
-    // ingredient — then it has no belt-fed input and no inner belt.
-    let c_in = consumer.inputs.iter().find(|f| !f.is_fluid && f.item != item);
+    // The consumer's belt-fed inputs — everything solid that the coupling
+    // does not already supply. Empty when the coupled item is its ONLY
+    // solid ingredient (then it has no belt-fed input and no inner belt);
+    // eligibility caps it at two.
+    //
+    // The BUSIER one takes the south face, which is reach-1: long-handed
+    // is the only reach-2 inserter (I8a) and it is the slower hand, so
+    // giving it the lighter flow is what keeps the column counts down.
+    // Ties break on item name, so the assignment is deterministic rather
+    // than dependent on solver input order.
+    let mut c_solids: Vec<&ItemFlow> =
+        consumer.inputs.iter().filter(|f| !f.is_fluid && f.item != item).collect();
+    c_solids.sort_by(|a, b| {
+        b.rate.partial_cmp(&a.rate).unwrap_or(std::cmp::Ordering::Equal).then(a.item.cmp(&b.item))
+    });
+    let c_in = c_solids.first().copied();
+    let c_in_b = c_solids.get(1).copied();
     let c_fluid = consumer.inputs.iter().find(|f| f.is_fluid);
     let out = consumer.outputs.iter().find(|f| !f.is_fluid)?;
 
@@ -2283,6 +2314,13 @@ fn try_build_row_cell(
         .map(|f| lane_capacity_stacked(in_belt, ctx.for_item(&f.item)) * 2.0)
         .unwrap_or(f64::INFINITY);
     if p_cap + 1e-9 < p_total || c_cap + 1e-9 < c_total {
+        return None;
+    }
+    let b_total = c_in_b.map(|f| f.rate * c_util * c_count as f64).unwrap_or(0.0);
+    let b_cap = c_in_b
+        .map(|f| lane_capacity_stacked(in_belt, ctx.for_item(&f.item)) * 2.0)
+        .unwrap_or(f64::INFINITY);
+    if b_cap + 1e-9 < b_total {
         return None;
     }
     // The output belt is single-lane (every output inserter shares a y and
@@ -2322,6 +2360,15 @@ fn try_build_row_cell(
     // Reach-2 only when the output inserter must step OVER the consumer's
     // input belt. Without that belt the output belt sits directly below the
     // face and reach-1 applies, which lifts the long-handed 2.40/s ceiling.
+    // B's face is reach-2 unconditionally: its belt is the OUTER north row,
+    // so its inserter always swings over the producer's belt.
+    let c_feed_b = match c_in_b {
+        Some(f) => size_side(f.rate * c_util, Reach::Far, c_budget, max_inserter_tier, quality, level),
+        None => crate::bus::inserter_ladder::SidePlan { entity: "inserter", count: 0, shortfall: None },
+    };
+    if c_feed_b.shortfall.is_some() || c_feed_b.count > cmw.max(1) as usize {
+        return None;
+    }
     let out_reach = if c_in.is_some() { Reach::Far } else { Reach::Near };
     let drop = size_belt_drop_side(
         out.rate * c_util, out_reach, c_budget, max_inserter_tier, quality, out_stack, level, out_belt,
@@ -2353,11 +2400,13 @@ fn try_build_row_cell(
             producer_fluid: p_fluid.map(|f| (f.item.as_str(), "pipe")),
             consumer_input: c_in.map(|f| (f.item.as_str(), in_belt, c_feed.entity)),
             consumer_fluid: c_fluid.map(|f| (f.item.as_str(), "pipe")),
+            consumer_input_b: c_in_b.map(|f| (f.item.as_str(), in_belt, c_feed_b.entity)),
             output_item: &out.item,
             output_belt: out_belt,
             out_inserter: drop.entity,
             producer_feed_count: p_feed.count,
             consumer_feed_count: c_feed.count,
+            consumer_feed_b_count: c_feed_b.count,
             out_count: drop.count,
         },
         bus_width,
@@ -2399,6 +2448,17 @@ fn try_build_row_cell(
                 });
             }
             if let Some(f) = c_in {
+                v.push(ItemFlow {
+                    item: f.item.clone(),
+                    rate: f.rate,
+                    is_fluid: false,
+                    module_id: f.module_id,
+                });
+            }
+            // LAST, matching `input_belt_ys`, which appends B's row last
+            // for the same reason: the two lists are paired by index, and
+            // appending leaves every existing index untouched.
+            if let Some(f) = c_in_b {
                 v.push(ItemFlow {
                     item: f.item.clone(),
                     rate: f.rate,
@@ -4079,6 +4139,111 @@ mod tests {
         // count, and the case the relaxation is FOR.
         let (p, c) = three_input_pair("copper-plate", "steel-plate", "plastic-bar");
         let _ = row_cell_eligible(&p, &c, "iron-plate");
+    }
+
+    /// The three-solid-input row cell, checked at TILE level rather than
+    /// by "it returned `Some`". The shape is `iron-stick -> rail`: the
+    /// consumer wants stone and steel-plate alongside the coupled stick.
+    ///
+    /// What must hold, and each is a way the design could have been wrong:
+    ///   - belt B is the OUTER north row, one above the producer's belt;
+    ///   - B's feed inserter is reach-2 (long-handed) and sits on the
+    ///     PRODUCER's feed row, over a CONSUMER column — sharing that row
+    ///     without colliding is the whole reason the design fits;
+    ///   - its drop tile lands INSIDE the consumer's body. This is the one
+    ///     the reach arithmetic can get silently wrong: the inserter drops
+    ///     two tiles south of itself, and bottom-alignment can push a
+    ///     shorter consumer's top below that.
+    #[test]
+    fn di_row_cell_places_a_third_input_on_the_outer_north_row() {
+        let flow = |item: &str, rate: f64| ItemFlow {
+            item: item.to_string(),
+            rate,
+            is_fluid: false,
+            module_id: 0,
+        };
+        let producer = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "iron-stick".to_string(),
+            self_loop: vec![], voider: false, game_modules: Vec::new(),
+            count: 1.0,
+            inputs: vec![flow("iron-plate", 1.0)],
+            outputs: vec![flow("iron-stick", 2.0)],
+        };
+        let consumer = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "rail".to_string(),
+            self_loop: vec![], voider: false, game_modules: Vec::new(),
+            count: 1.0,
+            inputs: vec![flow("iron-stick", 2.0), flow("stone", 2.0), flow("steel-plate", 1.0)],
+            outputs: vec![flow("rail", 2.0)],
+        };
+        assert!(
+            row_cell_eligible(&producer, &consumer, "iron-stick"),
+            "three distinct solid inputs on an equal-height pair is the target shape"
+        );
+        let cell = try_build_row_cell(
+            &producer, &consumer, "iron-stick", 0, 0, None,
+            InserterTier::default(), QualityTier::Normal,
+            crate::common::DEFAULT_INSERTER_CAPACITY, &StackingCtx::unstacked(),
+        )
+        .expect("the three-input row cell must build");
+        let (cell_ents, span, _) = cell;
+
+        // Three input belts, and the spec's solid inputs must agree with
+        // them INDEX for INDEX — the positional contract both `lane_planner`
+        // and `ghost_router` rely on. A mismatch here is the silent
+        // starvation class: every belt built, the wrong one tapped.
+        let belts = &span.input_belt_y;
+        assert_eq!(belts.len(), 3, "producer's belt, consumer's A, consumer's B");
+        let solids: Vec<&str> =
+            span.spec.inputs.iter().filter(|f| !f.is_fluid).map(|f| f.item.as_str()).collect();
+        assert_eq!(solids.len(), 3, "fused spec carries all three solids");
+        for (i, &y) in belts.iter().enumerate() {
+            let carried: Vec<&str> = cell_ents
+                .iter()
+                .filter(|e| e.y == y && e.name.ends_with("transport-belt"))
+                .filter_map(|e| e.carries.as_deref())
+                .collect();
+            assert!(
+                carried.iter().all(|c| *c == solids[i]),
+                "belt row {i} at y={y} must carry {}, found {:?}",
+                solids[i],
+                carried
+            );
+        }
+        // B's row is the outermost: strictly above every other input belt,
+        // and the topmost row the cell occupies.
+        let b_y = belts[2];
+        assert!(b_y < belts[0] && b_y < belts[1], "B is the OUTER north row, got {belts:?}");
+        assert_eq!(b_y, span.y_start, "the cell's top must follow B's belt up");
+
+        // B's feed inserter: reach-2, on the producer's feed row, dropping
+        // inside the consumer.
+        let b_item = solids[2];
+        let feeds: Vec<_> =
+            cell_ents.iter().filter(|e| e.carries.as_deref() == Some(b_item) && e.name.contains("inserter")).collect();
+        assert!(!feeds.is_empty(), "B must have a feed inserter");
+        let machine_tiles: std::collections::HashSet<(i32, i32)> = cell_ents
+            .iter()
+            .filter(|e| e.recipe.as_deref() == Some("rail"))
+            .flat_map(|e| {
+                let (w, h) = machine_dims(&e.name);
+                let (w, h) = (w as i32, h as i32);
+                (0..w).flat_map(move |dx| (0..h).map(move |dy| (e.x + dx, e.y + dy)))
+            })
+            .collect();
+        for f in &feeds {
+            assert_eq!(f.name, "long-handed-inserter", "B steps over the producer's belt");
+            assert_eq!(f.y, b_y + 2, "B's feed shares the producer's feed row");
+            assert_eq!(f.y - 2, b_y, "picks from B's belt");
+            assert!(
+                machine_tiles.contains(&(f.x, f.y + 2)),
+                "B's drop tile ({}, {}) must be inside a rail machine",
+                f.x,
+                f.y + 2
+            );
+        }
     }
 
     /// DI off is the default and must stay bit-identical: no fusion.

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -2149,14 +2149,24 @@ fn row_cell_eligible(producer: &MachineSpec, consumer: &MachineSpec, item: &str)
     if !(1..=2).contains(&c_in.len()) || !c_in.iter().any(|i| i == item) {
         return false;
     }
-    // The producer's belt-fed input and the consumer's must be DIFFERENT
-    // items. Same item on both would put two entries for one item in the
-    // fused spec at two different y, and both `lane_planner` and
-    // `ghost_router` break on the FIRST matching solid input — so the
-    // second belt would never be tapped and its machines would starve
-    // silently. Refuse; see the RFC decision log.
-    let c_other = c_in.iter().find(|i| *i != item).cloned().unwrap_or_default();
-    if p_in.first().is_some_and(|p| *p == c_other) {
+    // Every solid input the fused spec carries must be a DISTINCT item.
+    // Two entries for one item at two different y starve silently: both
+    // `lane_planner` and `ghost_router` break on the FIRST matching solid
+    // input, so the second belt is built, never tapped, never fed — and
+    // nothing disagrees with anything, so no validator fires. See the RFC
+    // decision log.
+    //
+    // This is checked PAIRWISE over all of them, not just the first. The
+    // predecessor used `.find()` to pull the consumer's one non-coupled
+    // input, which was sufficient only while the face count permitted
+    // exactly one; at three inputs it silently skipped producer×(second
+    // other) and other×other. Pinned by
+    // `di_row_cell_refuses_every_same_item_collision`.
+    let c_others: Vec<&String> = c_in.iter().filter(|i| *i != item).collect();
+    if c_others.iter().enumerate().any(|(i, a)| c_others[i + 1..].contains(a)) {
+        return false;
+    }
+    if p_in.first().is_some_and(|p| c_others.iter().any(|o| *o == p)) {
         return false;
     }
     // WIDTHS may differ freely — the row paces x by each machine's own
@@ -3992,6 +4002,83 @@ mod tests {
                 .is_some_and(|s| s.starts_with("di-cell:"))),
             "a two-solid-input consumer must never be fused into a STACKED cell"
         );
+    }
+
+    /// A consumer with `item` coupled plus two belt-fed inputs `a` and `b`,
+    /// against a producer whose own belt-fed input is `p_in`. Used to probe
+    /// every same-item collision the three-input shape makes reachable.
+    fn three_input_pair(p_in: &str, a: &str, b: &str) -> (MachineSpec, MachineSpec) {
+        let flow = |item: &str, rate: f64| ItemFlow {
+            item: item.to_string(),
+            rate,
+            is_fluid: false,
+            module_id: 0,
+        };
+        let producer = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "iron-plate".to_string(),
+            self_loop: vec![],
+            voider: false,
+            game_modules: Vec::new(),
+            count: 2.0,
+            inputs: vec![flow(p_in, 1.0)],
+            outputs: vec![flow("iron-plate", 2.0)],
+        };
+        let consumer = MachineSpec {
+            entity: "assembling-machine-2".to_string(),
+            recipe: "three-input-thing".to_string(),
+            self_loop: vec![],
+            voider: false,
+            game_modules: Vec::new(),
+            count: 1.0,
+            inputs: vec![flow("iron-plate", 2.0), flow(a, 1.0), flow(b, 1.0)],
+            outputs: vec![flow("three-input-thing", 1.0)],
+        };
+        (producer, consumer)
+    }
+
+    /// **The prerequisite for relaxing the face count to three solid
+    /// inputs.** Two entries for one item at two different `y` in the fused
+    /// spec starve silently: both `lane_planner` and `ghost_router` `break`
+    /// on the FIRST matching solid input, so the second belt is built,
+    /// never tapped, never fed — and no validator disagrees with anything,
+    /// because nothing disagrees. Exactly the failure this RFC already hit
+    /// once on the producer/consumer axis.
+    ///
+    /// The old guard read the consumer's non-coupled inputs with `.find()`,
+    /// which returns only the FIRST — sufficient while two solid inputs
+    /// permitted exactly one non-coupled item, silently partial at three.
+    /// All three pairs must be checked.
+    ///
+    /// Written BEFORE relaxing the gate, where it passes vacuously on the
+    /// input count alone; it is the safety net for the relaxation, so it
+    /// must go on passing for the stated reason afterwards.
+    #[test]
+    fn di_row_cell_refuses_every_same_item_collision() {
+        // producer's belt input collides with the consumer's FIRST other
+        // input — the only pair the old `.find()` guard actually checked.
+        let (p, c) = three_input_pair("copper-plate", "copper-plate", "steel-plate");
+        assert!(
+            !row_cell_eligible(&p, &c, "iron-plate"),
+            "producer's belt input == consumer's first other input"
+        );
+        // ...with the SECOND. `.find()` never looked here.
+        let (p, c) = three_input_pair("steel-plate", "copper-plate", "steel-plate");
+        assert!(
+            !row_cell_eligible(&p, &c, "iron-plate"),
+            "producer's belt input == consumer's second other input"
+        );
+        // ...and the two consumer inputs with each other, which needs no
+        // producer collision at all to put two belts on one item.
+        let (p, c) = three_input_pair("copper-plate", "steel-plate", "steel-plate");
+        assert!(
+            !row_cell_eligible(&p, &c, "iron-plate"),
+            "consumer's two other inputs are the same item"
+        );
+        // Control: all four items distinct — refused today on the face
+        // count, and the case the relaxation is FOR.
+        let (p, c) = three_input_pair("copper-plate", "steel-plate", "plastic-bar");
+        let _ = row_cell_eligible(&p, &c, "iron-plate");
     }
 
     /// DI off is the default and must stay bit-identical: no fusion.

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -2186,6 +2186,91 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   hand-waved prerequisite into a file:line change with a test to write
   first. Every one of those was cheaper found before building than after.*
 
+- *2026-07-26 — **The north-input-B design is BUILT, and building it
+  falsified the premise that motivated it.** The three-solid-input row
+  cell works and is verified at tile level. It also unlocks nothing on
+  its own, because the face count was never `rail`'s only blocker.*
+
+  ***What shipped.*** *The prerequisite first, as its own commit: the
+  same-item guard now checks all solid-input pairs instead of the first.
+  The test was written before the gate moved and **demonstrated to have
+  teeth** — relaxing the count to three WITHOUT the fix fails it on
+  `producer's belt input == consumer's second other input`, exactly the
+  pair `.find()` never looked at. It passes vacuously at a count of two,
+  which is the point: the net was in place before the fall.*
+
+  *Then the geometry. Belt B is the outer north row, one above the
+  producer's belt, fed by a reach-2 inserter sharing the producer's feed
+  row over the consumer's columns. All three of the review's risk
+  predictions held. The inserter swings OVER the producer's belt rather
+  than sitting on it, so no underground gap is needed — the
+  `RowKind::QuadInput` precedent turned out to be the harder version of
+  the same idea, not the same one.*
+
+  ***Two constraints the review did not name, both found by deriving the
+  drop tile rather than trusting the sketch.*** *B's inserter sits at
+  `machine_y - 1` and drops at `machine_y + 1`, so:*
+
+  - *a producer more than **one tile taller** lifts that drop above a
+    bottom-aligned consumer's body and the item lands on nothing.
+    **Foundry(5) over assembler(3) is exactly this case** — the shipped
+    fluid pairs would have been silently broken by a version of this
+    change that only relaxed the count.*
+  - *a piped producer's run already occupies the feed row, which is
+    where B's inserters go.*
+
+  *Both refuse explicitly. The tile-level test asserts the drop lands
+  **inside** the consumer, which is the assertion that would have caught
+  either.*
+
+  ***The falsified premise.*** *`rail` still does not build a cell, and
+  the reason is not face allocation at all:*
+
+  ```text
+  COUPLING iron-plate -> iron-stick on iron-plate    <- claimed first
+  COUPLING iron-stick -> rail       on iron-stick    <- never tried
+  ```
+
+  *The chain is `iron-plate → iron-stick → rail`. A spec may only be
+  fused once, so the dispatcher's greedy walk — consumers in topological
+  order, upstream first — claims `iron-stick` for a STACKED cell with
+  `iron-plate` and never reaches the row cell that motivated all of this.
+  **`iron-stick → rail` is skipped before eligibility is even
+  evaluated.** Confirmed by instrumenting the dispatch: the only three
+  couplings it prints for `rail` are the two foundry ones (correctly
+  refused) and the upstream pair.*
+
+  *Forcing the downstream coupling to claim first (consumers in reverse
+  order, behind a scratch env flag) builds it: `di-row:iron-stick:rail`,
+  **0 validation issues**, 261 entities against the forward order's 264.
+  So the geometry is right and reachable — by a policy this RFC has not
+  agreed.*
+
+  ***Why that policy change is NOT in this commit.*** *It decides which
+  pair gets fused for every DI layout in the corpus, and the evidence for
+  flipping it is thin: `electronic-circuit@10`, `steel-plate@5` and
+  `iron-gear-wheel@10` are byte-identical under both orders, the full
+  suite is green under both, and the win on the one target that changes
+  is **3 entities at one rate** (`rail@1`; at `rail@5` the straddle does
+  not balance and reverse order builds the same stacked cell as forward).
+  A green suite is weak evidence here — nearly every test runs with
+  `direct_insertion: false`. Flipping a corpus-wide tie-break on one
+  marginal case at one rate is the exploration-overruns-its-evidence
+  shape the kill criteria exist to stop.*
+
+  ***Status: the capability is built, tested and inert.*** *No corpus
+  target reaches it today. The open question is not geometric any more —
+  it is **how the dispatcher should choose when one spec is a candidate
+  in two cells**, which is a matching problem, not an ordering accident.
+  Whoever picks it up should note the current rule has no principle
+  behind it: upstream-first is iteration order, not a decision.*
+
+  ***Correction to the entry above.*** *That entry called 3+ inputs "face
+  allocation, not straddle" and scoped the work at 351 instances. The
+  first half is right about the geometry and wrong about the blocker; the
+  351 figure counts pairs that the dispatcher will not offer to the cell
+  builder in the first place. **Neither number has ever been an estimate
+  of what relaxing the face count would deliver — which is zero.***
 - *2026-07-26 — **`direct_insertion: true` as a blunt default is
   REFUSED by measurement. Attempted on request, reverted the same
   session.** The flip is one line; the case for it was wrong.*

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -2251,12 +2251,27 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   flipping it is thin: `electronic-circuit@10`, `steel-plate@5` and
   `iron-gear-wheel@10` are byte-identical under both orders, the full
   suite is green under both, and the win on the one target that changes
-  is **3 entities at one rate** (`rail@1`; at `rail@5` the straddle does
-  not balance and reverse order builds the same stacked cell as forward).
+  is **3 entities at one rate** (see the correction below on WHICH rate).
   A green suite is weak evidence here — nearly every test runs with
   `direct_insertion: false`. Flipping a corpus-wide tie-break on one
   marginal case at one rate is the exploration-overruns-its-evidence
   shape the kill criteria exist to stop.*
+
+  ***Correction (2026-07-30, review of #508):*** *this entry originally named
+  `rail@1` as the winning rate and said the straddle does not balance at
+  `rail@5`. That contradicts this document's own coupling table above, which
+  reports `plan_row_straddle` balancing at exactly **5/s and 10/s** of 12 sampled
+  rates, with 1/s explicitly unbalanced (`P1:C1, 3.0 vs 1.5`). Both statements
+  cannot hold, and the measurement came from a scratch env flag that was never
+  committed — so the winning rate is **not recoverable from this record** and
+  neither figure should be quoted. The table's claim is the more specific and
+  self-consistent of the two (it lists the sample and the failing arithmetic), so
+  5/s or 10/s is the likelier location, but that is inference, not measurement.
+  Establishing it is now phase 1 of
+  [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md), whose
+  kill criterion 1 cannot be evaluated until the sweep exists. Recorded rather
+  than silently corrected because the wrong half is not identifiable from the
+  document alone.*
 
   ***Status: the capability is built, tested and inert.*** *No corpus
   target reaches it today. The open question is not geometric any more —

--- a/docs/rfc-053-direct-insertion-cells.md
+++ b/docs/rfc-053-direct-insertion-cells.md
@@ -2267,9 +2267,10 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
   neither figure should be quoted. The table's claim is the more specific and
   self-consistent of the two (it lists the sample and the failing arithmetic), so
   5/s or 10/s is the likelier location, but that is inference, not measurement.
-  Establishing it is now phase 1 of
-  [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md), whose
-  kill criterion 1 cannot be evaluated until the sweep exists. Recorded rather
+  Establishing it is phase 1 of the DI coupling-assignment RFC, proposed in
+  **#509** (RFC-059) and not yet merged at the time of writing — cited by PR
+  rather than by filename precisely because the file does not exist on `main`
+  yet, and a link that 404s is worse than a pointer that names its own state. Recorded rather
   than silently corrected because the wrong half is not identifiable from the
   document alone.*
 


### PR DESCRIPTION
## Intent

Build the north-input-B design RFC-053 recorded as a reviewed candidate: let a row cell's consumer have a **third solid input**. Follows #470, which named 3+ inputs as the remaining top blocker.

**Building it falsified the premise that motivated it.** The geometry works and is tile-verified. It also unlocks nothing on its own, because the face count was never `rail`'s only blocker. That finding is the most useful thing in this PR, and it is why the branch ships a capability rather than a win.

## Scope

- **In:**
  1. **The prerequisite** (`2c025fdc`) — the same-item guard checks all solid-input pairs instead of only the first. Independently valuable and safe at the current face count.
  2. **The geometry** (`c2f6f7ae`) — belt B on the outer north row, fed by a reach-2 inserter sharing the producer's feed row over the consumer's columns.
  3. **The RFC correction** (`b3ea00ca`).
- **Out:** the dispatcher's claim policy — see below. That is the thing that would actually deliver `rail`, and it is a corpus-wide tie-break I am not flipping on this evidence.

### The falsified premise

```text
COUPLING iron-plate -> iron-stick on iron-plate    <- claimed first
COUPLING iron-stick -> rail       on iron-stick    <- never tried
```

The chain is `iron-plate → iron-stick → rail`. A spec may only be fused once, so the dispatcher's greedy walk — consumers in topological order, upstream first — claims `iron-stick` for a **stacked** cell and never reaches the row cell this PR builds. `iron-stick → rail` is skipped *before eligibility is evaluated*. Confirmed by instrumenting the dispatch.

Forcing the downstream coupling to claim first (scratch env flag, not in the diff) builds it: `di-row:iron-stick:rail`, **0 validation issues**, 261 entities vs the forward order's 264.

So the geometry is right and reachable — by a policy this RFC has not agreed. I left it alone because the evidence for flipping is thin: `electronic-circuit@10`, `steel-plate@5`, `iron-gear-wheel@10` are byte-identical under both orders, the full suite is green under both, and the win is **3 entities at one rate** (at `rail@5` the straddle doesn't balance and both orders build the same stacked cell). A green suite is weak evidence here — nearly every test runs with `direct_insertion: false`.

**The real open question is not geometric: how should the dispatcher choose when one spec is a candidate in two cells?** That's a matching problem. Worth noting the current rule has no principle behind it — upstream-first is iteration order, not a decision.

### Two constraints the design review did not name

Both derived from the drop tile rather than trusting the sketch. B's inserter sits at `machine_y - 1` and drops at `machine_y + 1`, so:

- a producer more than **one tile taller** lifts that drop above a bottom-aligned consumer's body and the item lands on nothing. **Foundry(5) over assembler(3) is exactly this case** — a version of this change that only relaxed the count would have silently broken the shipped fluid pairs.
- a piped producer's run already occupies the feed row, which is where B's inserters go.

Both refuse explicitly.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 908 lib + 64 e2e green, 0 failed
- [x] `cargo clippy -p spaghettio_core -- -D warnings` clean. (`--all-targets` reports pre-existing `doc quote line` errors in `bus/layout.rs` — confirmed present on `origin/main` by stashing.)
- [x] **The prerequisite test was demonstrated to have teeth**, not merely to pass: relaxing the count to three *without* the guard fix fails it on `producer's belt input == consumer's second other input` — precisely the pair `.find()` never looked at. It passes vacuously at a count of two, which is the point.
- [x] **Tile-level assertions, not "it returned `Some`"**: belt B is the outer north row and the cell's new top; its feed is long-handed, sits on the producer's feed row, picks from B's belt, and **drops inside the consumer's body**. The three input belts and the fused spec's three solids are asserted to agree index for index — the positional contract `lane_planner` and `ghost_router` both index into, and the one this RFC has already been bitten by once.
- [x] Full suite also run under the reversed claim order (green) — reported above as weak evidence, since most tests run DI-off.

Not run: sim. Nothing reaches the new path, so there is no layout to measure.

## Deviations from intent

**The intent was a win; the outcome is a capability plus a correction.** I did not flip the claim order to manufacture the win, because that decision has corpus-wide reach and belongs in the RFC, not in a drive-by. Flagging explicitly: **this merges dead code** — no corpus target reaches the new path today. That is a real cost and the reason to consider not merging is legitimate.

## Models / contracts touched

`docs/rfc-053-direct-insertion-cells.md`. `RowCellSpec` gains two fields (`consumer_input_b`, `consumer_feed_b_count`); the `input_belt_ys` ↔ fused-spec positional contract is unchanged and now asserted. No validator or router change.
