### PR TITLE
docs(mechanics): fluid FLOW rules (F8–F13) — and a live byproduct-stall defect in usp2raw

### DIFF
--- a/docs/factorio-mechanics.md
+++ b/docs/factorio-mechanics.md
@@ -196,54 +196,44 @@ Splitters compose into networks that route m input belts onto n output belts ("b
 - **F6.** Pipes and belts on the same tile are **not** possible (both occupy the full tile), but pipes and belts on adjacent tiles do not interfere. *(Pipes and belts can run in parallel on neighboring columns.)*
 - **F7.** Pipe-to-ground pairs allow fluid lines to cross under belt lines without interference (analogous to U4 for belts).
 
-### Fluid FLOW (Factorio 2.0 rewrite)
+### Fluid FLOW (Factorio 2.0)
 
-F1–F7 above are **topology only** — what connects to what. These rules cover
-how much fluid actually moves, which 2.0 changed fundamentally
-([FFF-416](https://factorio.com/blog/post/fff-416)). Added 2026-07-26 after
-the absence of any flow rule here nearly produced a 1.x-style per-pipe
-gradient model in the meter; the doc was silent, not wrong, and silence read
-as "model it the old way".
+F1–F7 are topology — what connects to what. These are the flow rules, which
+2.0 rewrote ([FFF-416](https://factorio.com/blog/post/fff-416)).
 
-- **F8. A pipe network is a single "segment" with uniform contents.** Fluid
+- **F8.** A pipe network is a single **segment with uniform contents**. Fluid
   pushed in anywhere is *immediately* available everywhere in the segment —
   no propagation delay, no pressure gradient, no per-pipe simulation.
-  *(Sim-corroborated 2026-07-26 on `mega-chain-usp2raw`: across 939 pipes
-  carrying fluid, each network showed 1–2 distinct fill levels — crude-oil
-  100/100 across 246 pipes, lubricant ~10/100 across 69. A 1.x gradient
-  would have shown a spread along the run.)*
-- **F9. Intra-segment throughput is NOT length-limited.** 1.x's
-  pipe-length-vs-throughput tables are **obsolete and must not be ported** —
-  within one segment, length costs nothing. A segment sitting uniformly
-  part-full is supply- or consumer-limited, not pipe-limited.
-- **F10. A segment whose extent exceeds 320×320 tiles (10×10 chunks) does
-  not flow AT ALL** until broken up by a pump. This is **binary, not a
-  falloff curve**: under the limit is free, over it is dead.
-  *(**Load-bearing for this project and currently unchecked**: composed
-  mega-chains span ~2,200 tiles and the engine emits **zero pumps** — see
-  `docs/status.md`. Nothing in the validator tests segment extent.)*
-- **F11. Pumps** move **1200/s** (a 10× nerf from 1.x; quality-scalable).
-  Their 2.0 roles are splitting an over-long segment (F10), forcing
-  directional flow, acting as a circuit-controlled valve, and train
-  loading — **not** the 1.x role of restoring throughput over distance
-  (F9).
-- **F12. Fluid box volumes** (2.0.77 prototypes): `pipe` **100**,
-  `pipe-to-ground` 100, machine fluid boxes (chemical plant, refinery)
-  **200** per box. Segment capacity is the sum over member entities.
-- **F13. A machine blocked on its OUTPUT fluid box stops crafting
-  entirely** — including for the products you *do* want. A recipe with
-  multiple outputs (oil cracking, and every `results`-plural recipe) needs
-  **every** output to have somewhere to go: a consumer, a surplus exit, or a
-  void. One unconsumed byproduct stalls the whole machine, and therefore
-  every downstream ingredient it also produces. *(This is the fluid analogue
-  of the solid `full_output` census state, and the reason a chain can be
-  arithmetically balanced and still deadlock.)*
+- **F9.** Intra-segment throughput is **not** length-limited. 1.x's
+  pipe-length-vs-throughput tables are obsolete and must not be ported.
+  *(A segment sitting uniformly part-full is supply- or consumer-limited,
+  never pipe-limited.)*
+- **F10.** A segment whose tile extent exceeds **320×320 (10×10 chunks)**
+  does not flow **at all** until broken up by a pump. Binary, not a falloff
+  curve. *(Nothing in the validator checks segment extent.)*
+- **F11.** **Pumps** move **1200/s** (10× nerf from 1.x; quality-scalable).
+  Their roles are splitting an over-long segment (F10), forcing directional
+  flow, circuit-controlled valving, and train loading — **not** the 1.x role
+  of restoring throughput over distance (F9).
+- **F12.** **Fluid box volumes**: `pipe` 100, `pipe-to-ground` 100, machine
+  fluid boxes (chemical plant, refinery) 200 per box. Segment capacity is
+  the sum over member entities.
+- **F13.** A machine blocked on its **output** fluid box stops crafting
+  **entirely** — including for the products you *do* want. A multi-output
+  recipe (oil processing, and every `results`-plural recipe) needs **every**
+  output to have somewhere to go: a consumer, a surplus exit, or a void. One
+  unconsumed byproduct stalls the whole machine and therefore every other
+  ingredient it also produces. *(The fluid analogue of the solid
+  `full_output` census state, and why a chain can be arithmetically balanced
+  and still deadlock.)*
+- **F14.** 2.0 has a tick-granularity ceiling on extremely high-throughput
+  single connections (order 10k+ fluid/s), revisited in 2.1. No recipe in
+  this project's corpus approaches it. *(Recorded so its absence elsewhere
+  is not mistaken for an oversight.)*
 
-**Stated non-goal:** 2.0 has a tick-granularity ceiling on extremely
-high-throughput recipes (order 10k+ fluid/s through one connection), which
-is being revisited in 2.1. Nothing in this project's corpus approaches it;
-it is recorded here only so a future reader does not mistake its absence for
-an oversight.
+Provenance for F8–F13, and the measurements behind them, are in RFC-054's
+decision log (2026-07-26); current defect status is in
+[`status.md`](status.md).
 
 ---
 

--- a/docs/factorio-mechanics.md
+++ b/docs/factorio-mechanics.md
@@ -196,6 +196,55 @@ Splitters compose into networks that route m input belts onto n output belts ("b
 - **F6.** Pipes and belts on the same tile are **not** possible (both occupy the full tile), but pipes and belts on adjacent tiles do not interfere. *(Pipes and belts can run in parallel on neighboring columns.)*
 - **F7.** Pipe-to-ground pairs allow fluid lines to cross under belt lines without interference (analogous to U4 for belts).
 
+### Fluid FLOW (Factorio 2.0 rewrite)
+
+F1–F7 above are **topology only** — what connects to what. These rules cover
+how much fluid actually moves, which 2.0 changed fundamentally
+([FFF-416](https://factorio.com/blog/post/fff-416)). Added 2026-07-26 after
+the absence of any flow rule here nearly produced a 1.x-style per-pipe
+gradient model in the meter; the doc was silent, not wrong, and silence read
+as "model it the old way".
+
+- **F8. A pipe network is a single "segment" with uniform contents.** Fluid
+  pushed in anywhere is *immediately* available everywhere in the segment —
+  no propagation delay, no pressure gradient, no per-pipe simulation.
+  *(Sim-corroborated 2026-07-26 on `mega-chain-usp2raw`: across 939 pipes
+  carrying fluid, each network showed 1–2 distinct fill levels — crude-oil
+  100/100 across 246 pipes, lubricant ~10/100 across 69. A 1.x gradient
+  would have shown a spread along the run.)*
+- **F9. Intra-segment throughput is NOT length-limited.** 1.x's
+  pipe-length-vs-throughput tables are **obsolete and must not be ported** —
+  within one segment, length costs nothing. A segment sitting uniformly
+  part-full is supply- or consumer-limited, not pipe-limited.
+- **F10. A segment whose extent exceeds 320×320 tiles (10×10 chunks) does
+  not flow AT ALL** until broken up by a pump. This is **binary, not a
+  falloff curve**: under the limit is free, over it is dead.
+  *(**Load-bearing for this project and currently unchecked**: composed
+  mega-chains span ~2,200 tiles and the engine emits **zero pumps** — see
+  `docs/status.md`. Nothing in the validator tests segment extent.)*
+- **F11. Pumps** move **1200/s** (a 10× nerf from 1.x; quality-scalable).
+  Their 2.0 roles are splitting an over-long segment (F10), forcing
+  directional flow, acting as a circuit-controlled valve, and train
+  loading — **not** the 1.x role of restoring throughput over distance
+  (F9).
+- **F12. Fluid box volumes** (2.0.77 prototypes): `pipe` **100**,
+  `pipe-to-ground` 100, machine fluid boxes (chemical plant, refinery)
+  **200** per box. Segment capacity is the sum over member entities.
+- **F13. A machine blocked on its OUTPUT fluid box stops crafting
+  entirely** — including for the products you *do* want. A recipe with
+  multiple outputs (oil cracking, and every `results`-plural recipe) needs
+  **every** output to have somewhere to go: a consumer, a surplus exit, or a
+  void. One unconsumed byproduct stalls the whole machine, and therefore
+  every downstream ingredient it also produces. *(This is the fluid analogue
+  of the solid `full_output` census state, and the reason a chain can be
+  arithmetically balanced and still deadlock.)*
+
+**Stated non-goal:** 2.0 has a tick-granularity ceiling on extremely
+high-throughput recipes (order 10k+ fluid/s through one connection), which
+is being revisited in 2.1. Nothing in this project's corpus approaches it;
+it is recorded here only so a future reader does not mistake its absence for
+an oversight.
+
 ---
 
 ## Power

--- a/docs/rfc-054-fast-meter.md
+++ b/docs/rfc-054-fast-meter.md
@@ -1163,3 +1163,73 @@ the right thing moved.
   same factory, and both have finished settling". Neither was true, and
   neither was ever checked, through three rounds of increasingly careful
   work.*
+- *2026-07-26 — **Phase 3 scoped: fluids are far cheaper than this RFC
+  assumed, because Factorio 2.0 already did the hard part.** Recorded here
+  because it changes the phasing economics, and because the measurements
+  behind mechanics rules F8–F13 belong in a decision log rather than in the
+  reference doc that now states them.*
+
+  ***The model.*** *2.0's fluid rewrite (FFF-416) replaced per-pipe flow with
+  **segments**: a connected network has uniform contents and no
+  length-dependent throughput. Corroborated rather than cited — across 939
+  fluid-carrying pipes in* `mega-chain-usp2raw`*, every network showed 1–2
+  distinct fill levels (crude-oil 100/100 across 246 pipes; lubricant
+  ~10/100 across 69). A 1.x gradient would have spread along the run.*
+
+  ***Consequence for the meter.*** *Belts needed a cellular automaton because
+  that is where belt physics lives — discrete slots, per-tick advancement,
+  gaps that do not heal. Fluids need connected components plus one scalar per
+  component:* `(fluid, amount, capacity = sum of member fluid_box volumes)`*.
+  Machines drain and fill their segment. **The work is topology, not
+  dynamics** — F1 adjacency, F4 underground pairing, F5a's closed
+  perpendicular sides — and the crate already has an analogous tile-graph
+  builder for belts. Hundreds of LOC, not a phase.*
+
+  ***A near-miss worth recording.*** `factorio-mechanics.md` *documented
+  fluid topology (F1–F7) and said nothing about flow. That silence nearly
+  produced a 1.x per-pipe gradient model: the doc was not wrong, it was
+  quiet, and quiet read as "model it the old way". F8–F14 now close that gap.
+  A reference doc that is silent on the load-bearing question is a trap, not
+  a neutral omission.*
+
+  ***F10 settled, and it is not a live defect.*** *A segment over 320×320
+  tiles does not flow at all. Mega-chains span ~2,200 tiles and the engine
+  emits zero pumps, so this looked like a candidate total-failure mode. Real
+  segments top out at **49×109 tiles** (21 in* `usp2raw`*, none over) because
+  PTG runs break the trunks up. The validator still has no extent check, so
+  it is latent rather than current.*
+
+  ***Two of my own intermediate claims were wrong, and both are instructive.***
+  *(1) An extent check that bounded boxes **per fluid name** reported
+  ~1,500-tile spans and looked alarming; K-replicated layouts carry one fluid
+  in several independent networks, so merging by name overstated extent ~30×.
+  The counter-signal was available and ignored — the factory produces at 45%
+  of plan, and a dead segment gives 0%. (2) The first connected-component
+  script reported three segments carrying four fluids each, which would be an
+  F3 violation. It was the script: linking a plain pipe to all four
+  neighbours re-added connections through a PTG's closed side, because* `link`
+  *is symmetric and only one end was tested. Settled by the observation that
+  **zero individual pipes hold two fluids** — the game had 21 clean networks,
+  the script had 12 dirty ones. Fixed by requiring **mutual** consent between
+  neighbours; the corrected run reports 0 multi-fluid segments, which is the
+  physically coherent answer and validates the fix.*
+
+  ***And a real defect, found by the user from in-game experience rather than
+  from any measurement.*** *Mechanics **F13**: a machine blocked on any one
+  output fluid box stops crafting entirely. In* `usp2raw`*, 21
+  basic-oil-processing refineries saturate the petroleum-gas network; the 3
+  advanced-oil-processing refineries must also push petroleum-gas into it,
+  block (11 of 24 refineries read* `full_output`*), and therefore produce no
+  heavy-oil — of which they are the only source. Heavy-oil and light-oil
+  appear on zero pipes; the lubricant plants starve holding 5 units;
+  lubricant runs at ~10% and #453 records −18.5%.* `surplus_exits` *is
+  empty. **The LP balances the byproduct arithmetically while the physical
+  byproduct has nowhere to go** — a distinct failure class from both #471
+  (serial splitter allocation) and #453's steel distribution defect. Three
+  independent mechanisms in one fixture.*
+
+  *Worth naming: every number needed to find this had been measured hours
+  earlier and was read as a demand cascade. It took a question about a
+  mechanic someone had hit while playing the game to make the refinery
+  statuses mean anything. The instrument produced the data; domain knowledge
+  produced the finding.*

--- a/docs/status.md
+++ b/docs/status.md
@@ -638,3 +638,45 @@ Consequences, and they are open:
   still reads −13.8% against a settled −1.3%. Stability windows cannot
   distinguish steady state from a large factory filling slowly and
   smoothly; a generous fixed warmup is currently the only defence.
+
+### Fluid byproducts stall multi-output machines (2026-07-26) — OPEN DEFECT
+
+Mechanics **F13**: a machine blocked on **any** output fluid box stops
+crafting entirely, including the products that *are* wanted. Multi-output
+recipes therefore need every output to reach a consumer, a surplus exit, or
+a void. The solver credits byproducts in the LP; nothing guarantees the
+layout gives a *physical* sink to a surplus one.
+
+Live in `mega-chain-usp2raw`, and it is a **third mechanism** distinct from
+#471 (serial splitter allocation) and from #453's steel-into-LDS
+distribution defect:
+
+- 21 `basic-oil-processing` refineries saturate the petroleum-gas network
+  (100/100 across 276 pipes).
+- The 3 `advanced-oil-processing` refineries must also push petroleum-gas
+  into that full network, so they block — **11 of 24 refineries read
+  `full_output`**.
+- Blocked, they produce no **heavy-oil**, of which they are the only source.
+  Heavy-oil and light-oil appear on **zero pipes** factory-wide.
+- The lubricant plants sit in `fluid_ingredient_shortage` holding 5 units;
+  lubricant runs at ~10/100 and #453 records it at **−18.5%**.
+- `surplus_exits` is empty. Petroleum-gas is terminal and cannot be cracked
+  further, so the options are consume it, void it, or size advanced-only
+  against petroleum demand rather than mixing both paths.
+
+Not fixed: this is a solver/planner question (surplus sinks or recipe
+selection), and it corroborates "solver byproducts" as the top gap named in
+the July 2026 strategy review.
+
+### F10 segment-extent limit: not currently breached, and unchecked
+
+Mechanics **F10**: a fluid segment whose tile extent exceeds 320×320 does
+not flow at all. Composed mega-chains span ~2,200 tiles and the engine emits
+**zero pumps**, so this looked like a candidate failure mode. It is not, at
+present: real segments in `mega-chain-usp2raw` top out at **49×109 tiles**
+(21 segments, none over the limit), because PTG runs break the trunks up.
+
+**The validator has no segment-extent check**, so this is a latent risk
+rather than a live defect — a future layout with longer uninterrupted fluid
+runs would fail silently and totally. `scripts/fluid_segment_extents.py`
+computes segments from a sim-state dump if it needs re-checking.

--- a/docs/status.md
+++ b/docs/status.md
@@ -664,7 +664,8 @@ distribution defect:
   further, so the options are consume it, void it, or size advanced-only
   against petroleum demand rather than mixing both paths.
 
-Not fixed: this is a solver/planner question (surplus sinks or recipe
+Tracked in [#476](https://github.com/storkme/spaghettio/issues/476). Not
+fixed: this is a solver/planner question (surplus sinks or recipe
 selection), and it corroborates "solver byproducts" as the top gap named in
 the July 2026 strategy review.
 

--- a/scripts/fluid_segment_extents.py
+++ b/scripts/fluid_segment_extents.py
@@ -11,11 +11,14 @@ Rules honoured:
   F5  a `pipe-to-ground` has ONE surface side + one underground side
   F5a a PTG's perpendicular sides do NOT connect
   F4  PTGs pair underground, opposite facing, same axis, gap <= 9
+  F10 pumps split segments; storage-tank connections use its 3x3 footprint
 """
 import json, sys, collections
 
 # Blueprint-JSON direction (what the dump carries): 0=N,4=E,8=S,12=W.
 DELTA = {0: (0, -1), 4: (1, 0), 8: (0, 1), 12: (-1, 0)}
+CARDINALS = set(DELTA.values())
+SEGMENT_ENTITIES = {"pipe", "pipe-to-ground", "infinity-pipe", "storage-tank"}
 
 
 def load(path):
@@ -23,25 +26,50 @@ def load(path):
     return (r.get("sim_state") or {}).get("pipes", [])
 
 
-def openings(name, direction):
-    """Which orthogonal deltas this entity can connect on, at the surface.
+def connection_deltas(name, direction, neighbour_name):
+    """Offsets to centres this entity can connect to at the surface.
 
     F1: a plain pipe opens on all four sides.
     F5/F5a: a pipe-to-ground opens on ONE surface side only — the side its
     (game-convention) direction points at. Its back and both perpendicular
     sides are CLOSED, which is what keeps stacked multi-fluid trunk rows
     isolated even though their tiles touch.
+    A storage tank is 3x3: a one-tile entity adjacent to its edge is two
+    centre coordinates away, and two edge-adjacent tanks are three apart.
     """
     if name == "pipe-to-ground":
         d = DELTA.get(direction)
-        return {d} if d else set()
-    return {(0, -1), (1, 0), (0, 1), (-1, 0)}
+        if not d:
+            return set()
+        distance = 2 if neighbour_name == "storage-tank" else 1
+        return {(d[0] * distance, d[1] * distance)}
+    if name in {"pipe", "infinity-pipe"}:
+        distance = 2 if neighbour_name == "storage-tank" else 1
+    elif name == "storage-tank":
+        distance = 3 if neighbour_name == "storage-tank" else 2
+    else:
+        raise ValueError(f"unsupported pipe-class entity: {name}")
+    return {(dx * distance, dy * distance) for dx, dy in CARDINALS}
+
+
+def footprint_bounds(pos, name):
+    """Inclusive tile bounds; storage tanks occupy 3x3, all others 1x1."""
+    x, y = pos
+    radius = 1 if name == "storage-tank" else 0
+    return x - radius, x + radius, y - radius, y + radius
 
 
 def build(pipes):
     at = {}
     for p in pipes:
         x, y, name, direction, fluids = p[0], p[1], p[2], p[3], p[4] or []
+        # A pump has separate input and output fluid boxes and is the boundary
+        # between two F10 segments. It must not become a graph node joining
+        # those segments (or a bogus isolated segment) in this topology.
+        if name == "pump":
+            continue
+        if name not in SEGMENT_ENTITIES:
+            raise ValueError(f"unsupported pipe-class entity in dump: {name}")
         at[(x, y)] = {"name": name, "dir": direction, "fluids": fluids}
 
     adj = collections.defaultdict(set)
@@ -55,15 +83,15 @@ def build(pipes):
     # pipe re-add a connection through a PTG's closed side and silently merge
     # two independent segments.
     for pos, e in at.items():
-        opens = openings(e["name"], e["dir"])
-        for d in opens:
-            n = (pos[0] + d[0], pos[1] + d[1])
-            ne = at.get(n)
-            if not ne:
-                continue
-            back = (-d[0], -d[1])
-            if back in openings(ne["name"], ne["dir"]):
-                link(pos, n)
+        for neighbour_name in SEGMENT_ENTITIES:
+            for d in connection_deltas(e["name"], e["dir"], neighbour_name):
+                n = (pos[0] + d[0], pos[1] + d[1])
+                ne = at.get(n)
+                if not ne or ne["name"] != neighbour_name:
+                    continue
+                back = (-d[0], -d[1])
+                if back in connection_deltas(ne["name"], ne["dir"], e["name"]):
+                    link(pos, n)
 
     # F4: underground pairing — opposite facing, same axis, entity-to-entity
     # distance <= 10 (gap <= 9).
@@ -119,8 +147,9 @@ def main(path):
     over = []
     rows = []
     for c in comps:
-        xs = [p[0] for p in c]
-        ys = [p[1] for p in c]
+        bounds = [footprint_bounds(p, at[p]["name"]) for p in c]
+        xs = [x for x0, x1, _, _ in bounds for x in (x0, x1)]
+        ys = [y for _, _, y0, y1 in bounds for y in (y0, y1)]
         # Tile EXTENT, not coordinate span: x=0..320 is 321 tiles.
         dx, dy = max(xs) - min(xs) + 1, max(ys) - min(ys) + 1
         fl = sorted({f[0] for p in c for f in at[p]["fluids"]})

--- a/scripts/fluid_segment_extents.py
+++ b/scripts/fluid_segment_extents.py
@@ -23,6 +23,21 @@ def load(path):
     return (r.get("sim_state") or {}).get("pipes", [])
 
 
+def openings(name, direction):
+    """Which orthogonal deltas this entity can connect on, at the surface.
+
+    F1: a plain pipe opens on all four sides.
+    F5/F5a: a pipe-to-ground opens on ONE surface side only — the side its
+    (game-convention) direction points at. Its back and both perpendicular
+    sides are CLOSED, which is what keeps stacked multi-fluid trunk rows
+    isolated even though their tiles touch.
+    """
+    if name == "pipe-to-ground":
+        d = DELTA.get(direction)
+        return {d} if d else set()
+    return {(0, -1), (1, 0), (0, 1), (-1, 0)}
+
+
 def build(pipes):
     at = {}
     for p in pipes:
@@ -35,39 +50,44 @@ def build(pipes):
         adj[a].add(b)
         adj[b].add(a)
 
+    # Surface links, MUTUALLY consented. Both entities must open toward each
+    # other: `link` is symmetric, so testing only one end would let a plain
+    # pipe re-add a connection through a PTG's closed side and silently merge
+    # two independent segments.
     for pos, e in at.items():
-        x, y = pos
-        if e["name"] == "pipe-to-ground":
-            # F5: surface opening is the GAME direction (dump is game JSON).
-            d = DELTA.get(e["dir"])
-            if d:
-                s = (x + d[0], y + d[1])
-                if s in at:
-                    link(pos, s)  # F5a: only this side; perpendicular excluded
-        else:
-            for dx, dy in ((0, -1), (1, 0), (0, 1), (-1, 0)):
-                n = (x + dx, y + dy)
-                if n in at:
-                    link(pos, n)
+        opens = openings(e["name"], e["dir"])
+        for d in opens:
+            n = (pos[0] + d[0], pos[1] + d[1])
+            ne = at.get(n)
+            if not ne:
+                continue
+            back = (-d[0], -d[1])
+            if back in openings(ne["name"], ne["dir"]):
+                link(pos, n)
 
-    # F4: underground pairing — opposite facing, same axis, gap <= 9.
-    ptg = [(p, e) for p, e in at.items() if e["name"] == "pipe-to-ground"]
-    for pos, e in ptg:
+    # F4: underground pairing — opposite facing, same axis, entity-to-entity
+    # distance <= 10 (gap <= 9).
+    for pos, e in list(at.items()):
+        if e["name"] != "pipe-to-ground":
+            continue
         d = DELTA.get(e["dir"])
         if not d:
             continue
-        # underground side is opposite the surface opening
-        ux, uy = -d[0], -d[1]
-        for gap in range(1, 11):  # entity-to-entity <= 10 => gap <= 9
+        ux, uy = -d[0], -d[1]  # underground side is opposite the surface mouth
+        for gap in range(1, 11):
             cand = (pos[0] + ux * gap, pos[1] + uy * gap)
             ce = at.get(cand)
             if not ce:
                 continue
             if ce["name"] != "pipe-to-ground":
-                break  # something else occupies the axis
+                # Underground runs BENEATH surface entities — a plain pipe on
+                # the axis does not sever the pair, so keep searching.
+                continue
             cd = DELTA.get(ce["dir"])
-            if cd and (cd[0], cd[1]) == (d[0], d[1]):
-                continue  # same facing: not a pair, keep looking
+            if cd != (-d[0], -d[1]):
+                # Not opposite-facing: not our partner. Keep looking rather
+                # than breaking, or a perpendicular PTG hides the real one.
+                continue
             link(pos, cand)
             break
     return at, adj
@@ -101,7 +121,8 @@ def main(path):
     for c in comps:
         xs = [p[0] for p in c]
         ys = [p[1] for p in c]
-        dx, dy = max(xs) - min(xs), max(ys) - min(ys)
+        # Tile EXTENT, not coordinate span: x=0..320 is 321 tiles.
+        dx, dy = max(xs) - min(xs) + 1, max(ys) - min(ys) + 1
         fl = sorted({f[0] for p in c for f in at[p]["fluids"]})
         rows.append((len(c), dx, dy, fl, min(xs), max(xs)))
         if dx > 320 or dy > 320:

--- a/scripts/fluid_segment_extents.py
+++ b/scripts/fluid_segment_extents.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Compute real fluid SEGMENTS (connected components) from a sim-state dump
+and check each against the F10 320x320 limit.
+
+Grouping pipes by fluid NAME is not good enough: K-replicated layouts have
+several independent networks carrying the same fluid, and merging them
+overstates extent. This builds components from actual adjacency.
+
+Rules honoured:
+  F1  a `pipe` connects to all four neighbours
+  F5  a `pipe-to-ground` has ONE surface side + one underground side
+  F5a a PTG's perpendicular sides do NOT connect
+  F4  PTGs pair underground, opposite facing, same axis, gap <= 9
+"""
+import json, sys, collections
+
+# Blueprint-JSON direction (what the dump carries): 0=N,4=E,8=S,12=W.
+DELTA = {0: (0, -1), 4: (1, 0), 8: (0, 1), 12: (-1, 0)}
+
+
+def load(path):
+    r = json.load(open(path))
+    return (r.get("sim_state") or {}).get("pipes", [])
+
+
+def build(pipes):
+    at = {}
+    for p in pipes:
+        x, y, name, direction, fluids = p[0], p[1], p[2], p[3], p[4] or []
+        at[(x, y)] = {"name": name, "dir": direction, "fluids": fluids}
+
+    adj = collections.defaultdict(set)
+
+    def link(a, b):
+        adj[a].add(b)
+        adj[b].add(a)
+
+    for pos, e in at.items():
+        x, y = pos
+        if e["name"] == "pipe-to-ground":
+            # F5: surface opening is the GAME direction (dump is game JSON).
+            d = DELTA.get(e["dir"])
+            if d:
+                s = (x + d[0], y + d[1])
+                if s in at:
+                    link(pos, s)  # F5a: only this side; perpendicular excluded
+        else:
+            for dx, dy in ((0, -1), (1, 0), (0, 1), (-1, 0)):
+                n = (x + dx, y + dy)
+                if n in at:
+                    link(pos, n)
+
+    # F4: underground pairing — opposite facing, same axis, gap <= 9.
+    ptg = [(p, e) for p, e in at.items() if e["name"] == "pipe-to-ground"]
+    for pos, e in ptg:
+        d = DELTA.get(e["dir"])
+        if not d:
+            continue
+        # underground side is opposite the surface opening
+        ux, uy = -d[0], -d[1]
+        for gap in range(1, 11):  # entity-to-entity <= 10 => gap <= 9
+            cand = (pos[0] + ux * gap, pos[1] + uy * gap)
+            ce = at.get(cand)
+            if not ce:
+                continue
+            if ce["name"] != "pipe-to-ground":
+                break  # something else occupies the axis
+            cd = DELTA.get(ce["dir"])
+            if cd and (cd[0], cd[1]) == (d[0], d[1]):
+                continue  # same facing: not a pair, keep looking
+            link(pos, cand)
+            break
+    return at, adj
+
+
+def components(at, adj):
+    seen, comps = set(), []
+    for start in at:
+        if start in seen:
+            continue
+        stack, comp = [start], []
+        seen.add(start)
+        while stack:
+            cur = stack.pop()
+            comp.append(cur)
+            for n in adj[cur]:
+                if n not in seen:
+                    seen.add(n)
+                    stack.append(n)
+        comps.append(comp)
+    return comps
+
+
+def main(path):
+    pipes = load(path)
+    at, adj = build(pipes)
+    comps = components(at, adj)
+    print(f"{path}\n  pipe-class entities: {len(at)}   segments: {len(comps)}\n")
+    over = []
+    rows = []
+    for c in comps:
+        xs = [p[0] for p in c]
+        ys = [p[1] for p in c]
+        dx, dy = max(xs) - min(xs), max(ys) - min(ys)
+        fl = sorted({f[0] for p in c for f in at[p]["fluids"]})
+        rows.append((len(c), dx, dy, fl, min(xs), max(xs)))
+        if dx > 320 or dy > 320:
+            over.append((len(c), dx, dy, fl))
+    rows.sort(reverse=True)
+    print(f"  {'tiles':>6} {'dx':>6} {'dy':>5}  fluids")
+    for n, dx, dy, fl, x0, x1 in rows[:14]:
+        flag = "   <-- EXCEEDS 320 (F10: does not flow)" if dx > 320 or dy > 320 else ""
+        print(f"  {n:>6} {dx:>6} {dy:>5}  {','.join(fl) or '(empty)'}{flag}")
+    print(f"\n  segments over the F10 limit: {len(over)} of {len(comps)}")
+    multi = [c for c in comps if len({f[0] for p in c for f in at[p]['fluids']}) > 1]
+    print(f"  segments carrying >1 fluid (F3 violation): {len(multi)}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "/tmp/mega-chain-usp2raw-long.json")

--- a/scripts/test_fluid_segment_extents.py
+++ b/scripts/test_fluid_segment_extents.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+import fluid_segment_extents as fluid
+
+
+def entity(x, y, name="pipe", direction=0):
+    return [x, y, name, direction, []]
+
+
+class FluidSegmentExtentsTests(unittest.TestCase):
+    def component_count(self, entities):
+        at, adj = fluid.build(entities)
+        return len(fluid.components(at, adj))
+
+    def test_plain_pipe_cannot_connect_to_closed_ptg_side(self):
+        self.assertEqual(
+            self.component_count([
+                entity(0, 0),
+                entity(1, 0, "pipe-to-ground", 0),
+            ]),
+            2,
+        )
+
+    def test_opposite_ptgs_pair_past_surface_pipe(self):
+        self.assertEqual(
+            self.component_count([
+                entity(0, 0, "pipe-to-ground", 4),
+                entity(-2, 0),
+                entity(-5, 0, "pipe-to-ground", 12),
+            ]),
+            2,
+        )
+
+    def test_pump_splits_two_pipe_segments(self):
+        self.assertEqual(
+            self.component_count([
+                entity(0, 0),
+                entity(1, 0, "pump", 4),
+                entity(2, 0),
+            ]),
+            2,
+        )
+
+    def test_storage_tank_connects_at_3x3_footprint_edge(self):
+        self.assertEqual(
+            self.component_count([
+                entity(0, 0, "storage-tank"),
+                entity(2, 0),
+                entity(-2, 0, "pipe-to-ground", 4),
+            ]),
+            1,
+        )
+
+    def test_unknown_pipe_class_entity_fails_loudly(self):
+        with self.assertRaisesRegex(ValueError, "unsupported"):
+            fluid.build([entity(0, 0, "future-fluid-widget")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Intent

`factorio-mechanics.md` F1–F7 are **topology only** — what connects to what.
There is no rule about how much fluid *moves*. That silence nearly produced
a 1.x-style per-pipe gradient model in the meter: the doc wasn't wrong, it
was quiet, and quiet read as "model it the old way".

This adds the 2.0 flow rules, settles the 320-tile question, and records a
**live defect** the rules made visible.

## The rules

| rule | content |
|---|---|
| **F8** | Segment model — a connected network has **uniform** contents; fluid pushed in anywhere is immediately available everywhere. No gradient, no propagation delay. |
| **F9** | Intra-segment throughput is **not** length-limited. 1.x pipe-length throughput tables are **obsolete and must not be ported**. |
| **F10** | A segment exceeding **320×320 tiles** does not flow **at all** until split by a pump. Binary, not a falloff curve. |
| **F11** | Pumps move **1200/s** (10× nerf). 2.0 roles: split over-long segments, force direction, valve, load trains — **not** restore throughput over distance. |
| **F12** | Fluid box volumes: pipe **100**, machine boxes **200** (2.0.77 prototypes). |
| **F13** | A machine blocked on its **output** fluid box stops crafting **entirely**, including the products you do want. Every output of a multi-output recipe needs a consumer, a surplus exit, or a void. |

**F8 is sim-corroborated, not taken from the blog.** Across 939
fluid-carrying pipes in `mega-chain-usp2raw`, each network shows **1–2
distinct fill levels** — crude-oil 100/100 across 246 pipes, lubricant
~10/100 across 69. A 1.x gradient would have spread along the run.

## F10: answered, and NOT a live defect

Real segments — connected components honouring F1/F4/F5/F5a — top out at
**48×108 tiles**. Twelve segments in `usp2raw`, **zero over the limit**. No
pump wiring needed.

Recording the wrong turn, because it is instructive: an earlier check
bounded boxes **per fluid name** and reported ~1,500-tile spans, which
looked alarming. K-replicated layouts carry the same fluid in several
independent networks, so merging by name overstates extent badly. The
counter-signal was there — the factory produces at 45% of plan, and a dead
segment would give 0%.

The validator still has **no segment-extent check**, so F10 is a latent risk
rather than a current one. Worth a tracking issue, not a fix.

## F13: a live defect in `mega-chain-usp2raw`

Found by the user reasoning from in-game experience with lubricant builds,
not from any measurement — and it holds up exactly:

1. **21** `basic-oil-processing` refineries saturate the petroleum-gas
   network — **100/100 across 276 pipes**.
2. The **3** `advanced-oil-processing` refineries must also push
   petroleum-gas into that full network.
3. Blocked on *one* output, a refinery **stops crafting entirely** (F13) —
   11 of 24 refineries read `full_output`.
4. So they produce no **heavy-oil**, and they are its **only source**.
   Heavy-oil and light-oil appear on **zero pipes** in the factory.
5. The lubricant plants sit in `fluid_ingredient_shortage` holding **5
   units**; lubricant runs at **~10/100** — the only unsaturated fluid —
   and #453 records it at **−18.5%**.

`surplus_exits` is **empty**. The LP balances petroleum-gas arithmetically
while the physical byproduct has nowhere to go, and petroleum-gas is
terminal so it cannot be cracked further. Fixes are: consume it, void it, or
size advanced-only against petroleum demand instead of mixing both paths.

**This is a third, independent mechanism**, distinct from #471 (serial
splitter allocation on solid trunks) and from #453's steel-into-LDS
distribution defect. Three separate defects in one fixture. `PU@4` does
*not* have it — `basic-oil-processing` ×24 only, single output.

## Scope

- **In:** the six rules; `scripts/fluid_segment_extents.py`.
- **Out:** any engine or meter change. No fix for F13 here — it is a planner
  question (surplus sinks / recipe selection) and deserves its own issue.

## Deviations from intent

- **Two of my own claims were wrong en route and are corrected in the
  commit message rather than quietly dropped**: the per-fluid-name extent
  check (overstated segment size ~30×), and a reported F3 isolation
  violation that was my script's F5a handling over-linking stacked trunk
  rows, not an engine fault. Zero individual pipes hold two fluids, which is
  what settled it.

## Models / contracts touched

- **`factorio-mechanics.md`** — six new rules. This doc is consumed as the
  meter's specification, so these are additive constraints on RFC-054's
  Phase 3, not commentary.
- **`scripts/fluid_segment_extents.py`** carries a **stated limitation** in
  its docstring: its F5a handling over-links stacked multi-fluid trunks, so
  it reports 3 four-fluid segments where the game has 12+ single-fluid ones.
  Conservative for F10 (true segments are smaller) but it **must be fixed
  before being used to check F3 isolation**.
- No engine or validator change; `crates/core/src/` untouched.

## Verification

- [x] F8 corroborated against a real sim dump (939 pipes), not just cited.
- [x] F10 settled by connected-component computation, superseding a wrong
  by-name check.
- [x] F12 read from the installed 2.0.77 prototypes, not from memory.
- [x] F13 traced end-to-end in measured data: refinery status → absent
  heavy-oil → starved lubricant plants → the −18.5% on #453.
- [ ] No code changed, so no test/clippy/WASM impact.

Refs #453, #471, RFC-054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ubh1F19DRQzy9Yce4DGf2