### PR TITLE
fix(solver): prevent mixed oil-path deadlock (#476)

### DIFF
--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -800,6 +800,7 @@ pub fn compose_chain_with_capacity(
     let mut entities: Vec<PlacedEntity> = Vec::new();
     let mut b_in: Vec<BoundaryRecord> = Vec::new();
     let mut b_out: Vec<BoundaryRecord> = Vec::new();
+    let mut surplus_exits: Vec<(String, i32, i32)> = Vec::new();
     let mut placed: Vec<Placed> = Vec::new();
     let mut cursor = 0i32;
 
@@ -912,6 +913,12 @@ pub fn compose_chain_with_capacity(
             }
             let mega_drains = if is_mega {
                 let block = mega_block_cache.as_ref().expect("block cached");
+                surplus_exits.extend(
+                    block
+                        .surplus_exits
+                        .iter()
+                        .map(|(item, sx, sy)| (item.clone(), sx + x, sy + y_off)),
+                );
                 // Boundary feeds of the block become CHAIN boundary
                 // records at the placed offset; each drain head anchors
                 // one outgoing corridor.
@@ -1582,6 +1589,11 @@ pub fn compose_chain_with_capacity(
             b
         },
         boundary_outputs: b_out,
+        // Mega blocks own their internal fluid topology, including any
+        // physically routed byproduct relief exits. Preserve those records
+        // at chain coordinates so the top-level stranded-byproduct check
+        // can cross-check them against the translated pipe entities (#476).
+        surplus_exits,
         ..Default::default()
     })
 }

--- a/crates/core/src/bus/cells/mega.rs
+++ b/crates/core/src/bus/cells/mega.rs
@@ -636,6 +636,11 @@ fn adapt_with_spacing(
             ..r.clone()
         })
         .collect();
+    let surplus_exits = l
+        .surplus_exits
+        .iter()
+        .map(|(item, x, y)| (item.clone(), *x, *y + margin))
+        .collect();
 
     let width = entities.iter().map(|e| e.x).max().unwrap_or(0) + 1;
     let height = entities.iter().map(|e| e.y).max().unwrap_or(0) + 1;
@@ -647,6 +652,7 @@ fn adapt_with_spacing(
         inserter_capacity: l.inserter_capacity,
         boundary_inputs: b_in,
         boundary_outputs: b_out,
+        surplus_exits,
         // The engine's warnings survive the adaptation — dropping them
         // hid the ships-uncovered power note during #400's diagnosis.
         warnings: l.warnings.clone(),
@@ -1009,9 +1015,9 @@ pub fn compose_mega_block(
             ..m.clone()
         })
         .collect();
-    let produced: FxHashSet<&str> = machines
+    let produced: FxHashSet<String> = machines
         .iter()
-        .flat_map(|m| m.outputs.iter().map(|o| o.item.as_str()))
+        .flat_map(|m| m.outputs.iter().map(|o| o.item.clone()))
         .collect();
     // External inputs of the SUBGRAPH at the scaled rate (per-machine
     // rates × scaled counts).
@@ -1045,7 +1051,20 @@ pub fn compose_mega_block(
                 module_id: 0,
             })
             .collect(),
-        surplus_outputs: Vec::new(),
+        // Preserve parent-declared surplus produced inside this collapsed
+        // fluid subgraph (#476). Dropping it here made the mega adapter
+        // erase the only signal that tells the bus to extend a fluid
+        // byproduct to the perimeter, yielding a validator-clean sublayout
+        // whose multi-output refinery deadlocked in-game.
+        surplus_outputs: sr
+            .surplus_outputs
+            .iter()
+            .filter(|f| produced.contains(f.item.as_str()))
+            .map(|f| crate::models::ItemFlow {
+                rate: f.rate * scale,
+                ..f.clone()
+            })
+            .collect(),
         dependency_order: sr
             .dependency_order
             .iter()

--- a/crates/core/src/netflow.rs
+++ b/crates/core/src/netflow.rs
@@ -357,7 +357,9 @@ pub fn solve_netflow_with_options(
     // retry removes at least one recipe, so the cap is just a backstop.
     let mut extra_excluded: FxHashSet<String> = FxHashSet::default();
     let mut last_refusal: Option<SolverError> = None;
-    for _ in 0..8 {
+    // Eight acyclic-fallback exclusions plus at most one free-mode oil-path
+    // exclusivity re-solve (#476).
+    for _ in 0..9 {
         match solve_attempt(
             target_item,
             target_rate,
@@ -370,7 +372,31 @@ pub fn solve_netflow_with_options(
             costs,
             options,
         ) {
-            Ok(r) => return Ok(r),
+            Ok(r) => {
+                // Physical recipe-path exclusivity (#476): mixing basic and
+                // advanced oil processing is arithmetically valid but can
+                // deadlock in-game. Advanced processing is forced whenever
+                // heavy oil is demanded; its petroleum-gas co-product then
+                // shares a network with basic processing. Whole placed
+                // refineries can fill that network, blocking advanced
+                // processing's entire multi-output recipe and starving
+                // heavy oil/lubricant.
+                //
+                // In free-selection mode, once the optimum proves advanced
+                // processing is required, re-solve without basic processing.
+                // The advanced-only plan makes unavoidable excess explicit
+                // in `surplus_outputs`, so the layout gives it a physical
+                // perimeter exit. Restricted compatibility mode remains the
+                // exact caller-requested recipe set.
+                let mixes_oil_paths = matches!(scope, RecipeScope::Free)
+                    && r.machines.iter().any(|m| m.recipe == "advanced-oil-processing")
+                    && r.machines.iter().any(|m| m.recipe == "basic-oil-processing");
+                if mixes_oil_paths {
+                    extra_excluded.insert("basic-oil-processing".to_string());
+                    continue;
+                }
+                return Ok(r);
+            }
             Err(AttemptError::Hard(e)) => return Err(e),
             Err(AttemptError::Cycle { refusal, excludable }) => match excludable {
                 Some(m) => {

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1240,6 +1240,20 @@ fn mega_chain_usp2_resolves_bus_failure() {
         "flagship must exercise multi-export fan + chain-fed inputs"
     );
     let l = compose_chain(&sr).expect("USP@2 from raw must compose");
+    let heavy_exit = l
+        .surplus_exits
+        .iter()
+        .find(|(item, _, _)| item == "heavy-oil")
+        .expect("advanced-only oil plan must route heavy-oil surplus to the perimeter");
+    assert!(
+        l.entities.iter().any(|e| {
+            e.x == heavy_exit.1
+                && e.y == heavy_exit.2
+                && matches!(e.name.as_str(), "pipe" | "pipe-to-ground")
+                && e.carries.as_deref() == Some("heavy-oil")
+        }),
+        "heavy-oil surplus exit must name a physical matching pipe: {heavy_exit:?}"
+    );
     let issues = match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
         Ok(v) => v,
         Err(e) => e.issues,

--- a/crates/core/tests/solver_netflow_parity.rs
+++ b/crates/core/tests/solver_netflow_parity.rs
@@ -466,6 +466,44 @@ fn golden_rocket_fuel_free_mode_zero_surplus() {
     assert!(recipes.contains(&"advanced-oil-processing"), "got {recipes:?}");
 }
 
+/// Regression for #476: lubricant forces advanced oil processing into the
+/// utility-science chain. Its unavoidable petroleum-gas co-product must
+/// displace basic oil processing rather than stack on top of it as an
+/// unroutable surplus that blocks the advanced refineries in-game.
+#[test]
+fn utility_science_credits_advanced_oil_petroleum_before_basic_oil() {
+    let inputs = set(&["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]);
+    let r = solve_netflow(
+        "utility-science-pack",
+        2.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("utility science solves");
+
+    assert_conservation("utility-science-pack", 2.0, &r);
+    let recipes: Vec<&str> = r.machines.iter().map(|m| m.recipe.as_str()).collect();
+    assert!(recipes.contains(&"advanced-oil-processing"), "got {recipes:?}");
+    assert!(
+        !recipes.contains(&"basic-oil-processing"),
+        "advanced oil's petroleum must displace basic oil; got {recipes:?}"
+    );
+    assert!(
+        r.surplus_outputs.iter().all(|f| f.item != "petroleum-gas"),
+        "petroleum gas must be consumed, not stranded: {:?}",
+        r.surplus_outputs
+    );
+    assert!(
+        r.surplus_outputs.iter().any(|f| f.item == "heavy-oil" && f.is_fluid),
+        "advanced-only plan must expose unavoidable heavy-oil surplus for physical routing: {:?}",
+        r.surplus_outputs
+    );
+}
+
 /// Golden: rocket-fuel compat mode — byproduct crediting within the tree
 /// walk's own recipe set. AOP is pinned in by the walk's light-oil choice;
 /// its gas byproduct must offset basic-oil production (strictly fewer

--- a/docs/rfc-solver-net-flow.md
+++ b/docs/rfc-solver-net-flow.md
@@ -730,3 +730,19 @@ independent follow-ups with their own gates.
   value-recovery design, PLUS solid-surplus perimeter routing (11+
   genuine surplus streams even without voiding). Layout-side RFC
   should start from that design decision, not from price tuning.*
+- *2026-07-26 — **#476 physical oil-path exclusivity.** A long
+  `mega-chain-usp2raw` simulation falsified the assumption that fractional
+  LP balance alone makes mixed oil paths physically safe: the optimum
+  correctly credited AOP petroleum but mixed 18.815 basic + 2 advanced
+  refineries; three-way composition placed 21 + 3 whole refineries, and the
+  petroleum network saturated, blocking AOP's whole multi-output recipe and
+  starving heavy oil/lubricant. Free mode now re-solves without
+  `basic-oil-processing` whenever its first optimum also requires
+  `advanced-oil-processing`; restricted compatibility mode remains literal.
+  USP@2 becomes advanced-only, with unavoidable heavy-oil excess declared
+  as surplus. The mega adapter had independently erased parent surplus at
+  three ownership boundaries (sub-solve, boundary translation, chain
+  placement); all three now preserve it. The opt-in real USP composition
+  gate asserts the recorded exit names a physical heavy-oil pipe and
+  validates clean. Long Factorio re-measurement remains the acceptance
+  oracle before closing #476.*

--- a/docs/status.md
+++ b/docs/status.md
@@ -645,17 +645,15 @@ Consequences, and they are open:
   distinguish steady state from a large factory filling slowly and
   smoothly; a generous fixed warmup is currently the only defence.
 
-### Fluid byproducts stall multi-output machines (2026-07-26) — OPEN DEFECT
+### Fluid byproducts stall multi-output machines (2026-07-26) — FIXED IN CODE, RE-MEASUREMENT PENDING
 
 Mechanics **F13**: a machine blocked on **any** output fluid box stops
 crafting entirely, including the products that *are* wanted. Multi-output
 recipes therefore need every output to reach a consumer, a surplus exit, or
-a void. The solver credits byproducts in the LP; nothing guarantees the
-layout gives a *physical* sink to a surplus one.
+a void.
 
-Live in `mega-chain-usp2raw`, and it is a **third mechanism** distinct from
-#471 (serial splitter allocation) and from #453's steel-into-LDS
-distribution defect:
+Observed in `mega-chain-usp2raw`, distinct from #471's serial splitter
+allocation:
 
 - 21 `basic-oil-processing` refineries saturate the petroleum-gas network
   (100/100 across 276 pipes).
@@ -670,10 +668,23 @@ distribution defect:
   further, so the options are consume it, void it, or size advanced-only
   against petroleum demand rather than mixing both paths.
 
-Tracked in [#476](https://github.com/storkme/spaghettio/issues/476). Not
-fixed: this is a solver/planner question (surplus sinks or recipe
-selection), and it corroborates "solver byproducts" as the top gap named in
-the July 2026 strategy review.
+The initial diagnosis was incomplete: the LP *did* credit advanced oil's
+petroleum before sizing basic oil. The unsafe shape appeared at the
+fractional-plan → physical-layout boundary: a mixed 18.815-basic /
+2-advanced plan became 21 + 3 whole refineries across three replicas, whose
+combined petroleum capacity could saturate the network and block advanced
+processing.
+
+Fix [#476](https://github.com/storkme/spaghettio/issues/476): free recipe
+selection now treats the oil paths as exclusive. If advanced processing is
+required, the solver re-solves without basic processing; USP@2 becomes
+advanced-only and its unavoidable heavy-oil excess is explicit. The mega
+adapter now preserves that surplus through its sub-solve, boundary
+translation, and chain placement, producing an entity-verified heavy-oil
+perimeter pipe. The solver regression and the real ignored USP composition
+gate pass. Keep this entry open until a long Factorio re-measurement confirms
+the refinery/lubricant stall has disappeared and quantifies the remaining
+#471 deficit.
 
 ### F10 segment-extent limit: not currently breached, and unchecked
 


### PR DESCRIPTION
## Intent

Fix #476: prevent the mixed basic/advanced oil plan that saturates petroleum gas, blocks advanced processing, and starves heavy oil/lubricant in mega-chain-usp2raw.

## Scope

- **In:** free-mode oil-path exclusivity; preservation of fluid surplus through mega sub-solves, boundary adaptation, and chain placement; solver and physical-layout regressions; status/RFC decision log.
- **Out:** #471 trunk allocation and final throughput attribution, deliberately deferred until the post-fix long simulation.

## Verification

- [x] cargo test --manifest-path crates/core/Cargo.toml
- [x] Full solver_netflow_parity integration binary (11 passed, 3 ignored)
- [x] Release ignored gate: mega_chain_usp2_resolves_bus_failure; asserts the heavy-oil exit record names a real matching pipe, then validates clean
- [ ] cargo clippy --all-targets -- -D warnings — blocked by pre-existing warnings in untouched junction_fixtures.rs, mode_d_baseline.rs, layout.rs, and power_wires.rs; no reported finding is in this diff
- [ ] WASM rebuild/browser eyeball — deferred because this is solver/metadata propagation, and the real composition + entity cross-check is the stronger bug-specific gate

## Deviations from intent

The initial “LP fails to credit AOP petroleum” diagnosis was falsified. The LP already credited it; the unsafe mixed fractional plan became over-capacity whole-machine fleets after three-way composition. The fix therefore enforces recipe-path exclusivity and preserves the resulting explicit heavy-oil surplus through the mega adapter.

## Models / contracts touched

Net-flow free-selection policy, SolverResult surplus ownership across mega-cell boundaries, and docs/status.md’s #476 record. The owning RFC decision log records the revised diagnosis and policy.
