### PR TITLE
docs: propose competing compact cell placement RFCs

### DIFF
--- a/docs/rfc-055-compact-cell-chain.md
+++ b/docs/rfc-055-compact-cell-chain.md
@@ -1,0 +1,278 @@
+# RFC-055: Compact cell chains — flow-weighted ordering and validated orientation
+
+Status: Design  
+Tracking: #456  
+Competes with: RFC-056
+
+## Summary
+
+Reduce the transport distance and startup inventory of composed cell chains
+without replacing their one-dimensional slot architecture.
+
+The current chain composer derives one deterministic recipe order, stamps each
+cell west-to-east, then routes producer→consumer edges between those fixed
+slots. The result is correct but spatially indifferent: a high-rate input can
+travel hundreds of tiles because dependency order, not physical transport
+cost, chose the slots.
+
+This RFC makes cell order and orientation placement decisions:
+
+1. Extract a weighted producer→consumer graph from `SolverResult`.
+2. Enumerate prevalidated orientation variants for every cell.
+3. Search deterministic linear orders and variants.
+4. Score candidates primarily by rate-weighted port distance and critical-path
+   length, with footprint and congestion as secondary terms.
+5. Route and validate only the best bounded set of candidates.
+
+The output remains a single logical chain. RFC-056 asks whether folding that
+chain across multiple rows justifies a larger architecture change.
+
+## Motivation
+
+`mega-chain-usp2raw` is the concrete anchor. In one replica of the current
+layout, approximate recipe positions are:
+
+| Recipe group | x |
+|---|---:|
+| oil mega-cell / plastic | 236 |
+| copper plate | 288 |
+| steel plate | 612 |
+| low-density structure | 692 |
+| utility science | 732 |
+
+LDS is close to steel but roughly 400–450 tiles from its high-rate copper and
+plastic sources. A long-warmup Factorio run after the oil deadlock fix produced
+only 0.85 LDS/s against 2.0/s planned. Replacing steel's serial fan-out with a
+balanced 1→3 topology raised LDS to 1.13/s, but the remaining long copper and
+plastic paths still dominate startup inventory.
+
+Local splitter policy cannot solve a placement problem.
+
+## Goals
+
+- Shorten rate-important producer→consumer connections.
+- Shorten the external-input→target critical path.
+- Reduce belt entities and in-flight item inventory.
+- Preserve existing cell interiors and the chain router.
+- Make rotations and mirrors first-class, tested placement choices.
+- Produce deterministic output for a fixed seed and budget.
+- Establish the baseline RFC-056 and later 2D placement must beat.
+
+## Non-goals
+
+- Arbitrary machine-level compaction inside cells.
+- General two-dimensional macro placement.
+- Rubber-band post-route compaction.
+- Sharing machinery between the K capacity replicas.
+- Optimizing area without a measured-throughput constraint.
+
+## Placement graph
+
+Create one macro vertex for every ordinary cell and collapsed mega-cell.
+Create an edge for each transported item from its producer macro to every
+consumer macro.
+
+Each edge records:
+
+- item;
+- planned rate delivered to that consumer;
+- fluid/solid kind;
+- producer port candidates;
+- consumer port candidates;
+- whether the edge is direct insertion, belt, or pipe;
+- whether it lies on an external-input→target critical path.
+
+The graph is placement intent. It is derived before tile routing and must not
+be reconstructed from a finished `LayoutResult`.
+
+## Objective
+
+For order `O` and selected variants `V`, estimate:
+
+```text
+score =
+    Σ solid_edge_rate × estimated_port_distance
+  + fluid_weight × Σ fluid_edge_rate × estimated_port_distance
+  + critical_weight × longest_external_to_target_path
+  + congestion_weight × estimated_cut_congestion
+  + area_weight × estimated_bounding_area
+  + backward_weight × rate_of_westward_edges
+```
+
+The first term is primary. Bounding area is deliberately not primary: #448
+showed that removing apparent belt slack can remove the margin required for
+real delivery. Throughput gates decide whether a smaller result is acceptable.
+
+`fluid_weight` is nonzero but lower than the solid weight. Factorio 2.0 fluids
+do not carry belt-style item inventory, but pipe length still consumes space
+and routing capacity.
+
+### Reported metrics
+
+Every candidate report includes:
+
+- total belt and underground-belt entities;
+- total pipe and pipe-to-ground entities;
+- bounding width, height, and area;
+- maximum producer→consumer route length;
+- rate-weighted route length;
+- external-input→target critical-path length;
+- estimated and realized crossing count;
+- fast-meter target rate;
+- Factorio target rate and time to 90% of its final rate.
+
+## Search
+
+Phase 1 implements several bounded, deterministic competitors:
+
+1. Current order (control).
+2. Reverse order.
+3. Weighted barycentric insertion.
+4. Adjacent-swap hill climbing.
+5. Seeded simulated annealing with a fixed evaluation budget.
+
+The cheap objective evaluates thousands of orders without routing. The best
+`N` distinct orders advance to geometry construction and validation. The best
+validated `M` advance to the fast meter. Factorio is reserved for the final
+winner and control.
+
+Default proposal: `N=16`, `M=4`; tune from measured runtime rather than
+assuming these values.
+
+Westward connections are legal. They carry a congestion penalty, not a hard
+prohibition, because the existing chain router already supports them.
+
+## Validated cell orientations
+
+Rotations are allowed and expected. What is forbidden is rotating arbitrary
+placed entities without proving that every associated contract transformed.
+
+Each extracted cell exposes `CellVariant` values:
+
+```text
+CellVariant {
+    transform: Identity | Rotate90 | Rotate180 | Rotate270
+             | MirrorX | MirrorY,
+    entities,
+    ports,
+    width,
+    height,
+    boundary_records,
+    validation_fingerprint,
+}
+```
+
+A variant enters the placement search only after passing:
+
+- entity-overlap validation;
+- belt and underground-belt connectivity;
+- inserter pickup/drop reachability;
+- pipe segment and pipe-to-ground pairing;
+- recipe fluid-port identity;
+- power coverage;
+- boundary-record/entity agreement;
+- item isolation;
+- blueprint export→parse round trip.
+
+### Why validation is required
+
+Several entities are not transformed by changing `(x,y,direction)` alone:
+
+- splitter anchors depend on their oriented two-tile footprint;
+- underground-belt input/output endpoints must rotate as a pair;
+- inserter blueprint direction uses the game's pickup-side convention;
+- pipe-to-ground blueprint direction names its surface opening;
+- mirrored fluid machines have recipe-specific port identities;
+- splitter priorities are relative left/right annotations;
+- boundaries, segment metadata, and harness access coordinates move too.
+
+These facts argue for validated variants, not against rotation.
+
+### Variant generation policy
+
+- Ordinary solid cells: attempt all four rotations and both useful mirrors.
+- Cells containing fluid machines: begin with identity and 180°; admit 90° and
+  mirrors only after the fluid-port validator passes.
+- Mega-cells: transform the whole block including surplus records and boundary
+  adapters, never the interior entities independently.
+- A rejected transform is a normal unavailable variant, not a composition
+  failure.
+
+Variants are geometry-hashed and cached beside existing cell artifacts.
+
+## Placement and routing phases
+
+1. Solve and identify the cell/mega-cell graph.
+2. Generate or load validated variants.
+3. Run cheap order/variant search.
+4. Assign slot widths using the selected variants and required corridor
+   reservations.
+5. Route the best candidates with the existing crossing-aware router.
+6. Validate full `LayoutResult`.
+7. Meter and rank validated candidates.
+8. Return the winner only if it clears the acceptance gates; otherwise return
+   the current-order control.
+
+The fallback makes the feature monotonic: search failure cannot make an
+otherwise composable factory unavailable.
+
+## Acceptance gates
+
+Corpus:
+
+- `mega-chain-usp2raw`;
+- `mega-chain-chem5raw`;
+- `mega-chain-pu4raw`;
+- one small solid-only chain;
+- all geometry-hashed cell registry fixtures.
+
+Correctness:
+
+- zero new validator errors;
+- no new item-isolation or fluid-segment warnings;
+- deterministic geometry hash for a fixed seed/budget;
+- blueprint round trip preserves selected variants and ports.
+
+Quality:
+
+- at least 25% lower rate-weighted route length on `usp2raw`;
+- at least 15% fewer belt/underground entities or 20% shorter critical path;
+- no fixture loses more than 2% fast-meter target throughput;
+- Factorio target throughput must not regress beyond measurement noise;
+- time to 90% of final target rate must improve on at least two deep fixtures.
+
+These are design thresholds. The implementation PR records the control
+distribution and may tighten them before the decision.
+
+## Interaction with RFC-056
+
+RFC-056 reuses:
+
+- `CellVariant`;
+- the weighted placement graph;
+- metrics and candidate reports;
+- search determinism;
+- validation and measurement gates.
+
+RFC-055 ships independently if it clears its gates. RFC-056 is accepted only
+if folding materially outperforms RFC-055 after controlling for orientation
+and search budget.
+
+## Phases
+
+1. Metrics-only control: report current order without changing geometry.
+2. Variant infrastructure and transform gates.
+3. Linear order search behind an opt-in flag.
+4. Fast-meter candidate ranking.
+5. Factorio anchors and default-candidate decision.
+
+## Open questions
+
+- Should belt occupancy (stacking) scale edge weight, or should planned
+  item-rate remain the stable cross-configuration metric?
+- Should the target macro be pinned to an external boundary?
+- Does cut congestion need a hard cap before routing?
+- Should K replicas share one chosen order or search independently? This RFC
+  says they share one order for deterministic identical copies.
+- Which cell transforms are valuable enough to cache eagerly?
+

--- a/docs/rfc-056-folded-cell-chain.md
+++ b/docs/rfc-056-folded-cell-chain.md
@@ -1,0 +1,244 @@
+# RFC-056: Folded cell chains — cut-aware multi-row macro placement
+
+Status: Design  
+Tracking: #456  
+Competes with: RFC-055
+
+## Summary
+
+Fold a logical cell chain across multiple physical rows, using validated cell
+orientations and cut-aware fold points to shorten the factory's dominant
+transport paths.
+
+RFC-055 asks how far a better one-dimensional order can go. This RFC keeps the
+same weighted placement graph and cell variants but adds row assignment,
+serpentine orientation, and explicit inter-row routing corridors.
+
+The initial candidate is deliberately narrower than general 2D placement:
+
+- cells remain in an ordered sequence;
+- each cell belongs to one row;
+- rows are contiguous intervals of that sequence;
+- alternate rows may run in opposite physical directions;
+- inter-row edges use reserved vertical trunks.
+
+This is a constrained floorplanner: more expressive than a line, much easier
+to reason about than arbitrary rectangle placement.
+
+## Motivation
+
+A single line has an unavoidable limitation: a macro with several high-rate
+inputs cannot be close to producer clusters on both sides without making
+other edges long. Folding provides a second spatial dimension while
+preserving most of the chain's ordering and routing structure.
+
+A naïve width cap is not sufficient. It can fold directly through a dense set
+of high-rate edges and turn short horizontal connections into congested
+inter-row trunks. Fold points must therefore minimize weighted graph cuts.
+
+## Goals
+
+- Beat RFC-055 on rate-weighted route length and startup time.
+- Bound factory width without merely exchanging it for longer belts.
+- Reuse the same validated orientation interface and candidate metrics.
+- Preserve independent K replicas.
+- Keep placement deterministic and bounded.
+- Retain a clean fallback to RFC-055 or the current composer.
+
+## Non-goals
+
+- Arbitrary free placement of rectangular macros.
+- Interleaving cells from unrelated sequence intervals within one row.
+- Machine-level movement inside a cell.
+- Post-route rubber-band compaction.
+- Shared production across capacity replicas.
+
+## Logical model
+
+Begin with an order proposed by RFC-055's search. Partition it into `R`
+contiguous intervals:
+
+```text
+row 0: A → B → C → D
+                    |
+row 1: H ← G ← F ← E
+|
+row 2: I → J → K → L
+```
+
+Alternate rows use 180° variants where available so sequence neighbours meet
+near a fold. If a macro has no validated 180° variant, the row may retain its
+orientation and pay the resulting port-distance cost; transform availability
+is a placement constraint, never an unchecked mutation.
+
+## Fold objective
+
+For a candidate order and row partition:
+
+```text
+score =
+    RFC-055 edge-distance objective
+  + inter_row_weight × Σ(rate crossing a row boundary)
+  + trunk_weight × estimated vertical-trunk length
+  + congestion_weight × maximum weighted cut
+  + aspect_weight × aspect-ratio penalty
+```
+
+The partitioner chooses fold points at low weighted cuts, not merely at equal
+width.
+
+Candidate row counts are bounded, initially `R ∈ {2,3,4}`. Row height and
+width limits are derived from macro dimensions plus corridor reservations.
+
+## Physical structure
+
+Each row owns:
+
+- one macro band;
+- local east/west connection corridors;
+- a north and south escape strip;
+- reserved columns at each end for fold and inter-row trunks.
+
+The floorplan owns:
+
+- external feed boundary on the north or west perimeter;
+- target drains on the south or east perimeter;
+- vertical trunk channels between row bands;
+- power-continuity corridors;
+- no-build margins required by the simulation boundary kit.
+
+Inter-row edges do not improvise paths through macro bands. They descend or
+ascend through allocated trunk columns, cross in the gap between rows, then
+enter the destination row through its escape strip.
+
+## Serpentine versus same-direction rows
+
+Both are candidates:
+
+- **Serpentine:** alternate rows rotate 180°. Consecutive sequence endpoints
+  meet at the same side, making fold edges short.
+- **Same direction:** every row faces the same way. Cell variants are simpler,
+  but sequence folds traverse the full row width.
+
+The search scores both. Serpentine is not assumed superior because shared
+producer edges may prefer aligned port sides.
+
+## Validated orientation contract
+
+RFC-056 imports RFC-055's `CellVariant` contract unchanged. In particular:
+
+- rotation is first-class;
+- unavailable transforms constrain placement;
+- splitter anchors, underground pairs, inserter semantics, fluid ports,
+  priorities, boundaries, power, and metadata are transformed and validated;
+- mega-cells rotate as complete adapted blocks.
+
+RFC-056 adds one requirement: a row reversal must use a validated 180° variant
+for every macro it reverses. There is no “flip the row after stamping” path.
+
+## Search
+
+The bounded search has three nested decisions:
+
+1. Select one of RFC-055's top linear orders.
+2. Select row count and contiguous fold points.
+3. Select legal variants and serpentine/same-direction row orientation.
+
+Initial algorithms:
+
+- dynamic programming for fixed-order weighted-cut partitioning;
+- adjacent fold-point improvement;
+- seeded annealing over order swaps plus fold shifts for the final bounded
+  candidate set.
+
+The dynamic program provides an exact baseline for “best folds of this order.”
+Annealing is allowed to improve the order but must beat that baseline.
+
+## Routing strategy
+
+Phase 1 supports:
+
+- adjacent cells in the same row;
+- fold edge between the last cell of one row and first of the next;
+- non-adjacent same-row bypass;
+- non-adjacent inter-row trunks;
+- solid belts only outside an unchanged mega-cell.
+
+Fluid edges crossing rows are initially refused unless their complete
+mega-cell adapter owns both endpoints. This prevents the first implementation
+from expanding into general multi-row pipe routing.
+
+The refusal is an RFC-056 candidate refusal: RFC-055 remains available.
+
+## Shared benchmark
+
+RFC-056 uses exactly RFC-055's corpus and metrics:
+
+- `mega-chain-usp2raw`;
+- `mega-chain-chem5raw`;
+- `mega-chain-pu4raw`;
+- small solid-only control;
+- geometry-hashed cell registry.
+
+Report:
+
+- belt and pipe entities;
+- area and aspect ratio;
+- maximum and rate-weighted route length;
+- critical-path length;
+- inter-row weighted cut and trunk occupancy;
+- fast-meter throughput;
+- Factorio final throughput and time to 90%.
+
+## Decision gate against RFC-055
+
+RFC-056 earns implementation/default consideration only if, under comparable
+search time:
+
+- rate-weighted route length improves at least 15% beyond RFC-055 on two deep
+  fixtures, or critical-path length improves at least 25%;
+- belt entity count does not grow more than 5%;
+- fast-meter target throughput does not regress more than 2%;
+- Factorio throughput is no worse within measurement noise;
+- time to 90% improves materially on at least one fixture where RFC-055 has
+  already improved the control;
+- routing/validation runtime stays within 2× RFC-055's bounded search.
+
+If it fails, the result is still useful: RFC-055 becomes the chosen compact
+chain architecture and full 2D placement remains a separate future RFC.
+
+## Relationship to general 2D placement
+
+Folded placement is an experiment, not a commitment to stop at rows.
+
+Evidence for a later general macro-placement RFC:
+
+- large remaining weighted distance caused by the contiguous-row constraint;
+- high-rate edges repeatedly crossing row cuts;
+- strong sensitivity to fold count;
+- a clear meter benefit from small manual non-contiguous moves.
+
+Evidence against escalation:
+
+- RFC-055 or RFC-056 already removes most transport inventory;
+- routing congestion, not macro distance, becomes dominant;
+- Factorio startup stops improving with geometric metrics.
+
+## Phases
+
+1. Metrics-only fold simulator over RFC-055 placement graphs.
+2. Two-row solid-only composer.
+3. Validated serpentine variants and fold routing.
+4. Three/four-row search plus fast-meter ranking.
+5. Deep-fixture Factorio comparison and accept/reject decision.
+
+## Open questions
+
+- Should row count be selected by score or exposed as a user constraint?
+- Where should external raw feeds enter a folded replica?
+- Should row gaps be fixed or congestion-sized?
+- Can power corridors double as reserved inter-row routing channels?
+- When does a high weighted cut justify duplicating a producer rather than
+  routing across rows? Duplication is out of scope here but should be measured.
+- Should K replicas be tiled in a grid after each replica is folded?
+

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -66,5 +66,7 @@ backfill the status next time the doc is touched.
 | RFC-052 | 2026-07-23 | [`rfc-052-oil-mega-cell.md`](rfc-052-oil-mega-cell.md) | Design (circulated for review) |
 | RFC-053 | 2026-07-24 | [`rfc-053-direct-insertion-cells.md`](rfc-053-direct-insertion-cells.md) | Active — **Phases 0 + 1 + 2 landed**; engine emits fused DI cells (stacked and horizontal-row). Both TOP corpus pairs build, validate at 0 issues and sim at/above plan: `copper-cable → electronic-circuit` 101.3%, `electric-furnace → electric-furnace` 109.5%. KC1–KC4 evaluated and passing (KC6 fired → pipes re-scoped into Phase 2, still outstanding). Inert by default. Remaining: pipes/fluids, Phase 3 multi-band, Phase 4 wasm+UI. |
 | RFC-054 | 2026-07-25 | [`rfc-054-fast-meter.md`](rfc-054-fast-meter.md) | Design (circulated for review) |
+| RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
+| RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 
-Next number: **RFC-055**.
+Next number: **RFC-057**.

--- a/docs/status.md
+++ b/docs/status.md
@@ -570,6 +570,7 @@ golden re-blesses across the arc. Full trail:
 
 ## Open tracking issues (layout quality)
 
+- [#456 flow-preserving compaction / the spaghettifier](https://github.com/storkme/spaghettio/issues/456) — design split into competing [RFC-055 compact linear chains](rfc-055-compact-cell-chain.md) and [RFC-056 folded chains](rfc-056-folded-cell-chain.md); both make validated cell rotations first-class and share one measured decision gate
 - [#135 balancer templates are oversized](https://github.com/storkme/spaghettio/issues/135) — main compaction lever
 - [#311 output merger over-commits a single final belt; lane-throughput check never visits merger tiles](https://github.com/storkme/spaghettio/issues/311) — gates >45/s headline claims
 - [#312 consumer-clamped fan-in refusal bites much earlier at high build quality](https://github.com/storkme/spaghettio/issues/312) — S=1; the wall now scales ×S with stacking (RFC-047 Leg C)


### PR DESCRIPTION
## Summary

- add RFC-055: flow-weighted linear cell ordering with validated orientations
- add RFC-056: cut-aware folded multi-row cell placement
- share benchmarks, throughput/startup metrics, transform contracts, and an explicit decision gate
- update the RFC registry and #456 roadmap entry

## Context

Drafted from the post-#476/#471 `usp2raw` measurements: balancing steel distribution improved LDS/USP from ~0.85/s to ~1.14/s, but the remaining hundreds-of-tiles copper/plastic paths point to placement rather than another local splitter policy.

Claude review is intentionally disabled while credits are unavailable; ordinary CI remains enabled.