### PR TITLE
RFC-057: compaction + snake folding (Strategy A landed, fold test-only)

### DIFF
--- a/crates/core/data/cell-sim-registry.json
+++ b/crates/core/data/cell-sim-registry.json
@@ -101,13 +101,13 @@
   {
     "target": "chemical-science-pack",
     "rate": 5.0,
-    "geometry_hash": "1cecb0e45320930a",
+    "geometry_hash": "b4bf67f82e324b51",
     "declared_inserter_capacity": 2,
     "declared_stacking": 1,
     "harness_world": "nb=1 bulk=3, S=1 (declared L2 \u2014 the post-#431 engine default)",
     "verdict": "PASS",
     "produced_per_s": 5.0,
-    "scenario": "spaghettio-sim mega-chain-chem5raw (Factorio 2.0.77, 172/172 working, converged, produced 5.00/s EXACT at plan, delivered 5.07/s; RFC-052 Phase C mega-cell from raw ore + plate inputs (iron-ore/copper-ore/crude-oil/water/coal + iron-plate/copper-plate/steel-plate \u2014 NOT ore-only; see the chem5 config row in tests/cell_composition.rs) \u2014 refinery + plastic + sulfur fluid subgraph collapsed into one mega block, K=2 chain quantization. First registration at the L2 default; unblocked by #383's resolution, which RFC-052's close-out named as the gate.)",
-    "date": "2026-07-24"
+    "scenario": "spaghettio-sim chem5-rebless (Factorio 2.0.77, 216k-tick warmup, 177 working, produced 5.00/s EXACT at plan, delivered 5.07/s; power: 1 pole network). RE-BLESSED after the chain composer's pole fix: its spanning pole line stepped by 8 on an absolute grid against wire reach 9, so any forward nudge past congestion orphaned the pole behind it, and composition never ran the connectivity repair that build_bus_layout has always run. This fixture composed with its power network in 17 pieces; it now composes as ONE. Geometry differs from the 2026-07-24 pin by added bridge poles only \u2014 no machine, recipe or belt changed \u2014 and was re-measured rather than re-hashed, since the pin carries a sim-verified claim. Convergence flag reads false at the tick ceiling, but the window series oscillates around plan (5.08/4.84/4.75/5.00/5.22/5.15/5.00/5.08/4.62/5.00/5.00) rather than trending; produced is exact at plan. Fluid boundaries remain UNCALIBRATED (RFC-050 Phase 1), as at first registration.",
+    "date": "2026-07-29"
   }
 ]

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -801,11 +801,29 @@ fn compose_chain_with_capacity_and_order(
         let initial: Vec<usize> = (0..specs.len()).collect();
         let control_metrics = graph.score_linear(&initial, CORRIDOR_GAP, 0.25)?;
         let candidate = graph.best_linear(&initial, CORRIDOR_GAP, 0.25)?;
+        let fold = graph.best_two_row_fold(
+            &candidate.order, CORRIDOR_GAP, 24, 0.25, 2.0, true)?;
+        let mut best_fold_critical = i32::MAX;
+        for end in 1..candidate.order.len() {
+            for serpentine in [false, true] {
+                let metrics = graph.score_folded(
+                    &candidate.order, &[end, candidate.order.len()],
+                    CORRIDOR_GAP, 24, 0.25, serpentine)?;
+                best_fold_critical = best_fold_critical.min(metrics.critical_path_distance);
+            }
+        }
         let original = specs.clone();
         specs = candidate.order.iter().map(|&idx| original[idx].clone()).collect();
-        eprintln!("RFC-055 estimated distance: {:.1} -> {:.1}; order: {:?}",
+        eprintln!("RFC placement estimates: control={:.1}/crit{} linear={:.1}/crit{} fold2={:.1}/crit{} best-fold-crit={} cut={:.1} serpentine={}; order: {:?}",
             control_metrics.rate_weighted_distance,
+            control_metrics.critical_path_distance,
             candidate.metrics.rate_weighted_distance,
+            candidate.metrics.critical_path_distance,
+            fold.metrics.rate_weighted_distance,
+            fold.metrics.critical_path_distance,
+            best_fold_critical,
+            fold.metrics.weighted_cut_sum,
+            fold.serpentine,
             specs.iter().map(|s| s.recipe.as_str()).collect::<Vec<_>>());
     }
 
@@ -1575,7 +1593,9 @@ fn compose_chain_with_capacity_and_order(
                     let down_demand = lane_demand[(pi + 1) % n];
                     let legacy_lane_down = placed[pi + 1].vlane_base
                         + *lane_next.get(&(pi + 1)).unwrap_or(&0) * lane_step(down_demand);
-                    let (drop_x, drop_top) = if router.is_row_stampable(by, bx, legacy_lane_down - 1) {
+                    let (drop_x, drop_top) = if legacy_lane_down < lane_up
+                        && router.is_row_stampable(by, bx, legacy_lane_down - 1)
+                    {
                         let lane_down = alloc_lane(&mut lane_next, pi + 1, placed[pi + 1].vlane_base, lane_step(down_demand));
                         router.hrow(&mut entities, by, bx, lane_down - 1, &out_item,
                             "express-transport-belt", "express-underground-belt", &seg);

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -1660,24 +1660,33 @@ fn compose_chain_with_capacity_and_order(
         }
     }
     let width = entities.iter().map(|e| e.x).max().unwrap_or(0) + 1;
+    // Spanning pole line. The step is measured from the LAST POLE ACTUALLY
+    // PLACED, not from an absolute grid: pitch 8 against wire reach 9 leaves
+    // exactly one tile of slack, so a pole nudged forward past congestion put
+    // itself out of reach of its predecessor and silently broke the chain it
+    // was nudging to preserve (nudged gap 12, or 16 when no free tile was
+    // found at all — both > 9). Advancing from the last placement keeps every
+    // consecutive gap within reach regardless of how far a nudge travelled.
+    let mut last_x: Option<i32> = None;
     let mut px = 1;
     while px < width {
-        for nudge in 0..5 {
-            let x = px + nudge;
-            if !occupied.contains(&(x, band_bottom)) {
-                entities.push(PlacedEntity {
-                    name: "medium-electric-pole".into(), x, y: band_bottom,
-                    direction: EntityDirection::North,
-                    segment_id: Some("pole".into()), ..Default::default()
-                });
-                break;
-            }
+        let placed_at = (0..5).map(|n| px + n).find(|&x| {
+            x < width + 4 && !occupied.contains(&(x, band_bottom))
+        });
+        if let Some(x) = placed_at {
+            occupied.insert((x, band_bottom));
+            entities.push(PlacedEntity {
+                name: "medium-electric-pole".into(), x, y: band_bottom,
+                direction: EntityDirection::North,
+                segment_id: Some("pole".into()), ..Default::default()
+            });
+            last_x = Some(x);
         }
-        px += 8;
+        px = last_x.map_or(px + 8, |x| x + 8);
     }
 
     let height = (entities.iter().map(|e| e.y).max().unwrap_or(0) + 1).max(band_bottom + 2);
-    Ok(LayoutResult {
+    let mut composed = LayoutResult {
         entities,
         width,
         height,
@@ -1697,5 +1706,12 @@ fn compose_chain_with_capacity_and_order(
         // can cross-check them against the translated pipe entities (#476).
         surplus_exits,
         ..Default::default()
-    })
+    };
+    // Heuristic pole placement leaves islands, which is why
+    // `build_bus_layout` follows its own placement with this repair.
+    // Composition never did, and shipped layouts whose power network was in
+    // as many as 41 pieces — every machine covered, most of them unreachable
+    // from any single power source. Additive: bridge poles only.
+    crate::bus::layout::repair_pole_network(&mut composed);
+    Ok(composed)
 }

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -653,6 +653,29 @@ pub fn compose_chain_with_capacity(
     sr: &SolverResult,
     inserter_capacity: u8,
 ) -> Result<LayoutResult, String> {
+    compose_chain_with_capacity_and_order(sr, inserter_capacity, ChainOrder::Current)
+}
+
+/// RFC-055 experimental entry point. Uses the production cell generator and
+/// router, changing only the macro order selected before slot placement.
+pub fn compose_chain_compact(
+    sr: &SolverResult,
+    inserter_capacity: u8,
+) -> Result<LayoutResult, String> {
+    compose_chain_with_capacity_and_order(sr, inserter_capacity, ChainOrder::Compact)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChainOrder {
+    Current,
+    Compact,
+}
+
+fn compose_chain_with_capacity_and_order(
+    sr: &SolverResult,
+    inserter_capacity: u8,
+    chain_order: ChainOrder,
+) -> Result<LayoutResult, String> {
     chain_eligible(sr)?;
     let kq = required_copies(sr);
     let scale = 1.0 / kq as f64;
@@ -755,6 +778,36 @@ pub fn compose_chain_with_capacity(
         Some(&i) => (0, std::cmp::Reverse(i)),
         None => (1, std::cmp::Reverse(usize::MAX)),
     });
+    if chain_order == ChainOrder::Compact {
+        let mut dimensions = FxHashMap::default();
+        for spec in &specs {
+            let (width, height) = if spec.recipe.starts_with(MEGA_PREFIX) {
+                let plan = mega_plan.as_ref().expect("mega spec implies plan");
+                let (_, block) = super::mega::compose_mega_block(sr, plan, scale)?;
+                (block.width, block.height)
+            } else {
+                let out = spec.outputs.first()
+                    .ok_or_else(|| format!("cells: {} has no output", spec.recipe))?;
+                let rate = out.rate * spec.count * scale;
+                let inputs: Vec<&str> = spec.inputs.iter().map(|i| i.item.as_str()).collect();
+                let (_, layout) = super::extract::generate_cell_layout_with_capacity(
+                    &out.item, rate, &inputs, inserter_capacity);
+                let cell = extract_cell(&layout);
+                (cell.width, cell.height)
+            };
+            dimensions.insert(spec.recipe.clone(), (width, height));
+        }
+        let graph = super::placement::PlacementGraph::from_specs(&specs, &dimensions)?;
+        let initial: Vec<usize> = (0..specs.len()).collect();
+        let control_metrics = graph.score_linear(&initial, CORRIDOR_GAP, 0.25)?;
+        let candidate = graph.best_linear(&initial, CORRIDOR_GAP, 0.25)?;
+        let original = specs.clone();
+        specs = candidate.order.iter().map(|&idx| original[idx].clone()).collect();
+        eprintln!("RFC-055 estimated distance: {:.1} -> {:.1}; order: {:?}",
+            control_metrics.rate_weighted_distance,
+            candidate.metrics.rate_weighted_distance,
+            specs.iter().map(|s| s.recipe.as_str()).collect::<Vec<_>>());
+    }
 
     // Per-slot vertical-lane demand, from the bypass edge list (an edge
     // p→c descends in slot p+1 and ascends in slot c; sizing by the
@@ -787,7 +840,13 @@ pub fn compose_chain_with_capacity(
                     }
                     continue;
                 }
-                if ci != pi && c.inputs.iter().any(|i| i.item == o.item) && ci != pi + 1 {
+                let consumes = ci != pi && c.inputs.iter().any(|i| i.item == o.item);
+                let fan_size = specs.iter()
+                    .filter(|cc| cc.inputs.iter().any(|i| i.item == o.item))
+                    .count();
+                let needs_bypass = ci != pi + 1
+                    || (chain_order == ChainOrder::Compact && fan_size >= 2);
+                if consumes && needs_bypass {
                     if pi + 1 < n {
                         lane_demand[pi + 1] += 1;
                     }
@@ -1029,12 +1088,19 @@ pub fn compose_chain_with_capacity(
                 if pi_mega { &m.outputs } else { &m.outputs[..1] };
             outs.iter()
                 .map(|o| {
+                    let fan_size = specs.iter()
+                        .enumerate()
+                        .filter(|(ci, c)| {
+                            *ci != pi && c.inputs.iter().any(|i| i.item == o.item)
+                        })
+                        .count();
                     let edges = specs
                         .iter()
                         .enumerate()
                         .filter(|(ci, c)| {
                             *ci != pi
-                                && (pi_mega || *ci != pi + 1)
+                                && (pi_mega || *ci != pi + 1
+                                    || (chain_order == ChainOrder::Compact && fan_size >= 2))
                                 && c.inputs.iter().any(|i| i.item == o.item)
                                 && cell_cache[*ci]
                                     .ports
@@ -1421,7 +1487,19 @@ pub fn compose_chain_with_capacity(
             fx += 2;
         }
         // Pass-through (or the only) branch.
-        branch_origins.push((if n_branches > 1 { fx - 1 } else { pass_x }, run_y));
+        branch_origins.push((
+            if n_branches > 1 {
+                // The legacy dependency order never sends two fan
+                // branches west, so it can begin at the splitters'
+                // shared output column. A compact order can; advance
+                // to the first genuinely free tile so each branch has
+                // a distinct descent column.
+                if chain_order == ChainOrder::Compact { fx } else { fx - 1 }
+            } else {
+                pass_x
+            },
+            run_y,
+        ));
 
         // Route each branch. Adjacent-east consumer: port-row corridor
         // (with a vertical jog on the consumer slot's first lane if the
@@ -1436,7 +1514,9 @@ pub fn compose_chain_with_capacity(
             let (tx, ty) = port_abs(port, c.x, c.y_off);
             let (bx, by) = branch_origins[bi];
             let seg = format!("corr:{}:{}", p.seg, c.seg);
-            if *ci == pi + 1 {
+            if *ci == pi + 1
+                && (chain_order == ChainOrder::Current || consumers.len() == 1)
+            {
                 if by == ty {
                     router.hrow(&mut entities, ty, bx, tx - 1, &out_item,
                         "express-transport-belt", "express-underground-belt", &seg);
@@ -1459,7 +1539,6 @@ pub fn compose_chain_with_capacity(
                 // In-copy by construction: the last slot of a copy is
                 // always the sink (dependency order), which has no
                 // consumers and never reaches this branch.
-                debug_assert_eq!(placed[pi + 1].copy, p.copy, "bypass descent lane must stay in-copy");
                 let up_demand = lane_demand[*ci % n];
                 let lane_up = alloc_lane(&mut lane_next, *ci, c.vlane_base, lane_step(up_demand));
                 let row = bypass_idx.entry(p.copy).or_insert(0);
@@ -1469,7 +1548,8 @@ pub fn compose_chain_with_capacity(
                     // WESTWARD consumer: the reversed-dependency
                     // placement can put an item's consumer west of its
                     // producer (shared inputs pulled in at different
-                    // depths). Descend in-gap, run west along the
+                    // depths). Compact fan origins are allocated on
+                    // distinct columns, so descend in-gap, run west along the
                     // bypass row, corner north into the consumer's
                     // strip lane; the ascent + port approach below are
                     // position-relative and shared with the eastward
@@ -1482,6 +1562,8 @@ pub fn compose_chain_with_capacity(
                         "express-transport-belt", "express-underground-belt", &seg);
                     router.corner_north(&mut entities, lane_up, by_y, &out_item, "express-transport-belt", &seg);
                 } else {
+                    debug_assert_eq!(placed[pi + 1].copy, p.copy,
+                        "bypass descent lane must stay in-copy");
                     // Descent: legacy path runs east on the branch row
                     // to a lane in the NEXT slot's strip. When that row
                     // segment is already occupied (sibling fan-out

--- a/crates/core/src/bus/cells/mod.rs
+++ b/crates/core/src/bus/cells/mod.rs
@@ -10,6 +10,7 @@ pub mod chain;
 pub mod compose;
 pub mod extract;
 pub mod mega;
+pub mod placement;
 pub mod registry;
 
 /// Cell-composition mode (RFC-051). `Off` = production pipeline

--- a/crates/core/src/bus/cells/placement.rs
+++ b/crates/core/src/bus/cells/placement.rs
@@ -1,0 +1,501 @@
+//! Shared macro-placement model for RFC-055 and RFC-056.
+//!
+//! This module deliberately knows nothing about tile routing. It converts a
+//! set of cell-like machine specs into a weighted producer→consumer graph and
+//! scores proposed linear orders or contiguous row folds cheaply. Expensive
+//! composition, validation, and metering are reserved for the best candidates.
+
+use rustc_hash::FxHashMap;
+
+use crate::models::MachineSpec;
+
+/// A rectangular cell or collapsed mega-cell considered by macro placement.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MacroNode {
+    pub recipe: String,
+    pub width: i32,
+    pub height: i32,
+}
+
+/// One transported item from a producer macro to a consumer macro.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FlowEdge {
+    pub producer: usize,
+    pub consumer: usize,
+    pub item: String,
+    /// Planned rate consumed by this consumer, in items or fluid units / s.
+    pub rate: f64,
+    pub is_fluid: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PlacementGraph {
+    pub nodes: Vec<MacroNode>,
+    pub edges: Vec<FlowEdge>,
+}
+
+/// Cheap placement metrics shared by both RFCs.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PlacementMetrics {
+    pub rate_weighted_distance: f64,
+    pub max_edge_distance: i32,
+    pub backward_rate: f64,
+    pub weighted_cut_sum: f64,
+    pub max_weighted_cut: f64,
+    pub estimated_width: i32,
+    pub estimated_height: i32,
+    pub estimated_area: i64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LinearCandidate {
+    pub order: Vec<usize>,
+    pub metrics: PlacementMetrics,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FoldCandidate {
+    pub order: Vec<usize>,
+    pub row_ends: Vec<usize>,
+    pub serpentine: bool,
+    pub metrics: PlacementMetrics,
+}
+
+impl PlacementGraph {
+    /// Build the placement graph from cell-like specs and their estimated
+    /// rectangular footprints.
+    ///
+    /// Each item must have at most one producer macro, matching chain
+    /// eligibility. Consumer edge rates come from the consumer spec's total
+    /// demand (`per_machine_rate × count`), not producer output, so fan-outs
+    /// retain their actual unequal weights.
+    pub fn from_specs(
+        specs: &[MachineSpec],
+        dimensions: &FxHashMap<String, (i32, i32)>,
+    ) -> Result<Self, String> {
+        let nodes: Vec<MacroNode> = specs
+            .iter()
+            .map(|m| {
+                let (width, height) = dimensions.get(&m.recipe).copied().unwrap_or((1, 1));
+                MacroNode {
+                    recipe: m.recipe.clone(),
+                    width: width.max(1),
+                    height: height.max(1),
+                }
+            })
+            .collect();
+
+        let mut producer_of: FxHashMap<&str, usize> = FxHashMap::default();
+        for (idx, spec) in specs.iter().enumerate() {
+            for output in &spec.outputs {
+                if let Some(previous) = producer_of.insert(output.item.as_str(), idx) {
+                    if previous != idx {
+                        return Err(format!(
+                            "placement: {} produced by both {} and {}",
+                            output.item, specs[previous].recipe, spec.recipe
+                        ));
+                    }
+                }
+            }
+        }
+
+        let mut edges = Vec::new();
+        for (consumer, spec) in specs.iter().enumerate() {
+            for input in &spec.inputs {
+                let Some(&producer) = producer_of.get(input.item.as_str()) else {
+                    continue; // external input
+                };
+                if producer == consumer {
+                    continue; // self-loop stays inside the macro
+                }
+                edges.push(FlowEdge {
+                    producer,
+                    consumer,
+                    item: input.item.clone(),
+                    rate: input.rate * spec.count,
+                    is_fluid: input.is_fluid,
+                });
+            }
+        }
+
+        Ok(Self { nodes, edges })
+    }
+
+    /// Score a left-to-right order using macro centres and a fixed inter-slot
+    /// gap. `fluid_weight` is deliberately explicit: fluid distance consumes
+    /// geometry but not belt-style in-flight item inventory.
+    pub fn score_linear(
+        &self,
+        order: &[usize],
+        gap: i32,
+        fluid_weight: f64,
+    ) -> Result<PlacementMetrics, String> {
+        self.validate_order(order)?;
+        let mut centre_x = vec![0i32; self.nodes.len()];
+        let mut cursor = 0i32;
+        let mut max_height = 0i32;
+        for &idx in order {
+            let node = &self.nodes[idx];
+            centre_x[idx] = cursor + node.width / 2;
+            cursor += node.width + gap.max(0);
+            max_height = max_height.max(node.height);
+        }
+        let width = (cursor - gap.max(0)).max(0);
+
+        let mut metrics = PlacementMetrics {
+            estimated_width: width,
+            estimated_height: max_height,
+            estimated_area: i64::from(width) * i64::from(max_height),
+            ..Default::default()
+        };
+        for edge in &self.edges {
+            let signed = centre_x[edge.consumer] - centre_x[edge.producer];
+            let distance = signed.abs();
+            let weight = edge.rate * if edge.is_fluid { fluid_weight } else { 1.0 };
+            metrics.rate_weighted_distance += weight * f64::from(distance);
+            metrics.max_edge_distance = metrics.max_edge_distance.max(distance);
+            if signed < 0 {
+                metrics.backward_rate += edge.rate;
+            }
+        }
+
+        // Weighted cut: total rate crossing every boundary between adjacent
+        // order positions. This is both a congestion estimate for RFC-055 and
+        // the fold-point input for RFC-056.
+        let mut position = vec![0usize; self.nodes.len()];
+        for (pos, &idx) in order.iter().enumerate() {
+            position[idx] = pos;
+        }
+        for cut in 0..order.len().saturating_sub(1) {
+            let mut weight = 0.0;
+            for edge in &self.edges {
+                let a = position[edge.producer];
+                let b = position[edge.consumer];
+                if a.min(b) <= cut && a.max(b) > cut {
+                    weight += edge.rate * if edge.is_fluid { fluid_weight } else { 1.0 };
+                }
+            }
+            metrics.weighted_cut_sum += weight;
+            metrics.max_weighted_cut = metrics.max_weighted_cut.max(weight);
+        }
+        Ok(metrics)
+    }
+
+    /// Score contiguous rows of one logical order. Rows alternate direction
+    /// when `serpentine` is true. This is a geometric estimator for RFC-056,
+    /// not a claim that the current router can yet realize the candidate.
+    pub fn score_folded(
+        &self,
+        order: &[usize],
+        row_ends: &[usize],
+        gap_x: i32,
+        gap_y: i32,
+        fluid_weight: f64,
+        serpentine: bool,
+    ) -> Result<PlacementMetrics, String> {
+        self.validate_order(order)?;
+        if row_ends.is_empty() || *row_ends.last().unwrap() != order.len() {
+            return Err("placement: row_ends must terminate at order length".into());
+        }
+        if row_ends.windows(2).any(|w| w[0] >= w[1]) || row_ends[0] == 0 {
+            return Err("placement: row_ends must be strictly increasing and nonzero".into());
+        }
+
+        let mut centres = vec![(0i32, 0i32); self.nodes.len()];
+        let mut start = 0usize;
+        let mut y = 0i32;
+        let mut total_width = 0i32;
+        let mut total_height = 0i32;
+        for (row, &end) in row_ends.iter().enumerate() {
+            let slice = &order[start..end];
+            let row_height = slice
+                .iter()
+                .map(|&i| self.nodes[i].height)
+                .max()
+                .unwrap_or(1);
+            let row_width = slice.iter().map(|&i| self.nodes[i].width).sum::<i32>()
+                + gap_x.max(0) * slice.len().saturating_sub(1) as i32;
+            let reverse = serpentine && row % 2 == 1;
+            let mut x = if reverse { row_width } else { 0 };
+            for &idx in slice {
+                let width = self.nodes[idx].width;
+                if reverse {
+                    x -= width;
+                    centres[idx] = (x + width / 2, y + self.nodes[idx].height / 2);
+                    x -= gap_x.max(0);
+                } else {
+                    centres[idx] = (x + width / 2, y + self.nodes[idx].height / 2);
+                    x += width + gap_x.max(0);
+                }
+            }
+            total_width = total_width.max(row_width);
+            y += row_height;
+            total_height = y;
+            if end != order.len() {
+                y += gap_y.max(0);
+                total_height = y;
+            }
+            start = end;
+        }
+
+        let mut metrics = PlacementMetrics {
+            estimated_width: total_width,
+            estimated_height: total_height,
+            estimated_area: i64::from(total_width) * i64::from(total_height),
+            ..Default::default()
+        };
+        for edge in &self.edges {
+            let (px, py) = centres[edge.producer];
+            let (cx, cy) = centres[edge.consumer];
+            let distance = (cx - px).abs() + (cy - py).abs();
+            let weight = edge.rate * if edge.is_fluid { fluid_weight } else { 1.0 };
+            metrics.rate_weighted_distance += weight * f64::from(distance);
+            metrics.max_edge_distance = metrics.max_edge_distance.max(distance);
+            if cx < px {
+                metrics.backward_rate += edge.rate;
+            }
+        }
+
+        // Row boundaries are the cuts RFC-056 must carry through inter-row
+        // trunks. Preserve both total and worst weighted cut explicitly.
+        let mut position = vec![0usize; self.nodes.len()];
+        for (pos, &idx) in order.iter().enumerate() {
+            position[idx] = pos;
+        }
+        for &end in row_ends.iter().take(row_ends.len().saturating_sub(1)) {
+            let cut = end - 1;
+            let mut weight = 0.0;
+            for edge in &self.edges {
+                let a = position[edge.producer];
+                let b = position[edge.consumer];
+                if a.min(b) <= cut && a.max(b) > cut {
+                    weight += edge.rate * if edge.is_fluid { fluid_weight } else { 1.0 };
+                }
+            }
+            metrics.weighted_cut_sum += weight;
+            metrics.max_weighted_cut = metrics.max_weighted_cut.max(weight);
+        }
+        Ok(metrics)
+    }
+
+    /// Deterministic RFC-055 baseline: repeatedly take the best improving
+    /// adjacent swap until reaching a local optimum.
+    pub fn improve_adjacent(
+        &self,
+        initial: &[usize],
+        gap: i32,
+        fluid_weight: f64,
+    ) -> Result<LinearCandidate, String> {
+        let mut order = initial.to_vec();
+        let mut metrics = self.score_linear(&order, gap, fluid_weight)?;
+        loop {
+            let mut best: Option<(usize, PlacementMetrics)> = None;
+            for i in 0..order.len().saturating_sub(1) {
+                order.swap(i, i + 1);
+                let candidate = self.score_linear(&order, gap, fluid_weight)?;
+                order.swap(i, i + 1);
+                if candidate.rate_weighted_distance + 1e-9 < metrics.rate_weighted_distance
+                    && best.as_ref().is_none_or(|(_, current)| {
+                        candidate.rate_weighted_distance + 1e-9 < current.rate_weighted_distance
+                    })
+                {
+                    best = Some((i, candidate));
+                }
+            }
+            let Some((i, improved)) = best else {
+                break;
+            };
+            order.swap(i, i + 1);
+            metrics = improved;
+        }
+        Ok(LinearCandidate { order, metrics })
+    }
+
+    /// Exact RFC-056 two-row baseline for a fixed logical order. Every
+    /// non-empty contiguous split is evaluated in serpentine mode and,
+    /// optionally, with both rows facing the same direction.
+    #[allow(clippy::too_many_arguments)]
+    pub fn best_two_row_fold(
+        &self,
+        order: &[usize],
+        gap_x: i32,
+        gap_y: i32,
+        fluid_weight: f64,
+        inter_row_weight: f64,
+        include_same_direction: bool,
+    ) -> Result<FoldCandidate, String> {
+        self.validate_order(order)?;
+        if order.len() < 2 {
+            return Err("placement: two-row fold needs at least two nodes".into());
+        }
+        let orientations: &[bool] = if include_same_direction {
+            &[false, true]
+        } else {
+            &[true]
+        };
+        let mut best: Option<(f64, FoldCandidate)> = None;
+        for end in 1..order.len() {
+            for &serpentine in orientations {
+                let row_ends = vec![end, order.len()];
+                let metrics =
+                    self.score_folded(order, &row_ends, gap_x, gap_y, fluid_weight, serpentine)?;
+                let objective =
+                    metrics.rate_weighted_distance + inter_row_weight * metrics.weighted_cut_sum;
+                let candidate = FoldCandidate {
+                    order: order.to_vec(),
+                    row_ends,
+                    serpentine,
+                    metrics,
+                };
+                if best
+                    .as_ref()
+                    .is_none_or(|(score, _)| objective + 1e-9 < *score)
+                {
+                    best = Some((objective, candidate));
+                }
+            }
+        }
+        Ok(best.expect("non-empty split search").1)
+    }
+
+    fn validate_order(&self, order: &[usize]) -> Result<(), String> {
+        if order.len() != self.nodes.len() {
+            return Err(format!(
+                "placement: order has {} nodes, expected {}",
+                order.len(),
+                self.nodes.len()
+            ));
+        }
+        let mut seen = vec![false; self.nodes.len()];
+        for &idx in order {
+            let Some(slot) = seen.get_mut(idx) else {
+                return Err(format!("placement: node index {idx} out of range"));
+            };
+            if std::mem::replace(slot, true) {
+                return Err(format!("placement: node index {idx} repeated"));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ItemFlow;
+
+    fn spec(
+        recipe: &str,
+        count: f64,
+        inputs: &[(&str, f64)],
+        outputs: &[(&str, f64)],
+    ) -> MachineSpec {
+        MachineSpec {
+            recipe: recipe.into(),
+            count,
+            inputs: inputs
+                .iter()
+                .map(|(item, rate)| ItemFlow {
+                    item: (*item).into(),
+                    rate: *rate,
+                    ..Default::default()
+                })
+                .collect(),
+            outputs: outputs
+                .iter()
+                .map(|(item, rate)| ItemFlow {
+                    item: (*item).into(),
+                    rate: *rate,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn fixture() -> PlacementGraph {
+        let specs = vec![
+            spec("plate", 1.0, &[], &[("plate", 10.0)]),
+            spec("plastic", 1.0, &[], &[("plastic", 4.0)]),
+            spec(
+                "lds",
+                1.0,
+                &[("plate", 10.0), ("plastic", 4.0)],
+                &[("lds", 1.0)],
+            ),
+            spec("science", 1.0, &[("lds", 1.0)], &[("science", 1.0)]),
+        ];
+        let dims = [
+            ("plate".into(), (10, 4)),
+            ("plastic".into(), (6, 4)),
+            ("lds".into(), (12, 6)),
+            ("science".into(), (8, 4)),
+        ]
+        .into_iter()
+        .collect();
+        PlacementGraph::from_specs(&specs, &dims).unwrap()
+    }
+
+    #[test]
+    fn graph_weights_consumers_by_total_demand() {
+        let g = fixture();
+        assert_eq!(g.edges.len(), 3);
+        assert_eq!(
+            g.edges.iter().find(|e| e.item == "plate").unwrap().rate,
+            10.0
+        );
+    }
+
+    #[test]
+    fn closer_high_rate_consumer_scores_better() {
+        let g = fixture();
+        let compact = g.score_linear(&[0, 2, 1, 3], 2, 0.25).unwrap();
+        let sprawling = g.score_linear(&[0, 1, 3, 2], 2, 0.25).unwrap();
+        assert!(
+            compact.rate_weighted_distance < sprawling.rate_weighted_distance,
+            "{compact:?} vs {sprawling:?}"
+        );
+    }
+
+    #[test]
+    fn folded_score_reports_inter_row_cut() {
+        let g = fixture();
+        let m = g
+            .score_folded(&[0, 1, 2, 3], &[2, 4], 2, 5, 0.25, true)
+            .unwrap();
+        assert!(m.weighted_cut_sum > 0.0);
+        assert!(m.max_weighted_cut > 0.0);
+        assert!(m.estimated_height > 6);
+    }
+
+    #[test]
+    fn malformed_orders_and_folds_refuse() {
+        let g = fixture();
+        assert!(g.score_linear(&[0, 1, 1, 3], 2, 0.25).is_err());
+        assert!(g
+            .score_folded(&[0, 1, 2, 3], &[2, 3], 2, 5, 0.25, true)
+            .is_err());
+    }
+
+    #[test]
+    fn adjacent_improvement_is_deterministic_and_non_regressing() {
+        let g = fixture();
+        let initial = [0, 3, 1, 2];
+        let before = g.score_linear(&initial, 2, 0.25).unwrap();
+        let a = g.improve_adjacent(&initial, 2, 0.25).unwrap();
+        let b = g.improve_adjacent(&initial, 2, 0.25).unwrap();
+        assert_eq!(a, b);
+        assert!(a.metrics.rate_weighted_distance <= before.rate_weighted_distance);
+    }
+
+    #[test]
+    fn best_two_row_fold_checks_every_cut_and_orientation() {
+        let g = fixture();
+        let candidate = g
+            .best_two_row_fold(&[0, 1, 2, 3], 2, 5, 0.25, 2.0, true)
+            .unwrap();
+        assert_eq!(*candidate.row_ends.last().unwrap(), 4);
+        assert_eq!(candidate.row_ends.len(), 2);
+        assert!(candidate.row_ends[0] > 0 && candidate.row_ends[0] < 4);
+    }
+}

--- a/crates/core/src/bus/cells/placement.rs
+++ b/crates/core/src/bus/cells/placement.rs
@@ -311,6 +311,75 @@ impl PlacementGraph {
         Ok(LinearCandidate { order, metrics })
     }
 
+    /// Deterministic best-improving single-node relocation. This explores a
+    /// materially wider neighbourhood than adjacent swaps while remaining
+    /// cheap for the small macro graphs used by cell chains.
+    pub fn improve_relocate(
+        &self,
+        initial: &[usize],
+        gap: i32,
+        fluid_weight: f64,
+    ) -> Result<LinearCandidate, String> {
+        self.validate_order(initial)?;
+        let mut order = initial.to_vec();
+        let mut metrics = self.score_linear(&order, gap, fluid_weight)?;
+        loop {
+            let mut best: Option<(Vec<usize>, PlacementMetrics)> = None;
+            for from in 0..order.len() {
+                for to in 0..order.len() {
+                    if from == to {
+                        continue;
+                    }
+                    let mut candidate_order = order.clone();
+                    let node = candidate_order.remove(from);
+                    candidate_order.insert(to, node);
+                    let candidate = self.score_linear(&candidate_order, gap, fluid_weight)?;
+                    if candidate.rate_weighted_distance + 1e-9
+                        < best.as_ref().map_or(metrics.rate_weighted_distance, |(_, m)| {
+                            m.rate_weighted_distance
+                        })
+                    {
+                        best = Some((candidate_order, candidate));
+                    }
+                }
+            }
+            let Some((improved_order, improved_metrics)) = best else {
+                break;
+            };
+            order = improved_order;
+            metrics = improved_metrics;
+        }
+        Ok(LinearCandidate { order, metrics })
+    }
+
+    /// RFC-055 bounded deterministic competitor set: improve the supplied
+    /// control and its reverse with both relocation and adjacent-swap
+    /// neighbourhoods, then return the lowest weighted-distance result.
+    pub fn best_linear(
+        &self,
+        control: &[usize],
+        gap: i32,
+        fluid_weight: f64,
+    ) -> Result<LinearCandidate, String> {
+        self.validate_order(control)?;
+        let mut starts = vec![control.to_vec()];
+        let mut reverse = control.to_vec();
+        reverse.reverse();
+        starts.push(reverse);
+        let mut best: Option<LinearCandidate> = None;
+        for start in starts {
+            let relocated = self.improve_relocate(&start, gap, fluid_weight)?;
+            let candidate = self.improve_adjacent(&relocated.order, gap, fluid_weight)?;
+            if best.as_ref().is_none_or(|current| {
+                candidate.metrics.rate_weighted_distance + 1e-9
+                    < current.metrics.rate_weighted_distance
+            }) {
+                best = Some(candidate);
+            }
+        }
+        Ok(best.expect("two deterministic starts"))
+    }
+
     /// Exact RFC-056 two-row baseline for a fixed logical order. Every
     /// non-empty contiguous split is evaluated in serpentine mode and,
     /// optionally, with both rows facing the same direction.
@@ -486,6 +555,17 @@ mod tests {
         let b = g.improve_adjacent(&initial, 2, 0.25).unwrap();
         assert_eq!(a, b);
         assert!(a.metrics.rate_weighted_distance <= before.rate_weighted_distance);
+    }
+
+    #[test]
+    fn relocation_search_is_deterministic_and_beats_control() {
+        let g = fixture();
+        let initial = [0, 3, 1, 2];
+        let before = g.score_linear(&initial, 2, 0.25).unwrap();
+        let a = g.best_linear(&initial, 2, 0.25).unwrap();
+        let b = g.best_linear(&initial, 2, 0.25).unwrap();
+        assert_eq!(a, b);
+        assert!(a.metrics.rate_weighted_distance < before.rate_weighted_distance);
     }
 
     #[test]

--- a/crates/core/src/bus/cells/placement.rs
+++ b/crates/core/src/bus/cells/placement.rs
@@ -39,6 +39,7 @@ pub struct PlacementGraph {
 pub struct PlacementMetrics {
     pub rate_weighted_distance: f64,
     pub max_edge_distance: i32,
+    pub critical_path_distance: i32,
     pub backward_rate: f64,
     pub weighted_cut_sum: f64,
     pub max_weighted_cut: f64,
@@ -158,6 +159,8 @@ impl PlacementGraph {
                 metrics.backward_rate += edge.rate;
             }
         }
+        metrics.critical_path_distance =
+            self.longest_path_distance(|idx| (centre_x[idx], 0));
 
         // Weighted cut: total rate crossing every boundary between adjacent
         // order positions. This is both a congestion estimate for RFC-055 and
@@ -255,6 +258,7 @@ impl PlacementGraph {
                 metrics.backward_rate += edge.rate;
             }
         }
+        metrics.critical_path_distance = self.longest_path_distance(|idx| centres[idx]);
 
         // Row boundaries are the cuts RFC-056 must carry through inter-row
         // trunks. Preserve both total and worst weighted cut explicitly.
@@ -445,6 +449,29 @@ impl PlacementGraph {
             }
         }
         Ok(())
+    }
+
+    /// Longest transported-distance path through the macro DAG. Sources begin
+    /// at zero; repeated relaxation avoids depending on placement order.
+    fn longest_path_distance(&self, centre: impl Fn(usize) -> (i32, i32)) -> i32 {
+        let mut distance = vec![0i32; self.nodes.len()];
+        for _ in 0..self.nodes.len() {
+            let mut changed = false;
+            for edge in &self.edges {
+                let (px, py) = centre(edge.producer);
+                let (cx, cy) = centre(edge.consumer);
+                let step = (cx - px).abs() + (cy - py).abs();
+                let candidate = distance[edge.producer].saturating_add(step);
+                if candidate > distance[edge.consumer] {
+                    distance[edge.consumer] = candidate;
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        distance.into_iter().max().unwrap_or(0)
     }
 }
 

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -491,6 +491,252 @@ pub fn compact_transport_geometry(layout: &LayoutResult) -> LayoutResult {
     current
 }
 
+/// Transactionally delete vertical coordinate cuts while preserving a fully
+/// valid factory. This is the exact #456-style post-pass baseline: everything
+/// on the right of a cut moves together, equivalent seam belts coalesce, and
+/// the move is committed only when full validation remains error-free.
+pub fn compact_validated_columns(
+    layout: &LayoutResult,
+    solver: &SolverResult,
+    max_commits: usize,
+) -> LayoutResult {
+    use crate::validate::{self, LayoutStyle, Severity};
+
+    let mut current = compact_transport_geometry(layout);
+    let mut commits = 0;
+    let mut cut = 1;
+    while cut < current.width && commits < max_commits {
+        let Some(candidate) = collapse_vertical_cut(&current, cut) else {
+            cut += 1;
+            continue;
+        };
+        let issues = match validate::validate(&candidate, Some(solver), LayoutStyle::Bus) {
+            Ok(issues) => issues,
+            Err(error) => error.issues,
+        };
+        if issues.iter().any(|issue| issue.severity == Severity::Error) {
+            cut += 1;
+            continue;
+        }
+        current = candidate;
+        commits += 1;
+        // Retry the same coordinate: several redundant columns may be
+        // adjacent, and accepting a move changes every later cut.
+    }
+    current
+}
+
+/// Row-axis transactional coordinate compactor.
+pub fn compact_validated_rows(
+    layout: &LayoutResult,
+    solver: &SolverResult,
+    max_commits: usize,
+) -> LayoutResult {
+    use crate::validate::{self, LayoutStyle, Severity};
+
+    let mut current = compact_transport_geometry(layout);
+    let mut commits = 0;
+    let mut cut = 1;
+    while cut < current.height && commits < max_commits {
+        let Some(candidate) = collapse_horizontal_cut(&current, cut) else {
+            cut += 1;
+            continue;
+        };
+        let issues = match validate::validate(&candidate, Some(solver), LayoutStyle::Bus) {
+            Ok(issues) => issues,
+            Err(error) => error.issues,
+        };
+        if issues.iter().any(|issue| issue.severity == Severity::Error) {
+            cut += 1;
+            continue;
+        }
+        current = candidate;
+        commits += 1;
+    }
+    current
+}
+
+/// Full safe compaction entry point: transport resynthesis followed by
+/// alternating validated X/Y coordinate cuts to a small fixed point.
+pub fn compact_validated_geometry(layout: &LayoutResult, solver: &SolverResult) -> LayoutResult {
+    let mut current = compact_transport_geometry(layout);
+    for _ in 0..3 {
+        let columns = compact_validated_columns(&current, solver, usize::MAX);
+        let next = compact_validated_rows(&columns, solver, usize::MAX);
+        if next.width == current.width
+            && next.height == current.height
+            && next.entities.len() == current.entities.len()
+        {
+            return next;
+        }
+        current = next;
+    }
+    current
+}
+
+fn collapse_vertical_cut(layout: &LayoutResult, cut: i32) -> Option<LayoutResult> {
+    if cut <= 0 || cut >= layout.width {
+        return None;
+    }
+    // A cut may not pass through the interior of a multi-tile footprint.
+    if layout.entities.iter().any(|entity| {
+        let (width, _) = entity_dims(&entity.name, entity.direction);
+        entity.x < cut && entity.x + width > cut
+    }) {
+        return None;
+    }
+
+    let mut candidate = layout.clone();
+    for entity in &mut candidate.entities {
+        if entity.x >= cut {
+            entity.x -= 1;
+        }
+    }
+    for boundary in candidate
+        .boundary_inputs
+        .iter_mut()
+        .chain(candidate.boundary_outputs.iter_mut())
+    {
+        if boundary.x >= cut {
+            boundary.x -= 1;
+        }
+    }
+    for (_, x, _) in &mut candidate.surplus_exits {
+        if *x >= cut {
+            *x -= 1;
+        }
+    }
+
+    // Coalesce the one expected seam collision: two consecutive tiles of the
+    // same surfaced route. All other footprint collisions refuse the cut.
+    let mut anchor_at: BTreeMap<(i32, i32), usize> = BTreeMap::new();
+    let mut remove = vec![false; candidate.entities.len()];
+    for (idx, entity) in candidate.entities.iter().enumerate() {
+        if let Some(&other_idx) = anchor_at.get(&(entity.x, entity.y)) {
+            let other = &candidate.entities[other_idx];
+            if is_surface_belt(&entity.name)
+                && is_surface_belt(&other.name)
+                && entity.name == other.name
+                && entity.direction == other.direction
+                && entity.carries == other.carries
+                && entity.segment_id == other.segment_id
+            {
+                remove[idx] = true;
+                continue;
+            }
+            return None;
+        }
+        anchor_at.insert((entity.x, entity.y), idx);
+    }
+    candidate.entities = candidate
+        .entities
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, entity)| (!remove[idx]).then_some(entity))
+        .collect();
+
+    let mut occupied = BTreeMap::new();
+    for (idx, entity) in candidate.entities.iter().enumerate() {
+        let (width, height) = entity_dims(&entity.name, entity.direction);
+        for x in entity.x..entity.x + width {
+            for y in entity.y..entity.y + height {
+                if occupied.insert((x, y), idx).is_some() {
+                    return None;
+                }
+            }
+        }
+    }
+    candidate.width -= 1;
+    candidate.regions.clear();
+    candidate.trace = None;
+    normalize_adjacent_undergrounds(&mut candidate);
+    candidate.power_wires = Some(crate::power_wires::compute_pole_wires(
+        &candidate.entities,
+        candidate.wire_mode,
+    ));
+    Some(candidate)
+}
+
+fn collapse_horizontal_cut(layout: &LayoutResult, cut: i32) -> Option<LayoutResult> {
+    if cut <= 0 || cut >= layout.height {
+        return None;
+    }
+    if layout.entities.iter().any(|entity| {
+        let (_, height) = entity_dims(&entity.name, entity.direction);
+        entity.y < cut && entity.y + height > cut
+    }) {
+        return None;
+    }
+
+    let mut candidate = layout.clone();
+    for entity in &mut candidate.entities {
+        if entity.y >= cut {
+            entity.y -= 1;
+        }
+    }
+    for boundary in candidate
+        .boundary_inputs
+        .iter_mut()
+        .chain(candidate.boundary_outputs.iter_mut())
+    {
+        if boundary.y >= cut {
+            boundary.y -= 1;
+        }
+    }
+    for (_, _, y) in &mut candidate.surplus_exits {
+        if *y >= cut {
+            *y -= 1;
+        }
+    }
+
+    let mut anchor_at: BTreeMap<(i32, i32), usize> = BTreeMap::new();
+    let mut remove = vec![false; candidate.entities.len()];
+    for (idx, entity) in candidate.entities.iter().enumerate() {
+        if let Some(&other_idx) = anchor_at.get(&(entity.x, entity.y)) {
+            let other = &candidate.entities[other_idx];
+            if is_surface_belt(&entity.name)
+                && is_surface_belt(&other.name)
+                && entity.name == other.name
+                && entity.direction == other.direction
+                && entity.carries == other.carries
+                && entity.segment_id == other.segment_id
+            {
+                remove[idx] = true;
+                continue;
+            }
+            return None;
+        }
+        anchor_at.insert((entity.x, entity.y), idx);
+    }
+    candidate.entities = candidate
+        .entities
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, entity)| (!remove[idx]).then_some(entity))
+        .collect();
+
+    let mut occupied = BTreeMap::new();
+    for (idx, entity) in candidate.entities.iter().enumerate() {
+        let (width, height) = entity_dims(&entity.name, entity.direction);
+        for x in entity.x..entity.x + width {
+            for y in entity.y..entity.y + height {
+                if occupied.insert((x, y), idx).is_some() {
+                    return None;
+                }
+            }
+        }
+    }
+    candidate.height -= 1;
+    candidate.regions.clear();
+    candidate.trace = None;
+    normalize_adjacent_undergrounds(&mut candidate);
+    candidate.power_wires = Some(crate::power_wires::compute_pole_wires(
+        &candidate.entities,
+        candidate.wire_mode,
+    ));
+    Some(candidate)
+}
+
 /// Replace safe uninterrupted straight surface-belt spans with maximal
 /// underground hops. Tiles addressed by inserters or boundaries are retained
 /// on the surface. Segment, item, tier and direction boundaries split runs.
@@ -1485,6 +1731,52 @@ mod tests {
             .entities
             .iter()
             .all(|entity| entity.name == "express-transport-belt"));
+    }
+
+    #[test]
+    fn vertical_cut_coalesces_equivalent_seam_belts() {
+        let belt = |x| crate::models::PlacedEntity {
+            name: "transport-belt".into(),
+            x,
+            direction: EntityDirection::East,
+            carries: Some("plate".into()),
+            segment_id: Some("route".into()),
+            ..Default::default()
+        };
+        let layout = LayoutResult {
+            width: 4,
+            height: 1,
+            entities: vec![belt(0), belt(1), belt(3)],
+            ..Default::default()
+        };
+        let collapsed = collapse_vertical_cut(&layout, 1).unwrap();
+        assert_eq!(collapsed.width, 3);
+        assert_eq!(collapsed.entities.len(), 2);
+        assert_eq!(collapsed.entities[0].x, 0);
+        assert_eq!(collapsed.entities[1].x, 2);
+    }
+
+    #[test]
+    fn horizontal_cut_coalesces_equivalent_seam_belts() {
+        let belt = |y| crate::models::PlacedEntity {
+            name: "transport-belt".into(),
+            y,
+            direction: EntityDirection::South,
+            carries: Some("plate".into()),
+            segment_id: Some("route".into()),
+            ..Default::default()
+        };
+        let layout = LayoutResult {
+            width: 1,
+            height: 4,
+            entities: vec![belt(0), belt(1), belt(3)],
+            ..Default::default()
+        };
+        let collapsed = collapse_horizontal_cut(&layout, 1).unwrap();
+        assert_eq!(collapsed.height, 3);
+        assert_eq!(collapsed.entities.len(), 2);
+        assert_eq!(collapsed.entities[0].y, 0);
+        assert_eq!(collapsed.entities[1].y, 2);
     }
 
     #[test]

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -1391,6 +1391,220 @@ pub fn estimated_manifold_wirelength(manifolds: &[ManifoldNet]) -> i128 {
         .sum()
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifoldLaneGroup {
+    pub lane: u32,
+    pub producers: Vec<ManifoldTerminal>,
+    pub consumers: Vec<ManifoldTerminal>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BalancerStage {
+    pub n: u32,
+    pub m: u32,
+    pub copies: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalManifoldPlan {
+    pub item: String,
+    pub planned_rate: i64,
+    pub belt_count: u32,
+    pub hub: CompactBlock,
+    pub lane_groups: Vec<ManifoldLaneGroup>,
+    pub producer_stages: Vec<Vec<BalancerStage>>,
+    pub consumer_stages: Vec<Vec<BalancerStage>>,
+    pub all_mergers_stampable: bool,
+    pub all_distributors_stampable: bool,
+}
+
+/// Plan one local, capacity-sized hub per solid commodity. Machine terminals
+/// are partitioned evenly across the minimum number of express belts; each
+/// lane receives an `(producers,1)` merger and `(1,consumers)` distributor.
+///
+/// Hubs are reserved near the terminal median and shifted to the nearest
+/// collision-free tile. Rendering the merger trees and branch routes is a
+/// separate transactional phase.
+pub fn plan_local_manifolds(
+    islands: &[RigidIsland],
+    manifolds: &[ManifoldNet],
+    clearance: i32,
+) -> Vec<LocalManifoldPlan> {
+    let clearance = clearance.max(0);
+    let mut plans = Vec::new();
+    for (plan_id, manifold) in manifolds.iter().enumerate() {
+        let belt_count = manifold.required_belts(45.0).max(1);
+        let mut producers: Vec<_> = manifold.producers().cloned().collect();
+        let mut consumers: Vec<_> = manifold.consumers().cloned().collect();
+        producers.sort_by_key(|terminal| (terminal.x, terminal.y, terminal.kind));
+        consumers.sort_by_key(|terminal| (terminal.x, terminal.y, terminal.kind));
+        let mut lane_groups: Vec<_> = (0..belt_count)
+            .map(|lane| ManifoldLaneGroup {
+                lane,
+                producers: Vec::new(),
+                consumers: Vec::new(),
+            })
+            .collect();
+        for (idx, terminal) in producers.into_iter().enumerate() {
+            lane_groups[idx % belt_count as usize]
+                .producers
+                .push(terminal);
+        }
+        for (idx, terminal) in consumers.into_iter().enumerate() {
+            lane_groups[idx % belt_count as usize]
+                .consumers
+                .push(terminal);
+        }
+
+        let mut xs: Vec<_> = manifold
+            .terminals
+            .iter()
+            .map(|terminal| terminal.x)
+            .collect();
+        let mut ys: Vec<_> = manifold
+            .terminals
+            .iter()
+            .map(|terminal| terminal.y)
+            .collect();
+        xs.sort_unstable();
+        ys.sort_unstable();
+        let center_x = xs.get(xs.len() / 2).copied().unwrap_or(0);
+        let center_y = ys.get(ys.len() / 2).copied().unwrap_or(0);
+        let max_group = lane_groups
+            .iter()
+            .map(|group| group.producers.len().max(group.consumers.len()))
+            .max()
+            .unwrap_or(1) as i32;
+        let depth = if max_group <= 1 {
+            1
+        } else {
+            (max_group as f64).log2().ceil() as i32 + 1
+        };
+        let width = (belt_count as i32 * 3).max(3);
+        let height = (depth * 2 + 1).max(3);
+        let base_x = center_x - width / 2;
+        let base_y = center_y - height / 2;
+        let mut chosen = None;
+        'radius: for radius in 0..=512 {
+            for dx in -radius..=radius {
+                for dy in [-radius, radius] {
+                    let candidate = CompactBlock {
+                        id: plan_id,
+                        x: base_x + dx,
+                        y: base_y + dy,
+                        width,
+                        height,
+                    };
+                    if hub_is_free(&candidate, islands, &plans, clearance) {
+                        chosen = Some(candidate);
+                        break 'radius;
+                    }
+                }
+            }
+            for dy in (-radius + 1)..radius {
+                for dx in [-radius, radius] {
+                    let candidate = CompactBlock {
+                        id: plan_id,
+                        x: base_x + dx,
+                        y: base_y + dy,
+                        width,
+                        height,
+                    };
+                    if hub_is_free(&candidate, islands, &plans, clearance) {
+                        chosen = Some(candidate);
+                        break 'radius;
+                    }
+                }
+            }
+        }
+        let hub = chosen.unwrap_or(CompactBlock {
+            id: plan_id,
+            x: base_x,
+            y: base_y,
+            width,
+            height,
+        });
+        let all_mergers_stampable = lane_groups.iter().all(|group| {
+            merger_stages(group.producers.len() as u32)
+                .iter()
+                .all(|stage| crate::bus::balancer::shape_is_stampable(stage.n, stage.m))
+        });
+        let all_distributors_stampable = lane_groups.iter().all(|group| {
+            distributor_stages(group.consumers.len() as u32)
+                .iter()
+                .all(|stage| crate::bus::balancer::shape_is_stampable(stage.n, stage.m))
+        });
+        let producer_stages = lane_groups
+            .iter()
+            .map(|group| merger_stages(group.producers.len() as u32))
+            .collect();
+        let consumer_stages = lane_groups
+            .iter()
+            .map(|group| distributor_stages(group.consumers.len() as u32))
+            .collect();
+        plans.push(LocalManifoldPlan {
+            item: manifold.item.clone(),
+            planned_rate: manifold.planned_rate,
+            belt_count,
+            hub,
+            lane_groups,
+            producer_stages,
+            consumer_stages,
+            all_mergers_stampable,
+            all_distributors_stampable,
+        });
+    }
+    plans
+}
+
+fn merger_stages(mut inputs: u32) -> Vec<BalancerStage> {
+    let mut stages = Vec::new();
+    while inputs > 1 {
+        let copies = inputs / 2;
+        if copies > 0 {
+            stages.push(BalancerStage { n: 2, m: 1, copies });
+        }
+        inputs = copies + inputs % 2;
+    }
+    stages
+}
+
+fn distributor_stages(outputs: u32) -> Vec<BalancerStage> {
+    if outputs <= 1 {
+        return Vec::new();
+    }
+    // Grow a possibly ragged binary tree to exactly the requested leaves.
+    let mut stages = Vec::new();
+    let mut leaves = 1;
+    while leaves < outputs {
+        let copies = leaves.min(outputs - leaves);
+        stages.push(BalancerStage { n: 1, m: 2, copies });
+        leaves += copies;
+    }
+    stages
+}
+
+fn hub_is_free(
+    candidate: &CompactBlock,
+    islands: &[RigidIsland],
+    plans: &[LocalManifoldPlan],
+    clearance: i32,
+) -> bool {
+    let expanded = CompactBlock {
+        id: candidate.id,
+        x: candidate.x - clearance,
+        y: candidate.y - clearance,
+        width: candidate.width + clearance * 2,
+        height: candidate.height + clearance * 2,
+    };
+    islands
+        .iter()
+        .all(|island| !blocks_overlap(&expanded, &island.block))
+        && plans
+            .iter()
+            .all(|plan| !blocks_overlap(&expanded, &plan.hub))
+}
+
 fn entity_dims(name: &str, direction: EntityDirection) -> (i32, i32) {
     let (mut width, mut height) =
         oriented_splitter_dims(name, direction).unwrap_or_else(|| entity_size(name));
@@ -2023,6 +2237,29 @@ mod tests {
         assert_eq!(collapsed.entities.len(), 2);
         assert_eq!(collapsed.entities[0].y, 0);
         assert_eq!(collapsed.entities[1].y, 2);
+    }
+
+    #[test]
+    fn binary_balancer_hierarchies_cover_arbitrary_terminal_counts() {
+        for count in 0..=129 {
+            let mergers = merger_stages(count);
+            let mut remaining = count;
+            for stage in &mergers {
+                assert_eq!((stage.n, stage.m), (2, 1));
+                remaining = remaining - stage.copies * 2 + stage.copies;
+            }
+            assert_eq!(remaining, count.min(1));
+
+            let distributors = distributor_stages(count);
+            let leaves = distributors
+                .iter()
+                .fold(1u32, |leaves, stage| leaves + stage.copies);
+            assert_eq!(leaves, count.max(1));
+            assert!(mergers
+                .iter()
+                .chain(distributors.iter())
+                .all(|stage| crate::bus::balancer::shape_is_stampable(stage.n, stage.m)));
+        }
     }
 
     #[test]

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -368,17 +368,87 @@ pub fn strip_empty_columns(layout: &LayoutResult) -> LayoutResult {
     for (_, x, _) in &mut compacted.surplus_exits {
         *x = remap_x(*x);
     }
-    // Column removal can collapse a valid underground pair to adjacent
-    // entities. Factorio requires at least one hidden tile; at distance one
-    // the equivalent topology is two ordinary surface belts.
-    let entity_at: BTreeMap<(i32, i32), usize> = compacted
+    // Coordinate removal can collapse a valid underground pair to adjacent
+    // entities. At distance one the equivalent topology is surface belts.
+    normalize_adjacent_undergrounds(&mut compacted);
+    compacted.width -= removed_before[layout.width as usize];
+    compacted.regions.clear();
+    compacted.trace = None;
+    compacted
+}
+
+/// Row-axis counterpart of [`strip_empty_columns`].
+pub fn strip_empty_rows(layout: &LayoutResult) -> LayoutResult {
+    if layout.height <= 0 {
+        return layout.clone();
+    }
+    let mut occupied = vec![false; layout.height as usize];
+    for entity in &layout.entities {
+        let (width, height) = entity_dims(&entity.name, entity.direction);
+        let _ = width;
+        for y in entity.y.max(0)..(entity.y + height).min(layout.height) {
+            occupied[y as usize] = true;
+        }
+    }
+    for boundary in layout
+        .boundary_inputs
+        .iter()
+        .chain(layout.boundary_outputs.iter())
+    {
+        if (0..layout.height).contains(&boundary.y) {
+            occupied[boundary.y as usize] = true;
+        }
+    }
+    for (_, _, y) in &layout.surplus_exits {
+        if (0..layout.height).contains(y) {
+            occupied[*y as usize] = true;
+        }
+    }
+
+    let mut removed_before = vec![0i32; layout.height as usize + 1];
+    for y in 0..layout.height as usize {
+        removed_before[y + 1] = removed_before[y] + i32::from(!occupied[y]);
+    }
+    let remap_y = |y: i32| -> i32 {
+        if y <= 0 {
+            y
+        } else if y >= layout.height {
+            y - removed_before[layout.height as usize]
+        } else {
+            y - removed_before[y as usize]
+        }
+    };
+
+    let mut compacted = layout.clone();
+    for entity in &mut compacted.entities {
+        entity.y = remap_y(entity.y);
+    }
+    for boundary in compacted
+        .boundary_inputs
+        .iter_mut()
+        .chain(compacted.boundary_outputs.iter_mut())
+    {
+        boundary.y = remap_y(boundary.y);
+    }
+    for (_, _, y) in &mut compacted.surplus_exits {
+        *y = remap_y(*y);
+    }
+    normalize_adjacent_undergrounds(&mut compacted);
+    compacted.height -= removed_before[layout.height as usize];
+    compacted.regions.clear();
+    compacted.trace = None;
+    compacted
+}
+
+fn normalize_adjacent_undergrounds(layout: &mut LayoutResult) {
+    let entity_at: BTreeMap<(i32, i32), usize> = layout
         .entities
         .iter()
         .enumerate()
         .map(|(idx, entity)| ((entity.x, entity.y), idx))
         .collect();
     let mut surface_pairs = Vec::new();
-    for (idx, entity) in compacted.entities.iter().enumerate() {
+    for (idx, entity) in layout.entities.iter().enumerate() {
         if !is_ug_belt(&entity.name) || entity.io_type.as_deref() != Some("input") {
             continue;
         }
@@ -386,7 +456,7 @@ pub fn strip_empty_columns(layout: &LayoutResult) -> LayoutResult {
         let Some(&output_idx) = entity_at.get(&(entity.x + dx, entity.y + dy)) else {
             continue;
         };
-        let output = &compacted.entities[output_idx];
+        let output = &layout.entities[output_idx];
         if output.name == entity.name
             && output.direction == entity.direction
             && output.io_type.as_deref() == Some("output")
@@ -396,25 +466,44 @@ pub fn strip_empty_columns(layout: &LayoutResult) -> LayoutResult {
     }
     for (input_idx, output_idx) in surface_pairs {
         for idx in [input_idx, output_idx] {
-            let entity = &mut compacted.entities[idx];
+            let entity = &mut layout.entities[idx];
             entity.name = ug_to_surface_tier(&entity.name).to_string();
             entity.io_type = None;
         }
     }
-    compacted.width -= removed_before[layout.width as usize];
-    compacted.regions.clear();
-    compacted.trace = None;
-    compacted
 }
 
-/// Replace safe uninterrupted horizontal surface-belt spans with maximal
+/// Run the safe transport compactor to a small fixed point.
+pub fn compact_transport_geometry(layout: &LayoutResult) -> LayoutResult {
+    let mut current = layout.clone();
+    for _ in 0..3 {
+        let next = strip_empty_rows(&strip_empty_columns(&undergroundify_straight_belts(
+            &current,
+        )));
+        if next.width == current.width
+            && next.height == current.height
+            && next.entities.len() == current.entities.len()
+        {
+            return next;
+        }
+        current = next;
+    }
+    current
+}
+
+/// Replace safe uninterrupted straight surface-belt spans with maximal
 /// underground hops. Tiles addressed by inserters or boundaries are retained
 /// on the surface. Segment, item, tier and direction boundaries split runs.
 pub fn undergroundify_straight_belts(layout: &LayoutResult) -> LayoutResult {
     use crate::bus::balancer::underground_for_belt;
     use std::collections::BTreeSet;
 
-    let mut protected = BTreeSet::new();
+    let mut protected_horizontal = BTreeSet::new();
+    let mut protected_vertical = BTreeSet::new();
+    let mut protect_both = |tile| {
+        protected_horizontal.insert(tile);
+        protected_vertical.insert(tile);
+    };
     for inserter in layout
         .entities
         .iter()
@@ -422,22 +511,24 @@ pub fn undergroundify_straight_belts(layout: &LayoutResult) -> LayoutResult {
     {
         let (dx, dy) = dir_to_vec(inserter.direction);
         let reach = inserter_reach(&inserter.name);
-        protected.insert((inserter.x - dx * reach, inserter.y - dy * reach));
-        protected.insert((inserter.x + dx * reach, inserter.y + dy * reach));
+        protect_both((inserter.x - dx * reach, inserter.y - dy * reach));
+        protect_both((inserter.x + dx * reach, inserter.y + dy * reach));
     }
     for boundary in layout
         .boundary_inputs
         .iter()
         .chain(layout.boundary_outputs.iter())
     {
-        protected.insert((boundary.x, boundary.y));
+        protect_both((boundary.x, boundary.y));
     }
     for (_, x, y) in &layout.surplus_exits {
-        protected.insert((*x, *y));
+        protect_both((*x, *y));
     }
+    drop(protect_both);
 
-    // A perpendicular belt feeding a horizontal tile is a side-load/turn
-    // junction. Splitters and existing undergrounds reserve their vicinity.
+    // A perpendicular belt feeding a straight tile is a side-load/turn
+    // junction. Splitters and existing undergrounds reserve their vicinity
+    // on both axes.
     for entity in layout
         .entities
         .iter()
@@ -445,48 +536,68 @@ pub fn undergroundify_straight_belts(layout: &LayoutResult) -> LayoutResult {
     {
         let (dx, dy) = dir_to_vec(entity.direction);
         if dx == 0 {
-            protected.insert((entity.x + dx, entity.y + dy));
+            protected_horizontal.insert((entity.x + dx, entity.y + dy));
+        } else {
+            protected_vertical.insert((entity.x + dx, entity.y + dy));
         }
         if !is_surface_belt(&entity.name) {
             for x in entity.x - 1..=entity.x + 2 {
                 for y in entity.y - 1..=entity.y + 2 {
-                    protected.insert((x, y));
+                    protected_horizontal.insert((x, y));
+                    protected_vertical.insert((x, y));
                 }
             }
         }
     }
 
-    type RunKey = (i32, bool, String, Option<String>, Option<String>);
+    // (horizontal, positive direction, fixed cross-axis coordinate, ...)
+    type RunKey = (bool, bool, i32, String, Option<String>, Option<String>);
     let mut runs: BTreeMap<RunKey, Vec<(i32, usize)>> = BTreeMap::new();
     for (idx, entity) in layout.entities.iter().enumerate() {
-        if !is_surface_belt(&entity.name)
-            || !matches!(
-                entity.direction,
-                EntityDirection::East | EntityDirection::West
-            )
-            || protected.contains(&(entity.x, entity.y))
-        {
+        if !is_surface_belt(&entity.name) {
             continue;
         }
+        let horizontal = matches!(
+            entity.direction,
+            EntityDirection::East | EntityDirection::West
+        );
+        let protected = if horizontal {
+            &protected_horizontal
+        } else {
+            &protected_vertical
+        };
+        if protected.contains(&(entity.x, entity.y)) {
+            continue;
+        }
+        let positive = matches!(
+            entity.direction,
+            EntityDirection::East | EntityDirection::South
+        );
+        let (fixed, coordinate) = if horizontal {
+            (entity.y, entity.x)
+        } else {
+            (entity.x, entity.y)
+        };
         runs.entry((
-            entity.y,
-            entity.direction == EntityDirection::East,
+            horizontal,
+            positive,
+            fixed,
             entity.name.clone(),
             entity.carries.clone(),
             entity.segment_id.clone(),
         ))
         .or_default()
-        .push((entity.x, idx));
+        .push((coordinate, idx));
     }
 
     let mut remove = vec![false; layout.entities.len()];
     let mut replacements = BTreeMap::new();
-    for ((_, eastbound, belt_name, _, _), mut tiles) in runs {
-        tiles.sort_by_key(|(x, _)| *x);
-        if !eastbound {
+    for ((_, positive, _, belt_name, _, _), mut tiles) in runs {
+        tiles.sort_by_key(|(coordinate, _)| *coordinate);
+        if !positive {
             tiles.reverse();
         }
-        let step = if eastbound { 1 } else { -1 };
+        let step = if positive { 1 } else { -1 };
         let mut run_start = 0;
         while run_start < tiles.len() {
             let mut run_end = run_start + 1;
@@ -1345,6 +1456,35 @@ mod tests {
         assert_eq!(compacted.entities[0].io_type.as_deref(), Some("input"));
         assert_eq!(compacted.entities[1].x, 9);
         assert_eq!(compacted.entities[1].io_type.as_deref(), Some("output"));
+    }
+
+    #[test]
+    fn vertical_belts_and_empty_rows_compact_symmetrically() {
+        let layout = LayoutResult {
+            width: 1,
+            height: 10,
+            entities: (0..10)
+                .map(|y| crate::models::PlacedEntity {
+                    name: "express-transport-belt".into(),
+                    y,
+                    direction: EntityDirection::South,
+                    carries: Some("plate".into()),
+                    segment_id: Some("test".into()),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let underground = undergroundify_straight_belts(&layout);
+        assert_eq!(underground.entities.len(), 2);
+        assert_eq!(underground.entities[0].name, "express-underground-belt");
+        assert_eq!(underground.entities[1].y, 9);
+        let compacted = strip_empty_rows(&underground);
+        assert_eq!(compacted.height, 2);
+        assert!(compacted
+            .entities
+            .iter()
+            .all(|entity| entity.name == "express-transport-belt"));
     }
 
     #[test]

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -1,0 +1,395 @@
+//! RFC-057 topology-preserving dense repacking foundation.
+//!
+//! This module freezes the logical production graph and the placed machine
+//! multiset before any geometric search.  The first placement primitive is an
+//! exact per-axis constraint-graph compactor: for a fixed relative order it
+//! computes the minimum legal coordinates by longest paths in a DAG.
+
+use std::collections::BTreeMap;
+
+use crate::common::{entity_size, oriented_splitter_dims, QualityTier};
+use crate::models::{EntityDirection, LayoutResult, ModuleItem, SolverResult};
+
+const RATE_SCALE: f64 = 1_000_000_000.0;
+
+fn fixed_rate(rate: f64) -> i64 {
+    (rate * RATE_SCALE).round() as i64
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProductionMachine {
+    pub recipe: String,
+    pub entity: String,
+    pub count: i64,
+    pub modules: Vec<(String, u32, Option<QualityTier>)>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProductionEdge {
+    /// Canonical set of recipes capable of supplying this item in the solved
+    /// graph. Oil co-products and cracking legitimately create more than one.
+    pub producer_recipes: Vec<String>,
+    pub item: String,
+    pub consumer_recipe: String,
+    pub rate: i64,
+    pub is_fluid: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProductionBoundary {
+    pub item: String,
+    pub rate: i64,
+    pub is_fluid: bool,
+}
+
+/// Canonical logical topology. Rates and fractional counts use fixed-point
+/// nanounits so equality and hashing do not depend on `f64` ordering.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProductionSignature {
+    pub machines: Vec<ProductionMachine>,
+    pub edges: Vec<ProductionEdge>,
+    pub external_inputs: Vec<ProductionBoundary>,
+    pub target_outputs: Vec<ProductionBoundary>,
+    pub surplus_outputs: Vec<ProductionBoundary>,
+}
+
+impl ProductionSignature {
+    pub fn from_solver(sr: &SolverResult) -> Result<Self, String> {
+        let mut producers_of: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+        for machine in &sr.machines {
+            for output in &machine.outputs {
+                let producers = producers_of.entry(output.item.as_str()).or_default();
+                if !producers.contains(&machine.recipe) {
+                    producers.push(machine.recipe.clone());
+                }
+            }
+        }
+        for producers in producers_of.values_mut() {
+            producers.sort();
+        }
+
+        let mut machines: Vec<_> = sr
+            .machines
+            .iter()
+            .map(|machine| ProductionMachine {
+                recipe: machine.recipe.clone(),
+                entity: machine.entity.clone(),
+                count: fixed_rate(machine.count),
+                modules: canonical_modules(&machine.game_modules),
+            })
+            .collect();
+        machines.sort();
+
+        let mut edges = Vec::new();
+        for consumer in &sr.machines {
+            for input in &consumer.inputs {
+                let Some(producer_recipes) = producers_of.get(input.item.as_str()) else {
+                    continue;
+                };
+                if producer_recipes.len() == 1 && producer_recipes[0] == consumer.recipe {
+                    continue;
+                }
+                edges.push(ProductionEdge {
+                    producer_recipes: producer_recipes.clone(),
+                    item: input.item.clone(),
+                    consumer_recipe: consumer.recipe.clone(),
+                    rate: fixed_rate(input.rate * consumer.count),
+                    is_fluid: input.is_fluid,
+                });
+            }
+        }
+        edges.sort();
+
+        Ok(Self {
+            machines,
+            edges,
+            external_inputs: canonical_boundaries(&sr.external_inputs),
+            target_outputs: canonical_boundaries(&sr.external_outputs),
+            surplus_outputs: canonical_boundaries(&sr.surplus_outputs),
+        })
+    }
+}
+
+fn canonical_modules(modules: &[ModuleItem]) -> Vec<(String, u32, Option<QualityTier>)> {
+    let mut result: Vec<_> = modules
+        .iter()
+        .map(|module| (module.item.clone(), module.count, module.quality))
+        .collect();
+    result.sort_by(|a, b| {
+        (&a.0, a.1, a.2.map(|q| q.level()))
+            .cmp(&(&b.0, b.1, b.2.map(|q| q.level())))
+    });
+    result
+}
+
+fn canonical_boundaries(flows: &[crate::models::ItemFlow]) -> Vec<ProductionBoundary> {
+    let mut result: Vec<_> = flows
+        .iter()
+        .map(|flow| ProductionBoundary {
+            item: flow.item.clone(),
+            rate: fixed_rate(flow.rate),
+            is_fluid: flow.is_fluid,
+        })
+        .collect();
+    result.sort();
+    result
+}
+
+/// Exact placed-machine multiset. Unlike the logical signature this records
+/// integer entities after capacity quantization, so a candidate can prove it
+/// only shuffled machines rather than silently adding/removing one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlacedMachineSignature(pub Vec<PlacedMachine>);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PlacedMachine {
+    pub recipe: String,
+    pub entity: String,
+    pub quality: Option<QualityTier>,
+    pub modules: Vec<(String, u32, Option<QualityTier>)>,
+}
+
+impl PlacedMachineSignature {
+    pub fn from_layout(layout: &LayoutResult) -> Self {
+        let mut machines: Vec<_> = layout
+            .entities
+            .iter()
+            .filter_map(|entity| {
+                Some(PlacedMachine {
+                    recipe: entity.recipe.clone()?,
+                    entity: entity.name.clone(),
+                    quality: entity.quality,
+                    modules: canonical_modules(&entity.items),
+                })
+            })
+            .collect();
+        machines.sort();
+        Self(machines)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompactAxis {
+    X,
+    Y,
+}
+
+/// One movable rectangle in the coarse compaction model.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactBlock {
+    pub id: usize,
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl CompactBlock {
+    fn axis_start(&self, axis: CompactAxis) -> i32 {
+        match axis {
+            CompactAxis::X => self.x,
+            CompactAxis::Y => self.y,
+        }
+    }
+
+    fn axis_size(&self, axis: CompactAxis) -> i32 {
+        match axis {
+            CompactAxis::X => self.width,
+            CompactAxis::Y => self.height,
+        }
+    }
+
+    fn overlaps_cross_axis(&self, other: &Self, axis: CompactAxis) -> bool {
+        let (a0, a1, b0, b1) = match axis {
+            CompactAxis::X => (
+                self.y,
+                self.y + self.height,
+                other.y,
+                other.y + other.height,
+            ),
+            CompactAxis::Y => (
+                self.x,
+                self.x + self.width,
+                other.x,
+                other.x + other.width,
+            ),
+        };
+        a0 < b1 && b0 < a1
+    }
+}
+
+/// Extract individual placed machines as the first coarse movable-block set.
+/// Inserters and routes enter the later `CompactIR` slices; this function is a
+/// metrics/constraint baseline and does not itself mutate a layout.
+pub fn machine_blocks(layout: &LayoutResult) -> Vec<CompactBlock> {
+    layout
+        .entities
+        .iter()
+        .enumerate()
+        .filter_map(|(id, entity)| {
+            entity.recipe.as_ref()?;
+            let (mut width, mut height) = oriented_splitter_dims(&entity.name, entity.direction)
+                .unwrap_or_else(|| entity_size(&entity.name));
+            if matches!(entity.direction, EntityDirection::East | EntityDirection::West)
+                && width != height
+                && oriented_splitter_dims(&entity.name, entity.direction).is_none()
+            {
+                std::mem::swap(&mut width, &mut height);
+            }
+            Some(CompactBlock {
+                id,
+                x: entity.x,
+                y: entity.y,
+                width: width as i32,
+                height: height as i32,
+            })
+        })
+        .collect()
+}
+
+/// Compact one axis while preserving the source order of every pair whose
+/// cross-axis footprints overlap. This is longest-path placement on the
+/// induced separation DAG.
+pub fn compact_axis(
+    blocks: &[CompactBlock],
+    axis: CompactAxis,
+    clearance: i32,
+) -> Vec<CompactBlock> {
+    let mut order: Vec<usize> = (0..blocks.len()).collect();
+    order.sort_by_key(|&idx| (blocks[idx].axis_start(axis), blocks[idx].id));
+
+    let mut coordinate = vec![0i32; blocks.len()];
+    for (position, &idx) in order.iter().enumerate() {
+        let mut lower_bound = 0;
+        for &previous in &order[..position] {
+            if blocks[previous].overlaps_cross_axis(&blocks[idx], axis) {
+                lower_bound = lower_bound.max(
+                    coordinate[previous]
+                        + blocks[previous].axis_size(axis)
+                        + clearance.max(0),
+                );
+            }
+        }
+        coordinate[idx] = lower_bound;
+    }
+
+    blocks
+        .iter()
+        .enumerate()
+        .map(|(idx, block)| {
+            let mut compacted = block.clone();
+            match axis {
+                CompactAxis::X => compacted.x = coordinate[idx],
+                CompactAxis::Y => compacted.y = coordinate[idx],
+            }
+            compacted
+        })
+        .collect()
+}
+
+pub fn occupied_bbox(blocks: &[CompactBlock]) -> (i32, i32) {
+    (
+        blocks.iter().map(|b| b.x + b.width).max().unwrap_or(0)
+            - blocks.iter().map(|b| b.x).min().unwrap_or(0),
+        blocks.iter().map(|b| b.y + b.height).max().unwrap_or(0)
+            - blocks.iter().map(|b| b.y).min().unwrap_or(0),
+    )
+}
+
+pub fn blocks_overlap(a: &CompactBlock, b: &CompactBlock) -> bool {
+    a.x < b.x + b.width
+        && b.x < a.x + a.width
+        && a.y < b.y + b.height
+        && b.y < a.y + a.height
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{ItemFlow, MachineSpec};
+
+    #[test]
+    fn production_signature_is_order_independent() {
+        let plate = MachineSpec {
+            entity: "electric-furnace".into(),
+            recipe: "iron-plate".into(),
+            count: 2.0,
+            outputs: vec![ItemFlow {
+                item: "iron-plate".into(),
+                rate: 1.0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let gear = MachineSpec {
+            entity: "assembling-machine-3".into(),
+            recipe: "iron-gear-wheel".into(),
+            count: 3.0,
+            inputs: vec![ItemFlow {
+                item: "iron-plate".into(),
+                rate: 2.0,
+                ..Default::default()
+            }],
+            outputs: vec![ItemFlow {
+                item: "iron-gear-wheel".into(),
+                rate: 1.0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let a = SolverResult {
+            machines: vec![plate.clone(), gear.clone()],
+            ..Default::default()
+        };
+        let b = SolverResult {
+            machines: vec![gear, plate],
+            ..Default::default()
+        };
+        assert_eq!(
+            ProductionSignature::from_solver(&a).unwrap(),
+            ProductionSignature::from_solver(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn x_compaction_is_exact_for_fixed_overlap_order() {
+        let blocks = vec![
+            CompactBlock { id: 0, x: 10, y: 0, width: 3, height: 3 },
+            CompactBlock { id: 1, x: 30, y: 1, width: 4, height: 2 },
+            CompactBlock { id: 2, x: 50, y: 8, width: 5, height: 2 },
+        ];
+        let compacted = compact_axis(&blocks, CompactAxis::X, 1);
+        assert_eq!(compacted[0].x, 0);
+        assert_eq!(compacted[1].x, 4);
+        // Cross-axis-disjoint block has no ordering constraint.
+        assert_eq!(compacted[2].x, 0);
+        assert_eq!(occupied_bbox(&compacted), (8, 10));
+        assert!(!blocks_overlap(&compacted[0], &compacted[1]));
+    }
+
+    #[test]
+    fn placed_machine_signature_ignores_geometry_and_entity_order() {
+        let machine = crate::models::PlacedEntity {
+            name: "assembling-machine-3".into(),
+            recipe: Some("iron-gear-wheel".into()),
+            x: 10,
+            y: 20,
+            ..Default::default()
+        };
+        let belt = crate::models::PlacedEntity {
+            name: "transport-belt".into(),
+            x: 2,
+            y: 3,
+            ..Default::default()
+        };
+        let a = LayoutResult { entities: vec![machine.clone(), belt.clone()], ..Default::default() };
+        let mut moved = machine;
+        moved.x = -7;
+        moved.y = 4;
+        let b = LayoutResult { entities: vec![belt, moved], ..Default::default() };
+        assert_eq!(
+            PlacedMachineSignature::from_layout(&a),
+            PlacedMachineSignature::from_layout(&b)
+        );
+    }
+}

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -401,7 +401,6 @@ pub struct RouteTerminal {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RouteNet {
     pub item: String,
-    pub copy: Option<u32>,
     pub segments: Vec<String>,
     pub entity_indices: Vec<usize>,
     pub terminals: Vec<RouteTerminal>,
@@ -413,7 +412,7 @@ pub struct RouteNet {
 /// preserving [`ProductionSignature`].
 pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
     let mut nets: Vec<RouteNet> = Vec::new();
-    let mut net_by_key: BTreeMap<(String, Option<u32>), usize> = BTreeMap::new();
+    let mut net_by_item: BTreeMap<String, usize> = BTreeMap::new();
     let mut entity_net: BTreeMap<usize, usize> = BTreeMap::new();
 
     for (entity_idx, entity) in layout.entities.iter().enumerate() {
@@ -426,13 +425,10 @@ pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
         let Some(item) = entity.carries.clone() else {
             continue;
         };
-        let copy = segment_copy(&segment);
-        let key = (item.clone(), copy);
-        let net_idx = *net_by_key.entry(key).or_insert_with(|| {
+        let net_idx = *net_by_item.entry(item.clone()).or_insert_with(|| {
             let idx = nets.len();
             nets.push(RouteNet {
                 item,
-                copy,
                 segments: Vec::new(),
                 entity_indices: Vec::new(),
                 terminals: Vec::new(),
@@ -528,18 +524,8 @@ pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
         net.terminals.sort();
         net.terminals.dedup();
     }
-    nets.sort_by(|a, b| (&a.item, a.copy).cmp(&(&b.item, b.copy)));
+    nets.sort_by(|a, b| a.item.cmp(&b.item));
     nets
-}
-
-fn segment_copy(segment: &str) -> Option<u32> {
-    let (_, suffix) = segment.rsplit_once('#')?;
-    let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
-    if digits.is_empty() {
-        None
-    } else {
-        digits.parse().ok()
-    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -497,6 +497,39 @@ pub fn compact_transport_geometry(layout: &LayoutResult) -> LayoutResult {
 /// valid factory. This is the exact #456-style post-pass baseline: everything
 /// on the right of a cut moves together, equivalent seam belts coalesce, and
 /// the move is committed only when full validation remains error-free.
+/// Apply a transform only if it validates no worse than its input.
+///
+/// `compact_transport_geometry` was applied unguarded at the head of all three
+/// compaction entry points, and the failure mode is self-reinforcing: if it
+/// introduces an error, every subsequent coordinate-cut candidate inherits
+/// that error, so every candidate is rejected, no cut commits, and the
+/// function returns exactly the broken unvalidated layout it started from.
+/// The per-cut validation below can never catch it, because it only ever
+/// examines candidates derived FROM it.
+///
+/// Compaction is an optimisation. Declining to compact is always acceptable;
+/// returning a broken factory is not.
+fn accept_if_no_worse(
+    input: &LayoutResult,
+    candidate: LayoutResult,
+    solver: &SolverResult,
+) -> LayoutResult {
+    use crate::validate::{self, LayoutStyle, Severity};
+    let errors = |l: &LayoutResult| -> usize {
+        match validate::validate(l, Some(solver), LayoutStyle::Bus) {
+            Ok(issues) => issues,
+            Err(error) => error.issues,
+        }
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .count()
+    };
+    if errors(&candidate) > errors(input) {
+        return input.clone();
+    }
+    candidate
+}
+
 pub fn compact_validated_columns(
     layout: &LayoutResult,
     solver: &SolverResult,
@@ -504,7 +537,7 @@ pub fn compact_validated_columns(
 ) -> LayoutResult {
     use crate::validate::{self, LayoutStyle, Severity};
 
-    let mut current = compact_transport_geometry(layout);
+    let mut current = accept_if_no_worse(layout, compact_transport_geometry(layout), solver);
     let mut commits = 0;
     let mut cut = 1;
     while cut < current.width && commits < max_commits {
@@ -536,7 +569,7 @@ pub fn compact_validated_rows(
 ) -> LayoutResult {
     use crate::validate::{self, LayoutStyle, Severity};
 
-    let mut current = compact_transport_geometry(layout);
+    let mut current = accept_if_no_worse(layout, compact_transport_geometry(layout), solver);
     let mut commits = 0;
     let mut cut = 1;
     while cut < current.height && commits < max_commits {
@@ -561,7 +594,7 @@ pub fn compact_validated_rows(
 /// Full safe compaction entry point: transport resynthesis followed by
 /// alternating validated X/Y coordinate cuts to a small fixed point.
 pub fn compact_validated_geometry(layout: &LayoutResult, solver: &SolverResult) -> LayoutResult {
-    let mut current = compact_transport_geometry(layout);
+    let mut current = accept_if_no_worse(layout, compact_transport_geometry(layout), solver);
     for _ in 0..3 {
         let columns = compact_validated_columns(&current, solver, usize::MAX);
         let next = compact_validated_rows(&columns, solver, usize::MAX);
@@ -1564,19 +1597,46 @@ pub fn plan_local_manifolds(
 
 const LOCAL_BALANCER_FAN: u32 = 4;
 
-fn merger_stages(mut inputs: u32) -> Vec<BalancerStage> {
+/// Predict the merge tree `build_local_manifold_graph` will actually build.
+///
+/// It must mirror that builder's chunking exactly, because
+/// `all_mergers_stampable` and `producer_stages` are derived from this and
+/// never cross-checked against the graph. The previous formulation folded the
+/// remainder back into the next level's input count instead of emitting it as
+/// its own node, so the two diverged whenever `inputs % 4` was 2 or 3 — at 6
+/// producers it predicted 2 nodes against the builder's 3, and likewise at 7
+/// and 10. Ordinary counts, not edge cases, and the stampability guarantee was
+/// being checked against a tree that was never built.
+fn merger_stages(inputs: u32) -> Vec<BalancerStage> {
     let mut stages = Vec::new();
-    while inputs > 1 {
-        let fan = inputs.min(LOCAL_BALANCER_FAN);
-        let copies = inputs / fan;
-        if copies > 0 {
+    let mut frontier = inputs;
+    while frontier > 1 {
+        // The builder walks the frontier in chunks of `LOCAL_BALANCER_FAN`:
+        // each full chunk becomes an (n,1) node, a trailing chunk of 2 or more
+        // becomes its own smaller node, and a lone leftover passes through
+        // untouched to the next level.
+        let full = frontier / LOCAL_BALANCER_FAN;
+        let remainder = frontier % LOCAL_BALANCER_FAN;
+        let mut next = 0;
+        if full > 0 {
             stages.push(BalancerStage {
-                n: fan,
+                n: LOCAL_BALANCER_FAN,
                 m: 1,
-                copies,
+                copies: full,
             });
+            next += full;
         }
-        inputs = copies + inputs % fan;
+        if remainder >= 2 {
+            stages.push(BalancerStage {
+                n: remainder,
+                m: 1,
+                copies: 1,
+            });
+            next += 1;
+        } else {
+            next += remainder;
+        }
+        frontier = next;
     }
     stages
 }
@@ -3798,6 +3858,42 @@ mod tests {
         );
     }
 
+    /// `merger_stages` predicts the merge tree; `build_local_manifold_graph`
+    /// builds it. They must agree, because `all_mergers_stampable` and
+    /// `producer_stages` are derived from the prediction and never
+    /// cross-checked against the graph — so a divergence means the
+    /// stampability guarantee is being checked against a tree nobody builds.
+    /// They diverged at 6, 7 and 10 producers: ordinary counts, not edges.
+    #[test]
+    fn merger_stage_prediction_matches_the_built_graph() {
+        for inputs in 2u32..40 {
+            let predicted: u32 = merger_stages(inputs).iter().map(|s| s.copies).sum();
+
+            // Mirror of the builder's frontier chunking: walk in chunks of
+            // LOCAL_BALANCER_FAN,each chunk of 2+ becomes a node, a lone
+            // leftover passes through.
+            let mut frontier = inputs as usize;
+            let mut built = 0u32;
+            while frontier > 1 {
+                let mut next = 0usize;
+                let mut i = 0usize;
+                while i < frontier {
+                    let chunk = (frontier - i).min(LOCAL_BALANCER_FAN as usize);
+                    if chunk > 1 {
+                        built += 1;
+                    }
+                    next += 1;
+                    i += chunk;
+                }
+                frontier = next;
+            }
+            assert_eq!(
+                predicted, built,
+                "inputs={inputs}: predicted {predicted} merge nodes, builder makes {built}"
+            );
+        }
+    }
+
     #[test]
     fn rigid_islands_bind_direct_insertion_and_expose_belt_terminals() {
         let machine = |x, recipe: &str| crate::models::PlacedEntity {
@@ -4752,6 +4848,21 @@ pub fn fold_snake(
                 _ => continue,
             };
 
+            // The connector's legs are horizontal, and `place_uturn` stamps
+            // every tile of the bottom leg with the DOWNSTREAM belt's
+            // direction. If that belt runs vertically — a tap turning at the
+            // fold column, which nothing above excludes — the leg becomes a
+            // row of north/south belts that cannot carry items along it and
+            // dump into whatever sits beside them. Refuse: reconnecting into
+            // a turn needs a sideload this pass does not synthesize.
+            if !matches!(
+                down.direction,
+                EntityDirection::East | EntityDirection::West
+            ) {
+                return Err(FoldRefusal::JunctionBlocked {
+                    at: (down.x, down.y),
+                });
+            }
             let (Some((ux, uy, udir)), Some((dx_, dy_, ddir))) = (transform(up), transform(down))
             else {
                 continue;
@@ -5192,9 +5303,22 @@ pub fn fold_snake(
     }
 
     // 6. Compute new dimensions and normalise X origin.
+    // Footprint-inclusive, not anchor-only: a 3x3 assembler anchored at the
+    // bottom row occupies two rows below its anchor, so an anchor-derived
+    // height under-reports by up to `footprint - 1` and the declared
+    // dimensions describe a box the factory does not fit in. The rest of this
+    // function already uses `entity_dims`; this was the one place that did not.
     let min_x = folded.iter().map(|e| e.x).min().unwrap_or(0);
-    let max_x = folded.iter().map(|e| e.x).max().unwrap_or(0);
-    let max_y = folded.iter().map(|e| e.y).max().unwrap_or(0);
+    let max_x = folded
+        .iter()
+        .map(|e| e.x + entity_dims(&e.name, e.direction).0 - 1)
+        .max()
+        .unwrap_or(0);
+    let max_y = folded
+        .iter()
+        .map(|e| e.y + entity_dims(&e.name, e.direction).1 - 1)
+        .max()
+        .unwrap_or(0);
     let x_shift = if min_x < 0 { -min_x } else { 0 };
     if x_shift > 0 {
         for e in &mut folded {

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -4454,6 +4454,9 @@ pub enum FoldRefusal {
     CornerNotATurn,
     /// Reconnection produced implausibly many entities — a runaway backstop.
     EntityExplosion,
+    /// A belt run that continued in the source now dead-ends. Carries the
+    /// source tile whose hand-off was lost.
+    RunSevered { at: (i32, i32) },
 }
 
 /// Snake-fold a layout at the given fold columns.
@@ -4698,6 +4701,13 @@ pub fn fold_snake(
     let edge_min_x = folded.iter().map(|e| e.x).min().unwrap_or(0);
     let edge_max_x = folded.iter().map(|e| e.x).max().unwrap_or(0);
 
+    // An exit that gets rerouted along a gap lane finishes somewhere new.
+    // Its boundary record has to follow it: the record is where a consumer
+    // (or the sim harness) expects to collect the output, and leaving it at
+    // the old tile means the factory produces into a spot nothing drains —
+    // every producer upstream then backs up and the whole line stalls.
+    let mut exit_moved: BTreeMap<(i32, i32), ((i32, i32), EntityDirection)> = BTreeMap::new();
+
     // 5. Give the layout's original exits somewhere to go.
     //
     // A belt on the source layout's bottom edge facing South deposited
@@ -4731,7 +4741,10 @@ pub fn fold_snake(
 
             // item claimed per tile on this row, so a conflict is detectable.
             let mut claimed: BTreeMap<i32, Option<String>> = BTreeMap::new();
+            let _ = &exit_moved;
             let mut pending: Vec<PlacedEntity> = Vec::new();
+            // Where each exit now finishes, so its boundary record can follow.
+            let mut termini: Vec<((i32, i32), (i32, i32), EntityDirection)> = Vec::new();
             for (x, name, carries) in &exits {
                 // Only true segment content can be an exit. A U-turn's
                 // vertical run passes through these same rows at a junction
@@ -4787,6 +4800,11 @@ pub fn fold_snake(
                         });
                     }
                 }
+                let term_x = if to_left { lo } else { hi };
+                termini.push(((*x, src_y), (term_x, row), dir));
+            }
+            for (from, to, dir) in termini {
+                exit_moved.insert(from, (to, dir));
             }
             folded.extend(pending);
         }
@@ -4802,6 +4820,144 @@ pub fn fold_snake(
     // bug in here refuses a fold instead of taking out the machine.
     if folded.len() > entities.len() * 2 + 1024 {
         return Err(FoldRefusal::EntityExplosion);
+    }
+
+    // 5c. Belt continuity: folding may not create a dead end.
+    //
+    // Every belt that handed off to another belt in the source must still
+    // hand off in the fold, or else leave the bounding box the way an output
+    // does. A severed run that nothing reconnected is not a geometry error —
+    // the tiles are all perfectly legal — so it surfaces far away as a
+    // starved machine ("items can't reach input", "delivers 0.0/s"), which is
+    // exactly the kind of silent functional break this transform must not
+    // produce. Checking it here turns that into an explicit refusal.
+    {
+        // Footprints, not anchors: a belt handing off to a splitter feeds
+        // whichever of its two tiles it abuts, which is often not the tile
+        // the splitter is anchored at.
+        let belt_tiles = |src: &[PlacedEntity]| -> FxHashSet<(i32, i32)> {
+            let mut tiles = FxHashSet::default();
+            for e in src.iter().filter(|e| is_belt_entity(&e.name)) {
+                let (w, hh) = entity_dims(&e.name, e.direction);
+                for dx in 0..w.max(1) {
+                    for dy in 0..hh.max(1) {
+                        tiles.insert((e.x + dx, e.y + dy));
+                    }
+                }
+            }
+            tiles
+        };
+        let src_belt = belt_tiles(&entities);
+        let out_belt = belt_tiles(&folded);
+        let (lo_x, hi_x) = (
+            folded.iter().map(|e| e.x).min().unwrap_or(0),
+            folded.iter().map(|e| e.x).max().unwrap_or(0),
+        );
+        let (lo_y, hi_y) = (
+            folded.iter().map(|e| e.y).min().unwrap_or(0),
+            folded.iter().map(|e| e.y).max().unwrap_or(0),
+        );
+
+        let debug = std::env::var("SPAGHETTIO_FOLD_DEBUG").is_ok();
+        let mut severed: Vec<((i32, i32), &'static str)> = Vec::new();
+
+        for e in entities.iter().filter(|e| is_belt_entity(&e.name)) {
+            // An underground entrance hands off to its exit, not to the tile
+            // in front of it.
+            if is_ug_belt(&e.name) && e.io_type.as_deref() == Some("input") {
+                continue;
+            }
+            let (dx, dy) = dir_to_vec(e.direction);
+            let (w, hh) = entity_dims(&e.name, e.direction);
+            let hands_off = |tiles: &FxHashSet<(i32, i32)>, x: i32, y: i32, w: i32, hh: i32, d: (i32, i32)| {
+                (0..w.max(1)).any(|ox| {
+                    (0..hh.max(1)).any(|oy| tiles.contains(&(x + ox + d.0, y + oy + d.1)))
+                })
+            };
+            if !hands_off(&src_belt, e.x, e.y, w, hh, (dx, dy)) {
+                continue; // already a terminus in the source
+            }
+            let Some((nx, ny, ndir)) = transform(e) else {
+                continue;
+            };
+            let (ndx, ndy) = dir_to_vec(ndir);
+            let (nw, nh) = entity_dims(&e.name, ndir);
+            let leaves_box = (0..nw.max(1)).any(|ox| {
+                (0..nh.max(1)).any(|oy| {
+                    let (fx, fy) = (nx + ox + ndx, ny + oy + ndy);
+                    fx < lo_x || fx > hi_x || fy < lo_y || fy > hi_y
+                })
+            });
+            if !hands_off(&out_belt, nx, ny, nw, nh, (ndx, ndy)) && !leaves_box {
+                severed.push(((e.x, e.y), "downstream"));
+            }
+        }
+
+        // And the mirror: a belt that HAD an upstream feeder must still have
+        // one. A severed run is usually not a dead end — it is perfectly well
+        // connected downstream and simply has nothing arriving, which is why
+        // it reads as "items can't reach input" on a machine rather than as a
+        // belt error on the run itself.
+        // Every footprint tile hands off, not just the anchor. A splitter is
+        // two tiles across the flow and outputs from both; keying off the
+        // anchor alone made a belt fed by a splitter's far tile look unfed —
+        // and the 180° rotation swaps which physical tile the anchor names,
+        // so it only ever showed up after folding.
+        let fed_tiles = |src: &[PlacedEntity]| -> FxHashSet<(i32, i32)> {
+            let mut fed = FxHashSet::default();
+            for e in src.iter().filter(|e| is_belt_entity(&e.name)) {
+                if is_ug_belt(&e.name) && e.io_type.as_deref() == Some("input") {
+                    continue;
+                }
+                let (dx, dy) = dir_to_vec(e.direction);
+                let (w, hh) = entity_dims(&e.name, e.direction);
+                for ox in 0..w.max(1) {
+                    for oy in 0..hh.max(1) {
+                        fed.insert((e.x + ox + dx, e.y + oy + dy));
+                    }
+                }
+            }
+            fed
+        };
+        let src_fed = fed_tiles(&entities);
+        let out_fed = fed_tiles(&folded);
+
+        for e in entities.iter().filter(|e| is_belt_entity(&e.name)) {
+            let (w, hh) = entity_dims(&e.name, e.direction);
+            let had_feed = (0..w.max(1)).any(|dx| {
+                (0..hh.max(1)).any(|dy| src_fed.contains(&(e.x + dx, e.y + dy)))
+            });
+            if !had_feed {
+                continue;
+            }
+            let Some((nx, ny, ndir)) = transform(e) else {
+                continue;
+            };
+            let (nw, nh) = entity_dims(&e.name, ndir);
+            let still_fed = (0..nw.max(1))
+                .any(|dx| (0..nh.max(1)).any(|dy| out_fed.contains(&(nx + dx, ny + dy))));
+            if !still_fed {
+                severed.push(((e.x, e.y), "upstream"));
+            }
+        }
+
+        if debug && !severed.is_empty() {
+            eprintln!("fold {folds:?}: {} severed belt(s)", severed.len());
+            for ((x, y), side) in severed.iter().take(24) {
+                let e = entities
+                    .iter()
+                    .find(|e| e.x == *x && e.y == *y && is_belt_entity(&e.name));
+                eprintln!(
+                    "  ({x},{y}) {side} name={:?} dir={:?} carries={:?}",
+                    e.map(|e| e.name.as_str()),
+                    e.map(|e| e.direction),
+                    e.and_then(|e| e.carries.clone()),
+                );
+            }
+        }
+        if let Some((at, _)) = severed.first() {
+            return Err(FoldRefusal::RunSevered { at: *at });
+        }
     }
 
     // 5b. Lane integrity at every U-turn corner.
@@ -4911,8 +5067,21 @@ pub fn fold_snake(
         (b.x, b.y) = fold_point(b.x, b.y);
     }
     for b in &mut result.boundary_outputs {
-        b.direction = fold_dir(b.x, b.direction);
-        (b.x, b.y) = fold_point(b.x, b.y);
+        let folded_dir = fold_dir(b.x, b.direction);
+        let (fx, fy) = fold_point(b.x, b.y);
+        // `fold_point` already applied the x-shift; the relocation map is in
+        // pre-shift coordinates.
+        match exit_moved.get(&(fx - x_shift, fy)) {
+            Some(((tx, ty), tdir)) => {
+                b.x = tx + x_shift;
+                b.y = *ty;
+                b.direction = *tdir;
+            }
+            None => {
+                b.direction = folded_dir;
+                (b.x, b.y) = (fx, fy);
+            }
+        }
     }
     for (_, x, y) in &mut result.surplus_exits {
         (*x, *y) = fold_point(*x, *y);

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -1143,6 +1143,254 @@ pub fn build_manifold_nets(
     Ok(result)
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecipeClusterPlacement {
+    pub recipes: Vec<String>,
+    pub island_ids: Vec<usize>,
+    pub block: CompactBlock,
+}
+
+/// Repack rigid islands into recipe banks, then place those banks in 2D by
+/// solver-rate-weighted production adjacency. This is the first RFC-057
+/// placement that does not preserve incumbent row/corridor coordinates.
+pub fn place_recipe_clusters(
+    ir: &CompactIr,
+    clearance: i32,
+) -> (Vec<RigidIsland>, Vec<RecipeClusterPlacement>) {
+    let clearance = clearance.max(0);
+    let mut groups: BTreeMap<Vec<String>, Vec<usize>> = BTreeMap::new();
+    for island in &ir.islands {
+        groups
+            .entry(island.recipes.clone())
+            .or_default()
+            .push(island.id);
+    }
+
+    let mut islands = ir.islands.clone();
+    let mut clusters = Vec::new();
+    for (recipes, mut island_ids) in groups {
+        island_ids.sort_by_key(|&id| {
+            let block = &ir.islands[id].block;
+            std::cmp::Reverse((block.height, block.width, id))
+        });
+        let area: i64 = island_ids
+            .iter()
+            .map(|&id| {
+                let block = &ir.islands[id].block;
+                i64::from(block.width + clearance) * i64::from(block.height + clearance)
+            })
+            .sum();
+        let target_width = (area as f64).sqrt().ceil() as i32;
+        let mut x = 0;
+        let mut y = 0;
+        let mut row_height = 0;
+        let mut max_x = 0;
+        for &id in &island_ids {
+            let width = islands[id].block.width;
+            let height = islands[id].block.height;
+            if x > 0 && x + width > target_width {
+                x = 0;
+                y += row_height + clearance;
+                row_height = 0;
+            }
+            islands[id].block.x = x;
+            islands[id].block.y = y;
+            x += width + clearance;
+            row_height = row_height.max(height);
+            max_x = max_x.max(x - clearance);
+        }
+        let max_y = island_ids
+            .iter()
+            .map(|&id| islands[id].block.y + islands[id].block.height)
+            .max()
+            .unwrap_or(0);
+        let id = clusters.len();
+        clusters.push(RecipeClusterPlacement {
+            recipes,
+            island_ids,
+            block: CompactBlock {
+                id,
+                x: 0,
+                y: 0,
+                width: max_x,
+                height: max_y,
+            },
+        });
+    }
+
+    let mut cluster_of = vec![0usize; islands.len()];
+    for (cluster_idx, cluster) in clusters.iter().enumerate() {
+        for &island_id in &cluster.island_ids {
+            cluster_of[island_id] = cluster_idx;
+        }
+    }
+    let mut weights: BTreeMap<(usize, usize), i64> = BTreeMap::new();
+    let flow_rate: BTreeMap<&str, i64> = ir
+        .commodity_flows
+        .iter()
+        .map(|flow| (flow.item.as_str(), flow.rate))
+        .collect();
+    for net in &ir.route_nets {
+        let mut producers = Vec::new();
+        let mut consumers = Vec::new();
+        for island in &ir.islands {
+            for terminal in island
+                .terminals
+                .iter()
+                .filter(|terminal| terminal.item == net.item)
+            {
+                match terminal.kind {
+                    RouteTerminalKind::ProducerDrop => producers.push(cluster_of[island.id]),
+                    RouteTerminalKind::ConsumerPickup => consumers.push(cluster_of[island.id]),
+                    _ => {}
+                }
+            }
+        }
+        producers.sort_unstable();
+        producers.dedup();
+        consumers.sort_unstable();
+        consumers.dedup();
+        let rate = flow_rate.get(net.item.as_str()).copied().unwrap_or(1);
+        for &producer in &producers {
+            for &consumer in &consumers {
+                if producer == consumer {
+                    continue;
+                }
+                let edge = if producer < consumer {
+                    (producer, consumer)
+                } else {
+                    (consumer, producer)
+                };
+                *weights.entry(edge).or_default() += rate;
+            }
+        }
+    }
+
+    let mut degree = vec![0i64; clusters.len()];
+    for (&(a, b), &weight) in &weights {
+        degree[a] += weight;
+        degree[b] += weight;
+    }
+    let mut order: Vec<usize> = (0..clusters.len()).collect();
+    order.sort_by_key(|&idx| std::cmp::Reverse((degree[idx], clusters[idx].block.width, idx)));
+    let mut placed = Vec::<usize>::new();
+    for &cluster_idx in &order {
+        if placed.is_empty() {
+            clusters[cluster_idx].block.x = 0;
+            clusters[cluster_idx].block.y = 0;
+            placed.push(cluster_idx);
+            continue;
+        }
+        let mut candidates = Vec::new();
+        for &other_idx in &placed {
+            let other = &clusters[other_idx].block;
+            let block = &clusters[cluster_idx].block;
+            candidates.extend([
+                (other.x + other.width + clearance, other.y),
+                (other.x - block.width - clearance, other.y),
+                (other.x, other.y + other.height + clearance),
+                (other.x, other.y - block.height - clearance),
+            ]);
+        }
+        candidates.sort();
+        candidates.dedup();
+        let best = candidates
+            .into_iter()
+            .filter(|&(x, y)| {
+                let mut candidate = clusters[cluster_idx].block.clone();
+                candidate.x = x;
+                candidate.y = y;
+                placed
+                    .iter()
+                    .all(|&other| !blocks_overlap(&candidate, &clusters[other].block))
+            })
+            .min_by_key(|&(x, y)| {
+                let center_x = x + clusters[cluster_idx].block.width / 2;
+                let center_y = y + clusters[cluster_idx].block.height / 2;
+                let wire_cost: i128 = placed
+                    .iter()
+                    .map(|&other| {
+                        let key = if cluster_idx < other {
+                            (cluster_idx, other)
+                        } else {
+                            (other, cluster_idx)
+                        };
+                        let weight = weights.get(&key).copied().unwrap_or(0) as i128;
+                        let other_block = &clusters[other].block;
+                        let distance = (center_x - (other_block.x + other_block.width / 2)).abs()
+                            + (center_y - (other_block.y + other_block.height / 2)).abs();
+                        weight * i128::from(distance)
+                    })
+                    .sum();
+                (wire_cost, x.abs() + y.abs(), x, y)
+            })
+            .unwrap_or_else(|| {
+                let right = placed
+                    .iter()
+                    .map(|&idx| clusters[idx].block.x + clusters[idx].block.width)
+                    .max()
+                    .unwrap_or(0);
+                (right + clearance, 0)
+            });
+        clusters[cluster_idx].block.x = best.0;
+        clusters[cluster_idx].block.y = best.1;
+        placed.push(cluster_idx);
+    }
+
+    let min_x = clusters
+        .iter()
+        .map(|cluster| cluster.block.x)
+        .min()
+        .unwrap_or(0);
+    let min_y = clusters
+        .iter()
+        .map(|cluster| cluster.block.y)
+        .min()
+        .unwrap_or(0);
+    for cluster in &mut clusters {
+        cluster.block.x -= min_x;
+        cluster.block.y -= min_y;
+        for &island_id in &cluster.island_ids {
+            islands[island_id].block.x += cluster.block.x;
+            islands[island_id].block.y += cluster.block.y;
+        }
+    }
+    (islands, clusters)
+}
+
+pub fn estimated_manifold_wirelength(manifolds: &[ManifoldNet]) -> i128 {
+    manifolds
+        .iter()
+        .map(|net| {
+            let min_x = net
+                .terminals
+                .iter()
+                .map(|terminal| terminal.x)
+                .min()
+                .unwrap_or(0);
+            let max_x = net
+                .terminals
+                .iter()
+                .map(|terminal| terminal.x)
+                .max()
+                .unwrap_or(0);
+            let min_y = net
+                .terminals
+                .iter()
+                .map(|terminal| terminal.y)
+                .min()
+                .unwrap_or(0);
+            let max_y = net
+                .terminals
+                .iter()
+                .map(|terminal| terminal.y)
+                .max()
+                .unwrap_or(0);
+            i128::from(net.planned_rate.max(1)) * i128::from((max_x - min_x) + (max_y - min_y))
+        })
+        .sum()
+}
+
 fn entity_dims(name: &str, direction: EntityDirection) -> (i32, i32) {
     let (mut width, mut height) =
         oriented_splitter_dims(name, direction).unwrap_or_else(|| entity_size(name));

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -1584,6 +1584,141 @@ fn distributor_stages(outputs: u32) -> Vec<BalancerStage> {
     stages
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ManifoldEndpoint {
+    Terminal(ManifoldTerminal),
+    NodeInput { node: usize, port: u32 },
+    NodeOutput { node: usize, port: u32 },
+    LaneInput(u32),
+    LaneOutput(u32),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BalancerNodeRole {
+    Merge,
+    Distribute,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifoldBalancerNode {
+    pub id: usize,
+    pub lane: u32,
+    pub role: BalancerNodeRole,
+    pub n: u32,
+    pub m: u32,
+    pub level: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ManifoldGraphEdge {
+    pub from: ManifoldEndpoint,
+    pub to: ManifoldEndpoint,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalManifoldGraph {
+    pub item: String,
+    pub belt_count: u32,
+    pub hub: CompactBlock,
+    pub nodes: Vec<ManifoldBalancerNode>,
+    pub edges: Vec<ManifoldGraphEdge>,
+}
+
+/// Expand a local manifold plan into exact balancer ports and routing edges.
+pub fn build_local_manifold_graph(plan: &LocalManifoldPlan) -> LocalManifoldGraph {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    for group in &plan.lane_groups {
+        let mut merge_frontier: Vec<_> = group
+            .producers
+            .iter()
+            .cloned()
+            .map(ManifoldEndpoint::Terminal)
+            .collect();
+        let mut level = 0;
+        while merge_frontier.len() > 1 {
+            let mut next = Vec::new();
+            let mut chunks = merge_frontier.into_iter();
+            loop {
+                let Some(first) = chunks.next() else {
+                    break;
+                };
+                let Some(second) = chunks.next() else {
+                    next.push(first);
+                    break;
+                };
+                let node = nodes.len();
+                nodes.push(ManifoldBalancerNode {
+                    id: node,
+                    lane: group.lane,
+                    role: BalancerNodeRole::Merge,
+                    n: 2,
+                    m: 1,
+                    level,
+                });
+                edges.push(ManifoldGraphEdge {
+                    from: first,
+                    to: ManifoldEndpoint::NodeInput { node, port: 0 },
+                });
+                edges.push(ManifoldGraphEdge {
+                    from: second,
+                    to: ManifoldEndpoint::NodeInput { node, port: 1 },
+                });
+                next.push(ManifoldEndpoint::NodeOutput { node, port: 0 });
+            }
+            merge_frontier = next;
+            level += 1;
+        }
+        if let Some(root) = merge_frontier.pop() {
+            edges.push(ManifoldGraphEdge {
+                from: root,
+                to: ManifoldEndpoint::LaneInput(group.lane),
+            });
+        }
+
+        let consumer_count = group.consumers.len();
+        let mut distribute_frontier = vec![ManifoldEndpoint::LaneOutput(group.lane)];
+        let mut level = 0;
+        while distribute_frontier.len() < consumer_count {
+            let source = distribute_frontier.remove(0);
+            let node = nodes.len();
+            nodes.push(ManifoldBalancerNode {
+                id: node,
+                lane: group.lane,
+                role: BalancerNodeRole::Distribute,
+                n: 1,
+                m: 2,
+                level,
+            });
+            edges.push(ManifoldGraphEdge {
+                from: source,
+                to: ManifoldEndpoint::NodeInput { node, port: 0 },
+            });
+            distribute_frontier.push(ManifoldEndpoint::NodeOutput { node, port: 0 });
+            distribute_frontier.push(ManifoldEndpoint::NodeOutput { node, port: 1 });
+            level += 1;
+        }
+        distribute_frontier.sort();
+        for (source, terminal) in distribute_frontier
+            .into_iter()
+            .zip(group.consumers.iter().cloned())
+        {
+            edges.push(ManifoldGraphEdge {
+                from: source,
+                to: ManifoldEndpoint::Terminal(terminal),
+            });
+        }
+    }
+    edges.sort();
+    LocalManifoldGraph {
+        item: plan.item.clone(),
+        belt_count: plan.belt_count,
+        hub: plan.hub.clone(),
+        nodes,
+        edges,
+    }
+}
+
 fn hub_is_free(
     candidate: &CompactBlock,
     islands: &[RigidIsland],

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -3881,12 +3881,23 @@ mod tests {
 // RFC-057 Phase 2: snake-fold transform
 // ---------------------------------------------------------------------------
 
-/// Mirror an `EntityDirection` across the X axis (East ↔ West, N/S unchanged).
-fn mirror_x_direction(dir: EntityDirection) -> EntityDirection {
+/// Rotate an `EntityDirection` by 180° (East ↔ West, North ↔ South).
+///
+/// Alternate fold segments are rotated, not reflected. A reflection in X
+/// alone is chirality-flipping: it swaps a splitter's left/right input and
+/// output priorities and invalidates the Space Age fluid-box `mirror` flag,
+/// neither of which the transform compensates for. Composing the X mirror
+/// with a Y mirror gives a 180° rotation, which is a rigid motion — every
+/// entity keeps its handedness. It is also the transform the routing
+/// measurement prefers by a wide margin (RFC-057 decision log, 2026-07-29):
+/// reflecting in X alone leaves each segment's trunk `height + gap` from the
+/// next one's, where rotating brings them together.
+fn rotate_180_direction(dir: EntityDirection) -> EntityDirection {
     match dir {
         EntityDirection::East => EntityDirection::West,
         EntityDirection::West => EntityDirection::East,
-        _ => dir,
+        EntityDirection::North => EntityDirection::South,
+        EntityDirection::South => EntityDirection::North,
     }
 }
 
@@ -3970,16 +3981,17 @@ fn replace_straddling_ug_pairs(entities: &[PlacedEntity], folds: &[i32]) -> Vec<
             if let Some(&out_idx) = ug_at.get(&(look_x, entity.y)) {
                 let out = &entities[out_idx];
                 if to_surface.contains(&out_idx) && out.io_type.as_deref() == Some("output") {
-                    // Fill in surface belts between entrance and exit,
-                    // but only on the same side of the fold as the entrance.
+                    // Fill the WHOLE span, both sides of the fold. Filling
+                    // only the entrance side left the exit tile an orphan
+                    // with a gap before it — an unfed belt on one side and a
+                    // dead end on the other. The fold's junction pass is what
+                    // severs the run; it needs a continuous surface belt on
+                    // each side to attach to, which means every tile between
+                    // entrance and exit must exist first.
                     let surface = ug_to_surface_tier(&entity.name);
                     for fill_x in 1..step {
                         let fx = entity.x + dx * fill_x;
-                        // Don't fill past any fold boundary.
-                        let same_side = folds
-                            .iter()
-                            .all(|&f| (entity.x < f && fx < f) || (entity.x >= f && fx >= f));
-                        if same_side && !existing.contains(&(fx, entity.y)) {
+                        if !existing.contains(&(fx, entity.y)) {
                             result.push(PlacedEntity {
                                 name: surface.to_string(),
                                 x: fx,
@@ -3999,33 +4011,57 @@ fn replace_straddling_ug_pairs(entities: &[PlacedEntity], folds: &[i32]) -> Vec<
     result
 }
 
-/// Helper: find surface belts at a given folded X going a specific direction.
-fn belts_at_x_going(
-    entities: &[PlacedEntity],
-    x: i32,
-    dir: EntityDirection,
-) -> Vec<(i32, String, Option<String>)> {
-    entities
-        .iter()
-        .filter(|e| e.x == x && e.direction == dir && is_surface_belt(&e.name))
-        .map(|e| (e.y, e.name.clone(), e.carries.clone()))
-        .collect()
+/// One severed belt run that a fold junction has to reconnect.
+struct UturnRequest {
+    /// Tile the upstream belt deposits into — the connector's first tile.
+    start: (i32, i32),
+    from_dir: EntityDirection,
+    /// Tile that feeds the downstream belt — the connector's last tile.
+    end: (i32, i32),
+    to_dir: EntityDirection,
+    belt: String,
+    carries: Option<String>,
 }
 
-/// Place a vertical U-turn chain at column `jx` connecting a belt at
-/// `(edge_x, y_top)` going `from_dir` to a belt at `(edge_x, y_bot)` going
-/// `to_dir`.
+/// Place a vertical U-turn chain at column `jx` joining two severed belt ends.
+///
+/// `start` is the first tile the connector must occupy — the tile the
+/// upstream belt deposits into — and `end` is the last, the tile that feeds
+/// the downstream belt. The two are independent: under the 180° segment
+/// rotation the downstream end lands at a different column *and* a different
+/// row than the upstream end, so a single shared `edge_x`/row (as an earlier
+/// version assumed) is only correct when consecutive segments happen to be
+/// the same width. When they are not, the connector either stops short in
+/// empty space — a dead-end belt — or runs into the next segment's body and
+/// sideloads into a belt carrying a different item.
+///
+/// `occupied` tracks anchor tiles so the connector can skip tiles that are
+/// already taken without rescanning the entity list; a linear scan per tile
+/// made an exhaustive fold search quadratic and unusably slow.
 fn place_uturn(
     entities: &mut Vec<PlacedEntity>,
+    occupied: &mut FxHashSet<(i32, i32)>,
+    corners: &mut Vec<(i32, i32)>,
     jx: i32,
-    edge_x: i32,
-    y_top: i32,
-    y_bot: i32,
-    from_dir: EntityDirection,
-    to_dir: EntityDirection,
-    belt_name: &str,
-    carries: &Option<String>,
-) {
+    request: &UturnRequest,
+) -> Result<(), (i32, i32)> {
+    let UturnRequest {
+        start,
+        from_dir,
+        end,
+        to_dir,
+        belt: belt_name,
+        carries,
+    } = request;
+    let (from_dir, to_dir) = (*from_dir, *to_dir);
+    let belt_name = belt_name.as_str();
+    let (start_x, y_top) = *start;
+    let (end_x, y_bot) = *end;
+
+    // Build the whole connector first, commit only if every tile it needs is
+    // free. A partially stamped U-turn that discovers a conflict halfway is
+    // worse than no U-turn: it leaves a belt run ending in mid air.
+    let mut planned: Vec<PlacedEntity> = Vec::new();
     // belt_name is a surface belt name (e.g. "express-transport-belt").
     let surface_name = belt_name;
     let ug_name = match belt_name {
@@ -4036,17 +4072,13 @@ fn place_uturn(
     };
     let max_reach = ug_max_reach(surface_name) as i32;
 
-    // Horizontal connector belts from edge_x to jx at y_top.
-    // The belt at (edge_x, y_top) going from_dir deposits at edge_x ± 1.
-    // We need belts from there to jx to carry items to the U-turn.
-    let (step_x, end_x) = if jx > edge_x {
-        (1, jx) // fill from edge_x+1 to jx-1 going East
-    } else {
-        (-1, jx) // fill from edge_x-1 to jx+1 going West
-    };
-    for x in (edge_x + step_x)..end_x {
-        if !entities.iter().any(|e| e.x == x && e.y == y_top) {
-            entities.push(PlacedEntity {
+    // Top leg: from the tile the upstream belt deposits into, out to the
+    // junction column, travelling in the upstream belt's direction.
+    let top_step = if jx >= start_x { 1 } else { -1 };
+    let mut x = start_x;
+    while x != jx {
+        {
+            planned.push(PlacedEntity {
                 name: surface_name.to_string(),
                 x,
                 y: y_top,
@@ -4055,86 +4087,98 @@ fn place_uturn(
                 ..Default::default()
             });
         }
+        x += top_step;
     }
 
-    // Belt at (jx, y_top) going South — receives from the horizontal belt.
-    entities.push(PlacedEntity {
+    // The vertical run may go either way: a belt crossing the fold westward
+    // travels from the LOWER segment back up to the upper one.
+    let (vdir, vstep) = if y_bot >= y_top {
+        (EntityDirection::South, 1)
+    } else {
+        (EntityDirection::North, -1)
+    };
+
+    // Corner at the top of the run — receives from the horizontal leg.
+    planned.push(PlacedEntity {
         name: surface_name.to_string(),
         x: jx,
         y: y_top,
-        direction: EntityDirection::South,
+        direction: vdir,
         carries: carries.clone(),
         ..Default::default()
     });
 
-    // Vertical chain from y_top+1 to y_bot-1.
-    let mut cy = y_top + 1;
-    while cy < y_bot {
-        let remaining = y_bot - cy;
-        if remaining >= 2 && remaining - 1 <= max_reach {
-            entities.push(PlacedEntity {
+    // Vertical chain between the two corners, undergrounding where it can.
+    let mut cy = y_top + vstep;
+    while cy != y_bot {
+        let remaining = (y_bot - cy).abs();
+        // `remaining == 2` would put the entrance and exit on adjacent tiles:
+        // nothing travels underground, and the validator reads it as two
+        // unpaired halves plus a one-tile belt loop. Needs a tile between.
+        if remaining >= 3 && remaining - 1 <= max_reach {
+            planned.push(PlacedEntity {
                 name: ug_name.to_string(),
                 x: jx,
                 y: cy,
-                direction: EntityDirection::South,
+                direction: vdir,
                 io_type: Some("input".into()),
                 carries: carries.clone(),
                 ..Default::default()
             });
-            entities.push(PlacedEntity {
+            planned.push(PlacedEntity {
                 name: ug_name.to_string(),
                 x: jx,
-                y: cy + remaining - 1,
-                direction: EntityDirection::South,
+                y: cy + vstep * (remaining - 1),
+                direction: vdir,
                 io_type: Some("output".into()),
                 carries: carries.clone(),
                 ..Default::default()
             });
-            cy += remaining;
+            cy += vstep * remaining;
         } else if remaining > max_reach + 1 {
-            entities.push(PlacedEntity {
+            planned.push(PlacedEntity {
                 name: ug_name.to_string(),
                 x: jx,
                 y: cy,
-                direction: EntityDirection::South,
+                direction: vdir,
                 io_type: Some("input".into()),
                 carries: carries.clone(),
                 ..Default::default()
             });
-            entities.push(PlacedEntity {
+            planned.push(PlacedEntity {
                 name: ug_name.to_string(),
                 x: jx,
-                y: cy + max_reach,
-                direction: EntityDirection::South,
+                y: cy + vstep * max_reach,
+                direction: vdir,
                 io_type: Some("output".into()),
                 carries: carries.clone(),
                 ..Default::default()
             });
-            cy += max_reach + 1;
-            entities.push(PlacedEntity {
+            cy += vstep * (max_reach + 1);
+            planned.push(PlacedEntity {
                 name: surface_name.to_string(),
                 x: jx,
                 y: cy,
-                direction: EntityDirection::South,
+                direction: vdir,
                 carries: carries.clone(),
                 ..Default::default()
             });
-            cy += 1;
+            cy += vstep;
         } else {
-            entities.push(PlacedEntity {
+            planned.push(PlacedEntity {
                 name: surface_name.to_string(),
                 x: jx,
                 y: cy,
-                direction: EntityDirection::South,
+                direction: vdir,
                 carries: carries.clone(),
                 ..Default::default()
             });
-            cy += 1;
+            cy += vstep;
         }
     }
 
     // Belt at (jx, y_bot) going to_dir — receives from South chain.
-    entities.push(PlacedEntity {
+    planned.push(PlacedEntity {
         name: surface_name.to_string(),
         x: jx,
         y: y_bot,
@@ -4143,28 +4187,23 @@ fn place_uturn(
         ..Default::default()
     });
 
-    // Horizontal connector belts from jx to edge_x at y_bot.
-    // The U-turn belt at (jx, y_bot) going to_dir deposits at jx ± 1.
-    // We need belts from there to edge_x to carry items back to the segment.
-    if edge_x > jx {
-        // edge_x is to the right: fill from jx+1 to edge_x-1 going to_dir.
-        for x in (jx + 1)..edge_x {
-            if !entities.iter().any(|e| e.x == x && e.y == y_bot) {
-                entities.push(PlacedEntity {
-                    name: surface_name.to_string(),
-                    x,
-                    y: y_bot,
-                    direction: to_dir,
-                    carries: carries.clone(),
-                    ..Default::default()
-                });
-            }
-        }
-    } else {
-        // edge_x is to the left: fill from jx-1 down to edge_x+1 going to_dir.
-        for x in (edge_x + 1)..jx {
-            if !entities.iter().any(|e| e.x == x && e.y == y_bot) {
-                entities.push(PlacedEntity {
+    // Bottom leg: from the junction column back to the tile that feeds the
+    // downstream belt, inclusive, travelling in the downstream direction.
+    //
+    // Expressed as a bounded range on purpose. A step-and-test loop here had
+    // no terminating case when `end_x == jx` — the corner already feeds the
+    // downstream belt, so there is no leg — and ran away allocating until the
+    // OOM killer took the process (and, being a global OOM, whatever else was
+    // running alongside it).
+    if end_x != jx {
+        let (lo, hi) = if end_x > jx {
+            (jx + 1, end_x)
+        } else {
+            (end_x, jx - 1)
+        };
+        for x in lo..=hi {
+            {
+                planned.push(PlacedEntity {
                     name: surface_name.to_string(),
                     x,
                     y: y_bot,
@@ -4175,6 +4214,246 @@ fn place_uturn(
             }
         }
     }
+
+    // Commit only if the connector is entirely clear. Reserving every tile —
+    // corners and vertical run included, not just the horizontal legs —
+    // is what makes a later chain's leg unable to stamp over this run.
+    if let Some(clash) = planned
+        .iter()
+        .find(|e| occupied.contains(&(e.x, e.y)))
+        .map(|e| (e.x, e.y))
+    {
+        return Err(clash);
+    }
+    for e in &planned {
+        occupied.insert((e.x, e.y));
+    }
+    corners.push((jx, y_top));
+    corners.push((jx, y_bot));
+    entities.extend(planned);
+    Ok(())
+}
+
+/// A fold that validated no worse than the layout it came from.
+pub struct FoldOutcome {
+    pub folds: Vec<i32>,
+    pub layout: LayoutResult,
+    /// Refusal reasons encountered while searching, for diagnosis.
+    pub refusals: Vec<(Vec<i32>, FoldRefusal)>,
+}
+
+/// Search for the squarest snake fold that does not break the factory.
+///
+/// Geometric legality is necessary but nowhere near sufficient: a fold column
+/// can be perfectly cuttable and still sever a belt run whose reconnection
+/// the junction pass does not see, and the symptom then shows up as a starved
+/// machine somewhere else entirely. Rather than try to make every column
+/// work, this admits a candidate only when it validates no worse than the
+/// source — same issue categories, same counts. Anything that introduces a
+/// new warning is rejected, whatever its geometry.
+///
+/// The comparison is against the source's own issue profile, not against
+/// zero, because the source is itself allowed to carry known warnings.
+pub fn search_snake_fold(
+    layout: &LayoutResult,
+    solver: &SolverResult,
+    max_folds: usize,
+) -> Option<FoldOutcome> {
+    use crate::validate::{self, LayoutStyle};
+
+    let profile = |l: &LayoutResult| -> Option<BTreeMap<String, usize>> {
+        let issues = validate::validate(l, Some(solver), LayoutStyle::Bus).ok()?;
+        let mut by_cat: BTreeMap<String, usize> = BTreeMap::new();
+        for i in &issues {
+            *by_cat.entry(i.category.clone()).or_default() += 1;
+        }
+        Some(by_cat)
+    };
+    let baseline = profile(layout)?;
+
+    let legal = legal_fold_columns(layout);
+    if legal.is_empty() {
+        return None;
+    }
+    let snap = |target: i32| -> Option<i32> {
+        legal.iter().copied().min_by_key(|&f| (f - target).abs())
+    };
+
+    let mut best: Option<(i64, Vec<i32>, LayoutResult)> = None;
+    let mut refusals = Vec::new();
+
+    for k in 1..=max_folds {
+        // Slide the whole comb of fold lines, snapping each tooth to the
+        // nearest legal column. Cheap, and it explores the seams that matter
+        // without a combinatorial blow-up over independent columns.
+        for delta in -24..=24 {
+            let mut folds: Vec<i32> = Vec::with_capacity(k);
+            for i in 1..=k {
+                let target = layout.width * i as i32 / (k + 1) as i32 + delta;
+                let Some(f) = snap(target) else { continue };
+                folds.push(f);
+            }
+            folds.dedup();
+            if folds.len() != k {
+                continue;
+            }
+            let mut bounds = vec![0];
+            bounds.extend_from_slice(&folds);
+            bounds.push(layout.width);
+            if bounds.windows(2).any(|b| b[1] - b[0] < 24) {
+                continue;
+            }
+
+            let folded = match fold_snake(layout, &folds) {
+                Ok(f) => f,
+                Err(reason) => {
+                    refusals.push((folds.clone(), reason));
+                    continue;
+                }
+            };
+            let Some(got) = profile(&folded) else {
+                continue;
+            };
+            // No new category, and no category worse than the source.
+            if got
+                .iter()
+                .any(|(cat, n)| baseline.get(cat).copied().unwrap_or(0) < *n)
+            {
+                continue;
+            }
+
+            // Prefer square, then small. Aspect in tenths keeps the ordering
+            // integral and therefore deterministic.
+            let (w, h) = (folded.width.max(1) as i64, folded.height.max(1) as i64);
+            let aspect10 = (w.max(h) * 10) / w.min(h);
+            let score = aspect10 * 1_000_000 + w * h;
+            if best.as_ref().is_none_or(|(bs, _, _)| score < *bs) {
+                best = Some((score, folds, folded));
+            }
+        }
+    }
+
+    best.map(|(_, folds, layout)| FoldOutcome {
+        folds,
+        layout,
+        refusals,
+    })
+}
+
+/// Columns a fold may legally cut, i.e. those that pass between entities
+/// rather than through one.
+///
+/// Multi-fold candidates picked at arithmetic fractions of the width are
+/// almost always rejected: on a dense layout most columns land inside some
+/// machine's footprint. Choosing fold lines from the entity-free seams
+/// instead turns "k evenly spaced folds" from a near-certain refusal into a
+/// short search.
+/// A fold may only cut things the junction pass can put back — that is,
+/// surface belt runs. Everything else it severs stays severed, and the
+/// symptom is not a geometry error but a starved machine several tiles away
+/// ("items can't reach input", "delivers 0.0/s").
+///
+/// So a column is blocked when it would split:
+/// - a multi-tile entity's footprint;
+/// - an inserter's pickup→drop span, which carries items across the column
+///   with no belt to reconnect;
+/// - a splitter's input or output adjacency — a splitter is not a surface
+///   belt, so a run entering or leaving one is invisible to the crossing
+///   detector;
+/// - a pipe-to-pipe adjacency, since fluid networks are connected by contact
+///   and a cut silently isolates a segment.
+pub fn legal_fold_columns(layout: &LayoutResult) -> Vec<i32> {
+    let mut blocked = vec![false; (layout.width.max(0) + 2) as usize];
+    let mut block_span = |lo: i32, hi: i32| {
+        // A column f splits [lo, hi] when lo < f <= hi.
+        for f in (lo + 1)..=hi {
+            if f > 0 && f < layout.width {
+                blocked[f as usize] = true;
+            }
+        }
+    };
+
+    let is_pipe = |name: &str| name.starts_with("pipe");
+    let pipe_at: FxHashSet<(i32, i32)> = layout
+        .entities
+        .iter()
+        .filter(|e| is_pipe(&e.name))
+        .map(|e| (e.x, e.y))
+        .collect();
+
+    for entity in &layout.entities {
+        let (w, _) = entity_dims(&entity.name, entity.direction);
+        block_span(entity.x, entity.x + w - 1);
+
+        if is_inserter(&entity.name) {
+            let (dx, _) = dir_to_vec(entity.direction);
+            if dx != 0 {
+                let reach = inserter_reach(&entity.name);
+                let a = entity.x - dx * reach;
+                let b = entity.x + dx * reach;
+                block_span(a.min(b), a.max(b));
+            }
+        }
+
+        if crate::common::is_splitter(&entity.name) {
+            // Whichever way it faces, its feed and its output sit on the
+            // columns either side of its own footprint.
+            block_span(entity.x - 1, entity.x + w);
+        }
+
+        if is_pipe(&entity.name) && pipe_at.contains(&(entity.x + 1, entity.y)) {
+            block_span(entity.x, entity.x + 1);
+        }
+    }
+
+    (1..layout.width)
+        .filter(|&f| !blocked[f as usize])
+        .collect()
+}
+
+/// Pick `k` legal fold columns as near as possible to evenly spaced targets,
+/// keeping them strictly increasing and at least `min_seg` apart.
+pub fn even_legal_folds(layout: &LayoutResult, k: usize, min_seg: i32) -> Option<Vec<i32>> {
+    let legal = legal_fold_columns(layout);
+    if legal.is_empty() {
+        return None;
+    }
+    let mut chosen: Vec<i32> = Vec::with_capacity(k);
+    for i in 1..=k {
+        let target = layout.width * i as i32 / (k + 1) as i32;
+        let lower = chosen.last().map(|f| f + min_seg).unwrap_or(min_seg);
+        let pick = legal
+            .iter()
+            .copied()
+            .filter(|&f| f >= lower && layout.width - f >= min_seg)
+            .min_by_key(|&f| (f - target).abs())?;
+        chosen.push(pick);
+    }
+    Some(chosen)
+}
+
+/// Why a fold could not be produced. Every refusal is a distinct physical
+/// cause, and lumping them into a bare `None` made the common ones invisible:
+/// a fold rejected for cutting a machine and one rejected for an unroutable
+/// junction need completely different responses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FoldRefusal {
+    /// Fold columns were empty, out of order, or outside the layout.
+    BadFoldColumns,
+    /// A fold column passes through a multi-tile entity's interior.
+    CutsEntity,
+    /// A severed belt run's reconnection collided with geometry already
+    /// placed, so no U-turn could be routed for it. Carries the first
+    /// conflicting tile — without it the cause is indistinguishable from any
+    /// other refusal and the fix is guesswork.
+    JunctionBlocked { at: (i32, i32) },
+    /// Two exits carrying different items would have to share one gap lane.
+    ExitLaneConflict,
+    /// A U-turn corner gained a second feeder, demoting a both-lane turn to a
+    /// single-lane sideload (`docs/factorio-mechanics.md` B8 vs B11).
+    CornerNotATurn,
+    /// Reconnection produced implausibly many entities — a runaway backstop.
+    EntityExplosion,
 }
 
 /// Snake-fold a layout at the given fold columns.
@@ -4186,25 +4465,28 @@ fn place_uturn(
 ///
 /// Returns `None` if any fold column cuts through a multi-tile entity
 /// interior or the folds are out of order.
-pub fn fold_snake(layout: &LayoutResult, folds: &[i32]) -> Option<LayoutResult> {
+pub fn fold_snake(
+    layout: &LayoutResult,
+    folds: &[i32],
+) -> Result<LayoutResult, FoldRefusal> {
     if folds.is_empty() {
-        return Some(layout.clone());
+        return Ok(layout.clone());
     }
     for w in folds.windows(2) {
         if w[0] >= w[1] {
-            return None;
+            return Err(FoldRefusal::BadFoldColumns);
         }
     }
     for &f in folds {
         if f <= 0 || f >= layout.width {
-            return None;
+            return Err(FoldRefusal::BadFoldColumns);
         }
     }
     for &f in folds {
         for entity in &layout.entities {
             let (w, _) = entity_dims(&entity.name, entity.direction);
             if entity.x < f && entity.x + w > f {
-                return None;
+                return Err(FoldRefusal::CutsEntity);
             }
         }
     }
@@ -4228,20 +4510,33 @@ pub fn fold_snake(layout: &LayoutResult, folds: &[i32]) -> Option<LayoutResult> 
         .max()
         .unwrap_or(0);
 
-    // 3. Transform every entity.
+    // 3. Transform every entity. Odd segments are rotated 180°, not mirrored
+    // in X — see `rotate_180_direction`. Because a 180° rotation does not
+    // change an entity's bounding box, the same `(w, h)` serves both axes.
+    let seg_of = |x: i32| (0..n_segs).find(|&k| x >= bounds[k] && x < bounds[k + 1]);
+    let transform = |e: &PlacedEntity| -> Option<(i32, i32, EntityDirection)> {
+        let seg = seg_of(e.x)?;
+        let (w, hh) = entity_dims(&e.name, e.direction);
+        if seg % 2 == 0 {
+            Some((
+                e.x - bounds[seg],
+                e.y + (seg as i32) * (h + gap),
+                e.direction,
+            ))
+        } else {
+            Some((
+                bounds[seg + 1] - w - e.x,
+                (h - hh - e.y) + (seg as i32) * (h + gap),
+                rotate_180_direction(e.direction),
+            ))
+        }
+    };
+
     let mut folded: Vec<PlacedEntity> = Vec::with_capacity(entities.len());
     for entity in &entities {
-        let seg = (0..n_segs).find(|&k| entity.x >= bounds[k] && entity.x < bounds[k + 1]);
-        let Some(seg) = seg else { continue };
-        let (new_x, new_dir) = if seg % 2 == 0 {
-            (entity.x - bounds[seg], entity.direction)
-        } else {
-            let (w, _) = entity_dims(&entity.name, entity.direction);
-            let nx = bounds[seg + 1] - w - entity.x;
-            (nx, mirror_x_direction(entity.direction))
+        let Some((new_x, new_y, new_dir)) = transform(entity) else {
+            continue;
         };
-        let new_y = entity.y + (seg as i32) * (h + gap);
-
         let mut e = entity.clone();
         e.x = new_x;
         e.y = new_y;
@@ -4249,91 +4544,313 @@ pub fn fold_snake(layout: &LayoutResult, folds: &[i32]) -> Option<LayoutResult> 
         folded.push(e);
     }
 
-    // 4. Place U-turns at each fold junction.
-    //
-    // Junctions are placed OUTSIDE the segment range: East→West folds use
-    // x = max_seg_w + 2*i (right side), West→East folds use x = -1 - 2*i
-    // (left side), where i is the chain index (staggered to avoid overlap).
-    for k in 0..n_segs - 1 {
-        let seg_w_k = bounds[k + 1] - bounds[k];
-        let y_top_base = (k as i32) * (h + gap);
-        let y_bot_base = ((k + 1) as i32) * (h + gap);
-
-        if k % 2 == 0 {
-            let edge_x = seg_w_k - 1;
-            let cut_belts = belts_at_x_going(&folded, edge_x, EntityDirection::East);
-            for (i, (y, name, carries)) in cut_belts.iter().enumerate() {
-                if *y < y_top_base || *y >= y_top_base + h {
-                    continue;
-                }
-                let jx = max_seg_w + (i as i32) * 2;
-                let y_bot = y - y_top_base + y_bot_base;
-                place_uturn(
-                    &mut folded,
-                    jx,
-                    edge_x,
-                    *y,
-                    y_bot,
-                    EntityDirection::East,
-                    EntityDirection::West,
-                    name,
-                    carries,
-                );
+    // Anchor-tile occupancy, kept in step with `folded` so the reconnection
+    // and exit passes can test a tile in O(1).
+    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+    for e in &folded {
+        let (w, hh) = entity_dims(&e.name, e.direction);
+        for dx in 0..w.max(1) {
+            for dy in 0..hh.max(1) {
+                occupied.insert((e.x + dx, e.y + dy));
             }
-        } else {
-            let edge_x = 0;
-            let cut_belts = belts_at_x_going(&folded, edge_x, EntityDirection::West);
-            for (i, (y, name, carries)) in cut_belts.iter().enumerate() {
-                if *y < y_top_base || *y >= y_top_base + h {
-                    continue;
+        }
+    }
+    // Every U-turn corner tile, checked for lane integrity once all junction
+    // and exit geometry is down.
+    let mut corners: Vec<(i32, i32)> = Vec::new();
+
+    // 4. Reconnect every belt run the folds severed.
+    //
+    // Crossings are identified in the ORIGINAL coordinate frame — a surface
+    // belt at `f-1` flowing East into `f`, or at `f` flowing West into `f-1`
+    // — and only then mapped through the transform. Scanning the *folded*
+    // frame for belts at a segment edge (as an earlier version did) cannot
+    // tell which severed end pairs with which, and silently assumed the two
+    // ends kept the same row and column.
+    //
+    // Junction columns sit outside the segment range, staggered so chains do
+    // not collide: right of the widest segment for even folds, left of zero
+    // for odd ones.
+    // Every belt entity, not just surface ones. A run crossing a fold may
+    // have an underground half on either side — an exit feeding the fold
+    // column, or an entrance receiving from it — and those are exactly as
+    // severed as a surface belt. Matching only surface belts left them
+    // unreconnected, which shows up not as a geometry error but as a starved
+    // machine downstream ("items can't reach input").
+    //
+    // Straddling pairs are already surface belts by this point, so a
+    // remaining underground half never spans the column itself.
+    let belt_at: BTreeMap<(i32, i32), &PlacedEntity> = entities
+        .iter()
+        .filter(|e| is_belt_entity(&e.name))
+        .map(|e| ((e.x, e.y), e))
+        .collect();
+    // An underground entrance swallows items; it cannot be a run's upstream
+    // side. It is a perfectly good downstream side, since a straight feed
+    // into an entrance carries both lanes.
+    let feeds_forward =
+        |e: &PlacedEntity| !(is_ug_belt(&e.name) && e.io_type.as_deref() == Some("input"));
+
+    for k in 0..n_segs - 1 {
+        let f = bounds[k + 1];
+        let mut crossings: Vec<UturnRequest> = Vec::new();
+        for y in 0..h {
+            // East crossing: (f-1) feeds (f). West crossing: (f) feeds (f-1).
+            let (up, down) = match (belt_at.get(&(f - 1, y)), belt_at.get(&(f, y))) {
+                (Some(left), Some(right))
+                    if left.direction == EntityDirection::East && feeds_forward(left) =>
+                {
+                    (*left, *right)
                 }
-                let jx = -1 - (i as i32) * 2;
-                let y_bot = y - y_top_base + y_bot_base;
-                place_uturn(
-                    &mut folded,
-                    jx,
-                    edge_x,
-                    *y,
-                    y_bot,
-                    EntityDirection::West,
-                    EntityDirection::East,
-                    name,
-                    carries,
-                );
+                (Some(left), Some(right))
+                    if right.direction == EntityDirection::West && feeds_forward(right) =>
+                {
+                    (*right, *left)
+                }
+                _ => continue,
+            };
+
+            let (Some((ux, uy, udir)), Some((dx_, dy_, ddir))) = (transform(up), transform(down))
+            else {
+                continue;
+            };
+            let (uvx, uvy) = dir_to_vec(udir);
+            let (dvx, dvy) = dir_to_vec(ddir);
+            // First tile of the connector is what the upstream belt feeds;
+            // last tile is what feeds the downstream belt.
+            let belt = if is_ug_belt(&up.name) {
+                ug_to_surface_tier(&up.name).to_string()
+            } else {
+                up.name.clone()
+            };
+            crossings.push(UturnRequest {
+                start: (ux + uvx, uy + uvy),
+                from_dir: udir,
+                end: (dx_ - dvx, dy_ - dvy),
+                to_dir: ddir,
+                belt,
+                carries: up.carries.clone(),
+            });
+        }
+
+        // Junction-column assignment order is what keeps chains from crossing
+        // each other, and it is not free choice.
+        //
+        // Chain `j`'s horizontal legs sweep every column between the segment
+        // edge and `jx_j`, so a leg runs over chain `i`'s vertical column
+        // exactly when `jx_j` is further out than `jx_i` and one of `j`'s two
+        // rows falls inside the row span `i`'s vertical run occupies. Ordering
+        // the chains so their spans NEST — narrowest nearest the segment,
+        // each subsequent span enclosing all the ones before it — makes that
+        // unsatisfiable, because an enclosing span's endpoints are by
+        // definition outside every span it contains.
+        //
+        // Sorting by landing row would do the same job if every connector ran
+        // downward, but west-flowing crossings run *upward* (their upstream
+        // end is in the lower segment), so row order mixes two orientations
+        // and the nesting silently breaks. Span width is orientation-free.
+        //
+        // Getting this wrong is not a validation error at the junction; it is
+        // a belt stamped on top of an underground run several tiles away.
+        crossings.sort_by_key(|c| {
+            let (lo, hi) = if c.start.1 <= c.end.1 {
+                (c.start.1, c.end.1)
+            } else {
+                (c.end.1, c.start.1)
+            };
+            (hi - lo, lo)
+        });
+
+        // Slot 0 sits one column clear of the segment: a connector's own
+        // start/end tiles land on the column immediately outside the segment
+        // edge, so a junction column there would collide with them.
+        let mut slot = 0i32;
+        for request in &crossings {
+            let mut clash = (0, 0);
+            let mut placed = false;
+            // Nesting should make the first slot fit. The retry covers spans
+            // that genuinely cannot nest (mixed-orientation crossings at the
+            // same junction) rather than refusing the whole fold for one.
+            for attempt in 0..32 {
+                let s = slot + attempt;
+                let jx = if k % 2 == 0 {
+                    max_seg_w + 1 + s * 2
+                } else {
+                    -2 - s * 2
+                };
+                match place_uturn(&mut folded, &mut occupied, &mut corners, jx, request) {
+                    Ok(()) => {
+                        slot = s + 1;
+                        placed = true;
+                        break;
+                    }
+                    Err(at) => clash = at,
+                }
+            }
+            if !placed {
+                return Err(FoldRefusal::JunctionBlocked { at: clash });
             }
         }
     }
 
-    // 5. Bridge gap for dead-end South belts at segment boundaries.
+    // Extent after all junction geometry is down — the exits below have to
+    // reach these edges to actually leave the finished bounding box.
+    let edge_min_x = folded.iter().map(|e| e.x).min().unwrap_or(0);
+    let edge_max_x = folded.iter().map(|e| e.x).max().unwrap_or(0);
+
+    // 5. Give the layout's original exits somewhere to go.
     //
-    // Belts at the bottom edge of a segment (y = seg_end - 1) going South
-    // deposited outside the layout in the original. After folding, they
-    // deposit into the gap. Place a belt going East at the gap row to
-    // redirect items along the gap (avoids item-mismatch with whatever
-    // is at the same x in the next segment).
+    // A belt on the source layout's bottom edge facing South deposited
+    // outside the bounding box — an exit. After folding it deposits into an
+    // inter-segment gap instead, and a gap row is interior, so the exit
+    // becomes a dead end. Rotation means each gap collects exits from both
+    // sides: the segment above contributes South-facing belts on its last
+    // row, and the rotated segment below contributes North-facing belts on
+    // its first row.
+    //
+    // Each exit is carried along its own gap row to the nearer vertical edge,
+    // where it once again deposits outside the box. The two sources get
+    // separate rows so they cannot collide. Two exits carrying *different*
+    // items that would share a row refuse the fold rather than silently
+    // merging into one belt — the failure this replaces.
     for k in 0..n_segs - 1 {
-        let seg_end_y = (k as i32) * (h + gap) + h; // first gap row
-                                                    // Find surface belts at y = seg_end_y - 1 going South.
-        let edge_belts: Vec<(i32, String, Option<String>)> = folded
+        let gap_top = (k as i32) * (h + gap) + h;
+        let gap_bot = gap_top + 1;
+
+        for (row, src_y, want_dir) in [
+            (gap_top, gap_top - 1, EntityDirection::South),
+            (gap_bot, gap_bot + 1, EntityDirection::North),
+        ] {
+            let exits: Vec<(i32, String, Option<String>)> = folded
+                .iter()
+                .filter(|e| {
+                    e.y == src_y && e.direction == want_dir && is_surface_belt(&e.name)
+                })
+                .map(|e| (e.x, e.name.clone(), e.carries.clone()))
+                .collect();
+
+            // item claimed per tile on this row, so a conflict is detectable.
+            let mut claimed: BTreeMap<i32, Option<String>> = BTreeMap::new();
+            let mut pending: Vec<PlacedEntity> = Vec::new();
+            for (x, name, carries) in &exits {
+                // Only true segment content can be an exit. A U-turn's
+                // vertical run passes through these same rows at a junction
+                // column outside the segment range; treating one as an exit
+                // used to start the run beyond its own stop value, which then
+                // never terminated.
+                if *x < 0 || *x >= max_seg_w {
+                    continue;
+                }
+                // Which side an exit leaves by is forced, not a preference.
+                // Only fold `k`'s own U-turns span gap `k` — junctions k-1 and
+                // k+1 cross the gaps either side of it — and fold `k` puts its
+                // junction columns on the right when `k` is even. So the
+                // opposite side is the one guaranteed clear of vertical runs
+                // in this row.
+                let to_left = k % 2 == 0;
+                let dir = if to_left {
+                    EntityDirection::West
+                } else {
+                    EntityDirection::East
+                };
+                // Run to the layout's eventual edge, not the segment's. The
+                // junction columns extend the bounding box past the segment
+                // range, so a run that stopped at the segment edge ended
+                // *inside* the finished factory and dead-ended there.
+                let (lo, hi) = if to_left {
+                    (edge_min_x, *x)
+                } else {
+                    (*x, edge_max_x)
+                };
+                for cx in lo..=hi {
+                    match claimed.get(&cx) {
+                        Some(existing) if existing != carries => {
+                            return Err(FoldRefusal::ExitLaneConflict)
+                        }
+                        _ => {}
+                    }
+                    claimed.insert(cx, carries.clone());
+                    if occupied.contains(&(cx, row)) {
+                        // Skipping the tile would leave the run with a hole
+                        // and the upstream half dead-ending into it.
+                        return Err(FoldRefusal::ExitLaneConflict);
+                    }
+                    {
+                        occupied.insert((cx, row));
+                        pending.push(PlacedEntity {
+                            name: name.clone(),
+                            x: cx,
+                            y: row,
+                            direction: dir,
+                            carries: carries.clone(),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            folded.extend(pending);
+        }
+    }
+
+    // 5a. Runaway backstop.
+    //
+    // A fold rearranges a fixed entity set and adds reconnection geometry; it
+    // has no business more than doubling the entity count. Two unbounded
+    // reconnection loops once allocated until the OOM killer fired, and
+    // because that OOM was global it took down unrelated processes with it.
+    // The loops are ranges now, but a cheap absolute ceiling means the next
+    // bug in here refuses a fold instead of taking out the machine.
+    if folded.len() > entities.len() * 2 + 1024 {
+        return Err(FoldRefusal::EntityExplosion);
+    }
+
+    // 5b. Lane integrity at every U-turn corner.
+    //
+    // A corner whose only input is perpendicular is a 90° TURN and carries
+    // both lanes (`docs/factorio-mechanics.md` B11). A corner that also has a
+    // straight input — or a second perpendicular one — is a SIDELOAD (B8) and
+    // fills one lane only, halving the run's throughput and merging whatever
+    // the second feeder carries.
+    //
+    // Nothing in the geometry guarantees the difference: one U-turn's
+    // horizontal leg can cross another's vertical run. Where that run is
+    // underground the leg passes over it harmlessly, but at a surface tile or
+    // a UG endpoint the leg becomes a second input and silently downgrades
+    // the turn. Refuse the fold rather than emit a layout whose belt
+    // behaviour differs from the source it claims to preserve.
+    {
+        let belt_at: BTreeMap<(i32, i32), &PlacedEntity> = folded
             .iter()
-            .filter(|e| {
-                e.y == seg_end_y - 1
-                    && e.direction == EntityDirection::South
-                    && is_surface_belt(&e.name)
-            })
-            .map(|e| (e.x, e.name.clone(), e.carries.clone()))
+            .filter(|e| is_belt_entity(&e.name))
+            .map(|e| ((e.x, e.y), e))
             .collect();
-        for (x, name, carries) in &edge_belts {
-            // Place a belt going East at (x, seg_end_y) to redirect.
-            if !folded.iter().any(|e| e.x == *x && e.y == seg_end_y) {
-                folded.push(PlacedEntity {
-                    name: name.clone(),
-                    x: *x,
-                    y: seg_end_y,
-                    direction: EntityDirection::East,
-                    carries: carries.clone(),
-                    ..Default::default()
-                });
+        for &(cx, cy) in &corners {
+            let corner = belt_at
+                .get(&(cx, cy))
+                .ok_or(FoldRefusal::CornerNotATurn)?;
+            let mut straight = 0usize;
+            let mut perpendicular = 0usize;
+            for (nx, ny) in [(cx - 1, cy), (cx + 1, cy), (cx, cy - 1), (cx, cy + 1)] {
+                let Some(n) = belt_at.get(&(nx, ny)) else {
+                    continue;
+                };
+                // A UG entrance swallows items; it never feeds a neighbour.
+                if is_ug_belt(&n.name) && n.io_type.as_deref() == Some("input") {
+                    continue;
+                }
+                let (dx, dy) = dir_to_vec(n.direction);
+                if (nx + dx, ny + dy) != (cx, cy) {
+                    continue;
+                }
+                if n.direction == corner.direction {
+                    straight += 1;
+                } else {
+                    perpendicular += 1;
+                }
+            }
+            // Exactly one perpendicular feeder and nothing else is a turn.
+            if straight > 0 || perpendicular != 1 {
+                return Err(FoldRefusal::CornerNotATurn);
             }
         }
     }
@@ -4364,14 +4881,41 @@ pub fn fold_snake(layout: &LayoutResult, folds: &[i32]) -> Option<LayoutResult> 
         &result.entities,
         result.wire_mode,
     ));
+    // Boundary records and surplus exits are coordinates into the layout and
+    // must go through the fold like everything else. Shifting only their X
+    // (as an earlier version did) left every one of them pointing at an
+    // unrelated tile the moment any segment rotated, which the boundary and
+    // input-rate-delivery checks then reported against the wrong geometry.
+    let fold_point = |x: i32, y: i32| -> (i32, i32) {
+        // Boundary tiles may sit one past the right edge; clamp into the last
+        // segment so an output terminal folds with the machinery feeding it.
+        let seg = seg_of(x).unwrap_or(n_segs - 1);
+        let (nx, ny) = if seg % 2 == 0 {
+            (x - bounds[seg], y + (seg as i32) * (h + gap))
+        } else {
+            (
+                bounds[seg + 1] - 1 - x,
+                (h - 1 - y) + (seg as i32) * (h + gap),
+            )
+        };
+        (nx + x_shift, ny)
+    };
+    let fold_dir = |x: i32, d: EntityDirection| -> EntityDirection {
+        match seg_of(x) {
+            Some(seg) if seg % 2 == 1 => rotate_180_direction(d),
+            _ => d,
+        }
+    };
     for b in &mut result.boundary_inputs {
-        b.x += x_shift;
+        b.direction = fold_dir(b.x, b.direction);
+        (b.x, b.y) = fold_point(b.x, b.y);
     }
     for b in &mut result.boundary_outputs {
-        b.x += x_shift;
+        b.direction = fold_dir(b.x, b.direction);
+        (b.x, b.y) = fold_point(b.x, b.y);
     }
-    for (_, x, _) in &mut result.surplus_exits {
-        *x += x_shift;
+    for (_, x, y) in &mut result.surplus_exits {
+        (*x, *y) = fold_point(*x, *y);
     }
-    Some(result)
+    Ok(result)
 }

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -4457,6 +4457,9 @@ pub enum FoldRefusal {
     /// A belt run that continued in the source now dead-ends. Carries the
     /// source tile whose hand-off was lost.
     RunSevered { at: (i32, i32) },
+    /// A boundary input landed on an interior row, where nothing outside the
+    /// factory can feed it.
+    InputStranded { at: (i32, i32) },
 }
 
 /// Snake-fold a layout at the given fold columns.
@@ -4957,6 +4960,47 @@ pub fn fold_snake(
         }
         if let Some((at, _)) = severed.first() {
             return Err(FoldRefusal::RunSevered { at: *at });
+        }
+    }
+
+    // 5d. A boundary input must stay on the boundary.
+    //
+    // Inputs are fed from outside the bounding box, so they only work on an
+    // edge. Segment parity decides where they land: an unrotated segment
+    // keeps its inputs on its top row, a rotated one carries them to its
+    // bottom row, and in both cases that row is interior for every segment
+    // except the outermost. A single fold is fine — segment 0's inputs stay
+    // at the top, segment 1's rotate to the layout's bottom — but from two
+    // folds up, inputs land on gap rows with nothing able to supply them.
+    //
+    // Supplying them means routing a feed lane per item along a two-row gap
+    // that already carries the exits, which is a channel-routing problem this
+    // pass does not solve. Refuse rather than emit a factory whose inputs are
+    // stranded: the failure is otherwise silent, showing up as starved
+    // machines rather than as anything wrong at the boundary.
+    {
+        let (lo_x, hi_x) = (
+            folded.iter().map(|e| e.x).min().unwrap_or(0),
+            folded.iter().map(|e| e.x).max().unwrap_or(0),
+        );
+        let (lo_y, hi_y) = (
+            folded.iter().map(|e| e.y).min().unwrap_or(0),
+            folded.iter().map(|e| e.y).max().unwrap_or(0),
+        );
+        for b in &layout.boundary_inputs {
+            let seg = seg_of(b.x).unwrap_or(n_segs - 1);
+            let (nx, ny) = if seg % 2 == 0 {
+                (b.x - bounds[seg], b.y + (seg as i32) * (h + gap))
+            } else {
+                (
+                    bounds[seg + 1] - 1 - b.x,
+                    (h - 1 - b.y) + (seg as i32) * (h + gap),
+                )
+            };
+            let on_edge = nx <= lo_x || nx >= hi_x || ny <= lo_y || ny >= hi_y;
+            if !on_edge {
+                return Err(FoldRefusal::InputStranded { at: (b.x, b.y) });
+            }
         }
     }
 

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -7,6 +7,8 @@
 
 use std::collections::BTreeMap;
 
+use rustc_hash::{FxHashMap, FxHashSet};
+
 use crate::common::{
     dir_to_vec, entity_size, inserter_reach, is_belt_entity, is_inserter, is_surface_belt,
     is_ug_belt, oriented_splitter_dims, ug_max_reach, ug_to_surface_tier, QualityTier,
@@ -1557,14 +1559,21 @@ pub fn plan_local_manifolds(
     plans
 }
 
+const LOCAL_BALANCER_FAN: u32 = 4;
+
 fn merger_stages(mut inputs: u32) -> Vec<BalancerStage> {
     let mut stages = Vec::new();
     while inputs > 1 {
-        let copies = inputs / 2;
+        let fan = inputs.min(LOCAL_BALANCER_FAN);
+        let copies = inputs / fan;
         if copies > 0 {
-            stages.push(BalancerStage { n: 2, m: 1, copies });
+            stages.push(BalancerStage {
+                n: fan,
+                m: 1,
+                copies,
+            });
         }
-        inputs = copies + inputs % 2;
+        inputs = copies + inputs % fan;
     }
     stages
 }
@@ -1573,13 +1582,17 @@ fn distributor_stages(outputs: u32) -> Vec<BalancerStage> {
     if outputs <= 1 {
         return Vec::new();
     }
-    // Grow a possibly ragged binary tree to exactly the requested leaves.
+    // Grow a possibly ragged high-fanout tree to exactly the requested leaves.
     let mut stages = Vec::new();
     let mut leaves = 1;
     while leaves < outputs {
-        let copies = leaves.min(outputs - leaves);
-        stages.push(BalancerStage { n: 1, m: 2, copies });
-        leaves += copies;
+        let fan = (outputs - leaves + 1).min(LOCAL_BALANCER_FAN);
+        stages.push(BalancerStage {
+            n: 1,
+            m: fan,
+            copies: 1,
+        });
+        leaves += fan - 1;
     }
     stages
 }
@@ -1638,32 +1651,29 @@ pub fn build_local_manifold_graph(plan: &LocalManifoldPlan) -> LocalManifoldGrap
         let mut level = 0;
         while merge_frontier.len() > 1 {
             let mut next = Vec::new();
-            let mut chunks = merge_frontier.into_iter();
-            loop {
-                let Some(first) = chunks.next() else {
-                    break;
-                };
-                let Some(second) = chunks.next() else {
-                    next.push(first);
-                    break;
-                };
+            for chunk in merge_frontier.chunks(LOCAL_BALANCER_FAN as usize) {
+                if chunk.len() == 1 {
+                    next.push(chunk[0].clone());
+                    continue;
+                }
                 let node = nodes.len();
                 nodes.push(ManifoldBalancerNode {
                     id: node,
                     lane: group.lane,
                     role: BalancerNodeRole::Merge,
-                    n: 2,
+                    n: chunk.len() as u32,
                     m: 1,
                     level,
                 });
-                edges.push(ManifoldGraphEdge {
-                    from: first,
-                    to: ManifoldEndpoint::NodeInput { node, port: 0 },
-                });
-                edges.push(ManifoldGraphEdge {
-                    from: second,
-                    to: ManifoldEndpoint::NodeInput { node, port: 1 },
-                });
+                for (port, source) in chunk.iter().cloned().enumerate() {
+                    edges.push(ManifoldGraphEdge {
+                        from: source,
+                        to: ManifoldEndpoint::NodeInput {
+                            node,
+                            port: port as u32,
+                        },
+                    });
+                }
                 next.push(ManifoldEndpoint::NodeOutput { node, port: 0 });
             }
             merge_frontier = next;
@@ -1680,21 +1690,24 @@ pub fn build_local_manifold_graph(plan: &LocalManifoldPlan) -> LocalManifoldGrap
         let mut distribute_frontier = vec![(ManifoldEndpoint::LaneOutput(group.lane), 0u32)];
         while distribute_frontier.len() < consumer_count {
             let (source, level) = distribute_frontier.remove(0);
+            let fan = (consumer_count - distribute_frontier.len()).min(LOCAL_BALANCER_FAN as usize)
+                as u32;
             let node = nodes.len();
             nodes.push(ManifoldBalancerNode {
                 id: node,
                 lane: group.lane,
                 role: BalancerNodeRole::Distribute,
                 n: 1,
-                m: 2,
+                m: fan,
                 level,
             });
             edges.push(ManifoldGraphEdge {
                 from: source,
                 to: ManifoldEndpoint::NodeInput { node, port: 0 },
             });
-            distribute_frontier.push((ManifoldEndpoint::NodeOutput { node, port: 0 }, level + 1));
-            distribute_frontier.push((ManifoldEndpoint::NodeOutput { node, port: 1 }, level + 1));
+            for port in 0..fan {
+                distribute_frontier.push((ManifoldEndpoint::NodeOutput { node, port }, level + 1));
+            }
         }
         distribute_frontier.sort_by(|a, b| a.0.cmp(&b.0));
         for (source, terminal) in distribute_frontier
@@ -1735,7 +1748,206 @@ pub struct PlacedLocalManifold {
     pub entities: Vec<PlacedEntity>,
 }
 
-/// Stamp all `(2,1)` / `(1,2)` nodes into collision-free local hubs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RoutedManifoldEdge {
+    pub item: String,
+    pub edge: ManifoldGraphEdge,
+    /// Manhattan-adjacent tiles, including both graph endpoints.
+    pub path: Vec<(i32, i32)>,
+    /// Tiles already claimed by an earlier edge. These require a shared
+    /// segment, an underground crossing, or negotiated rerouting before the
+    /// path can be materialised.
+    pub crossings: Vec<(i32, i32)>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ManifoldRoutingResult {
+    pub routes: Vec<RoutedManifoldEdge>,
+    pub unroutable: Vec<(String, ManifoldGraphEdge)>,
+}
+
+/// Route every explicit edge in the local manifold graphs.
+///
+/// This is deliberately a topology result, not yet belt geometry: paths may
+/// overlap earlier paths and report those tiles as crossings. A later
+/// transactional materialiser must resolve each crossing before committing
+/// entities. Keeping this boundary explicit prevents provisional ghost belts
+/// from masquerading as a valid factory.
+pub fn route_local_manifold_edges(
+    islands: &[RigidIsland],
+    graphs: &[LocalManifoldGraph],
+    hubs: &[PlacedLocalManifold],
+) -> Result<ManifoldRoutingResult, String> {
+    use crate::astar::ghost_astar;
+
+    if graphs.len() != hubs.len() {
+        return Err(format!(
+            "manifold graph/hub count differs: {} != {}",
+            graphs.len(),
+            hubs.len()
+        ));
+    }
+
+    let mut points = Vec::new();
+    for island in islands {
+        points.push((island.block.x, island.block.y));
+        points.push((
+            island.block.x + island.block.width - 1,
+            island.block.y + island.block.height - 1,
+        ));
+    }
+    for hub in hubs {
+        points.push((hub.hub.x, hub.hub.y));
+        points.push((
+            hub.hub.x + hub.hub.width - 1,
+            hub.hub.y + hub.hub.height - 1,
+        ));
+    }
+    for (graph, hub) in graphs.iter().zip(hubs) {
+        if graph.item != hub.item {
+            return Err(format!(
+                "manifold graph/hub item differs: {} != {}",
+                graph.item, hub.item
+            ));
+        }
+        for edge in &graph.edges {
+            points.push(manifold_endpoint_point(&edge.from, hub)?);
+            points.push(manifold_endpoint_point(&edge.to, hub)?);
+        }
+    }
+    if points.is_empty() {
+        return Ok(ManifoldRoutingResult::default());
+    }
+
+    const PADDING: i32 = 8;
+    let min_x = points.iter().map(|point| point.0).min().unwrap() - PADDING;
+    let min_y = points.iter().map(|point| point.1).min().unwrap() - PADDING;
+    let max_x = points.iter().map(|point| point.0).max().unwrap() + PADDING;
+    let max_y = points.iter().map(|point| point.1).max().unwrap() + PADDING;
+    let shift = (-min_x, -min_y);
+    let width = max_x - min_x + 1;
+    let height = max_y - min_y + 1;
+    let shifted = |point: (i32, i32)| (point.0 + shift.0, point.1 + shift.1);
+
+    // Island blocks are conservative hard reservations: they include the
+    // machine/inserter geometry and the deliberately retained local space
+    // between them. Hub reservations use exact stamped entity footprints so
+    // paths can use the otherwise empty interior of a large hub block.
+    let mut hard = FxHashSet::default();
+    for island in islands {
+        for x in island.block.x..island.block.x + island.block.width {
+            for y in island.block.y..island.block.y + island.block.height {
+                hard.insert(shifted((x, y)));
+            }
+        }
+    }
+    for hub in hubs {
+        for entity in &hub.entities {
+            let (entity_width, entity_height) = entity_dims(&entity.name, entity.direction);
+            for x in entity.x..entity.x + entity_width {
+                for y in entity.y..entity.y + entity_height {
+                    hard.insert(shifted((x, y)));
+                }
+            }
+        }
+    }
+
+    let mut claimed = FxHashSet::default();
+    let mut axis_costs = FxHashMap::default();
+    let mut result = ManifoldRoutingResult::default();
+    for (graph, hub) in graphs.iter().zip(hubs) {
+        for edge in &graph.edges {
+            let start = manifold_endpoint_point(&edge.from, hub)?;
+            let goal = manifold_endpoint_point(&edge.to, hub)?;
+            let shifted_start = shifted(start);
+            let shifted_goal = shifted(goal);
+            let mut edge_hard = hard.clone();
+            edge_hard.remove(&shifted_start);
+            edge_hard.remove(&shifted_goal);
+            let Some((path, crossings)) = ghost_astar(
+                shifted_start,
+                shifted_goal,
+                &edge_hard,
+                &claimed,
+                width,
+                height,
+                2,
+                &axis_costs,
+            ) else {
+                result.unroutable.push((graph.item.clone(), edge.clone()));
+                continue;
+            };
+            let path: Vec<_> = path
+                .into_iter()
+                .map(|point| (point.0 - shift.0, point.1 - shift.1))
+                .collect();
+            let crossings: Vec<_> = crossings
+                .into_iter()
+                .map(|point| (point.0 - shift.0, point.1 - shift.1))
+                .collect();
+            claimed.extend(path.iter().copied().map(shifted));
+            // Prefer clean parallel channels and cheap perpendicular
+            // crossings over running along an already claimed belt. This is
+            // the first negotiated-routing pass: a later legalizer can turn
+            // an isolated perpendicular crossing into an underground pair,
+            // whereas a same-axis overlap cannot be materialised directly.
+            for pair in path.windows(2) {
+                let from = shifted(pair[0]);
+                let to = shifted(pair[1]);
+                let horizontal = pair[0].1 == pair[1].1;
+                for tile in [from, to] {
+                    let penalty = axis_costs.entry(tile).or_insert((0u32, 0u32));
+                    if horizontal {
+                        penalty.1 = penalty.1.max(4);
+                    } else {
+                        penalty.0 = penalty.0.max(4);
+                    }
+                }
+            }
+            result.routes.push(RoutedManifoldEdge {
+                item: graph.item.clone(),
+                edge: edge.clone(),
+                path,
+                crossings,
+            });
+        }
+    }
+    Ok(result)
+}
+
+fn manifold_endpoint_point(
+    endpoint: &ManifoldEndpoint,
+    hub: &PlacedLocalManifold,
+) -> Result<(i32, i32), String> {
+    match endpoint {
+        ManifoldEndpoint::Terminal(terminal) => Ok((terminal.x, terminal.y)),
+        ManifoldEndpoint::NodeInput { node, port } => hub
+            .nodes
+            .get(*node)
+            .and_then(|placed| placed.input_ports.get(*port as usize))
+            .copied()
+            .ok_or_else(|| format!("{} node {node} input port {port} is missing", hub.item)),
+        ManifoldEndpoint::NodeOutput { node, port } => hub
+            .nodes
+            .get(*node)
+            .and_then(|placed| placed.output_ports.get(*port as usize))
+            .copied()
+            .ok_or_else(|| format!("{} node {node} output port {port} is missing", hub.item)),
+        ManifoldEndpoint::LaneInput(lane) => hub
+            .lane_inputs
+            .get(*lane as usize)
+            .copied()
+            .ok_or_else(|| format!("{} lane {lane} input is missing", hub.item)),
+        ManifoldEndpoint::LaneOutput(lane) => hub
+            .lane_outputs
+            .get(*lane as usize)
+            .copied()
+            .ok_or_else(|| format!("{} lane {lane} output is missing", hub.item)),
+    }
+}
+
+/// Stamp the largest available `(n,1)` / `(1,m)` nodes into collision-free
+/// local hubs.
 /// Inter-node and terminal edges remain explicit in [`LocalManifoldGraph`]
 /// for the negotiated router.
 pub fn place_local_manifold_nodes(
@@ -1750,50 +1962,55 @@ pub fn place_local_manifold_nodes(
     let clearance = clearance.max(0);
     let mut result: Vec<PlacedLocalManifold> = Vec::new();
     for (graph_idx, graph) in graphs.iter().enumerate() {
+        let mut level_dims = BTreeMap::<(u32, u8, u32), (i32, i32)>::new();
+        for node in &graph.nodes {
+            let role = match node.role {
+                BalancerNodeRole::Merge => 0,
+                BalancerNodeRole::Distribute => 1,
+            };
+            let template = templates
+                .get(&(node.n, node.m))
+                .expect("planned local balancer template missing");
+            let dims = level_dims.entry((node.lane, role, node.level)).or_default();
+            if dims.0 > 0 {
+                dims.0 += clearance;
+            }
+            dims.0 += template.width as i32;
+            dims.1 = dims.1.max(template.height as i32);
+        }
         let mut lane_widths = Vec::new();
-        let mut merge_levels = 0u32;
-        let mut distribute_levels = 0u32;
+        let mut merge_height = 0;
+        let mut distribute_height = 0;
         for lane in 0..graph.belt_count {
-            let max_level_width = graph
-                .nodes
-                .iter()
-                .filter(|node| node.lane == lane)
-                .fold(BTreeMap::<(u8, u32), usize>::new(), |mut counts, node| {
-                    let role = match node.role {
-                        BalancerNodeRole::Merge => 0,
-                        BalancerNodeRole::Distribute => 1,
-                    };
-                    *counts.entry((role, node.level)).or_default() += 1;
-                    counts
-                })
-                .into_values()
-                .max()
-                .unwrap_or(1);
-            lane_widths.push((max_level_width as i32 * 3).max(3));
-            merge_levels = merge_levels.max(
-                graph
-                    .nodes
+            lane_widths.push(
+                level_dims
                     .iter()
-                    .filter(|node| node.lane == lane && node.role == BalancerNodeRole::Merge)
-                    .map(|node| node.level + 1)
+                    .filter(|((node_lane, _, _), _)| *node_lane == lane)
+                    .map(|(_, dims)| dims.0)
                     .max()
-                    .unwrap_or(0),
+                    .unwrap_or(1)
+                    .max(1),
             );
-            distribute_levels = distribute_levels.max(
-                graph
-                    .nodes
+            let role_height = |role: u8| {
+                let levels: Vec<_> = level_dims
                     .iter()
-                    .filter(|node| node.lane == lane && node.role == BalancerNodeRole::Distribute)
-                    .map(|node| node.level + 1)
-                    .max()
-                    .unwrap_or(0),
-            );
+                    .filter(|((node_lane, node_role, _), _)| {
+                        *node_lane == lane && *node_role == role
+                    })
+                    .map(|((_, _, level), (_, height))| (*level, *height))
+                    .collect();
+                let count = levels.len();
+                levels.into_iter().map(|(_, height)| height).sum::<i32>()
+                    + clearance * count.saturating_sub(1) as i32
+            };
+            merge_height = merge_height.max(role_height(0));
+            distribute_height = distribute_height.max(role_height(1));
         }
         let width = lane_widths.iter().sum::<i32>()
             + clearance * (lane_widths.len().saturating_sub(1) as i32);
-        let lane_y = merge_levels as i32 * 4;
+        let lane_y = merge_height;
         let distribute_y = lane_y + 2;
-        let height = distribute_y + distribute_levels as i32 * 4 + 3;
+        let height = distribute_y + distribute_height.max(1);
         let preferred_x = graph.hub.x + graph.hub.width / 2 - width / 2;
         let preferred_y = graph.hub.y + graph.hub.height / 2 - height / 2;
         let mut hub = None;
@@ -1843,7 +2060,7 @@ pub fn place_local_manifold_nodes(
             lane_starts.push(cursor);
             cursor += *lane_width + clearance;
         }
-        let mut level_ordinals = BTreeMap::<(u32, u8, u32), i32>::new();
+        let mut level_x_offsets = BTreeMap::<(u32, u8, u32), i32>::new();
         let mut placed_nodes = Vec::new();
         let mut entities = Vec::new();
         for node in &graph.nodes {
@@ -1851,20 +2068,33 @@ pub fn place_local_manifold_nodes(
                 BalancerNodeRole::Merge => 0,
                 BalancerNodeRole::Distribute => 1,
             };
-            let ordinal = level_ordinals
-                .entry((node.lane, role, node.level))
-                .or_default();
-            let origin_x = lane_starts[node.lane as usize] + *ordinal * 3;
-            let origin_y = hub.y
-                + if node.role == BalancerNodeRole::Merge {
-                    node.level as i32 * 4
-                } else {
-                    distribute_y + node.level as i32 * 4
-                };
-            *ordinal += 1;
             let template = templates
                 .get(&(node.n, node.m))
-                .expect("planned primitive balancer template missing");
+                .expect("planned local balancer template missing");
+            let x_offset = level_x_offsets
+                .entry((node.lane, role, node.level))
+                .or_default();
+            let origin_x = lane_starts[node.lane as usize] + *x_offset;
+            let origin_y = hub.y
+                + if node.role == BalancerNodeRole::Merge {
+                    level_dims
+                        .iter()
+                        .filter(|((lane, node_role, level), _)| {
+                            *lane == node.lane && *node_role == role && *level < node.level
+                        })
+                        .map(|(_, (_, height))| *height + clearance)
+                        .sum::<i32>()
+                } else {
+                    distribute_y
+                        + level_dims
+                            .iter()
+                            .filter(|((lane, node_role, level), _)| {
+                                *lane == node.lane && *node_role == role && *level < node.level
+                            })
+                            .map(|(_, (_, height))| *height + clearance)
+                            .sum::<i32>()
+                };
+            *x_offset += template.width as i32 + clearance;
             let mut stamped = template.stamp(
                 origin_x,
                 origin_y,
@@ -1928,6 +2158,288 @@ pub fn place_local_manifold_nodes(
         });
     }
     result
+}
+
+/// Place manifold primitives near the terminals they aggregate instead of in
+/// one commodity-wide rectangle. Leaf mergers sit near their producer group;
+/// distributors sit near the consumers reachable from their outputs. Only
+/// the capacity lanes remain at the commodity median.
+pub fn place_distributed_local_manifold_nodes(
+    islands: &[RigidIsland],
+    graphs: &[LocalManifoldGraph],
+    clearance: i32,
+) -> Result<Vec<PlacedLocalManifold>, String> {
+    use crate::bus::balancer::{splitter_for_belt, underground_for_belt};
+    use crate::bus::balancer_library::balancer_templates;
+
+    let templates = balancer_templates();
+    let clearance = clearance.max(0);
+    let mut reserved: Vec<CompactBlock> =
+        islands.iter().map(|island| island.block.clone()).collect();
+    let mut result = Vec::new();
+    for (graph_idx, graph) in graphs.iter().enumerate() {
+        let reservation_start = reserved.len();
+        let terminals: Vec<_> = graph
+            .edges
+            .iter()
+            .flat_map(|edge| [&edge.from, &edge.to])
+            .filter_map(|endpoint| match endpoint {
+                ManifoldEndpoint::Terminal(terminal) => Some((terminal.x, terminal.y)),
+                _ => None,
+            })
+            .collect();
+        let median = coordinate_median(&terminals);
+        let lane_width = graph.belt_count.max(1) as i32;
+        let lane_block = nearest_free_block(
+            CompactBlock {
+                id: graph_idx,
+                x: median.0 - lane_width / 2,
+                y: median.1 - 1,
+                width: lane_width,
+                height: 2,
+            },
+            &reserved,
+            clearance,
+            1024,
+        )
+        .ok_or_else(|| format!("{} has no collision-free lane block", graph.item))?;
+        reserved.push(lane_block.clone());
+        let lane_inputs: Vec<_> = (0..graph.belt_count)
+            .map(|lane| (lane_block.x + lane as i32, lane_block.y))
+            .collect();
+        let lane_outputs: Vec<_> = lane_inputs.iter().map(|&(x, y)| (x, y + 1)).collect();
+        let mut entities = Vec::new();
+        for (lane, (&input, &output)) in lane_inputs.iter().zip(&lane_outputs).enumerate() {
+            for y in input.1..=output.1 {
+                entities.push(PlacedEntity {
+                    name: "express-transport-belt".into(),
+                    x: input.0,
+                    y,
+                    direction: EntityDirection::South,
+                    carries: Some(graph.item.clone()),
+                    segment_id: Some(format!("compact-lane:{}:{lane}", graph.item)),
+                    ..Default::default()
+                });
+            }
+        }
+
+        let mut placed_nodes: Vec<PlacedManifoldNode> = Vec::new();
+        for node in &graph.nodes {
+            let template = templates
+                .get(&(node.n, node.m))
+                .ok_or_else(|| format!("missing local template ({},{})", node.n, node.m))?;
+            let desired_points = match node.role {
+                BalancerNodeRole::Merge => graph
+                    .edges
+                    .iter()
+                    .filter_map(|edge| match &edge.to {
+                        ManifoldEndpoint::NodeInput { node: target, .. } if *target == node.id => {
+                            partial_endpoint_point(
+                                &edge.from,
+                                &placed_nodes,
+                                &lane_inputs,
+                                &lane_outputs,
+                            )
+                        }
+                        _ => None,
+                    })
+                    .collect(),
+                BalancerNodeRole::Distribute => descendant_terminal_points(graph, node.id),
+            };
+            let center = if desired_points.is_empty() {
+                median
+            } else {
+                coordinate_median(&desired_points)
+            };
+            let block = nearest_free_block(
+                CompactBlock {
+                    id: node.id,
+                    x: center.0 - template.width as i32 / 2,
+                    y: center.1 - template.height as i32 / 2,
+                    width: template.width as i32,
+                    height: template.height as i32,
+                },
+                &reserved,
+                clearance,
+                1024,
+            )
+            .ok_or_else(|| {
+                format!(
+                    "{} node {} ({},{}) has no collision-free placement",
+                    graph.item, node.id, node.n, node.m
+                )
+            })?;
+            reserved.push(block.clone());
+            let mut stamped = template.stamp(
+                block.x,
+                block.y,
+                "express-transport-belt",
+                splitter_for_belt("express-transport-belt"),
+                underground_for_belt("express-transport-belt"),
+                Some(&graph.item),
+            );
+            for entity in &mut stamped {
+                entity.segment_id = Some(format!(
+                    "compact-hub:{}:{}:{}",
+                    graph.item, node.lane, node.id
+                ));
+            }
+            entities.extend(stamped);
+            placed_nodes.push(PlacedManifoldNode {
+                node_id: node.id,
+                origin: (block.x, block.y),
+                input_ports: template
+                    .input_tiles
+                    .iter()
+                    .map(|&(x, y)| (block.x + x, block.y + y))
+                    .collect(),
+                output_ports: template
+                    .output_tiles
+                    .iter()
+                    .map(|&(x, y)| (block.x + x, block.y + y))
+                    .collect(),
+            });
+        }
+        placed_nodes.sort_by_key(|node| node.node_id);
+        let manifold_blocks = &reserved[reservation_start..];
+        let min_x = manifold_blocks.iter().map(|block| block.x).min().unwrap();
+        let min_y = manifold_blocks.iter().map(|block| block.y).min().unwrap();
+        let max_x = manifold_blocks
+            .iter()
+            .map(|block| block.x + block.width)
+            .max()
+            .unwrap();
+        let max_y = manifold_blocks
+            .iter()
+            .map(|block| block.y + block.height)
+            .max()
+            .unwrap();
+        result.push(PlacedLocalManifold {
+            item: graph.item.clone(),
+            hub: CompactBlock {
+                id: graph_idx,
+                x: min_x,
+                y: min_y,
+                width: max_x - min_x,
+                height: max_y - min_y,
+            },
+            nodes: placed_nodes,
+            lane_inputs,
+            lane_outputs,
+            entities,
+        });
+    }
+    Ok(result)
+}
+
+fn partial_endpoint_point(
+    endpoint: &ManifoldEndpoint,
+    nodes: &[PlacedManifoldNode],
+    lane_inputs: &[(i32, i32)],
+    lane_outputs: &[(i32, i32)],
+) -> Option<(i32, i32)> {
+    match endpoint {
+        ManifoldEndpoint::Terminal(terminal) => Some((terminal.x, terminal.y)),
+        ManifoldEndpoint::NodeInput { node, port } => nodes
+            .get(*node)
+            .and_then(|placed| placed.input_ports.get(*port as usize))
+            .copied(),
+        ManifoldEndpoint::NodeOutput { node, port } => nodes
+            .get(*node)
+            .and_then(|placed| placed.output_ports.get(*port as usize))
+            .copied(),
+        ManifoldEndpoint::LaneInput(lane) => lane_inputs.get(*lane as usize).copied(),
+        ManifoldEndpoint::LaneOutput(lane) => lane_outputs.get(*lane as usize).copied(),
+    }
+}
+
+fn descendant_terminal_points(graph: &LocalManifoldGraph, node: usize) -> Vec<(i32, i32)> {
+    let mut frontier: Vec<_> = graph
+        .nodes
+        .get(node)
+        .into_iter()
+        .flat_map(|placed| {
+            (0..placed.m).map(move |port| ManifoldEndpoint::NodeOutput { node, port })
+        })
+        .collect();
+    let mut visited = Vec::new();
+    let mut terminals = Vec::new();
+    while let Some(endpoint) = frontier.pop() {
+        if visited.contains(&endpoint) {
+            continue;
+        }
+        visited.push(endpoint.clone());
+        for edge in graph.edges.iter().filter(|edge| edge.from == endpoint) {
+            match &edge.to {
+                ManifoldEndpoint::Terminal(terminal) => terminals.push((terminal.x, terminal.y)),
+                ManifoldEndpoint::NodeInput { node, .. } => {
+                    if let Some(next) = graph.nodes.get(*node) {
+                        frontier.extend(
+                            (0..next.m)
+                                .map(|port| ManifoldEndpoint::NodeOutput { node: *node, port }),
+                        );
+                    }
+                }
+                _ => frontier.push(edge.to.clone()),
+            }
+        }
+    }
+    terminals
+}
+
+fn coordinate_median(points: &[(i32, i32)]) -> (i32, i32) {
+    if points.is_empty() {
+        return (0, 0);
+    }
+    let mut xs: Vec<_> = points.iter().map(|point| point.0).collect();
+    let mut ys: Vec<_> = points.iter().map(|point| point.1).collect();
+    xs.sort_unstable();
+    ys.sort_unstable();
+    (xs[xs.len() / 2], ys[ys.len() / 2])
+}
+
+fn nearest_free_block(
+    preferred: CompactBlock,
+    reserved: &[CompactBlock],
+    clearance: i32,
+    max_radius: i32,
+) -> Option<CompactBlock> {
+    for radius in 0..=max_radius {
+        for dx in -radius..=radius {
+            for dy in [-radius, radius] {
+                let mut candidate = preferred.clone();
+                candidate.x += dx;
+                candidate.y += dy;
+                if block_clears_all(&candidate, reserved, clearance) {
+                    return Some(candidate);
+                }
+            }
+        }
+        for dy in (-radius + 1)..radius {
+            for dx in [-radius, radius] {
+                let mut candidate = preferred.clone();
+                candidate.x += dx;
+                candidate.y += dy;
+                if block_clears_all(&candidate, reserved, clearance) {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn block_clears_all(block: &CompactBlock, reserved: &[CompactBlock], clearance: i32) -> bool {
+    let expanded = CompactBlock {
+        id: block.id,
+        x: block.x - clearance,
+        y: block.y - clearance,
+        width: block.width + clearance * 2,
+        height: block.height + clearance * 2,
+    };
+    reserved
+        .iter()
+        .all(|other| !blocks_overlap(&expanded, other))
 }
 
 fn placed_hub_is_free(
@@ -2605,20 +3117,23 @@ mod tests {
     }
 
     #[test]
-    fn binary_balancer_hierarchies_cover_arbitrary_terminal_counts() {
+    fn bounded_balancer_hierarchies_cover_arbitrary_terminal_counts() {
         for count in 0..=129 {
             let mergers = merger_stages(count);
             let mut remaining = count;
             for stage in &mergers {
-                assert_eq!((stage.n, stage.m), (2, 1));
-                remaining = remaining - stage.copies * 2 + stage.copies;
+                assert_eq!(stage.m, 1);
+                assert!((2..=LOCAL_BALANCER_FAN).contains(&stage.n));
+                remaining = remaining - stage.copies * stage.n + stage.copies * stage.m;
             }
             assert_eq!(remaining, count.min(1));
 
             let distributors = distributor_stages(count);
-            let leaves = distributors
-                .iter()
-                .fold(1u32, |leaves, stage| leaves + stage.copies);
+            let leaves = distributors.iter().fold(1u32, |leaves, stage| {
+                assert_eq!(stage.n, 1);
+                assert!((2..=LOCAL_BALANCER_FAN).contains(&stage.m));
+                leaves - stage.copies * stage.n + stage.copies * stage.m
+            });
             assert_eq!(leaves, count.max(1));
             assert!(mergers
                 .iter()

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -8,8 +8,8 @@
 use std::collections::BTreeMap;
 
 use crate::common::{
-    dir_to_vec, entity_size, inserter_reach, is_belt_entity, is_inserter, oriented_splitter_dims,
-    QualityTier,
+    dir_to_vec, entity_size, inserter_reach, is_belt_entity, is_inserter, is_surface_belt,
+    is_ug_belt, oriented_splitter_dims, ug_max_reach, ug_to_surface_tier, QualityTier,
 };
 use crate::models::{EntityDirection, LayoutResult, ModuleItem, SolverResult};
 
@@ -368,10 +368,183 @@ pub fn strip_empty_columns(layout: &LayoutResult) -> LayoutResult {
     for (_, x, _) in &mut compacted.surplus_exits {
         *x = remap_x(*x);
     }
+    // Column removal can collapse a valid underground pair to adjacent
+    // entities. Factorio requires at least one hidden tile; at distance one
+    // the equivalent topology is two ordinary surface belts.
+    let entity_at: BTreeMap<(i32, i32), usize> = compacted
+        .entities
+        .iter()
+        .enumerate()
+        .map(|(idx, entity)| ((entity.x, entity.y), idx))
+        .collect();
+    let mut surface_pairs = Vec::new();
+    for (idx, entity) in compacted.entities.iter().enumerate() {
+        if !is_ug_belt(&entity.name) || entity.io_type.as_deref() != Some("input") {
+            continue;
+        }
+        let (dx, dy) = dir_to_vec(entity.direction);
+        let Some(&output_idx) = entity_at.get(&(entity.x + dx, entity.y + dy)) else {
+            continue;
+        };
+        let output = &compacted.entities[output_idx];
+        if output.name == entity.name
+            && output.direction == entity.direction
+            && output.io_type.as_deref() == Some("output")
+        {
+            surface_pairs.push((idx, output_idx));
+        }
+    }
+    for (input_idx, output_idx) in surface_pairs {
+        for idx in [input_idx, output_idx] {
+            let entity = &mut compacted.entities[idx];
+            entity.name = ug_to_surface_tier(&entity.name).to_string();
+            entity.io_type = None;
+        }
+    }
     compacted.width -= removed_before[layout.width as usize];
     compacted.regions.clear();
     compacted.trace = None;
     compacted
+}
+
+/// Replace safe uninterrupted horizontal surface-belt spans with maximal
+/// underground hops. Tiles addressed by inserters or boundaries are retained
+/// on the surface. Segment, item, tier and direction boundaries split runs.
+pub fn undergroundify_straight_belts(layout: &LayoutResult) -> LayoutResult {
+    use crate::bus::balancer::underground_for_belt;
+    use std::collections::BTreeSet;
+
+    let mut protected = BTreeSet::new();
+    for inserter in layout
+        .entities
+        .iter()
+        .filter(|entity| is_inserter(&entity.name))
+    {
+        let (dx, dy) = dir_to_vec(inserter.direction);
+        let reach = inserter_reach(&inserter.name);
+        protected.insert((inserter.x - dx * reach, inserter.y - dy * reach));
+        protected.insert((inserter.x + dx * reach, inserter.y + dy * reach));
+    }
+    for boundary in layout
+        .boundary_inputs
+        .iter()
+        .chain(layout.boundary_outputs.iter())
+    {
+        protected.insert((boundary.x, boundary.y));
+    }
+    for (_, x, y) in &layout.surplus_exits {
+        protected.insert((*x, *y));
+    }
+
+    // A perpendicular belt feeding a horizontal tile is a side-load/turn
+    // junction. Splitters and existing undergrounds reserve their vicinity.
+    for entity in layout
+        .entities
+        .iter()
+        .filter(|entity| is_belt_entity(&entity.name))
+    {
+        let (dx, dy) = dir_to_vec(entity.direction);
+        if dx == 0 {
+            protected.insert((entity.x + dx, entity.y + dy));
+        }
+        if !is_surface_belt(&entity.name) {
+            for x in entity.x - 1..=entity.x + 2 {
+                for y in entity.y - 1..=entity.y + 2 {
+                    protected.insert((x, y));
+                }
+            }
+        }
+    }
+
+    type RunKey = (i32, bool, String, Option<String>, Option<String>);
+    let mut runs: BTreeMap<RunKey, Vec<(i32, usize)>> = BTreeMap::new();
+    for (idx, entity) in layout.entities.iter().enumerate() {
+        if !is_surface_belt(&entity.name)
+            || !matches!(
+                entity.direction,
+                EntityDirection::East | EntityDirection::West
+            )
+            || protected.contains(&(entity.x, entity.y))
+        {
+            continue;
+        }
+        runs.entry((
+            entity.y,
+            entity.direction == EntityDirection::East,
+            entity.name.clone(),
+            entity.carries.clone(),
+            entity.segment_id.clone(),
+        ))
+        .or_default()
+        .push((entity.x, idx));
+    }
+
+    let mut remove = vec![false; layout.entities.len()];
+    let mut replacements = BTreeMap::new();
+    for ((_, eastbound, belt_name, _, _), mut tiles) in runs {
+        tiles.sort_by_key(|(x, _)| *x);
+        if !eastbound {
+            tiles.reverse();
+        }
+        let step = if eastbound { 1 } else { -1 };
+        let mut run_start = 0;
+        while run_start < tiles.len() {
+            let mut run_end = run_start + 1;
+            while run_end < tiles.len() && tiles[run_end].0 - tiles[run_end - 1].0 == step {
+                run_end += 1;
+            }
+            let run = &tiles[run_start..run_end];
+            if run.len() < 4 {
+                run_start = run_end;
+                continue;
+            }
+            let max_distance = ug_max_reach(&belt_name) as usize + 1;
+            let mut start = 0;
+            while run.len() - start >= 4 {
+                let end = (start + max_distance).min(run.len() - 1);
+                if end - start < 3 {
+                    break;
+                }
+                let start_idx = run[start].1;
+                let end_idx = run[end].1;
+                let mut entrance = layout.entities[start_idx].clone();
+                entrance.name = underground_for_belt(&belt_name).to_string();
+                entrance.io_type = Some("input".into());
+                let mut exit = layout.entities[end_idx].clone();
+                exit.name = underground_for_belt(&belt_name).to_string();
+                exit.io_type = Some("output".into());
+                replacements.insert(start_idx, entrance);
+                replacements.insert(end_idx, exit);
+                for &(_, idx) in &run[start + 1..end] {
+                    remove[idx] = true;
+                }
+                start = end + 1;
+            }
+            run_start = run_end;
+        }
+    }
+
+    let mut result = layout.clone();
+    result.entities = layout
+        .entities
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, entity)| {
+            if remove[idx] {
+                None
+            } else {
+                Some(
+                    replacements
+                        .get(&idx)
+                        .cloned()
+                        .unwrap_or_else(|| entity.clone()),
+                )
+            }
+        })
+        .collect();
+    result.regions.clear();
+    result.trace = None;
+    result
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -429,6 +602,7 @@ pub struct IslandTerminal {
 pub struct CompactIr {
     pub islands: Vec<RigidIsland>,
     pub route_nets: Vec<RouteNet>,
+    pub commodity_flows: Vec<CommodityFlow>,
 }
 
 impl CompactIr {
@@ -436,8 +610,52 @@ impl CompactIr {
         Self {
             islands: extract_rigid_islands(layout),
             route_nets: extract_route_nets(layout),
+            commodity_flows: Vec::new(),
         }
     }
+
+    pub fn from_source(layout: &LayoutResult, solver: &SolverResult) -> Self {
+        Self {
+            islands: extract_rigid_islands(layout),
+            route_nets: extract_route_nets(layout),
+            commodity_flows: commodity_flows(solver),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CommodityFlow {
+    pub item: String,
+    pub rate: i64,
+    pub is_fluid: bool,
+}
+
+fn commodity_flows(solver: &SolverResult) -> Vec<CommodityFlow> {
+    let mut totals: BTreeMap<String, (f64, f64, bool)> = BTreeMap::new();
+    for machine in &solver.machines {
+        for input in &machine.inputs {
+            let total = totals
+                .entry(input.item.clone())
+                .or_insert((0.0, 0.0, input.is_fluid));
+            total.0 += input.rate * machine.count;
+            total.2 |= input.is_fluid;
+        }
+        for output in &machine.outputs {
+            let total = totals
+                .entry(output.item.clone())
+                .or_insert((0.0, 0.0, output.is_fluid));
+            total.1 += output.rate * machine.count;
+            total.2 |= output.is_fluid;
+        }
+    }
+    totals
+        .into_iter()
+        .map(|(item, (consumed, produced, is_fluid))| CommodityFlow {
+            item,
+            rate: fixed_rate(consumed.max(produced)),
+            is_fluid,
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -453,10 +671,20 @@ pub struct ManifoldTerminal {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ManifoldNet {
     pub item: String,
+    pub planned_rate: i64,
     pub terminals: Vec<ManifoldTerminal>,
 }
 
 impl ManifoldNet {
+    pub fn required_belts(&self, belt_capacity: f64) -> u32 {
+        if self.planned_rate <= 0 || belt_capacity <= 0.0 {
+            return 1;
+        }
+        ((self.planned_rate as f64 / RATE_SCALE) / belt_capacity)
+            .ceil()
+            .max(1.0) as u32
+    }
+
     pub fn producers(&self) -> impl Iterator<Item = &ManifoldTerminal> {
         self.terminals.iter().filter(|terminal| {
             matches!(
@@ -492,6 +720,12 @@ pub fn build_manifold_nets(
         .route_nets
         .iter()
         .map(|net| (net.item.clone(), Vec::new()))
+        .collect();
+    let planned_rate_by_item: BTreeMap<_, _> = ir
+        .commodity_flows
+        .iter()
+        .filter(|flow| !flow.is_fluid)
+        .map(|flow| (flow.item.as_str(), flow.rate))
         .collect();
 
     for (source, placed) in ir.islands.iter().zip(placed_islands) {
@@ -542,7 +776,14 @@ pub fn build_manifold_nets(
         if terminals.is_empty() {
             return Err(format!("route net {item} has no terminals"));
         }
-        result.push(ManifoldNet { item, terminals });
+        result.push(ManifoldNet {
+            planned_rate: planned_rate_by_item
+                .get(item.as_str())
+                .copied()
+                .unwrap_or(0),
+            item,
+            terminals,
+        });
     }
     Ok(result)
 }
@@ -1079,6 +1320,31 @@ mod tests {
         assert_eq!(PlacedMachineSignature::from_layout(&compacted), signature);
         layout.entities.reverse();
         assert_eq!(strip_empty_columns(&layout).width, 2);
+    }
+
+    #[test]
+    fn straight_belts_become_maximal_underground_hops() {
+        let layout = LayoutResult {
+            width: 10,
+            height: 1,
+            entities: (0..10)
+                .map(|x| crate::models::PlacedEntity {
+                    name: "express-transport-belt".into(),
+                    x,
+                    direction: EntityDirection::East,
+                    carries: Some("plate".into()),
+                    segment_id: Some("test".into()),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let compacted = undergroundify_straight_belts(&layout);
+        assert_eq!(compacted.entities.len(), 2);
+        assert_eq!(compacted.entities[0].name, "express-underground-belt");
+        assert_eq!(compacted.entities[0].io_type.as_deref(), Some("input"));
+        assert_eq!(compacted.entities[1].x, 9);
+        assert_eq!(compacted.entities[1].io_type.as_deref(), Some("output"));
     }
 
     #[test]

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -7,7 +7,10 @@
 
 use std::collections::BTreeMap;
 
-use crate::common::{entity_size, oriented_splitter_dims, QualityTier};
+use crate::common::{
+    dir_to_vec, entity_size, inserter_reach, is_belt_entity, is_inserter,
+    oriented_splitter_dims, QualityTier,
+};
 use crate::models::{EntityDirection, LayoutResult, ModuleItem, SolverResult};
 
 const RATE_SCALE: f64 = 1_000_000_000.0;
@@ -303,6 +306,242 @@ pub fn blocks_overlap(a: &CompactBlock, b: &CompactBlock) -> bool {
         && b.y < a.y + a.height
 }
 
+/// Remove globally empty tile columns while preserving entity order and
+/// shortening horizontal underground spans. This is the first runnable
+/// constraint-compaction baseline: it never deletes or rotates an entity.
+///
+/// The result deliberately drops region/trace metadata because their
+/// coordinate-rich solver provenance describes the source embedding, not the
+/// compacted artifact. Functional boundary/effective-row records are remapped.
+pub fn strip_empty_columns(layout: &LayoutResult) -> LayoutResult {
+    if layout.width <= 0 {
+        return layout.clone();
+    }
+    let mut occupied = vec![false; layout.width as usize];
+    for entity in &layout.entities {
+        let (mut width, mut height) = oriented_splitter_dims(&entity.name, entity.direction)
+            .unwrap_or_else(|| entity_size(&entity.name));
+        if matches!(entity.direction, EntityDirection::East | EntityDirection::West)
+            && width != height
+            && oriented_splitter_dims(&entity.name, entity.direction).is_none()
+        {
+            std::mem::swap(&mut width, &mut height);
+        }
+        let _ = height;
+        for x in entity.x.max(0)..(entity.x + width as i32).min(layout.width) {
+            occupied[x as usize] = true;
+        }
+    }
+    for boundary in layout
+        .boundary_inputs
+        .iter()
+        .chain(layout.boundary_outputs.iter())
+    {
+        if (0..layout.width).contains(&boundary.x) {
+            occupied[boundary.x as usize] = true;
+        }
+    }
+    for (_, x, _) in &layout.surplus_exits {
+        if (0..layout.width).contains(x) {
+            occupied[*x as usize] = true;
+        }
+    }
+
+    let mut removed_before = vec![0i32; layout.width as usize + 1];
+    for x in 0..layout.width as usize {
+        removed_before[x + 1] = removed_before[x] + i32::from(!occupied[x]);
+    }
+    let remap_x = |x: i32| -> i32 {
+        if x <= 0 {
+            x
+        } else if x >= layout.width {
+            x - removed_before[layout.width as usize]
+        } else {
+            x - removed_before[x as usize]
+        }
+    };
+
+    let mut compacted = layout.clone();
+    for entity in &mut compacted.entities {
+        entity.x = remap_x(entity.x);
+    }
+    for boundary in compacted
+        .boundary_inputs
+        .iter_mut()
+        .chain(compacted.boundary_outputs.iter_mut())
+    {
+        boundary.x = remap_x(boundary.x);
+    }
+    for (_, x, _) in &mut compacted.surplus_exits {
+        *x = remap_x(*x);
+    }
+    compacted.width -= removed_before[layout.width as usize];
+    compacted.regions.clear();
+    compacted.trace = None;
+    compacted
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RouteTerminalKind {
+    ProducerDrop,
+    ConsumerPickup,
+    BoundaryInput,
+    BoundaryOutput,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RouteTerminal {
+    pub kind: RouteTerminalKind,
+    pub x: i32,
+    pub y: i32,
+    pub recipe: Option<String>,
+}
+
+/// Replaceable logistics net recovered from the current embedding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RouteNet {
+    pub item: String,
+    pub copy: Option<u32>,
+    pub segments: Vec<String>,
+    pub entity_indices: Vec<usize>,
+    pub terminals: Vec<RouteTerminal>,
+}
+
+/// Recover belt nets and their machine/boundary terminals from a validated
+/// layout. This is routing intent for rubber-band re-embedding, not part of
+/// the production invariant: later phases may merge or split these nets while
+/// preserving [`ProductionSignature`].
+pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
+    let mut nets: Vec<RouteNet> = Vec::new();
+    let mut net_by_key: BTreeMap<(String, Option<u32>), usize> = BTreeMap::new();
+    let mut entity_net: BTreeMap<usize, usize> = BTreeMap::new();
+
+    for (entity_idx, entity) in layout.entities.iter().enumerate() {
+        if !is_belt_entity(&entity.name) {
+            continue;
+        }
+        let Some(segment) = entity.segment_id.clone() else {
+            continue;
+        };
+        let Some(item) = entity.carries.clone() else {
+            continue;
+        };
+        let copy = segment_copy(&segment);
+        let key = (item.clone(), copy);
+        let net_idx = *net_by_key.entry(key).or_insert_with(|| {
+            let idx = nets.len();
+            nets.push(RouteNet {
+                item,
+                copy,
+                segments: Vec::new(),
+                entity_indices: Vec::new(),
+                terminals: Vec::new(),
+            });
+            idx
+        });
+        if !nets[net_idx].segments.contains(&segment) {
+            nets[net_idx].segments.push(segment);
+        }
+        nets[net_idx].entity_indices.push(entity_idx);
+        entity_net.insert(entity_idx, net_idx);
+    }
+
+    let mut machine_at: BTreeMap<(i32, i32), String> = BTreeMap::new();
+    for entity in &layout.entities {
+        let Some(recipe) = entity.recipe.as_ref() else {
+            continue;
+        };
+        let (mut width, mut height) = entity_size(&entity.name);
+        if matches!(entity.direction, EntityDirection::East | EntityDirection::West)
+            && width != height
+        {
+            std::mem::swap(&mut width, &mut height);
+        }
+        for x in entity.x..entity.x + width as i32 {
+            for y in entity.y..entity.y + height as i32 {
+                machine_at.insert((x, y), recipe.clone());
+            }
+        }
+    }
+
+    // Map every surface tile occupied by a belt-like entity to its net. A
+    // splitter has a two-tile footprint and an inserter may address either
+    // half.
+    let mut belt_net_at: BTreeMap<(i32, i32), usize> = BTreeMap::new();
+    for (&entity_idx, &net_idx) in &entity_net {
+        let entity = &layout.entities[entity_idx];
+        let (width, height) = oriented_splitter_dims(&entity.name, entity.direction)
+            .unwrap_or((1, 1));
+        for x in entity.x..entity.x + width as i32 {
+            for y in entity.y..entity.y + height as i32 {
+                belt_net_at.insert((x, y), net_idx);
+            }
+        }
+    }
+
+    for inserter in layout.entities.iter().filter(|e| is_inserter(&e.name)) {
+        let (dx, dy) = dir_to_vec(inserter.direction);
+        let reach = inserter_reach(&inserter.name);
+        let pickup = (inserter.x - dx * reach, inserter.y - dy * reach);
+        let drop = (inserter.x + dx * reach, inserter.y + dy * reach);
+        if let (Some(&net_idx), Some(recipe)) =
+            (belt_net_at.get(&drop), machine_at.get(&pickup))
+        {
+            nets[net_idx].terminals.push(RouteTerminal {
+                kind: RouteTerminalKind::ProducerDrop,
+                x: drop.0,
+                y: drop.1,
+                recipe: Some(recipe.clone()),
+            });
+        }
+        if let (Some(&net_idx), Some(recipe)) =
+            (belt_net_at.get(&pickup), machine_at.get(&drop))
+        {
+            nets[net_idx].terminals.push(RouteTerminal {
+                kind: RouteTerminalKind::ConsumerPickup,
+                x: pickup.0,
+                y: pickup.1,
+                recipe: Some(recipe.clone()),
+            });
+        }
+    }
+
+    for (kind, boundaries) in [
+        (RouteTerminalKind::BoundaryInput, &layout.boundary_inputs),
+        (RouteTerminalKind::BoundaryOutput, &layout.boundary_outputs),
+    ] {
+        for boundary in boundaries {
+            if let Some(&net_idx) = belt_net_at.get(&(boundary.x, boundary.y)) {
+                nets[net_idx].terminals.push(RouteTerminal {
+                    kind,
+                    x: boundary.x,
+                    y: boundary.y,
+                    recipe: None,
+                });
+            }
+        }
+    }
+
+    for net in &mut nets {
+        net.entity_indices.sort_unstable();
+        net.segments.sort();
+        net.terminals.sort();
+        net.terminals.dedup();
+    }
+    nets.sort_by(|a, b| (&a.item, a.copy).cmp(&(&b.item, b.copy)));
+    nets
+}
+
+fn segment_copy(segment: &str) -> Option<u32> {
+    let (_, suffix) = segment.rsplit_once('#')?;
+    let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -390,6 +629,86 @@ mod tests {
         assert_eq!(
             PlacedMachineSignature::from_layout(&a),
             PlacedMachineSignature::from_layout(&b)
+        );
+    }
+
+    #[test]
+    fn empty_column_strip_preserves_entities_and_shortens_geometry() {
+        let mut layout = LayoutResult {
+            width: 6,
+            height: 1,
+            entities: vec![
+                crate::models::PlacedEntity {
+                    name: "express-underground-belt".into(),
+                    x: 0,
+                    direction: EntityDirection::East,
+                    io_type: Some("input".into()),
+                    ..Default::default()
+                },
+                crate::models::PlacedEntity {
+                    name: "express-underground-belt".into(),
+                    x: 5,
+                    direction: EntityDirection::East,
+                    io_type: Some("output".into()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let signature = PlacedMachineSignature::from_layout(&layout);
+        let compacted = strip_empty_columns(&layout);
+        assert_eq!(compacted.width, 2);
+        assert_eq!(compacted.entities[0].x, 0);
+        assert_eq!(compacted.entities[1].x, 1);
+        assert_eq!(PlacedMachineSignature::from_layout(&compacted), signature);
+        layout.entities.reverse();
+        assert_eq!(strip_empty_columns(&layout).width, 2);
+    }
+
+    #[test]
+    fn route_net_extraction_finds_machine_endpoints() {
+        let layout = LayoutResult {
+            entities: vec![
+                crate::models::PlacedEntity {
+                    name: "assembling-machine-3".into(),
+                    x: 0,
+                    y: 0,
+                    recipe: Some("plate".into()),
+                    ..Default::default()
+                },
+                crate::models::PlacedEntity {
+                    name: "inserter".into(),
+                    x: 1,
+                    y: 3,
+                    direction: EntityDirection::South,
+                    ..Default::default()
+                },
+                crate::models::PlacedEntity {
+                    name: "transport-belt".into(),
+                    x: 1,
+                    y: 4,
+                    direction: EntityDirection::East,
+                    carries: Some("plate".into()),
+                    segment_id: Some("corr:plate".into()),
+                    ..Default::default()
+                },
+            ],
+            width: 3,
+            height: 5,
+            ..Default::default()
+        };
+        let nets = extract_route_nets(&layout);
+        assert_eq!(nets.len(), 1);
+        assert_eq!(nets[0].item, "plate");
+        assert_eq!(nets[0].segments, vec!["corr:plate"]);
+        assert_eq!(
+            nets[0].terminals,
+            vec![RouteTerminal {
+                kind: RouteTerminalKind::ProducerDrop,
+                x: 1,
+                y: 4,
+                recipe: Some("plate".into()),
+            }]
         );
     }
 }

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -440,6 +440,113 @@ impl CompactIr {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ManifoldTerminal {
+    pub kind: RouteTerminalKind,
+    pub x: i32,
+    pub y: i32,
+    pub island_id: Option<usize>,
+    pub inserter_entity_index: Option<usize>,
+}
+
+/// One multi-terminal commodity-routing problem after island placement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifoldNet {
+    pub item: String,
+    pub terminals: Vec<ManifoldTerminal>,
+}
+
+impl ManifoldNet {
+    pub fn producers(&self) -> impl Iterator<Item = &ManifoldTerminal> {
+        self.terminals.iter().filter(|terminal| {
+            matches!(
+                terminal.kind,
+                RouteTerminalKind::ProducerDrop | RouteTerminalKind::BoundaryInput
+            )
+        })
+    }
+
+    pub fn consumers(&self) -> impl Iterator<Item = &ManifoldTerminal> {
+        self.terminals.iter().filter(|terminal| {
+            matches!(
+                terminal.kind,
+                RouteTerminalKind::ConsumerPickup | RouteTerminalKind::BoundaryOutput
+            )
+        })
+    }
+}
+
+/// Materialise route terminals at a proposed island placement.
+///
+/// Machine terminals move with their islands. External boundaries remain
+/// relocatable interfaces at this stage: their source coordinates are kept as
+/// an incumbent, but the manifold renderer may move them to its perimeter.
+pub fn build_manifold_nets(
+    ir: &CompactIr,
+    placed_islands: &[RigidIsland],
+) -> Result<Vec<ManifoldNet>, String> {
+    if ir.islands.len() != placed_islands.len() {
+        return Err("CompactIR and placed island counts differ".into());
+    }
+    let mut by_item: BTreeMap<String, Vec<ManifoldTerminal>> = ir
+        .route_nets
+        .iter()
+        .map(|net| (net.item.clone(), Vec::new()))
+        .collect();
+
+    for (source, placed) in ir.islands.iter().zip(placed_islands) {
+        if source.id != placed.id || source.entity_indices != placed.entity_indices {
+            return Err(format!("island identity changed at {}", source.id));
+        }
+        for terminal in &source.terminals {
+            let Some(terminals) = by_item.get_mut(&terminal.item) else {
+                return Err(format!(
+                    "island {} terminal item {} has no route net",
+                    source.id, terminal.item
+                ));
+            };
+            terminals.push(ManifoldTerminal {
+                kind: terminal.kind,
+                x: placed.block.x + terminal.dx,
+                y: placed.block.y + terminal.dy,
+                island_id: Some(placed.id),
+                inserter_entity_index: Some(terminal.inserter_entity_index),
+            });
+        }
+    }
+
+    // Boundary terminals have no island-relative representation.
+    for net in &ir.route_nets {
+        let terminals = by_item.get_mut(&net.item).unwrap();
+        for terminal in &net.terminals {
+            if !matches!(
+                terminal.kind,
+                RouteTerminalKind::BoundaryInput | RouteTerminalKind::BoundaryOutput
+            ) {
+                continue;
+            }
+            terminals.push(ManifoldTerminal {
+                kind: terminal.kind,
+                x: terminal.x,
+                y: terminal.y,
+                island_id: None,
+                inserter_entity_index: None,
+            });
+        }
+    }
+
+    let mut result = Vec::with_capacity(by_item.len());
+    for (item, mut terminals) in by_item {
+        terminals.sort();
+        terminals.dedup();
+        if terminals.is_empty() {
+            return Err(format!("route net {item} has no terminals"));
+        }
+        result.push(ManifoldNet { item, terminals });
+    }
+    Ok(result)
+}
+
 fn entity_dims(name: &str, direction: EntityDirection) -> (i32, i32) {
     let (mut width, mut height) =
         oriented_splitter_dims(name, direction).unwrap_or_else(|| entity_size(name));
@@ -1085,6 +1192,17 @@ mod tests {
         assert_eq!(
             PlacedMachineSignature::from_layout(&layout),
             PlacedMachineSignature::from_layout(&moved),
+        );
+
+        let ir = CompactIr::from_layout(&layout);
+        let manifolds = build_manifold_nets(&ir, &placed).unwrap();
+        assert_eq!(manifolds.len(), 1);
+        assert_eq!(manifolds[0].item, "gear");
+        assert_eq!(manifolds[0].producers().count(), 1);
+        assert_eq!(manifolds[0].consumers().count(), 0);
+        assert_eq!(
+            (manifolds[0].terminals[0].x, manifolds[0].terminals[0].y),
+            (25, 14),
         );
     }
 }

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -1734,6 +1734,7 @@ pub fn build_local_manifold_graph(plan: &LocalManifoldPlan) -> LocalManifoldGrap
 pub struct PlacedManifoldNode {
     pub node_id: usize,
     pub origin: (i32, i32),
+    pub direction: EntityDirection,
     pub input_ports: Vec<(i32, i32)>,
     pub output_ports: Vec<(i32, i32)>,
 }
@@ -1766,6 +1767,99 @@ pub struct ManifoldRoutingResult {
     pub unroutable: Vec<(String, ManifoldGraphEdge)>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LegalizedManifoldRoute {
+    pub item: String,
+    pub edge: ManifoldGraphEdge,
+    /// Adjacent surface steps plus legal underground jumps.
+    pub path: Vec<(i32, i32)>,
+    /// Surface tiles still claimed by an earlier route.
+    pub unresolved_tiles: Vec<(i32, i32)>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ManifoldLegalizationResult {
+    pub routes: Vec<LegalizedManifoldRoute>,
+    pub unresolved_routes: usize,
+    pub unresolved_tiles: usize,
+    pub underground_spans: usize,
+}
+
+/// Convert a fully legalised route set into belt entities.
+///
+/// Fixed node/lane endpoint belts are already present in the stamped hubs and
+/// are omitted here. Any unresolved surface claim rejects the whole
+/// transaction.
+pub fn materialize_legalized_manifold_routes(
+    routes: &[LegalizedManifoldRoute],
+) -> Result<Vec<PlacedEntity>, String> {
+    use crate::bus::trunk_renderer::render_path;
+
+    let unresolved_routes = routes
+        .iter()
+        .filter(|route| !route.unresolved_tiles.is_empty())
+        .count();
+    if unresolved_routes > 0 {
+        return Err(format!(
+            "{unresolved_routes} manifold routes still contain surface conflicts"
+        ));
+    }
+
+    let mut entities = Vec::new();
+    let mut occupied = FxHashSet::default();
+    for (route_idx, route) in routes.iter().enumerate() {
+        if route.path.len() < 2 {
+            return Err(format!(
+                "manifold route {route_idx} has fewer than two points"
+            ));
+        }
+        let direction = path_exit_direction(&route.path)
+            .ok_or_else(|| format!("manifold route {route_idx} has no cardinal exit direction"))?;
+        let mut rendered = render_path(
+            &route.path,
+            &route.item,
+            "express-transport-belt",
+            direction,
+            Some(format!("compact-route:{}:{route_idx}", route.item)),
+            None,
+        );
+        let omit_start =
+            endpoint_has_fixed_port_direction(&route.edge.from).then_some(route.path[0]);
+        let omit_end = endpoint_has_fixed_port_direction(&route.edge.to)
+            .then_some(*route.path.last().unwrap());
+        rendered.retain(|entity| {
+            Some((entity.x, entity.y)) != omit_start && Some((entity.x, entity.y)) != omit_end
+        });
+        for entity in &rendered {
+            let (width, height) = entity_dims(&entity.name, entity.direction);
+            for x in entity.x..entity.x + width {
+                for y in entity.y..entity.y + height {
+                    if !occupied.insert((x, y)) {
+                        return Err(format!("materialized manifold routes overlap at ({x},{y})"));
+                    }
+                }
+            }
+        }
+        entities.extend(rendered);
+    }
+    Ok(entities)
+}
+
+fn path_exit_direction(path: &[(i32, i32)]) -> Option<EntityDirection> {
+    for pair in path.windows(2).rev() {
+        let dx = (pair[1].0 - pair[0].0).signum();
+        let dy = (pair[1].1 - pair[0].1).signum();
+        match (dx, dy) {
+            (1, 0) => return Some(EntityDirection::East),
+            (-1, 0) => return Some(EntityDirection::West),
+            (0, 1) => return Some(EntityDirection::South),
+            (0, -1) => return Some(EntityDirection::North),
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Route every explicit edge in the local manifold graphs.
 ///
 /// This is deliberately a topology result, not yet belt geometry: paths may
@@ -1778,8 +1872,6 @@ pub fn route_local_manifold_edges(
     graphs: &[LocalManifoldGraph],
     hubs: &[PlacedLocalManifold],
 ) -> Result<ManifoldRoutingResult, String> {
-    use crate::astar::ghost_astar;
-
     if graphs.len() != hubs.len() {
         return Err(format!(
             "manifold graph/hub count differs: {} != {}",
@@ -1851,68 +1943,395 @@ pub fn route_local_manifold_edges(
             }
         }
     }
-
-    let mut claimed = FxHashSet::default();
-    let mut axis_costs = FxHashMap::default();
-    let mut result = ManifoldRoutingResult::default();
+    let mut exclusive_hard = hard.clone();
+    // Keep every terminal and fixed-port access socket available until its
+    // own edge is routed. Underground interiors may pass beneath these
+    // reservations, but no unrelated surface endpoint may consume them.
     for (graph, hub) in graphs.iter().zip(hubs) {
         for edge in &graph.edges {
-            let start = manifold_endpoint_point(&edge.from, hub)?;
-            let goal = manifold_endpoint_point(&edge.to, hub)?;
-            let shifted_start = shifted(start);
-            let shifted_goal = shifted(goal);
-            let mut edge_hard = hard.clone();
-            edge_hard.remove(&shifted_start);
-            edge_hard.remove(&shifted_goal);
-            let Some((path, crossings)) = ghost_astar(
-                shifted_start,
-                shifted_goal,
-                &edge_hard,
-                &claimed,
-                width,
-                height,
-                2,
-                &axis_costs,
-            ) else {
-                result.unroutable.push((graph.item.clone(), edge.clone()));
-                continue;
-            };
-            let path: Vec<_> = path
-                .into_iter()
-                .map(|point| (point.0 - shift.0, point.1 - shift.1))
-                .collect();
-            let crossings: Vec<_> = crossings
-                .into_iter()
-                .map(|point| (point.0 - shift.0, point.1 - shift.1))
-                .collect();
-            claimed.extend(path.iter().copied().map(shifted));
-            // Prefer clean parallel channels and cheap perpendicular
-            // crossings over running along an already claimed belt. This is
-            // the first negotiated-routing pass: a later legalizer can turn
-            // an isolated perpendicular crossing into an underground pair,
-            // whereas a same-axis overlap cannot be materialised directly.
-            for pair in path.windows(2) {
-                let from = shifted(pair[0]);
-                let to = shifted(pair[1]);
-                let horizontal = pair[0].1 == pair[1].1;
-                for tile in [from, to] {
-                    let penalty = axis_costs.entry(tile).or_insert((0u32, 0u32));
-                    if horizontal {
-                        penalty.1 = penalty.1.max(4);
-                    } else {
-                        penalty.0 = penalty.0.max(4);
-                    }
-                }
+            for (endpoint, output_side) in [(&edge.from, true), (&edge.to, false)] {
+                let socket = manifold_endpoint_socket(endpoint, hub, output_side)?;
+                exclusive_hard.insert(shifted(socket));
             }
-            result.routes.push(RoutedManifoldEdge {
-                item: graph.item.clone(),
-                edge: edge.clone(),
-                path,
-                crossings,
-            });
         }
     }
+    let mut claimed = FxHashSet::default();
+    let mut result = ManifoldRoutingResult::default();
+    let mut tasks = Vec::new();
+    for (graph_idx, graph) in graphs.iter().enumerate() {
+        for edge in &graph.edges {
+            let hub = &hubs[graph_idx];
+            let start = manifold_endpoint_point(&edge.from, hub)?;
+            let goal = manifold_endpoint_point(&edge.to, hub)?;
+            let span = (start.0 - goal.0).abs() + (start.1 - goal.1).abs();
+            tasks.push((span, graph_idx, edge));
+        }
+    }
+    tasks.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)).then(a.2.cmp(b.2)));
+    let mut fallback = Vec::new();
+    for &(_, graph_idx, edge) in &tasks {
+        let graph = &graphs[graph_idx];
+        let hub = &hubs[graph_idx];
+        let start = manifold_endpoint_point(&edge.from, hub)?;
+        let goal = manifold_endpoint_point(&edge.to, hub)?;
+        // Library balancers and capacity lanes are SOUTH-oriented.
+        // Route from the tile immediately below an output and into the
+        // tile immediately above an input; the stamped endpoint belt then
+        // supplies the final directed step. Terminals are newly emitted
+        // belts and therefore impose no pre-existing direction.
+        let route_start = manifold_endpoint_socket(&edge.from, hub, true)?;
+        let route_goal = manifold_endpoint_socket(&edge.to, hub, false)?;
+        let shifted_start = shifted(route_start);
+        let shifted_goal = shifted(route_goal);
+        let mut edge_hard = exclusive_hard.clone();
+        edge_hard.remove(&shifted_start);
+        edge_hard.remove(&shifted_goal);
+        let Some(path) = compact_belt_astar(
+            shifted_start,
+            shifted_goal,
+            &edge_hard,
+            &claimed,
+            width,
+            height,
+        ) else {
+            fallback.push((graph_idx, edge));
+            continue;
+        };
+        let mut path: Vec<_> = path
+            .into_iter()
+            .map(|point| (point.0 - shift.0, point.1 - shift.1))
+            .collect();
+        if route_start != start {
+            path.insert(0, start);
+        }
+        if route_goal != goal {
+            path.push(goal);
+        }
+        let crossings = Vec::new();
+        let claim_start = usize::from(route_start != start);
+        let claim_end = path.len() - usize::from(route_goal != goal);
+        claimed.extend(path[claim_start..claim_end].iter().copied().map(shifted));
+        result.routes.push(RoutedManifoldEdge {
+            item: graph.item.clone(),
+            edge: edge.clone(),
+            path,
+            crossings,
+        });
+    }
+    let mut retry_hard = hard.clone();
+    for &(graph_idx, edge) in &fallback {
+        let hub = &hubs[graph_idx];
+        retry_hard.insert(shifted(manifold_endpoint_socket(&edge.from, hub, true)?));
+        retry_hard.insert(shifted(manifold_endpoint_socket(&edge.to, hub, false)?));
+    }
+    let mut ghost_fallback = Vec::new();
+    for (graph_idx, edge) in fallback {
+        let graph = &graphs[graph_idx];
+        let hub = &hubs[graph_idx];
+        let start = manifold_endpoint_point(&edge.from, hub)?;
+        let goal = manifold_endpoint_point(&edge.to, hub)?;
+        let route_start = manifold_endpoint_socket(&edge.from, hub, true)?;
+        let route_goal = manifold_endpoint_socket(&edge.to, hub, false)?;
+        let shifted_start = shifted(route_start);
+        let shifted_goal = shifted(route_goal);
+        let mut edge_hard = retry_hard.clone();
+        edge_hard.remove(&shifted_start);
+        edge_hard.remove(&shifted_goal);
+        let Some(path) = compact_belt_astar(
+            shifted_start,
+            shifted_goal,
+            &edge_hard,
+            &claimed,
+            width,
+            height,
+        ) else {
+            ghost_fallback.push((graph_idx, edge));
+            continue;
+        };
+        let mut path: Vec<_> = path
+            .into_iter()
+            .map(|point| (point.0 - shift.0, point.1 - shift.1))
+            .collect();
+        if route_start != start {
+            path.insert(0, start);
+        }
+        if route_goal != goal {
+            path.push(goal);
+        }
+        let claim_start = usize::from(route_start != start);
+        let claim_end = path.len() - usize::from(route_goal != goal);
+        claimed.extend(path[claim_start..claim_end].iter().copied().map(shifted));
+        result.routes.push(RoutedManifoldEdge {
+            item: graph.item.clone(),
+            edge: edge.clone(),
+            path,
+            crossings: Vec::new(),
+        });
+    }
+    // Preserve progress from the exclusive underground-aware pass, then use
+    // ghost paths only for the residual edges. These routes remain explicit
+    // legalization work instead of causing the entire candidate to vanish.
+    let axis_costs = FxHashMap::default();
+    for (graph_idx, edge) in ghost_fallback {
+        let graph = &graphs[graph_idx];
+        let hub = &hubs[graph_idx];
+        let start = manifold_endpoint_point(&edge.from, hub)?;
+        let goal = manifold_endpoint_point(&edge.to, hub)?;
+        let route_start = manifold_endpoint_socket(&edge.from, hub, true)?;
+        let route_goal = manifold_endpoint_socket(&edge.to, hub, false)?;
+        let shifted_start = shifted(route_start);
+        let shifted_goal = shifted(route_goal);
+        let mut edge_hard = hard.clone();
+        edge_hard.remove(&shifted_start);
+        edge_hard.remove(&shifted_goal);
+        let Some((path, crossings)) = crate::astar::ghost_astar(
+            shifted_start,
+            shifted_goal,
+            &edge_hard,
+            &claimed,
+            width,
+            height,
+            2,
+            &axis_costs,
+        ) else {
+            result.unroutable.push((graph.item.clone(), edge.clone()));
+            continue;
+        };
+        let mut path: Vec<_> = path
+            .into_iter()
+            .map(|point| (point.0 - shift.0, point.1 - shift.1))
+            .collect();
+        if route_start != start {
+            path.insert(0, start);
+        }
+        if route_goal != goal {
+            path.push(goal);
+        }
+        let crossings: Vec<_> = crossings
+            .into_iter()
+            .map(|point| (point.0 - shift.0, point.1 - shift.1))
+            .collect();
+        let claim_start = usize::from(route_start != start);
+        let claim_end = path.len() - usize::from(route_goal != goal);
+        claimed.extend(path[claim_start..claim_end].iter().copied().map(shifted));
+        result.routes.push(RoutedManifoldEdge {
+            item: graph.item.clone(),
+            edge: edge.clone(),
+            path,
+            crossings,
+        });
+    }
     Ok(result)
+}
+
+/// Entity-cost A* for dense solid routing.
+///
+/// Surface moves require a free destination. Underground moves may cross any
+/// hard or previously routed interior tile, but their endpoints must be free.
+/// A jump costs two entities regardless of distance, so the search naturally
+/// prefers maximal legal underground spans without a separate compression
+/// pass.
+fn compact_belt_astar(
+    start: (i32, i32),
+    goal: (i32, i32),
+    hard: &FxHashSet<(i32, i32)>,
+    occupied: &FxHashSet<(i32, i32)>,
+    width: i32,
+    height: i32,
+) -> Option<Vec<(i32, i32)>> {
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    struct State {
+        x: i32,
+        y: i32,
+        dir: i8,
+    }
+
+    const DIRECTIONS: [(i32, i32, i8); 4] = [(1, 0, 0), (0, 1, 1), (-1, 0, 2), (0, -1, 3)];
+    if occupied.contains(&start) || occupied.contains(&goal) {
+        return None;
+    }
+    let start_state = State {
+        x: start.0,
+        y: start.1,
+        dir: -1,
+    };
+    let mut queue = BinaryHeap::new();
+    let mut distance: FxHashMap<State, u32> = FxHashMap::default();
+    let mut parent: FxHashMap<State, State> = FxHashMap::default();
+    let max_jump = ug_max_reach("express-transport-belt") as i32 + 1;
+    let axis_lower_bound = |distance: i32| {
+        let distance = distance.unsigned_abs();
+        let full = distance / max_jump as u32;
+        let remainder = distance % max_jump as u32;
+        full * 2
+            + match remainder {
+                0 => 0,
+                1 => 1,
+                _ => 2,
+            }
+    };
+    let heuristic =
+        |point: (i32, i32)| axis_lower_bound(goal.0 - point.0) + axis_lower_bound(goal.1 - point.1);
+    queue.push(Reverse((heuristic(start), 0u32, start_state)));
+    distance.insert(start_state, 0u32);
+
+    while let Some(Reverse((_, cost, state))) = queue.pop() {
+        if cost != distance.get(&state).copied().unwrap_or(u32::MAX) {
+            continue;
+        }
+        if (state.x, state.y) == goal {
+            let mut path = vec![goal];
+            let mut cursor = state;
+            while let Some(&previous) = parent.get(&cursor) {
+                path.push((previous.x, previous.y));
+                cursor = previous;
+            }
+            path.reverse();
+            return Some(path);
+        }
+        for &(dx, dy, dir) in &DIRECTIONS {
+            let turn_cost = u32::from(state.dir != -1 && state.dir != dir) * 2;
+            for jump in 1..=max_jump {
+                // A distance-two underground pair is never cheaper than two
+                // surface belts. Keep it available only when the intervening
+                // tile is blocked.
+                if jump == 2 {
+                    let middle = (state.x + dx, state.y + dy);
+                    if !hard.contains(&middle) && !occupied.contains(&middle) {
+                        continue;
+                    }
+                }
+                let next = (state.x + dx * jump, state.y + dy * jump);
+                if next.0 < 0 || next.0 >= width || next.1 < 0 || next.1 >= height {
+                    break;
+                }
+                if occupied.contains(&next) || (next != goal && hard.contains(&next)) {
+                    continue;
+                }
+                let entity_cost = if jump == 1 { 1 } else { 2 };
+                let next_cost = cost + entity_cost + turn_cost;
+                let next_state = State {
+                    x: next.0,
+                    y: next.1,
+                    dir,
+                };
+                if next_cost < distance.get(&next_state).copied().unwrap_or(u32::MAX) {
+                    distance.insert(next_state, next_cost);
+                    parent.insert(next_state, state);
+                    queue.push(Reverse((
+                        next_cost + heuristic(next),
+                        next_cost,
+                        next_state,
+                    )));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Hide bounded conflicting runs beneath earlier routes.
+///
+/// Express underground belts may bridge at most eight hidden tiles, so their
+/// endpoints may be nine tiles apart. This pass greedily replaces a straight
+/// adjacent subpath with such a jump whenever its interior contains an
+/// already claimed surface tile and both endpoints remain free. Fixed
+/// balancer/lane ports cannot themselves become underground endpoints.
+///
+/// Residual overlaps remain explicit and make the candidate non-exportable.
+pub fn legalize_manifold_routes(routes: &[RoutedManifoldEdge]) -> ManifoldLegalizationResult {
+    let max_distance = ug_max_reach("express-transport-belt") as usize + 1;
+    let mut occupied = FxHashSet::default();
+    let mut result = ManifoldLegalizationResult::default();
+    for route in routes {
+        if route.path.is_empty() {
+            result.unresolved_routes += 1;
+            result.routes.push(LegalizedManifoldRoute {
+                item: route.item.clone(),
+                edge: route.edge.clone(),
+                path: Vec::new(),
+                unresolved_tiles: Vec::new(),
+            });
+            continue;
+        }
+        let source_fixed = endpoint_has_fixed_port_direction(&route.edge.from);
+        let target_fixed = endpoint_has_fixed_port_direction(&route.edge.to);
+        let mut path = Vec::with_capacity(route.path.len());
+        let mut i = 0;
+        path.push(route.path[0]);
+        while i + 1 < route.path.len() {
+            let mut jump = None;
+            let max_j = (i + max_distance).min(route.path.len() - 1);
+            for j in ((i + 2)..=max_j).rev() {
+                if (i == 0 && source_fixed) || (j + 1 == route.path.len() && target_fixed) {
+                    continue;
+                }
+                if occupied.contains(&route.path[i]) || occupied.contains(&route.path[j]) {
+                    continue;
+                }
+                let Some(step) = straight_adjacent_step(&route.path[i..=j]) else {
+                    continue;
+                };
+                if step == (0, 0) {
+                    continue;
+                }
+                if route.path[i + 1..j]
+                    .iter()
+                    .any(|tile| occupied.contains(tile))
+                {
+                    jump = Some(j);
+                    break;
+                }
+            }
+            if let Some(j) = jump {
+                path.push(route.path[j]);
+                result.underground_spans += 1;
+                i = j;
+            } else {
+                i += 1;
+                path.push(route.path[i]);
+            }
+        }
+
+        let claim_start = usize::from(source_fixed);
+        let claim_end = path.len() - usize::from(target_fixed);
+        let unresolved_tiles: Vec<_> = path[claim_start..claim_end]
+            .iter()
+            .copied()
+            .filter(|tile| occupied.contains(tile))
+            .collect();
+        if !unresolved_tiles.is_empty() {
+            result.unresolved_routes += 1;
+            result.unresolved_tiles += unresolved_tiles.len();
+        }
+        occupied.extend(path[claim_start..claim_end].iter().copied());
+        result.routes.push(LegalizedManifoldRoute {
+            item: route.item.clone(),
+            edge: route.edge.clone(),
+            path,
+            unresolved_tiles,
+        });
+    }
+    result
+}
+
+fn straight_adjacent_step(path: &[(i32, i32)]) -> Option<(i32, i32)> {
+    let first = *path.first()?;
+    let second = *path.get(1)?;
+    let step = (second.0 - first.0, second.1 - first.1);
+    if step.0.abs() + step.1.abs() != 1 {
+        return None;
+    }
+    path.windows(2)
+        .all(|pair| (pair[1].0 - pair[0].0, pair[1].1 - pair[0].1) == step)
+        .then_some(step)
+}
+
+fn endpoint_has_fixed_port_direction(endpoint: &ManifoldEndpoint) -> bool {
+    !matches!(endpoint, ManifoldEndpoint::Terminal(_))
 }
 
 fn manifold_endpoint_point(
@@ -1943,6 +2362,29 @@ fn manifold_endpoint_point(
             .get(*lane as usize)
             .copied()
             .ok_or_else(|| format!("{} lane {lane} output is missing", hub.item)),
+    }
+}
+
+fn manifold_endpoint_socket(
+    endpoint: &ManifoldEndpoint,
+    hub: &PlacedLocalManifold,
+    output_side: bool,
+) -> Result<(i32, i32), String> {
+    let point = manifold_endpoint_point(endpoint, hub)?;
+    let direction = match endpoint {
+        ManifoldEndpoint::Terminal(_) => return Ok(point),
+        ManifoldEndpoint::NodeInput { node, .. } | ManifoldEndpoint::NodeOutput { node, .. } => hub
+            .nodes
+            .get(*node)
+            .map(|placed| placed.direction)
+            .ok_or_else(|| format!("{} node {node} direction is missing", hub.item))?,
+        ManifoldEndpoint::LaneInput(_) | ManifoldEndpoint::LaneOutput(_) => EntityDirection::South,
+    };
+    let (dx, dy) = dir_to_vec(direction);
+    if output_side {
+        Ok((point.0 + dx, point.1 + dy))
+    } else {
+        Ok((point.0 - dx, point.1 - dy))
     }
 }
 
@@ -2113,6 +2555,7 @@ pub fn place_local_manifold_nodes(
             placed_nodes.push(PlacedManifoldNode {
                 node_id: node.id,
                 origin: (origin_x, origin_y),
+                direction: EntityDirection::South,
                 input_ports: template
                     .input_tiles
                     .iter()
@@ -2169,7 +2612,6 @@ pub fn place_distributed_local_manifold_nodes(
     graphs: &[LocalManifoldGraph],
     clearance: i32,
 ) -> Result<Vec<PlacedLocalManifold>, String> {
-    use crate::bus::balancer::{splitter_for_belt, underground_for_belt};
     use crate::bus::balancer_library::balancer_templates;
 
     let templates = balancer_templates();
@@ -2251,13 +2693,23 @@ pub fn place_distributed_local_manifold_nodes(
             } else {
                 coordinate_median(&desired_points)
             };
+            let (flow_from, flow_to) = match node.role {
+                BalancerNodeRole::Merge => (center, lane_inputs[node.lane as usize]),
+                BalancerNodeRole::Distribute => (lane_outputs[node.lane as usize], center),
+            };
+            let direction = preferred_cardinal_direction(flow_from, flow_to);
+            let (template_width, template_height) = rotated_template_dimensions(
+                template.width as i32,
+                template.height as i32,
+                direction,
+            );
             let block = nearest_free_block(
                 CompactBlock {
                     id: node.id,
-                    x: center.0 - template.width as i32 / 2,
-                    y: center.1 - template.height as i32 / 2,
-                    width: template.width as i32,
-                    height: template.height as i32,
+                    x: center.0 - template_width / 2,
+                    y: center.1 - template_height / 2,
+                    width: template_width,
+                    height: template_height,
                 },
                 &reserved,
                 clearance,
@@ -2270,14 +2722,8 @@ pub fn place_distributed_local_manifold_nodes(
                 )
             })?;
             reserved.push(block.clone());
-            let mut stamped = template.stamp(
-                block.x,
-                block.y,
-                "express-transport-belt",
-                splitter_for_belt("express-transport-belt"),
-                underground_for_belt("express-transport-belt"),
-                Some(&graph.item),
-            );
+            let (mut stamped, input_ports, output_ports) =
+                stamp_rotated_balancer(template, block.x, block.y, direction, &graph.item);
             for entity in &mut stamped {
                 entity.segment_id = Some(format!(
                     "compact-hub:{}:{}:{}",
@@ -2288,16 +2734,9 @@ pub fn place_distributed_local_manifold_nodes(
             placed_nodes.push(PlacedManifoldNode {
                 node_id: node.id,
                 origin: (block.x, block.y),
-                input_ports: template
-                    .input_tiles
-                    .iter()
-                    .map(|&(x, y)| (block.x + x, block.y + y))
-                    .collect(),
-                output_ports: template
-                    .output_tiles
-                    .iter()
-                    .map(|&(x, y)| (block.x + x, block.y + y))
-                    .collect(),
+                direction,
+                input_ports,
+                output_ports,
             });
         }
         placed_nodes.sort_by_key(|node| node.node_id);
@@ -2330,6 +2769,108 @@ pub fn place_distributed_local_manifold_nodes(
         });
     }
     Ok(result)
+}
+
+fn preferred_cardinal_direction(from: (i32, i32), to: (i32, i32)) -> EntityDirection {
+    let dx = to.0 - from.0;
+    let dy = to.1 - from.1;
+    if dx.abs() > dy.abs() {
+        if dx >= 0 {
+            EntityDirection::East
+        } else {
+            EntityDirection::West
+        }
+    } else if dy < 0 {
+        EntityDirection::North
+    } else {
+        EntityDirection::South
+    }
+}
+
+fn rotated_template_dimensions(width: i32, height: i32, direction: EntityDirection) -> (i32, i32) {
+    if matches!(direction, EntityDirection::East | EntityDirection::West) {
+        (height, width)
+    } else {
+        (width, height)
+    }
+}
+
+fn rotate_template_tile(
+    point: (i32, i32),
+    width: i32,
+    height: i32,
+    direction: EntityDirection,
+) -> (i32, i32) {
+    match direction {
+        EntityDirection::South => point,
+        EntityDirection::North => (width - 1 - point.0, height - 1 - point.1),
+        EntityDirection::East => (point.1, width - 1 - point.0),
+        EntityDirection::West => (height - 1 - point.1, point.0),
+    }
+}
+
+fn rotate_template_direction(direction: EntityDirection, flow: EntityDirection) -> EntityDirection {
+    let value = direction as u8;
+    let rotated = match flow {
+        EntityDirection::South => value,
+        EntityDirection::North => (value + 8) % 16,
+        EntityDirection::East => (value + 12) % 16,
+        EntityDirection::West => (value + 4) % 16,
+    };
+    match rotated {
+        0 => EntityDirection::North,
+        4 => EntityDirection::East,
+        8 => EntityDirection::South,
+        12 => EntityDirection::West,
+        _ => unreachable!("cardinal rotation produced {rotated}"),
+    }
+}
+
+fn stamp_rotated_balancer(
+    template: &crate::bus::balancer_library::BalancerTemplate,
+    origin_x: i32,
+    origin_y: i32,
+    direction: EntityDirection,
+    item: &str,
+) -> (Vec<PlacedEntity>, Vec<(i32, i32)>, Vec<(i32, i32)>) {
+    use crate::bus::balancer::{splitter_for_belt, underground_for_belt};
+
+    let width = template.width as i32;
+    let height = template.height as i32;
+    let mut entities = template.stamp(
+        0,
+        0,
+        "express-transport-belt",
+        splitter_for_belt("express-transport-belt"),
+        underground_for_belt("express-transport-belt"),
+        Some(item),
+    );
+    for entity in &mut entities {
+        let (entity_width, entity_height) = entity_dims(&entity.name, entity.direction);
+        let mut rotated_tiles = Vec::new();
+        for x in entity.x..entity.x + entity_width {
+            for y in entity.y..entity.y + entity_height {
+                rotated_tiles.push(rotate_template_tile((x, y), width, height, direction));
+            }
+        }
+        entity.x = origin_x + rotated_tiles.iter().map(|tile| tile.0).min().unwrap();
+        entity.y = origin_y + rotated_tiles.iter().map(|tile| tile.1).min().unwrap();
+        entity.direction = rotate_template_direction(entity.direction, direction);
+    }
+    let rotate_ports = |ports: &[(i32, i32)]| {
+        ports
+            .iter()
+            .map(|&point| {
+                let point = rotate_template_tile(point, width, height, direction);
+                (origin_x + point.0, origin_y + point.1)
+            })
+            .collect()
+    };
+    (
+        entities,
+        rotate_ports(template.input_tiles),
+        rotate_ports(template.output_tiles),
+    )
 }
 
 fn partial_endpoint_point(
@@ -3139,6 +3680,71 @@ mod tests {
                 .iter()
                 .chain(distributors.iter())
                 .all(|stage| crate::bus::balancer::shape_is_stampable(stage.n, stage.m)));
+        }
+    }
+
+    #[test]
+    fn legalized_manifold_routes_materialize_underground_jumps() {
+        let terminal = |x| {
+            ManifoldEndpoint::Terminal(ManifoldTerminal {
+                kind: RouteTerminalKind::ProducerDrop,
+                x,
+                y: 0,
+                island_id: None,
+                inserter_entity_index: None,
+            })
+        };
+        let routes = vec![LegalizedManifoldRoute {
+            item: "iron-plate".into(),
+            edge: ManifoldGraphEdge {
+                from: terminal(0),
+                to: terminal(6),
+            },
+            path: vec![(0, 0), (6, 0)],
+            unresolved_tiles: Vec::new(),
+        }];
+        let entities = materialize_legalized_manifold_routes(&routes).unwrap();
+        assert_eq!(entities.len(), 2);
+        assert!(entities.iter().all(|entity| is_ug_belt(&entity.name)));
+        assert_eq!(entities[0].io_type.as_deref(), Some("input"));
+        assert_eq!(entities[1].io_type.as_deref(), Some("output"));
+    }
+
+    #[test]
+    fn unresolved_manifold_routes_are_not_materialized() {
+        let terminal = ManifoldEndpoint::Terminal(ManifoldTerminal {
+            kind: RouteTerminalKind::ProducerDrop,
+            x: 0,
+            y: 0,
+            island_id: None,
+            inserter_entity_index: None,
+        });
+        let routes = vec![LegalizedManifoldRoute {
+            item: "iron-plate".into(),
+            edge: ManifoldGraphEdge {
+                from: terminal.clone(),
+                to: terminal,
+            },
+            path: vec![(0, 0), (1, 0)],
+            unresolved_tiles: vec![(1, 0)],
+        }];
+        assert!(materialize_legalized_manifold_routes(&routes).is_err());
+    }
+
+    #[test]
+    fn balancer_rotation_preserves_ports_and_footprint() {
+        let template = crate::bus::balancer_library::balancer_templates()
+            .get(&(2, 1))
+            .unwrap();
+        let (entities, mut inputs, outputs) =
+            stamp_rotated_balancer(template, 10, 20, EntityDirection::East, "iron-plate");
+        inputs.sort();
+        assert_eq!(inputs, vec![(10, 20), (10, 21)]);
+        assert_eq!(outputs, vec![(12, 20)]);
+        for entity in entities {
+            let (width, height) = entity_dims(&entity.name, entity.direction);
+            assert!(entity.x >= 10 && entity.x + width <= 13);
+            assert!(entity.y >= 20 && entity.y + height <= 22);
         }
     }
 

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -4480,6 +4480,79 @@ pub enum FoldRefusal {
     InputStranded { at: (i32, i32) },
 }
 
+/// Re-place power poles for a layout whose geometry has moved.
+///
+/// Poles are the one thing a fold cannot carry along. `build_bus_layout`
+/// places them LAST, after routing, precisely because their positions depend
+/// on final geometry; translating the originals leaves a network that is
+/// correct nowhere — segments end up tens of tiles apart and the copper-wire
+/// graph fragments into islands. That shows up as `power` warnings on a fold
+/// whose belts are all perfect, which is what blocked most bus fixtures.
+///
+/// Strips existing poles, rebuilds the coverage subjects and occupancy from
+/// what remains, and runs the same placement the pipeline uses.
+fn replace_poles(layout: &LayoutResult) -> LayoutResult {
+    use crate::common::{is_inserter, is_machine_entity};
+
+    let mut kept: Vec<PlacedEntity> = layout
+        .entities
+        .iter()
+        .filter(|e| !e.name.ends_with("electric-pole") && e.name != "substation")
+        .cloned()
+        .collect();
+
+    let mut machines: Vec<(i32, i32, i32)> = Vec::new();
+    let mut inserters: Vec<(i32, i32)> = Vec::new();
+    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+    for ent in &kept {
+        if is_machine_entity(&ent.name) {
+            let (mw, mh) = crate::common::machine_dims(&ent.name);
+            let (mw, mh) = (mw as i32, mh as i32);
+            for dx in 0..mw {
+                for dy in 0..mh {
+                    occupied.insert((ent.x + dx, ent.y + dy));
+                }
+            }
+            machines.push((ent.x + mw / 2, ent.y, mh));
+        } else {
+            occupied.insert((ent.x, ent.y));
+            if is_inserter(&ent.name) {
+                inserters.push((ent.x, ent.y));
+            }
+            if crate::common::is_splitter(&ent.name) {
+                let (sx, sy) = crate::common::splitter_second_tile(ent);
+                occupied.insert((sx, sy));
+            }
+        }
+    }
+
+    let (poles, _uncovered) = crate::bus::layout::place_poles(
+        &machines,
+        &inserters,
+        &occupied,
+        &[],
+        // Quality is per-entity here; take it from a machine, since pole
+        // supply radius scales with it.
+        layout
+            .entities
+            .iter()
+            .find(|e| crate::common::is_machine_entity(&e.name))
+            .and_then(|e| e.quality)
+            .unwrap_or_default(),
+    );
+    kept.extend(poles);
+
+    let mut out = LayoutResult {
+        entities: kept,
+        ..layout.clone()
+    };
+    out.power_wires = Some(crate::power_wires::compute_pole_wires(
+        &out.entities,
+        out.wire_mode,
+    ));
+    out
+}
+
 /// Snake-fold a layout at the given fold columns.
 ///
 /// The layout is divided into `folds.len() + 1` vertical segments.  Even
@@ -5095,10 +5168,8 @@ pub fn fold_snake(
     };
     result.regions.clear();
     result.trace = None;
-    result.power_wires = Some(crate::power_wires::compute_pole_wires(
-        &result.entities,
-        result.wire_mode,
-    ));
+    // Poles must be re-placed, not carried: see `replace_poles`.
+    result = replace_poles(&result);
     // Boundary records and surplus exits are coordinates into the layout and
     // must go through the fold like everything else. Shifting only their X
     // (as an earlier version did) left every one of them pointing at an

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -770,7 +770,10 @@ pub fn undergroundify_straight_belts(layout: &LayoutResult) -> LayoutResult {
     for (_, x, y) in &layout.surplus_exits {
         protect_both((*x, *y));
     }
-    drop(protect_both);
+    // `protect_both` mutably borrows both sets; NLL ends that borrow here at
+    // its last use, so the sets are free for the direct inserts below. (An
+    // explicit `drop` would be a `clippy::drop_non_drop` error — a closure
+    // does not implement `Drop`.)
 
     // A perpendicular belt feeding a straight tile is a side-load/turn
     // junction. Splitters and existing undergrounds reserve their vicinity

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -4526,21 +4526,66 @@ fn replace_poles(layout: &LayoutResult) -> LayoutResult {
         }
     }
 
+    // Quality is per-entity here; take it from a machine, since pole supply
+    // radius and wire reach both scale with it.
+    let quality = layout
+        .entities
+        .iter()
+        .find(|e| crate::common::is_machine_entity(&e.name))
+        .and_then(|e| e.quality)
+        .unwrap_or_default();
     let (poles, _uncovered) = crate::bus::layout::place_poles(
         &machines,
         &inserters,
         &occupied,
         &[],
-        // Quality is per-entity here; take it from a machine, since pole
-        // supply radius scales with it.
-        layout
-            .entities
-            .iter()
-            .find(|e| crate::common::is_machine_entity(&e.name))
-            .and_then(|e| e.quality)
-            .unwrap_or_default(),
+        quality,
     );
     kept.extend(poles);
+
+    // Placement alone leaves islands. `build_bus_layout` follows it with
+    // `repair_pole_connectivity`, which drops bridge poles until the emitted
+    // wire graph is ONE component; skipping that step here produced a folded
+    // layout whose 89 poles formed two separate networks — a factory that
+    // pastes into a real game as two dead halves.
+    //
+    // It was invisible for two reasons worth remembering: the connectivity
+    // check aggregated its count into one warning, so the fold's admission
+    // gate saw the same issue count as the control; and the sim harness
+    // energises every pole network it finds, so the measured run powered both
+    // islands and passed.
+    // `repair_pole_connectivity` treats every element of the vec it is given
+    // as a wire node — it calls `pole_center` on each — so it takes a
+    // poles-ONLY vec, as the pipeline gives it. Handing it the whole layout
+    // makes it read belts and machines as poles, conclude the graph is one
+    // component, and return having done nothing.
+    let is_pole_ent =
+        |e: &PlacedEntity| e.name.ends_with("electric-pole") || e.name == "substation";
+    let mut pole_ents: Vec<PlacedEntity> =
+        kept.iter().filter(|e| is_pole_ent(e)).cloned().collect();
+    kept.retain(|e| !is_pole_ent(e));
+
+    let placed_tiles: FxHashSet<(i32, i32)> = pole_ents.iter().map(|e| (e.x, e.y)).collect();
+    let mut occupied_after = occupied.clone();
+    for tile in &placed_tiles {
+        occupied_after.insert(*tile);
+    }
+    let before = pole_ents.len();
+    crate::bus::layout::repair_pole_connectivity(
+        &mut pole_ents,
+        &placed_tiles,
+        &occupied_after,
+        quality,
+    );
+    if std::env::var("SPAGHETTIO_FOLD_DEBUG").is_ok() {
+        let w = crate::power_wires::compute_pole_wires(&pole_ents, layout.wire_mode);
+        eprintln!(
+            "replace_poles: {before} poles, bridges added {}, still disconnected {}",
+            pole_ents.len() - before,
+            crate::power_wires::count_disconnected_poles(&pole_ents, &w),
+        );
+    }
+    kept.extend(pole_ents);
 
     let mut out = LayoutResult {
         entities: kept,

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -4576,121 +4576,22 @@ pub enum FoldRefusal {
     InputStranded { at: (i32, i32) },
 }
 
-/// Re-place power poles for a layout whose geometry has moved.
+/// Reconnect a folded layout's power network.
 ///
-/// Poles are the one thing a fold cannot carry along. `build_bus_layout`
-/// places them LAST, after routing, precisely because their positions depend
-/// on final geometry; translating the originals leaves a network that is
-/// correct nowhere — segments end up tens of tiles apart and the copper-wire
-/// graph fragments into islands. That shows up as `power` warnings on a fold
-/// whose belts are all perfect, which is what blocked most bus fixtures.
+/// This used to strip every pole and re-place from scratch, on the reasoning
+/// that poles depend on final geometry. That was wrong: a fold is a RIGID
+/// MOTION per segment, so poles inside a segment keep their relative
+/// positions, and a connected source network stays connected within each
+/// segment — only the seams between segments break. Re-placing discarded a
+/// good network and rebuilt a worse one with `place_poles`, which is shaped
+/// for row layouts rather than folded geometry. On `chain-mil5ore` that turned
+/// a fully connected source into 89 unreachable poles.
 ///
-/// Strips existing poles, rebuilds the coverage subjects and occupancy from
-/// what remains, and runs the same placement the pipeline uses.
+/// So: keep what the transform produced, and bridge only what the seams
+/// severed.
 fn replace_poles(layout: &LayoutResult) -> LayoutResult {
-    use crate::common::{is_inserter, is_machine_entity};
-
-    let mut kept: Vec<PlacedEntity> = layout
-        .entities
-        .iter()
-        .filter(|e| !e.name.ends_with("electric-pole") && e.name != "substation")
-        .cloned()
-        .collect();
-
-    let mut machines: Vec<(i32, i32, i32)> = Vec::new();
-    let mut inserters: Vec<(i32, i32)> = Vec::new();
-    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
-    for ent in &kept {
-        if is_machine_entity(&ent.name) {
-            let (mw, mh) = crate::common::machine_dims(&ent.name);
-            let (mw, mh) = (mw as i32, mh as i32);
-            for dx in 0..mw {
-                for dy in 0..mh {
-                    occupied.insert((ent.x + dx, ent.y + dy));
-                }
-            }
-            machines.push((ent.x + mw / 2, ent.y, mh));
-        } else {
-            occupied.insert((ent.x, ent.y));
-            if is_inserter(&ent.name) {
-                inserters.push((ent.x, ent.y));
-            }
-            if crate::common::is_splitter(&ent.name) {
-                let (sx, sy) = crate::common::splitter_second_tile(ent);
-                occupied.insert((sx, sy));
-            }
-        }
-    }
-
-    // Quality is per-entity here; take it from a machine, since pole supply
-    // radius and wire reach both scale with it.
-    let quality = layout
-        .entities
-        .iter()
-        .find(|e| crate::common::is_machine_entity(&e.name))
-        .and_then(|e| e.quality)
-        .unwrap_or_default();
-    let (poles, _uncovered) = crate::bus::layout::place_poles(
-        &machines,
-        &inserters,
-        &occupied,
-        &[],
-        quality,
-    );
-    kept.extend(poles);
-
-    // Placement alone leaves islands. `build_bus_layout` follows it with
-    // `repair_pole_connectivity`, which drops bridge poles until the emitted
-    // wire graph is ONE component; skipping that step here produced a folded
-    // layout whose 89 poles formed two separate networks — a factory that
-    // pastes into a real game as two dead halves.
-    //
-    // It was invisible for two reasons worth remembering: the connectivity
-    // check aggregated its count into one warning, so the fold's admission
-    // gate saw the same issue count as the control; and the sim harness
-    // energises every pole network it finds, so the measured run powered both
-    // islands and passed.
-    // `repair_pole_connectivity` treats every element of the vec it is given
-    // as a wire node — it calls `pole_center` on each — so it takes a
-    // poles-ONLY vec, as the pipeline gives it. Handing it the whole layout
-    // makes it read belts and machines as poles, conclude the graph is one
-    // component, and return having done nothing.
-    let is_pole_ent =
-        |e: &PlacedEntity| e.name.ends_with("electric-pole") || e.name == "substation";
-    let mut pole_ents: Vec<PlacedEntity> =
-        kept.iter().filter(|e| is_pole_ent(e)).cloned().collect();
-    kept.retain(|e| !is_pole_ent(e));
-
-    let placed_tiles: FxHashSet<(i32, i32)> = pole_ents.iter().map(|e| (e.x, e.y)).collect();
-    let mut occupied_after = occupied.clone();
-    for tile in &placed_tiles {
-        occupied_after.insert(*tile);
-    }
-    let before = pole_ents.len();
-    crate::bus::layout::repair_pole_connectivity(
-        &mut pole_ents,
-        &placed_tiles,
-        &occupied_after,
-        quality,
-    );
-    if std::env::var("SPAGHETTIO_FOLD_DEBUG").is_ok() {
-        let w = crate::power_wires::compute_pole_wires(&pole_ents, layout.wire_mode);
-        eprintln!(
-            "replace_poles: {before} poles, bridges added {}, still disconnected {}",
-            pole_ents.len() - before,
-            crate::power_wires::count_disconnected_poles(&pole_ents, &w),
-        );
-    }
-    kept.extend(pole_ents);
-
-    let mut out = LayoutResult {
-        entities: kept,
-        ..layout.clone()
-    };
-    out.power_wires = Some(crate::power_wires::compute_pole_wires(
-        &out.entities,
-        out.wire_mode,
-    ));
+    let mut out = layout.clone();
+    crate::bus::layout::repair_pole_network(&mut out);
     out
 }
 

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -619,7 +619,6 @@ fn collapse_vertical_cut(layout: &LayoutResult, cut: i32) -> Option<LayoutResult
                 && entity.name == other.name
                 && entity.direction == other.direction
                 && entity.carries == other.carries
-                && entity.segment_id == other.segment_id
             {
                 remove[idx] = true;
                 continue;
@@ -699,7 +698,6 @@ fn collapse_horizontal_cut(layout: &LayoutResult, cut: i32) -> Option<LayoutResu
                 && entity.name == other.name
                 && entity.direction == other.direction
                 && entity.carries == other.carries
-                && entity.segment_id == other.segment_id
             {
                 remove[idx] = true;
                 continue;
@@ -1735,18 +1733,18 @@ mod tests {
 
     #[test]
     fn vertical_cut_coalesces_equivalent_seam_belts() {
-        let belt = |x| crate::models::PlacedEntity {
+        let belt = |x, segment: &str| crate::models::PlacedEntity {
             name: "transport-belt".into(),
             x,
             direction: EntityDirection::East,
             carries: Some("plate".into()),
-            segment_id: Some("route".into()),
+            segment_id: Some(segment.into()),
             ..Default::default()
         };
         let layout = LayoutResult {
             width: 4,
             height: 1,
-            entities: vec![belt(0), belt(1), belt(3)],
+            entities: vec![belt(0, "row"), belt(1, "corridor"), belt(3, "tail")],
             ..Default::default()
         };
         let collapsed = collapse_vertical_cut(&layout, 1).unwrap();

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -4238,8 +4238,20 @@ fn place_uturn(
 pub struct FoldOutcome {
     pub folds: Vec<i32>,
     pub layout: LayoutResult,
-    /// Refusal reasons encountered while searching, for diagnosis.
+}
+
+/// Outcome of a fold search, including why candidates were turned away.
+///
+/// The refusal mix is the useful half when nothing is found: "no fold" is
+/// not actionable, whereas "every candidate stranded an input" or "there were
+/// no legal columns to begin with" says exactly which constraint is binding.
+pub struct FoldSearch {
+    pub best: Option<FoldOutcome>,
+    pub legal_columns: usize,
+    /// Candidates the folder refused, by cause.
     pub refusals: Vec<(Vec<i32>, FoldRefusal)>,
+    /// Candidates that folded but validated worse than the source.
+    pub rejected_by_validation: usize,
 }
 
 /// Search for the squarest snake fold that does not break the factory.
@@ -4258,7 +4270,7 @@ pub fn search_snake_fold(
     layout: &LayoutResult,
     solver: &SolverResult,
     max_folds: usize,
-) -> Option<FoldOutcome> {
+) -> FoldSearch {
     use crate::validate::{self, LayoutStyle};
 
     let profile = |l: &LayoutResult| -> Option<BTreeMap<String, usize>> {
@@ -4269,18 +4281,26 @@ pub fn search_snake_fold(
         }
         Some(by_cat)
     };
-    let baseline = profile(layout)?;
+    let mut out = FoldSearch {
+        best: None,
+        legal_columns: 0,
+        refusals: Vec::new(),
+        rejected_by_validation: 0,
+    };
+    let Some(baseline) = profile(layout) else {
+        return out;
+    };
 
     let legal = legal_fold_columns(layout);
+    out.legal_columns = legal.len();
     if legal.is_empty() {
-        return None;
+        return out;
     }
     let snap = |target: i32| -> Option<i32> {
         legal.iter().copied().min_by_key(|&f| (f - target).abs())
     };
 
     let mut best: Option<(i64, Vec<i32>, LayoutResult)> = None;
-    let mut refusals = Vec::new();
 
     for k in 1..=max_folds {
         // Slide the whole comb of fold lines, snapping each tooth to the
@@ -4307,7 +4327,7 @@ pub fn search_snake_fold(
             let folded = match fold_snake(layout, &folds) {
                 Ok(f) => f,
                 Err(reason) => {
-                    refusals.push((folds.clone(), reason));
+                    out.refusals.push((folds.clone(), reason));
                     continue;
                 }
             };
@@ -4319,6 +4339,7 @@ pub fn search_snake_fold(
                 .iter()
                 .any(|(cat, n)| baseline.get(cat).copied().unwrap_or(0) < *n)
             {
+                out.rejected_by_validation += 1;
                 continue;
             }
 
@@ -4333,11 +4354,8 @@ pub fn search_snake_fold(
         }
     }
 
-    best.map(|(_, folds, layout)| FoldOutcome {
-        folds,
-        layout,
-        refusals,
-    })
+    out.best = best.map(|(_, folds, layout)| FoldOutcome { folds, layout });
+    out
 }
 
 /// Columns a fold may legally cut, i.e. those that pass between entities

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -11,7 +11,7 @@ use crate::common::{
     dir_to_vec, entity_size, inserter_reach, is_belt_entity, is_inserter, is_surface_belt,
     is_ug_belt, oriented_splitter_dims, ug_max_reach, ug_to_surface_tier, QualityTier,
 };
-use crate::models::{EntityDirection, LayoutResult, ModuleItem, SolverResult};
+use crate::models::{EntityDirection, LayoutResult, ModuleItem, PlacedEntity, SolverResult};
 
 const RATE_SCALE: f64 = 1_000_000_000.0;
 
@@ -1677,10 +1677,9 @@ pub fn build_local_manifold_graph(plan: &LocalManifoldPlan) -> LocalManifoldGrap
         }
 
         let consumer_count = group.consumers.len();
-        let mut distribute_frontier = vec![ManifoldEndpoint::LaneOutput(group.lane)];
-        let mut level = 0;
+        let mut distribute_frontier = vec![(ManifoldEndpoint::LaneOutput(group.lane), 0u32)];
         while distribute_frontier.len() < consumer_count {
-            let source = distribute_frontier.remove(0);
+            let (source, level) = distribute_frontier.remove(0);
             let node = nodes.len();
             nodes.push(ManifoldBalancerNode {
                 id: node,
@@ -1694,17 +1693,16 @@ pub fn build_local_manifold_graph(plan: &LocalManifoldPlan) -> LocalManifoldGrap
                 from: source,
                 to: ManifoldEndpoint::NodeInput { node, port: 0 },
             });
-            distribute_frontier.push(ManifoldEndpoint::NodeOutput { node, port: 0 });
-            distribute_frontier.push(ManifoldEndpoint::NodeOutput { node, port: 1 });
-            level += 1;
+            distribute_frontier.push((ManifoldEndpoint::NodeOutput { node, port: 0 }, level + 1));
+            distribute_frontier.push((ManifoldEndpoint::NodeOutput { node, port: 1 }, level + 1));
         }
-        distribute_frontier.sort();
+        distribute_frontier.sort_by(|a, b| a.0.cmp(&b.0));
         for (source, terminal) in distribute_frontier
             .into_iter()
             .zip(group.consumers.iter().cloned())
         {
             edges.push(ManifoldGraphEdge {
-                from: source,
+                from: source.0,
                 to: ManifoldEndpoint::Terminal(terminal),
             });
         }
@@ -1717,6 +1715,238 @@ pub fn build_local_manifold_graph(plan: &LocalManifoldPlan) -> LocalManifoldGrap
         nodes,
         edges,
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct PlacedManifoldNode {
+    pub node_id: usize,
+    pub origin: (i32, i32),
+    pub input_ports: Vec<(i32, i32)>,
+    pub output_ports: Vec<(i32, i32)>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PlacedLocalManifold {
+    pub item: String,
+    pub hub: CompactBlock,
+    pub nodes: Vec<PlacedManifoldNode>,
+    pub lane_inputs: Vec<(i32, i32)>,
+    pub lane_outputs: Vec<(i32, i32)>,
+    pub entities: Vec<PlacedEntity>,
+}
+
+/// Stamp all `(2,1)` / `(1,2)` nodes into collision-free local hubs.
+/// Inter-node and terminal edges remain explicit in [`LocalManifoldGraph`]
+/// for the negotiated router.
+pub fn place_local_manifold_nodes(
+    islands: &[RigidIsland],
+    graphs: &[LocalManifoldGraph],
+    clearance: i32,
+) -> Vec<PlacedLocalManifold> {
+    use crate::bus::balancer::{splitter_for_belt, underground_for_belt};
+    use crate::bus::balancer_library::balancer_templates;
+
+    let templates = balancer_templates();
+    let clearance = clearance.max(0);
+    let mut result: Vec<PlacedLocalManifold> = Vec::new();
+    for (graph_idx, graph) in graphs.iter().enumerate() {
+        let mut lane_widths = Vec::new();
+        let mut merge_levels = 0u32;
+        let mut distribute_levels = 0u32;
+        for lane in 0..graph.belt_count {
+            let max_level_width = graph
+                .nodes
+                .iter()
+                .filter(|node| node.lane == lane)
+                .fold(BTreeMap::<(u8, u32), usize>::new(), |mut counts, node| {
+                    let role = match node.role {
+                        BalancerNodeRole::Merge => 0,
+                        BalancerNodeRole::Distribute => 1,
+                    };
+                    *counts.entry((role, node.level)).or_default() += 1;
+                    counts
+                })
+                .into_values()
+                .max()
+                .unwrap_or(1);
+            lane_widths.push((max_level_width as i32 * 3).max(3));
+            merge_levels = merge_levels.max(
+                graph
+                    .nodes
+                    .iter()
+                    .filter(|node| node.lane == lane && node.role == BalancerNodeRole::Merge)
+                    .map(|node| node.level + 1)
+                    .max()
+                    .unwrap_or(0),
+            );
+            distribute_levels = distribute_levels.max(
+                graph
+                    .nodes
+                    .iter()
+                    .filter(|node| node.lane == lane && node.role == BalancerNodeRole::Distribute)
+                    .map(|node| node.level + 1)
+                    .max()
+                    .unwrap_or(0),
+            );
+        }
+        let width = lane_widths.iter().sum::<i32>()
+            + clearance * (lane_widths.len().saturating_sub(1) as i32);
+        let lane_y = merge_levels as i32 * 4;
+        let distribute_y = lane_y + 2;
+        let height = distribute_y + distribute_levels as i32 * 4 + 3;
+        let preferred_x = graph.hub.x + graph.hub.width / 2 - width / 2;
+        let preferred_y = graph.hub.y + graph.hub.height / 2 - height / 2;
+        let mut hub = None;
+        'radius: for radius in 0..=1024 {
+            for dx in -radius..=radius {
+                for dy in [-radius, radius] {
+                    let candidate = CompactBlock {
+                        id: graph_idx,
+                        x: preferred_x + dx,
+                        y: preferred_y + dy,
+                        width,
+                        height,
+                    };
+                    if placed_hub_is_free(&candidate, islands, &result, clearance) {
+                        hub = Some(candidate);
+                        break 'radius;
+                    }
+                }
+            }
+            for dy in (-radius + 1)..radius {
+                for dx in [-radius, radius] {
+                    let candidate = CompactBlock {
+                        id: graph_idx,
+                        x: preferred_x + dx,
+                        y: preferred_y + dy,
+                        width,
+                        height,
+                    };
+                    if placed_hub_is_free(&candidate, islands, &result, clearance) {
+                        hub = Some(candidate);
+                        break 'radius;
+                    }
+                }
+            }
+        }
+        let hub = hub.unwrap_or(CompactBlock {
+            id: graph_idx,
+            x: preferred_x,
+            y: preferred_y,
+            width,
+            height,
+        });
+
+        let mut lane_starts = Vec::new();
+        let mut cursor = hub.x;
+        for lane_width in &lane_widths {
+            lane_starts.push(cursor);
+            cursor += *lane_width + clearance;
+        }
+        let mut level_ordinals = BTreeMap::<(u32, u8, u32), i32>::new();
+        let mut placed_nodes = Vec::new();
+        let mut entities = Vec::new();
+        for node in &graph.nodes {
+            let role = match node.role {
+                BalancerNodeRole::Merge => 0,
+                BalancerNodeRole::Distribute => 1,
+            };
+            let ordinal = level_ordinals
+                .entry((node.lane, role, node.level))
+                .or_default();
+            let origin_x = lane_starts[node.lane as usize] + *ordinal * 3;
+            let origin_y = hub.y
+                + if node.role == BalancerNodeRole::Merge {
+                    node.level as i32 * 4
+                } else {
+                    distribute_y + node.level as i32 * 4
+                };
+            *ordinal += 1;
+            let template = templates
+                .get(&(node.n, node.m))
+                .expect("planned primitive balancer template missing");
+            let mut stamped = template.stamp(
+                origin_x,
+                origin_y,
+                "express-transport-belt",
+                splitter_for_belt("express-transport-belt"),
+                underground_for_belt("express-transport-belt"),
+                Some(&graph.item),
+            );
+            for entity in &mut stamped {
+                entity.segment_id = Some(format!(
+                    "compact-hub:{}:{}:{}",
+                    graph.item, node.lane, node.id
+                ));
+            }
+            entities.extend(stamped);
+            placed_nodes.push(PlacedManifoldNode {
+                node_id: node.id,
+                origin: (origin_x, origin_y),
+                input_ports: template
+                    .input_tiles
+                    .iter()
+                    .map(|&(x, y)| (origin_x + x, origin_y + y))
+                    .collect(),
+                output_ports: template
+                    .output_tiles
+                    .iter()
+                    .map(|&(x, y)| (origin_x + x, origin_y + y))
+                    .collect(),
+            });
+        }
+        placed_nodes.sort_by_key(|node| node.node_id);
+        let lane_inputs: Vec<_> = lane_starts
+            .iter()
+            .zip(&lane_widths)
+            .map(|(&x, &lane_width)| (x + lane_width / 2, hub.y + lane_y))
+            .collect();
+        let lane_outputs: Vec<_> = lane_inputs
+            .iter()
+            .map(|&(x, _)| (x, hub.y + distribute_y - 1))
+            .collect();
+        for (lane, (&input, &output)) in lane_inputs.iter().zip(&lane_outputs).enumerate() {
+            for y in input.1..=output.1 {
+                entities.push(PlacedEntity {
+                    name: "express-transport-belt".into(),
+                    x: input.0,
+                    y,
+                    direction: EntityDirection::South,
+                    carries: Some(graph.item.clone()),
+                    segment_id: Some(format!("compact-lane:{}:{lane}", graph.item)),
+                    ..Default::default()
+                });
+            }
+        }
+        result.push(PlacedLocalManifold {
+            item: graph.item.clone(),
+            hub,
+            nodes: placed_nodes,
+            lane_inputs,
+            lane_outputs,
+            entities,
+        });
+    }
+    result
+}
+
+fn placed_hub_is_free(
+    candidate: &CompactBlock,
+    islands: &[RigidIsland],
+    hubs: &[PlacedLocalManifold],
+    clearance: i32,
+) -> bool {
+    let expanded = CompactBlock {
+        id: candidate.id,
+        x: candidate.x - clearance,
+        y: candidate.y - clearance,
+        width: candidate.width + clearance * 2,
+        height: candidate.height + clearance * 2,
+    };
+    islands
+        .iter()
+        .all(|island| !blocks_overlap(&expanded, &island.block))
+        && hubs.iter().all(|hub| !blocks_overlap(&expanded, &hub.hub))
 }
 
 fn hub_is_free(

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -3876,3 +3876,502 @@ mod tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// RFC-057 Phase 2: snake-fold transform
+// ---------------------------------------------------------------------------
+
+/// Mirror an `EntityDirection` across the X axis (East ↔ West, N/S unchanged).
+fn mirror_x_direction(dir: EntityDirection) -> EntityDirection {
+    match dir {
+        EntityDirection::East => EntityDirection::West,
+        EntityDirection::West => EntityDirection::East,
+        _ => dir,
+    }
+}
+
+/// Replace UG-belt pairs that straddle any fold boundary with surface belts.
+///
+/// A pair straddles fold `f` when one half is at `x < f` and the other at
+/// `x >= f`.  Only East/West-facing pairs can straddle (South-facing pairs
+/// are perpendicular to the fold axis).
+fn replace_straddling_ug_pairs(entities: &[PlacedEntity], folds: &[i32]) -> Vec<PlacedEntity> {
+    let ug_at: BTreeMap<(i32, i32), usize> = entities
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| is_ug_belt(&e.name))
+        .map(|(i, e)| ((e.x, e.y), i))
+        .collect();
+
+    let mut to_surface: FxHashSet<usize> = FxHashSet::default();
+    for (idx, entity) in entities.iter().enumerate() {
+        if !is_ug_belt(&entity.name) || entity.io_type.as_deref() != Some("input") {
+            continue;
+        }
+        let (dx, _dy) = dir_to_vec(entity.direction);
+        if dx == 0 {
+            continue;
+        }
+        let max_reach = ug_max_reach(ug_to_surface_tier(&entity.name)) as i32;
+        // ug_max_reach returns tiles BETWEEN entrance and exit (exclusive),
+        // so the max step from entrance to exit is max_reach + 1.
+        for step in 1..=(max_reach + 1) {
+            let look_x = entity.x + dx * step;
+            if let Some(&out_idx) = ug_at.get(&(look_x, entity.y)) {
+                let out = &entities[out_idx];
+                if out.name == entity.name
+                    && out.direction == entity.direction
+                    && out.io_type.as_deref() == Some("output")
+                {
+                    for &f in folds {
+                        if (entity.x < f && out.x >= f) || (out.x < f && entity.x >= f) {
+                            to_surface.insert(idx);
+                            to_surface.insert(out_idx);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut result: Vec<PlacedEntity> = entities
+        .iter()
+        .enumerate()
+        .map(|(idx, e)| {
+            if to_surface.contains(&idx) {
+                let mut s = e.clone();
+                s.name = ug_to_surface_tier(&e.name).to_string();
+                s.io_type = None;
+                s
+            } else {
+                e.clone()
+            }
+        })
+        .collect();
+
+    // Fill in surface belts between replaced UG entrance/exit pairs.
+    // The UG pair spanned from entrance to exit with items going
+    // underground.  After replacement, we need surface belts at every
+    // tile between them to carry items across.
+    let existing: FxHashSet<(i32, i32)> = result.iter().map(|e| (e.x, e.y)).collect();
+    for (idx, entity) in entities.iter().enumerate() {
+        if !to_surface.contains(&idx) || entity.io_type.as_deref() != Some("input") {
+            continue;
+        }
+        let (dx, _dy) = dir_to_vec(entity.direction);
+        if dx == 0 {
+            continue;
+        }
+        let max_reach = ug_max_reach(ug_to_surface_tier(&entity.name)) as i32;
+        // Find the matching output (already confirmed to exist above).
+        for step in 1..=(max_reach + 1) {
+            let look_x = entity.x + dx * step;
+            if let Some(&out_idx) = ug_at.get(&(look_x, entity.y)) {
+                let out = &entities[out_idx];
+                if to_surface.contains(&out_idx) && out.io_type.as_deref() == Some("output") {
+                    // Fill in surface belts between entrance and exit,
+                    // but only on the same side of the fold as the entrance.
+                    let surface = ug_to_surface_tier(&entity.name);
+                    for fill_x in 1..step {
+                        let fx = entity.x + dx * fill_x;
+                        // Don't fill past any fold boundary.
+                        let same_side = folds
+                            .iter()
+                            .all(|&f| (entity.x < f && fx < f) || (entity.x >= f && fx >= f));
+                        if same_side && !existing.contains(&(fx, entity.y)) {
+                            result.push(PlacedEntity {
+                                name: surface.to_string(),
+                                x: fx,
+                                y: entity.y,
+                                direction: entity.direction,
+                                carries: entity.carries.clone(),
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Helper: find surface belts at a given folded X going a specific direction.
+fn belts_at_x_going(
+    entities: &[PlacedEntity],
+    x: i32,
+    dir: EntityDirection,
+) -> Vec<(i32, String, Option<String>)> {
+    entities
+        .iter()
+        .filter(|e| e.x == x && e.direction == dir && is_surface_belt(&e.name))
+        .map(|e| (e.y, e.name.clone(), e.carries.clone()))
+        .collect()
+}
+
+/// Place a vertical U-turn chain at column `jx` connecting a belt at
+/// `(edge_x, y_top)` going `from_dir` to a belt at `(edge_x, y_bot)` going
+/// `to_dir`.
+fn place_uturn(
+    entities: &mut Vec<PlacedEntity>,
+    jx: i32,
+    edge_x: i32,
+    y_top: i32,
+    y_bot: i32,
+    from_dir: EntityDirection,
+    to_dir: EntityDirection,
+    belt_name: &str,
+    carries: &Option<String>,
+) {
+    // belt_name is a surface belt name (e.g. "express-transport-belt").
+    let surface_name = belt_name;
+    let ug_name = match belt_name {
+        "express-transport-belt" => "express-underground-belt",
+        "fast-transport-belt" => "fast-underground-belt",
+        "transport-belt" => "underground-belt",
+        _ => "underground-belt",
+    };
+    let max_reach = ug_max_reach(surface_name) as i32;
+
+    // Horizontal connector belts from edge_x to jx at y_top.
+    // The belt at (edge_x, y_top) going from_dir deposits at edge_x ± 1.
+    // We need belts from there to jx to carry items to the U-turn.
+    let (step_x, end_x) = if jx > edge_x {
+        (1, jx) // fill from edge_x+1 to jx-1 going East
+    } else {
+        (-1, jx) // fill from edge_x-1 to jx+1 going West
+    };
+    for x in (edge_x + step_x)..end_x {
+        if !entities.iter().any(|e| e.x == x && e.y == y_top) {
+            entities.push(PlacedEntity {
+                name: surface_name.to_string(),
+                x,
+                y: y_top,
+                direction: from_dir,
+                carries: carries.clone(),
+                ..Default::default()
+            });
+        }
+    }
+
+    // Belt at (jx, y_top) going South — receives from the horizontal belt.
+    entities.push(PlacedEntity {
+        name: surface_name.to_string(),
+        x: jx,
+        y: y_top,
+        direction: EntityDirection::South,
+        carries: carries.clone(),
+        ..Default::default()
+    });
+
+    // Vertical chain from y_top+1 to y_bot-1.
+    let mut cy = y_top + 1;
+    while cy < y_bot {
+        let remaining = y_bot - cy;
+        if remaining >= 2 && remaining - 1 <= max_reach {
+            entities.push(PlacedEntity {
+                name: ug_name.to_string(),
+                x: jx,
+                y: cy,
+                direction: EntityDirection::South,
+                io_type: Some("input".into()),
+                carries: carries.clone(),
+                ..Default::default()
+            });
+            entities.push(PlacedEntity {
+                name: ug_name.to_string(),
+                x: jx,
+                y: cy + remaining - 1,
+                direction: EntityDirection::South,
+                io_type: Some("output".into()),
+                carries: carries.clone(),
+                ..Default::default()
+            });
+            cy += remaining;
+        } else if remaining > max_reach + 1 {
+            entities.push(PlacedEntity {
+                name: ug_name.to_string(),
+                x: jx,
+                y: cy,
+                direction: EntityDirection::South,
+                io_type: Some("input".into()),
+                carries: carries.clone(),
+                ..Default::default()
+            });
+            entities.push(PlacedEntity {
+                name: ug_name.to_string(),
+                x: jx,
+                y: cy + max_reach,
+                direction: EntityDirection::South,
+                io_type: Some("output".into()),
+                carries: carries.clone(),
+                ..Default::default()
+            });
+            cy += max_reach + 1;
+            entities.push(PlacedEntity {
+                name: surface_name.to_string(),
+                x: jx,
+                y: cy,
+                direction: EntityDirection::South,
+                carries: carries.clone(),
+                ..Default::default()
+            });
+            cy += 1;
+        } else {
+            entities.push(PlacedEntity {
+                name: surface_name.to_string(),
+                x: jx,
+                y: cy,
+                direction: EntityDirection::South,
+                carries: carries.clone(),
+                ..Default::default()
+            });
+            cy += 1;
+        }
+    }
+
+    // Belt at (jx, y_bot) going to_dir — receives from South chain.
+    entities.push(PlacedEntity {
+        name: surface_name.to_string(),
+        x: jx,
+        y: y_bot,
+        direction: to_dir,
+        carries: carries.clone(),
+        ..Default::default()
+    });
+
+    // Horizontal connector belts from jx to edge_x at y_bot.
+    // The U-turn belt at (jx, y_bot) going to_dir deposits at jx ± 1.
+    // We need belts from there to edge_x to carry items back to the segment.
+    if edge_x > jx {
+        // edge_x is to the right: fill from jx+1 to edge_x-1 going to_dir.
+        for x in (jx + 1)..edge_x {
+            if !entities.iter().any(|e| e.x == x && e.y == y_bot) {
+                entities.push(PlacedEntity {
+                    name: surface_name.to_string(),
+                    x,
+                    y: y_bot,
+                    direction: to_dir,
+                    carries: carries.clone(),
+                    ..Default::default()
+                });
+            }
+        }
+    } else {
+        // edge_x is to the left: fill from jx-1 down to edge_x+1 going to_dir.
+        for x in (edge_x + 1)..jx {
+            if !entities.iter().any(|e| e.x == x && e.y == y_bot) {
+                entities.push(PlacedEntity {
+                    name: surface_name.to_string(),
+                    x,
+                    y: y_bot,
+                    direction: to_dir,
+                    carries: carries.clone(),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+}
+
+/// Snake-fold a layout at the given fold columns.
+///
+/// The layout is divided into `folds.len() + 1` vertical segments.  Even
+/// segments keep their X orientation; odd segments are mirrored.  At each
+/// fold junction, belts that were cut are reconnected with vertical
+/// U-turns in the empty junction column.
+///
+/// Returns `None` if any fold column cuts through a multi-tile entity
+/// interior or the folds are out of order.
+pub fn fold_snake(layout: &LayoutResult, folds: &[i32]) -> Option<LayoutResult> {
+    if folds.is_empty() {
+        return Some(layout.clone());
+    }
+    for w in folds.windows(2) {
+        if w[0] >= w[1] {
+            return None;
+        }
+    }
+    for &f in folds {
+        if f <= 0 || f >= layout.width {
+            return None;
+        }
+    }
+    for &f in folds {
+        for entity in &layout.entities {
+            let (w, _) = entity_dims(&entity.name, entity.direction);
+            if entity.x < f && entity.x + w > f {
+                return None;
+            }
+        }
+    }
+
+    let h = layout.height;
+    let gap = 2;
+
+    let mut bounds = vec![0];
+    bounds.extend_from_slice(folds);
+    bounds.push(layout.width);
+    let n_segs = bounds.len() - 1;
+
+    // 1. Replace straddling UG pairs with surface belts.
+    let entities = replace_straddling_ug_pairs(&layout.entities, folds);
+
+    // 2. Left-align all segments to x=0.  This prevents X-overlap between
+    // segments at different Y levels (the main multi-fold failure mode).
+    // The junction columns go OUTSIDE the segment range.
+    let max_seg_w = (0..n_segs)
+        .map(|k| bounds[k + 1] - bounds[k])
+        .max()
+        .unwrap_or(0);
+
+    // 3. Transform every entity.
+    let mut folded: Vec<PlacedEntity> = Vec::with_capacity(entities.len());
+    for entity in &entities {
+        let seg = (0..n_segs).find(|&k| entity.x >= bounds[k] && entity.x < bounds[k + 1]);
+        let Some(seg) = seg else { continue };
+        let (new_x, new_dir) = if seg % 2 == 0 {
+            (entity.x - bounds[seg], entity.direction)
+        } else {
+            let (w, _) = entity_dims(&entity.name, entity.direction);
+            let nx = bounds[seg + 1] - w - entity.x;
+            (nx, mirror_x_direction(entity.direction))
+        };
+        let new_y = entity.y + (seg as i32) * (h + gap);
+
+        let mut e = entity.clone();
+        e.x = new_x;
+        e.y = new_y;
+        e.direction = new_dir;
+        folded.push(e);
+    }
+
+    // 4. Place U-turns at each fold junction.
+    //
+    // Junctions are placed OUTSIDE the segment range: East→West folds use
+    // x = max_seg_w + 2*i (right side), West→East folds use x = -1 - 2*i
+    // (left side), where i is the chain index (staggered to avoid overlap).
+    for k in 0..n_segs - 1 {
+        let seg_w_k = bounds[k + 1] - bounds[k];
+        let y_top_base = (k as i32) * (h + gap);
+        let y_bot_base = ((k + 1) as i32) * (h + gap);
+
+        if k % 2 == 0 {
+            let edge_x = seg_w_k - 1;
+            let cut_belts = belts_at_x_going(&folded, edge_x, EntityDirection::East);
+            for (i, (y, name, carries)) in cut_belts.iter().enumerate() {
+                if *y < y_top_base || *y >= y_top_base + h {
+                    continue;
+                }
+                let jx = max_seg_w + (i as i32) * 2;
+                let y_bot = y - y_top_base + y_bot_base;
+                place_uturn(
+                    &mut folded,
+                    jx,
+                    edge_x,
+                    *y,
+                    y_bot,
+                    EntityDirection::East,
+                    EntityDirection::West,
+                    name,
+                    carries,
+                );
+            }
+        } else {
+            let edge_x = 0;
+            let cut_belts = belts_at_x_going(&folded, edge_x, EntityDirection::West);
+            for (i, (y, name, carries)) in cut_belts.iter().enumerate() {
+                if *y < y_top_base || *y >= y_top_base + h {
+                    continue;
+                }
+                let jx = -1 - (i as i32) * 2;
+                let y_bot = y - y_top_base + y_bot_base;
+                place_uturn(
+                    &mut folded,
+                    jx,
+                    edge_x,
+                    *y,
+                    y_bot,
+                    EntityDirection::West,
+                    EntityDirection::East,
+                    name,
+                    carries,
+                );
+            }
+        }
+    }
+
+    // 5. Bridge gap for dead-end South belts at segment boundaries.
+    //
+    // Belts at the bottom edge of a segment (y = seg_end - 1) going South
+    // deposited outside the layout in the original. After folding, they
+    // deposit into the gap. Place a belt going East at the gap row to
+    // redirect items along the gap (avoids item-mismatch with whatever
+    // is at the same x in the next segment).
+    for k in 0..n_segs - 1 {
+        let seg_end_y = (k as i32) * (h + gap) + h; // first gap row
+                                                    // Find surface belts at y = seg_end_y - 1 going South.
+        let edge_belts: Vec<(i32, String, Option<String>)> = folded
+            .iter()
+            .filter(|e| {
+                e.y == seg_end_y - 1
+                    && e.direction == EntityDirection::South
+                    && is_surface_belt(&e.name)
+            })
+            .map(|e| (e.x, e.name.clone(), e.carries.clone()))
+            .collect();
+        for (x, name, carries) in &edge_belts {
+            // Place a belt going East at (x, seg_end_y) to redirect.
+            if !folded.iter().any(|e| e.x == *x && e.y == seg_end_y) {
+                folded.push(PlacedEntity {
+                    name: name.clone(),
+                    x: *x,
+                    y: seg_end_y,
+                    direction: EntityDirection::East,
+                    carries: carries.clone(),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    // 6. Compute new dimensions and normalise X origin.
+    let min_x = folded.iter().map(|e| e.x).min().unwrap_or(0);
+    let max_x = folded.iter().map(|e| e.x).max().unwrap_or(0);
+    let max_y = folded.iter().map(|e| e.y).max().unwrap_or(0);
+    let x_shift = if min_x < 0 { -min_x } else { 0 };
+    if x_shift > 0 {
+        for e in &mut folded {
+            e.x += x_shift;
+        }
+    }
+    let new_width = (max_x - min_x + 1).max(1);
+    let new_height = (max_y + 1).max(1);
+
+    // 6. Build the result.
+    let mut result = LayoutResult {
+        entities: folded,
+        width: new_width,
+        height: new_height,
+        ..layout.clone()
+    };
+    result.regions.clear();
+    result.trace = None;
+    result.power_wires = Some(crate::power_wires::compute_pole_wires(
+        &result.entities,
+        result.wire_mode,
+    ));
+    for b in &mut result.boundary_inputs {
+        b.x += x_shift;
+    }
+    for b in &mut result.boundary_outputs {
+        b.x += x_shift;
+    }
+    for (_, x, _) in &mut result.surplus_exits {
+        *x += x_shift;
+    }
+    Some(result)
+}

--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -8,8 +8,8 @@
 use std::collections::BTreeMap;
 
 use crate::common::{
-    dir_to_vec, entity_size, inserter_reach, is_belt_entity, is_inserter,
-    oriented_splitter_dims, QualityTier,
+    dir_to_vec, entity_size, inserter_reach, is_belt_entity, is_inserter, oriented_splitter_dims,
+    QualityTier,
 };
 use crate::models::{EntityDirection, LayoutResult, ModuleItem, SolverResult};
 
@@ -119,8 +119,7 @@ fn canonical_modules(modules: &[ModuleItem]) -> Vec<(String, u32, Option<Quality
         .map(|module| (module.item.clone(), module.count, module.quality))
         .collect();
     result.sort_by(|a, b| {
-        (&a.0, a.1, a.2.map(|q| q.level()))
-            .cmp(&(&b.0, b.1, b.2.map(|q| q.level())))
+        (&a.0, a.1, a.2.map(|q| q.level())).cmp(&(&b.0, b.1, b.2.map(|q| q.level())))
     });
     result
 }
@@ -210,12 +209,7 @@ impl CompactBlock {
                 other.y,
                 other.y + other.height,
             ),
-            CompactAxis::Y => (
-                self.x,
-                self.x + self.width,
-                other.x,
-                other.x + other.width,
-            ),
+            CompactAxis::Y => (self.x, self.x + self.width, other.x, other.x + other.width),
         };
         a0 < b1 && b0 < a1
     }
@@ -233,8 +227,10 @@ pub fn machine_blocks(layout: &LayoutResult) -> Vec<CompactBlock> {
             entity.recipe.as_ref()?;
             let (mut width, mut height) = oriented_splitter_dims(&entity.name, entity.direction)
                 .unwrap_or_else(|| entity_size(&entity.name));
-            if matches!(entity.direction, EntityDirection::East | EntityDirection::West)
-                && width != height
+            if matches!(
+                entity.direction,
+                EntityDirection::East | EntityDirection::West
+            ) && width != height
                 && oriented_splitter_dims(&entity.name, entity.direction).is_none()
             {
                 std::mem::swap(&mut width, &mut height);
@@ -267,9 +263,7 @@ pub fn compact_axis(
         for &previous in &order[..position] {
             if blocks[previous].overlaps_cross_axis(&blocks[idx], axis) {
                 lower_bound = lower_bound.max(
-                    coordinate[previous]
-                        + blocks[previous].axis_size(axis)
-                        + clearance.max(0),
+                    coordinate[previous] + blocks[previous].axis_size(axis) + clearance.max(0),
                 );
             }
         }
@@ -300,10 +294,7 @@ pub fn occupied_bbox(blocks: &[CompactBlock]) -> (i32, i32) {
 }
 
 pub fn blocks_overlap(a: &CompactBlock, b: &CompactBlock) -> bool {
-    a.x < b.x + b.width
-        && b.x < a.x + a.width
-        && a.y < b.y + b.height
-        && b.y < a.y + a.height
+    a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height
 }
 
 /// Remove globally empty tile columns while preserving entity order and
@@ -321,8 +312,10 @@ pub fn strip_empty_columns(layout: &LayoutResult) -> LayoutResult {
     for entity in &layout.entities {
         let (mut width, mut height) = oriented_splitter_dims(&entity.name, entity.direction)
             .unwrap_or_else(|| entity_size(&entity.name));
-        if matches!(entity.direction, EntityDirection::East | EntityDirection::West)
-            && width != height
+        if matches!(
+            entity.direction,
+            EntityDirection::East | EntityDirection::West
+        ) && width != height
             && oriented_splitter_dims(&entity.name, entity.direction).is_none()
         {
             std::mem::swap(&mut width, &mut height);
@@ -406,6 +399,314 @@ pub struct RouteNet {
     pub terminals: Vec<RouteTerminal>,
 }
 
+/// A machine or direct-insertion cluster that must move as one unit.
+///
+/// `entity_indices` contains recipe-bearing machines and every inserter that
+/// touches one of them. An inserter touching two machines unions those
+/// machines into the same island, preserving direct insertion exactly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RigidIsland {
+    pub id: usize,
+    pub entity_indices: Vec<usize>,
+    pub recipes: Vec<String>,
+    pub block: CompactBlock,
+    pub terminals: Vec<IslandTerminal>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct IslandTerminal {
+    pub item: String,
+    pub kind: RouteTerminalKind,
+    /// Belt contact relative to the island block's top-left corner.
+    pub dx: i32,
+    pub dy: i32,
+    /// Inserter entity that establishes this terminal.
+    pub inserter_entity_index: usize,
+}
+
+/// The geometry/logistics split consumed by the RFC-057 search.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactIr {
+    pub islands: Vec<RigidIsland>,
+    pub route_nets: Vec<RouteNet>,
+}
+
+impl CompactIr {
+    pub fn from_layout(layout: &LayoutResult) -> Self {
+        Self {
+            islands: extract_rigid_islands(layout),
+            route_nets: extract_route_nets(layout),
+        }
+    }
+}
+
+fn entity_dims(name: &str, direction: EntityDirection) -> (i32, i32) {
+    let (mut width, mut height) =
+        oriented_splitter_dims(name, direction).unwrap_or_else(|| entity_size(name));
+    if matches!(direction, EntityDirection::East | EntityDirection::West)
+        && width != height
+        && oriented_splitter_dims(name, direction).is_none()
+    {
+        std::mem::swap(&mut width, &mut height);
+    }
+    (width as i32, height as i32)
+}
+
+/// Recover the rigid production islands used by RFC-057's placement search.
+///
+/// Belt routes and power are intentionally excluded. Their contacts are
+/// recorded as relative terminals so they can be regenerated after an island
+/// moves. Direct machine-to-machine inserters are retained inside an island
+/// and create no route terminal.
+pub fn extract_rigid_islands(layout: &LayoutResult) -> Vec<RigidIsland> {
+    let machine_indices: Vec<usize> = layout
+        .entities
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, entity)| entity.recipe.as_ref().map(|_| idx))
+        .collect();
+    let mut machine_ordinal = BTreeMap::new();
+    let mut machine_at = BTreeMap::new();
+    for (ordinal, &entity_idx) in machine_indices.iter().enumerate() {
+        machine_ordinal.insert(entity_idx, ordinal);
+        let entity = &layout.entities[entity_idx];
+        let (width, height) = entity_dims(&entity.name, entity.direction);
+        for x in entity.x..entity.x + width {
+            for y in entity.y..entity.y + height {
+                machine_at.insert((x, y), entity_idx);
+            }
+        }
+    }
+
+    let mut parent: Vec<usize> = (0..machine_indices.len()).collect();
+    fn root(parent: &mut [usize], mut node: usize) -> usize {
+        while parent[node] != node {
+            parent[node] = parent[parent[node]];
+            node = parent[node];
+        }
+        node
+    }
+    fn union(parent: &mut [usize], a: usize, b: usize) {
+        let ra = root(parent, a);
+        let rb = root(parent, b);
+        if ra != rb {
+            parent[rb] = ra;
+        }
+    }
+
+    struct InserterContact {
+        entity_idx: usize,
+        pickup: (i32, i32),
+        drop: (i32, i32),
+        pickup_machine: Option<usize>,
+        drop_machine: Option<usize>,
+    }
+    let mut contacts = Vec::new();
+    for (entity_idx, inserter) in layout.entities.iter().enumerate() {
+        if !is_inserter(&inserter.name) {
+            continue;
+        }
+        let (dx, dy) = dir_to_vec(inserter.direction);
+        let reach = inserter_reach(&inserter.name);
+        let pickup = (inserter.x - dx * reach, inserter.y - dy * reach);
+        let drop = (inserter.x + dx * reach, inserter.y + dy * reach);
+        let pickup_machine = machine_at.get(&pickup).copied();
+        let drop_machine = machine_at.get(&drop).copied();
+        if let (Some(a), Some(b)) = (pickup_machine, drop_machine) {
+            union(&mut parent, machine_ordinal[&a], machine_ordinal[&b]);
+        }
+        if pickup_machine.is_some() || drop_machine.is_some() {
+            contacts.push(InserterContact {
+                entity_idx,
+                pickup,
+                drop,
+                pickup_machine,
+                drop_machine,
+            });
+        }
+    }
+
+    let mut belt_item_at = BTreeMap::new();
+    for entity in &layout.entities {
+        if !is_belt_entity(&entity.name) {
+            continue;
+        }
+        let Some(item) = entity.carries.as_ref() else {
+            continue;
+        };
+        let (width, height) = entity_dims(&entity.name, entity.direction);
+        for x in entity.x..entity.x + width {
+            for y in entity.y..entity.y + height {
+                belt_item_at.insert((x, y), item.clone());
+            }
+        }
+    }
+
+    let mut groups: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (ordinal, &entity_idx) in machine_indices.iter().enumerate() {
+        let group = root(&mut parent, ordinal);
+        groups.entry(group).or_default().push(entity_idx);
+    }
+
+    let mut islands = Vec::new();
+    for machine_entities in groups.into_values() {
+        let mut entity_indices = machine_entities.clone();
+        let mut terminals = Vec::new();
+        for contact in &contacts {
+            let belongs = contact
+                .pickup_machine
+                .into_iter()
+                .chain(contact.drop_machine)
+                .any(|idx| machine_entities.contains(&idx));
+            if !belongs {
+                continue;
+            }
+            entity_indices.push(contact.entity_idx);
+            // Both ends on machines means direct insertion, already captured
+            // by the rigid geometry.
+            if contact.pickup_machine.is_some() && contact.drop_machine.is_some() {
+                continue;
+            }
+            if contact.pickup_machine.is_some() {
+                if let Some(item) = belt_item_at.get(&contact.drop) {
+                    terminals.push((
+                        item.clone(),
+                        RouteTerminalKind::ProducerDrop,
+                        contact.drop,
+                        contact.entity_idx,
+                    ));
+                }
+            } else if contact.drop_machine.is_some() {
+                if let Some(item) = belt_item_at.get(&contact.pickup) {
+                    terminals.push((
+                        item.clone(),
+                        RouteTerminalKind::ConsumerPickup,
+                        contact.pickup,
+                        contact.entity_idx,
+                    ));
+                }
+            }
+        }
+        entity_indices.sort_unstable();
+        entity_indices.dedup();
+
+        let min_x = entity_indices
+            .iter()
+            .map(|&idx| layout.entities[idx].x)
+            .min()
+            .unwrap();
+        let min_y = entity_indices
+            .iter()
+            .map(|&idx| layout.entities[idx].y)
+            .min()
+            .unwrap();
+        let max_x = entity_indices
+            .iter()
+            .map(|&idx| {
+                let entity = &layout.entities[idx];
+                entity.x + entity_dims(&entity.name, entity.direction).0
+            })
+            .max()
+            .unwrap();
+        let max_y = entity_indices
+            .iter()
+            .map(|&idx| {
+                let entity = &layout.entities[idx];
+                entity.y + entity_dims(&entity.name, entity.direction).1
+            })
+            .max()
+            .unwrap();
+        let mut recipes: Vec<_> = machine_entities
+            .iter()
+            .filter_map(|&idx| layout.entities[idx].recipe.clone())
+            .collect();
+        recipes.sort();
+        terminals.sort();
+        let terminals = terminals
+            .into_iter()
+            .map(
+                |(item, kind, point, inserter_entity_index)| IslandTerminal {
+                    item,
+                    kind,
+                    dx: point.0 - min_x,
+                    dy: point.1 - min_y,
+                    inserter_entity_index,
+                },
+            )
+            .collect();
+        let id = islands.len();
+        islands.push(RigidIsland {
+            id,
+            entity_indices,
+            recipes,
+            block: CompactBlock {
+                id,
+                x: min_x,
+                y: min_y,
+                width: max_x - min_x,
+                height: max_y - min_y,
+            },
+            terminals,
+        });
+    }
+    islands
+}
+
+/// Compact rigid islands along one axis and carry their relative terminals
+/// with them. This only computes a placement; it does not retain or reroute
+/// the incumbent belts.
+pub fn compact_island_axis(
+    islands: &[RigidIsland],
+    axis: CompactAxis,
+    clearance: i32,
+) -> Vec<RigidIsland> {
+    let blocks: Vec<_> = islands.iter().map(|island| island.block.clone()).collect();
+    let compacted = compact_axis(&blocks, axis, clearance);
+    islands
+        .iter()
+        .zip(compacted)
+        .map(|(island, block)| {
+            let mut moved = island.clone();
+            moved.block = block;
+            moved
+        })
+        .collect()
+}
+
+/// Apply an island placement to its rigid entities. Replaceable logistics is
+/// left untouched; callers must rip it up and reroute before validating the
+/// result as a factory.
+pub fn apply_island_placement(
+    layout: &LayoutResult,
+    source_islands: &[RigidIsland],
+    placed_islands: &[RigidIsland],
+) -> Result<LayoutResult, String> {
+    if source_islands.len() != placed_islands.len() {
+        return Err("source and placed island counts differ".into());
+    }
+    let mut result = layout.clone();
+    for (source, placed) in source_islands.iter().zip(placed_islands) {
+        if source.id != placed.id || source.entity_indices != placed.entity_indices {
+            return Err(format!("island identity changed at {}", source.id));
+        }
+        let dx = placed.block.x - source.block.x;
+        let dy = placed.block.y - source.block.y;
+        for &entity_idx in &source.entity_indices {
+            let Some(entity) = result.entities.get_mut(entity_idx) else {
+                return Err(format!(
+                    "island {} entity {entity_idx} is missing",
+                    source.id
+                ));
+            };
+            entity.x += dx;
+            entity.y += dy;
+        }
+    }
+    result.regions.clear();
+    result.trace = None;
+    Ok(result)
+}
+
 /// Recover belt nets and their machine/boundary terminals from a validated
 /// layout. This is routing intent for rubber-band re-embedding, not part of
 /// the production invariant: later phases may merge or split these nets while
@@ -448,8 +749,10 @@ pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
             continue;
         };
         let (mut width, mut height) = entity_size(&entity.name);
-        if matches!(entity.direction, EntityDirection::East | EntityDirection::West)
-            && width != height
+        if matches!(
+            entity.direction,
+            EntityDirection::East | EntityDirection::West
+        ) && width != height
         {
             std::mem::swap(&mut width, &mut height);
         }
@@ -466,8 +769,8 @@ pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
     let mut belt_net_at: BTreeMap<(i32, i32), usize> = BTreeMap::new();
     for (&entity_idx, &net_idx) in &entity_net {
         let entity = &layout.entities[entity_idx];
-        let (width, height) = oriented_splitter_dims(&entity.name, entity.direction)
-            .unwrap_or((1, 1));
+        let (width, height) =
+            oriented_splitter_dims(&entity.name, entity.direction).unwrap_or((1, 1));
         for x in entity.x..entity.x + width as i32 {
             for y in entity.y..entity.y + height as i32 {
                 belt_net_at.insert((x, y), net_idx);
@@ -480,9 +783,7 @@ pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
         let reach = inserter_reach(&inserter.name);
         let pickup = (inserter.x - dx * reach, inserter.y - dy * reach);
         let drop = (inserter.x + dx * reach, inserter.y + dy * reach);
-        if let (Some(&net_idx), Some(recipe)) =
-            (belt_net_at.get(&drop), machine_at.get(&pickup))
-        {
+        if let (Some(&net_idx), Some(recipe)) = (belt_net_at.get(&drop), machine_at.get(&pickup)) {
             nets[net_idx].terminals.push(RouteTerminal {
                 kind: RouteTerminalKind::ProducerDrop,
                 x: drop.0,
@@ -490,9 +791,7 @@ pub fn extract_route_nets(layout: &LayoutResult) -> Vec<RouteNet> {
                 recipe: Some(recipe.clone()),
             });
         }
-        if let (Some(&net_idx), Some(recipe)) =
-            (belt_net_at.get(&pickup), machine_at.get(&drop))
-        {
+        if let (Some(&net_idx), Some(recipe)) = (belt_net_at.get(&pickup), machine_at.get(&drop)) {
             nets[net_idx].terminals.push(RouteTerminal {
                 kind: RouteTerminalKind::ConsumerPickup,
                 x: pickup.0,
@@ -579,9 +878,27 @@ mod tests {
     #[test]
     fn x_compaction_is_exact_for_fixed_overlap_order() {
         let blocks = vec![
-            CompactBlock { id: 0, x: 10, y: 0, width: 3, height: 3 },
-            CompactBlock { id: 1, x: 30, y: 1, width: 4, height: 2 },
-            CompactBlock { id: 2, x: 50, y: 8, width: 5, height: 2 },
+            CompactBlock {
+                id: 0,
+                x: 10,
+                y: 0,
+                width: 3,
+                height: 3,
+            },
+            CompactBlock {
+                id: 1,
+                x: 30,
+                y: 1,
+                width: 4,
+                height: 2,
+            },
+            CompactBlock {
+                id: 2,
+                x: 50,
+                y: 8,
+                width: 5,
+                height: 2,
+            },
         ];
         let compacted = compact_axis(&blocks, CompactAxis::X, 1);
         assert_eq!(compacted[0].x, 0);
@@ -607,11 +924,17 @@ mod tests {
             y: 3,
             ..Default::default()
         };
-        let a = LayoutResult { entities: vec![machine.clone(), belt.clone()], ..Default::default() };
+        let a = LayoutResult {
+            entities: vec![machine.clone(), belt.clone()],
+            ..Default::default()
+        };
         let mut moved = machine;
         moved.x = -7;
         moved.y = 4;
-        let b = LayoutResult { entities: vec![belt, moved], ..Default::default() };
+        let b = LayoutResult {
+            entities: vec![belt, moved],
+            ..Default::default()
+        };
         assert_eq!(
             PlacedMachineSignature::from_layout(&a),
             PlacedMachineSignature::from_layout(&b)
@@ -695,6 +1018,73 @@ mod tests {
                 y: 4,
                 recipe: Some("plate".into()),
             }]
+        );
+    }
+
+    #[test]
+    fn rigid_islands_bind_direct_insertion_and_expose_belt_terminals() {
+        let machine = |x, recipe: &str| crate::models::PlacedEntity {
+            name: "assembling-machine-3".into(),
+            x,
+            y: 0,
+            recipe: Some(recipe.into()),
+            ..Default::default()
+        };
+        let layout = LayoutResult {
+            entities: vec![
+                machine(0, "producer"),
+                machine(4, "consumer"),
+                crate::models::PlacedEntity {
+                    name: "inserter".into(),
+                    x: 3,
+                    y: 1,
+                    direction: EntityDirection::East,
+                    ..Default::default()
+                },
+                crate::models::PlacedEntity {
+                    name: "inserter".into(),
+                    x: 5,
+                    y: 3,
+                    direction: EntityDirection::South,
+                    ..Default::default()
+                },
+                crate::models::PlacedEntity {
+                    name: "transport-belt".into(),
+                    x: 5,
+                    y: 4,
+                    carries: Some("gear".into()),
+                    segment_id: Some("gear".into()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let islands = extract_rigid_islands(&layout);
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].recipes, vec!["consumer", "producer"]);
+        assert_eq!(islands[0].entity_indices, vec![0, 1, 2, 3]);
+        assert_eq!(
+            islands[0].terminals,
+            vec![IslandTerminal {
+                item: "gear".into(),
+                kind: RouteTerminalKind::ProducerDrop,
+                dx: 5,
+                dy: 4,
+                inserter_entity_index: 3,
+            }]
+        );
+
+        let mut placed = islands.clone();
+        placed[0].block.x = 20;
+        placed[0].block.y = 10;
+        let moved = apply_island_placement(&layout, &islands, &placed).unwrap();
+        assert_eq!((moved.entities[0].x, moved.entities[0].y), (20, 10));
+        assert_eq!((moved.entities[3].x, moved.entities[3].y), (25, 13));
+        // Replaceable belt routing is deliberately not translated.
+        assert_eq!((moved.entities[4].x, moved.entities[4].y), (5, 4));
+        assert_eq!(
+            PlacedMachineSignature::from_layout(&layout),
+            PlacedMachineSignature::from_layout(&moved),
         );
     }
 }

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -309,6 +309,7 @@ impl DecompositionCandidate for ModuleSizeSplit {
             cell_composition: opts.cell_composition,
             splitter_tap_spacers: opts.splitter_tap_spacers,
             direct_insertion: opts.direct_insertion,
+            compact_layout: false,
         };
         run_layout_with_retry(&transformed, &inner_opts)
     }

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -462,7 +462,7 @@ struct SubstationBand {
 /// rows (inclusive); `inserters` is the deep input-inserter band of the row
 /// below, which the substation's supply must cover under the exact continuous
 /// check.
-struct SubstationTarget {
+pub(crate) struct SubstationTarget {
     band_y0: i32,
     band_y1: i32,
     inserters: Vec<(i32, i32)>,
@@ -1650,7 +1650,7 @@ fn place_unified_band_line(
 /// NEITHER a substation NOR a medium pole could reach (the `give_up` set),
 /// the reactive substation pass's trigger; a final `repair_pole_connectivity` bridges any disconnected pole
 /// clusters.
-fn place_poles(
+pub(crate) fn place_poles(
     machines: &[(i32, i32, i32)],
     inserters: &[(i32, i32)],
     occupied: &FxHashSet<(i32, i32)>,

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -133,6 +133,9 @@ pub struct LayoutOptions {
     /// The solver always populates `di_couplings`; this flag only
     /// controls whether the placer acts on them.
     pub direct_insertion: bool,
+    /// RFC-057 topology-preserving post-layout compaction. Experimental and
+    /// default off, so the normal pipeline remains byte-identical.
+    pub compact_layout: bool,
 }
 
 impl Default for LayoutOptions {
@@ -162,6 +165,7 @@ impl Default for LayoutOptions {
             // bit-identical (goldens gate this).
             cell_composition: crate::bus::cells::CellComposition::Candidate,
             direct_insertion: false,
+            compact_layout: false,
         }
     }
 }
@@ -205,7 +209,17 @@ pub fn build_bus_layout(
             opts.stacking, opts.max_inserter_tier
         ));
     }
-    crate::bus::decomposition_search::select_best_decomposition(solver_result, opts)
+    let compact_layout = opts.compact_layout;
+    let result =
+        crate::bus::decomposition_search::select_best_decomposition(solver_result, opts)?;
+    if compact_layout {
+        Ok(crate::bus::compaction::compact_validated_geometry(
+            &result,
+            solver_result,
+        ))
+    } else {
+        Ok(result)
+    }
 }
 
 /// Today's `build_bus_layout` body — the retry orchestrator that
@@ -2841,6 +2855,55 @@ mod tests {
     /// `inserter-direction` (which would otherwise flag them as touching no
     /// machine) nor `belt-flow-reachability` (which would otherwise call the
     /// producer's bridge-consumed output belt a dead-end) fires on them.
+    #[test]
+    fn compact_layout_option_is_explicit_and_validated() {
+        let inputs: FxHashSet<String> =
+            ["iron-plate"].iter().map(|item| item.to_string()).collect();
+        let sr = crate::solver::solve_with_exclusions(
+            "iron-gear-wheel",
+            5.0,
+            &inputs,
+            "assembling-machine-3",
+            &FxHashSet::default(),
+        )
+        .expect("solve iron gears");
+        let base_opts = LayoutOptions {
+            cell_composition: crate::bus::cells::CellComposition::Off,
+            ..Default::default()
+        };
+        let control =
+            build_bus_layout(&sr, base_opts.clone()).expect("control layout should succeed");
+        let compacted = build_bus_layout(
+            &sr,
+            LayoutOptions {
+                compact_layout: true,
+                ..base_opts
+            },
+        )
+        .expect("compacted layout should succeed");
+
+        assert_eq!(
+            crate::bus::compaction::PlacedMachineSignature::from_layout(&control),
+            crate::bus::compaction::PlacedMachineSignature::from_layout(&compacted),
+        );
+        assert!(compacted.width <= control.width);
+        assert!(compacted.height <= control.height);
+        let issues = match crate::validate::validate(
+            &compacted,
+            Some(&sr),
+            crate::validate::LayoutStyle::Bus,
+        ) {
+            Ok(issues) => issues,
+            Err(error) => error.issues,
+        };
+        assert!(
+            issues
+                .iter()
+                .all(|issue| issue.severity != crate::validate::Severity::Error),
+            "compacted option emitted errors: {issues:?}",
+        );
+    }
+
     #[test]
     fn di_full_pipeline_ec_from_plates() {
         let inputs: FxHashSet<String> =

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -1964,6 +1964,61 @@ pub(crate) fn place_poles(
 /// every pole, so post-stamp `compute_pole_wires` (which reads per-entity
 /// `quality`) sees exactly the graph repair reasoned about. At legendary the
 /// medium reach is 19, so repair neither mis-clusters nor over-bridges.
+/// Bridge a layout's pole network until every pole reaches the others.
+///
+/// `build_bus_layout` runs this after placement because heuristic pole
+/// placement leaves islands; cell composition stamps its own poles and never
+/// did, which is why composed layouts can ship with most of their network
+/// unreachable. Public so any producer of a `LayoutResult` can close that gap.
+///
+/// Adds bridge poles only — never moves or removes existing ones — and
+/// recomputes the wire graph. Returns how many bridges it added.
+pub fn repair_pole_network(layout: &mut LayoutResult) -> usize {
+    let is_pole_ent = |e: &PlacedEntity| {
+        e.name.ends_with("electric-pole") || e.name == "substation"
+    };
+    let quality = layout
+        .entities
+        .iter()
+        .find(|e| is_machine_entity(&e.name))
+        .and_then(|e| e.quality)
+        .unwrap_or_default();
+
+    // `repair_pole_connectivity` treats every element it is handed as a wire
+    // node, so it takes a poles-only vec.
+    let mut poles: Vec<PlacedEntity> =
+        layout.entities.iter().filter(|e| is_pole_ent(e)).cloned().collect();
+    if poles.len() <= 1 {
+        return 0;
+    }
+    layout.entities.retain(|e| !is_pole_ent(e));
+
+    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+    for e in &layout.entities {
+        let (w, h) = crate::common::entity_size(&e.name);
+        for dx in 0..w as i32 {
+            for dy in 0..h as i32 {
+                occupied.insert((e.x + dx, e.y + dy));
+            }
+        }
+    }
+    let placed: FxHashSet<(i32, i32)> = poles.iter().map(|e| (e.x, e.y)).collect();
+    for tile in &placed {
+        occupied.insert(*tile);
+    }
+
+    let before = poles.len();
+    repair_pole_connectivity(&mut poles, &placed, &occupied, quality);
+    let added = poles.len() - before;
+
+    layout.entities.extend(poles);
+    layout.power_wires = Some(crate::power_wires::compute_pole_wires(
+        &layout.entities,
+        layout.wire_mode,
+    ));
+    added
+}
+
 pub(crate) fn repair_pole_connectivity(
     entities: &mut Vec<PlacedEntity>,
     placed: &FxHashSet<(i32, i32)>,
@@ -1991,7 +2046,16 @@ pub(crate) fn repair_pole_connectivity(
         all_occupied.insert(p);
     }
 
-    for _ in 0..20 {
+    // Bridge budget. Scaled to the problem rather than fixed at 20: a
+    // pathological layout (mega-chain-pu4raw composes with 1192 of 1202 poles
+    // isolated) exhausted a flat 20 and returned quietly, leaving the caller
+    // to believe the network was repaired. Still bounded — this is a repair,
+    // not a placer — but it now reports when it gives up rather than
+    // truncating in silence.
+    let budget = 20.max(entities.len() / 4);
+    let mut spent = 0usize;
+    for _ in 0..budget {
+        spent += 1;
         let n = entities.len();
         if n <= 1 {
             return;
@@ -2103,6 +2167,15 @@ pub(crate) fn repair_pole_connectivity(
         entities.push(make_pole(p.0, p.1));
         all_occupied.insert(p);
     }
+
+    // Budget exhausted with components still separate. Say so: the caller
+    // otherwise cannot distinguish "repaired" from "gave up", and a layout
+    // whose power network is still in pieces looks identical to a fixed one
+    // from here.
+    crate::trace::emit(crate::trace::TraceEvent::PolesPlaced {
+        count: spent,
+        strategy: "repair-budget-exhausted".to_string(),
+    });
 }
 
 

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -1964,7 +1964,7 @@ pub(crate) fn place_poles(
 /// every pole, so post-stamp `compute_pole_wires` (which reads per-entity
 /// `quality`) sees exactly the graph repair reasoned about. At legendary the
 /// medium reach is 19, so repair neither mis-clusters nor over-bridges.
-fn repair_pole_connectivity(
+pub(crate) fn repair_pole_connectivity(
     entities: &mut Vec<PlacedEntity>,
     placed: &FxHashSet<(i32, i32)>,
     occupied: &FxHashSet<(i32, i32)>,

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod balancer;
 pub mod cells;
+pub mod compaction;
 pub mod balancer_classify;
 pub mod balancer_generate;
 pub mod balancer_library;

--- a/crates/core/src/netflow.rs
+++ b/crates/core/src/netflow.rs
@@ -88,6 +88,10 @@ pub struct NetflowOptions {
     /// and reachability guard exemptions documented at their call sites.
     /// Requires `allow_recycling` to have any candidates to exempt.
     pub allow_voiding: bool,
+    /// Require every produced fluid to be consumed by the plan. Enabled
+    /// internally for the advanced-oil retry because vanilla Factorio has no
+    /// ordinary fluid void.
+    pub disallow_fluid_surplus: bool,
     /// Build quality of the machines being planned
     /// (`docs/rfc-build-quality.md` Phase 1). Scales every column's
     /// crafting speed via [`effective_crafting_speed`] — `Normal`
@@ -356,6 +360,7 @@ pub fn solve_netflow_with_options(
     // uranium-processing excluded) still refuse with a typed error. Each
     // retry removes at least one recipe, so the cap is just a backstop.
     let mut extra_excluded: FxHashSet<String> = FxHashSet::default();
+    let mut attempt_options = *options;
     let mut last_refusal: Option<SolverError> = None;
     // Eight acyclic-fallback exclusions plus at most one free-mode oil-path
     // exclusivity re-solve (#476).
@@ -370,7 +375,7 @@ pub fn solve_netflow_with_options(
             &extra_excluded,
             scope,
             costs,
-            options,
+            &attempt_options,
         ) {
             Ok(r) => {
                 // Physical recipe-path exclusivity (#476): mixing basic and
@@ -388,11 +393,19 @@ pub fn solve_netflow_with_options(
                 // in `surplus_outputs`, so the layout gives it a physical
                 // perimeter exit. Restricted compatibility mode remains the
                 // exact caller-requested recipe set.
-                let mixes_oil_paths = matches!(scope, RecipeScope::Free)
-                    && r.machines.iter().any(|m| m.recipe == "advanced-oil-processing")
-                    && r.machines.iter().any(|m| m.recipe == "basic-oil-processing");
-                if mixes_oil_paths {
-                    extra_excluded.insert("basic-oil-processing".to_string());
+                let has_advanced =
+                    r.machines.iter().any(|m| m.recipe == "advanced-oil-processing");
+                let has_basic =
+                    r.machines.iter().any(|m| m.recipe == "basic-oil-processing");
+                let has_fluid_surplus = r.surplus_outputs.iter().any(|f| f.is_fluid);
+                let needs_oil_physical_retry = matches!(scope, RecipeScope::Free)
+                    && has_advanced
+                    && (has_basic || has_fluid_surplus);
+                if needs_oil_physical_retry {
+                    if has_basic {
+                        extra_excluded.insert("basic-oil-processing".to_string());
+                    }
+                    attempt_options.disallow_fluid_surplus = true;
                     continue;
                 }
                 return Ok(r);
@@ -739,7 +752,12 @@ fn solve_attempt(
     let o_vars: Vec<Option<Variable>> = (0..items.len())
         .map(|i| {
             if has_producer[i] {
-                Some(problem.add_var(costs.eps_surplus, (0.0, f64::INFINITY)))
+                let upper = if options.disallow_fluid_surplus && items.is_fluid[i] {
+                    0.0
+                } else {
+                    f64::INFINITY
+                };
+                Some(problem.add_var(costs.eps_surplus, (0.0, upper)))
             } else {
                 None
             }

--- a/crates/core/src/power_wires.rs
+++ b/crates/core/src/power_wires.rs
@@ -236,7 +236,17 @@ pub fn wires_for(layout: &LayoutResult) -> Cow<'_, [(u32, u32)]> {
 /// electric network. `wires` are index pairs into `entities` (as produced by
 /// [`compute_pole_wires`] or parsed from a blueprint). Non-pole entities and
 /// out-of-range endpoints are ignored defensively.
-pub fn count_disconnected_poles(entities: &[PlacedEntity], wires: &[(u32, u32)]) -> usize {
+/// Tiles of every pole that cannot reach the main pole network.
+///
+/// Returns positions rather than a bare count so callers can report one issue
+/// per pole. A single aggregate issue carrying the number in its message text
+/// is invisible to anything that compares issue *counts* — which is how a fold
+/// that took a layout from 2 disconnected poles to 89 passed an admission gate
+/// as "no worse than source".
+pub fn disconnected_poles(
+    entities: &[PlacedEntity],
+    wires: &[(u32, u32)],
+) -> Vec<(i32, i32)> {
     let pole_idxs: Vec<usize> = entities
         .iter()
         .enumerate()
@@ -244,7 +254,7 @@ pub fn count_disconnected_poles(entities: &[PlacedEntity], wires: &[(u32, u32)])
         .map(|(i, _)| i)
         .collect();
     if pole_idxs.len() <= 1 {
-        return 0;
+        return Vec::new();
     }
 
     // Union-find over pole entity indices.
@@ -272,7 +282,14 @@ pub fn count_disconnected_poles(entities: &[PlacedEntity], wires: &[(u32, u32)])
     pole_idxs
         .iter()
         .filter(|&&i| find(&mut parent, i) != root0)
-        .count()
+        .map(|&i| (entities[i].x, entities[i].y))
+        .collect()
+}
+
+/// How many poles cannot reach the main network. Thin wrapper over
+/// [`disconnected_poles`] for callers that only need the magnitude.
+pub fn count_disconnected_poles(entities: &[PlacedEntity], wires: &[(u32, u32)]) -> usize {
+    disconnected_poles(entities, wires).len()
 }
 
 #[cfg(test)]

--- a/crates/core/src/validate/inserters.rs
+++ b/crates/core/src/validate/inserters.rs
@@ -1217,7 +1217,7 @@ pub fn check_row_input_belt_margin(
 /// real layouts never place two unrelated rows' tiles edge-adjacent,
 /// while a row's own main line and its midpoint sideload bridge (one
 /// tile off-axis, touching the main line directly) always are.
-fn cluster_tiles_by_adjacency(positions: &[(i32, i32)]) -> Vec<usize> {
+pub(crate) fn cluster_tiles_by_adjacency(positions: &[(i32, i32)]) -> Vec<usize> {
     let index: FxHashMap<(i32, i32), usize> =
         positions.iter().enumerate().map(|(i, &p)| (p, i)).collect();
     let mut component = vec![usize::MAX; positions.len()];

--- a/crates/core/src/validate/mod.rs
+++ b/crates/core/src/validate/mod.rs
@@ -293,6 +293,92 @@ pub(crate) fn resolve_row_spec<'a>(
 /// extends the same entity-cross-checked acceptance fluids already had —
 /// the step-7 solid-surplus merger records an exit tile in
 /// `LayoutResult::surplus_exits` the same way the fluid trunk router does.
+/// A boundary record is a ledger entry; the entity at its tile is the fact.
+///
+/// `boundary_inputs` / `boundary_outputs` say where the factory expects to
+/// receive and hand over goods. Everything downstream treats them as
+/// authoritative — blueprint export, and the sim harness, which places its
+/// source and collection chests at exactly these coordinates. Nothing
+/// previously checked they still described reality.
+///
+/// That gap is not hypothetical. A layout transform relocated an output belt
+/// to a new bounding-box edge and left the record on the old tile. The
+/// geometry was flawless and validation passed with an issue profile
+/// identical to the untransformed control; in Factorio the factory produced
+/// **0.00/s**, because output arrived where nothing collected it and every
+/// producer upstream backed up behind a full buffer.
+///
+/// `check_stranded_byproducts` already applies exactly this reasoning to
+/// `surplus_exits` and `voided_streams` — "a ledger without the physical
+/// entity is exactly the stalled-machine bug this check exists to catch". It
+/// was never extended to the primary product, which is the one boundary the
+/// factory exists to serve.
+///
+/// The assertion is deliberately narrow: the tile must hold a transport
+/// entity of the right family carrying the right item. Facing is not checked,
+/// because a boundary belt may legitimately run along an edge rather than
+/// through it, and a false error here would be worse than the gap.
+pub fn check_boundary_record_integrity(layout: &LayoutResult) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    let mut check = |record: &crate::models::BoundaryRecord, role: &str| {
+        let matched = layout.entities.iter().any(|e| {
+            e.x == record.x
+                && e.y == record.y
+                && if record.is_fluid {
+                    e.name == "pipe" || e.name == "pipe-to-ground"
+                } else {
+                    crate::common::is_belt_entity(&e.name)
+                }
+        });
+        if !matched {
+            issues.push(ValidationIssue {
+                severity: Severity::Error,
+                category: "boundary-record-integrity".to_string(),
+                message: format!(
+                    "{role} boundary for {} claims ({},{}), but no {} entity is there —                      goods would be handed over at a tile nothing reaches",
+                    record.item,
+                    record.x,
+                    record.y,
+                    if record.is_fluid { "pipe" } else { "belt" },
+                ),
+                x: Some(record.x),
+                y: Some(record.y),
+                detail: None,
+            });
+            return;
+        }
+        // Present, but carrying something else: the record and the geometry
+        // disagree about what crosses here.
+        let carries_ok = layout.entities.iter().any(|e| {
+            e.x == record.x
+                && e.y == record.y
+                && e.carries.as_deref() == Some(record.item.as_str())
+        });
+        if !carries_ok {
+            issues.push(ValidationIssue {
+                severity: Severity::Warning,
+                category: "boundary-record-integrity".to_string(),
+                message: format!(
+                    "{role} boundary for {} at ({},{}) sits on transport that does not                      carry {}",
+                    record.item, record.x, record.y, record.item,
+                ),
+                x: Some(record.x),
+                y: Some(record.y),
+                detail: None,
+            });
+        }
+    };
+
+    for record in &layout.boundary_inputs {
+        check(record, "Input");
+    }
+    for record in &layout.boundary_outputs {
+        check(record, "Output");
+    }
+    issues
+}
+
 pub fn check_stranded_byproducts(
     layout: &LayoutResult,
     solver: &SolverResult,
@@ -539,6 +625,7 @@ pub fn validate(
                 .unwrap_or_default()
         }),
         Box::new(|| check_unresolved_junctions(layout)),
+        Box::new(|| check_boundary_record_integrity(layout)),
         Box::new(|| {
             solver
                 .map(|s| check_stranded_byproducts(layout, s))
@@ -593,6 +680,60 @@ mod tests {
             height: 0,
             ..Default::default()
         }
+    }
+
+    /// Reconstructs the failure this check exists for: a transform moved the
+    /// output belt and left the boundary record behind. The geometry is
+    /// entirely legal — a belt, carrying the right item, correctly placed —
+    /// which is why every geometry check passed while the factory produced
+    /// nothing in Factorio.
+    #[test]
+    fn stale_boundary_output_record_is_an_error() {
+        use crate::models::BoundaryRecord;
+        let belt_at = |x: i32, y: i32| PlacedEntity {
+            name: "transport-belt".to_string(),
+            x,
+            y,
+            direction: EntityDirection::South,
+            carries: Some("iron-plate".to_string()),
+            ..Default::default()
+        };
+
+        // The belt actually lives at (5,9).
+        let mut layout = LayoutResult {
+            entities: vec![belt_at(5, 9)],
+            width: 10,
+            height: 10,
+            ..Default::default()
+        };
+        let record = |x: i32, y: i32| BoundaryRecord {
+            item: "iron-plate".to_string(),
+            x,
+            y,
+            direction: EntityDirection::South,
+            is_fluid: false,
+            entity: "transport-belt".to_string(),
+        };
+
+        // Record agrees with the belt: nothing to report.
+        layout.boundary_outputs = vec![record(5, 9)];
+        assert!(
+            check_boundary_record_integrity(&layout).is_empty(),
+            "a record that matches its belt must not be flagged"
+        );
+
+        // Record left behind at the pre-transform tile.
+        layout.boundary_outputs = vec![record(5, 3)];
+        let issues = check_boundary_record_integrity(&layout);
+        assert_eq!(issues.len(), 1, "stale record must be reported: {issues:?}");
+        assert_eq!(issues[0].severity, Severity::Error);
+        assert_eq!(issues[0].category, "boundary-record-integrity");
+
+        // Inputs get the same treatment; they were previously checked for
+        // fluids only, so a solid input record was unguarded entirely.
+        layout.boundary_outputs = vec![];
+        layout.boundary_inputs = vec![record(5, 3)];
+        assert_eq!(check_boundary_record_integrity(&layout).len(), 1);
     }
 
     fn layout_with_machine() -> LayoutResult {

--- a/crates/core/src/validate/power.rs
+++ b/crates/core/src/validate/power.rs
@@ -40,18 +40,28 @@ use crate::validate::{Severity, ValidationIssue};
 /// it). Returns a single `Warning` when any pole is unreachable.
 pub fn check_pole_network_connectivity(layout: &LayoutResult) -> Vec<ValidationIssue> {
     let wires = crate::power_wires::wires_for(layout);
-    let disconnected = crate::power_wires::count_disconnected_poles(&layout.entities, &wires);
-    if disconnected == 0 {
-        return vec![];
-    }
+    let disconnected = crate::power_wires::disconnected_poles(&layout.entities, &wires);
 
-    vec![ValidationIssue::new(
-        Severity::Warning,
-        "power",
-        format!(
-            "{disconnected} power pole(s) are not connected to the main pole network via copper wire"
-        ),
-    )]
+    // One issue per pole, not one issue naming a count. An aggregate issue is
+    // invisible to any consumer that compares issue counts: a layout transform
+    // took this from 2 disconnected poles to 89 and its admission gate saw
+    // `{"power": 1}` on both sides, admitting a factory that pastes as two
+    // unpowered islands. `check_power_coverage` below is already per-entity;
+    // this now matches it.
+    disconnected
+        .into_iter()
+        .map(|(x, y)| {
+            ValidationIssue::with_pos(
+                Severity::Warning,
+                "power",
+                format!(
+                    "Power pole at ({x},{y}) is not connected to the main pole network via copper wire"
+                ),
+                x,
+                y,
+            )
+        })
+        .collect()
 }
 
 /// Check that every electric entity is within a power pole's supply area.
@@ -505,12 +515,34 @@ mod tests {
     }
 
     #[test]
-    fn disconnected_cluster_reports_warning() {
+    fn disconnected_cluster_reports_one_issue_per_pole() {
         // Two groups: poles at x=0 and x=20 (dist=20 > reach=9)
         let lr = layout(vec![pole(0, 0), pole(0, 8), pole(20, 0), pole(20, 8)]);
         let issues = check_pole_network_connectivity(&lr);
-        assert_eq!(issues.len(), 1);
-        assert!(issues[0].message.contains("2 power pole(s)"));
+        // One issue PER unreachable pole, not one issue naming a count. A
+        // count buried in message text is invisible to any consumer that
+        // compares issue counts, which let a layout transform go from 2
+        // unreachable poles to 89 while its gate saw both as "one power
+        // warning" and admitted a factory that pastes as two dead islands.
+        assert_eq!(issues.len(), 2, "both poles in the far cluster: {issues:?}");
+        assert!(issues.iter().all(|i| i.severity == Severity::Warning));
+        // Positions are carried so the issue is actionable, not just countable.
+        let mut located: Vec<_> = issues.iter().map(|i| (i.x, i.y)).collect();
+        located.sort();
+        assert_eq!(located, vec![(Some(20), Some(0)), (Some(20), Some(8))]);
+    }
+
+    /// The magnitude must actually scale — the property the old aggregate
+    /// shape silently lacked.
+    #[test]
+    fn issue_count_tracks_number_of_unreachable_poles() {
+        let far = |n: i32| (0..n).map(|k| pole(20, k * 8)).collect::<Vec<_>>();
+        for n in [1, 3, 5] {
+            let mut poles = vec![pole(0, 0)];
+            poles.extend(far(n));
+            let issues = check_pole_network_connectivity(&layout(poles));
+            assert_eq!(issues.len(), n as usize, "n={n}: {issues:?}");
+        }
     }
 
     #[test]

--- a/crates/core/src/validate/sushi.rs
+++ b/crates/core/src/validate/sushi.rs
@@ -168,20 +168,60 @@ pub fn check_sushi_saturation(
 ) -> Vec<ValidationIssue> {
     let mut issues = Vec::new();
 
-    // Group sushi belt tiles by segment id; record the belt entity (tier).
-    let mut seg_belt: FxHashMap<&str, &str> = FxHashMap::default();
+    // Group sushi belt tiles into PHYSICAL runs, not by segment id.
+    //
+    // `templates::scrap_recycling_row` tags every sushi belt
+    // `row:{recipe}:sushi:{item}` — keyed on recipe and item with no row
+    // index — and `place_rows` splits any recipe whose machine count exceeds
+    // `max_per_row` into several physical rows, each getting that identical
+    // string. Keying a map on it therefore collapsed N separate belts into
+    // one arbitrary entry (`or_insert` keeps whichever was seen first) and
+    // compared the recipe's WHOLE output against that single belt's capacity:
+    // two rows each at 60% of their own belt read as 120% of one, while an
+    // asymmetric split could stay silent on a row that was genuinely jammed.
+    // Either way the issue count never reflected how many rows were affected.
+    //
+    // `check_row_output_lane_budget` and `check_row_input_belt_margin` hit
+    // this same collision and solve it by clustering tiles by adjacency; this
+    // now matches them.
+    let mut sushi_tiles: Vec<(i32, i32)> = Vec::new();
+    let mut sushi_meta: Vec<(&str, &str)> = Vec::new(); // (segment, belt entity)
     for e in &layout.entities {
         if !is_belt_entity(&e.name) {
             continue;
         }
         if let Some(seg) = e.segment_id.as_deref() {
             if seg.contains(SUSHI_MARKER) {
-                seg_belt.entry(seg).or_insert(e.name.as_str());
+                sushi_tiles.push((e.x, e.y));
+                sushi_meta.push((seg, e.name.as_str()));
             }
         }
     }
+    let cluster_of = crate::validate::inserters::cluster_tiles_by_adjacency(&sushi_tiles);
+    // One entry per physical run: its segment, its slowest belt tier (the
+    // real constraint), and how many machine-equivalents it serves.
+    let mut runs: FxHashMap<usize, (&str, &str)> = FxHashMap::default();
+    for (i, &(seg, belt)) in sushi_meta.iter().enumerate() {
+        let c = cluster_of[i];
+        runs.entry(c)
+            .and_modify(|(_, b)| {
+                if belt_throughput(belt) < belt_throughput(b) {
+                    *b = belt;
+                }
+            })
+            .or_insert((seg, belt));
+    }
+    // Recipe-wide output is shared across that recipe's physical runs.
+    let mut runs_per_recipe: FxHashMap<&str, f64> = FxHashMap::default();
+    for (seg, _) in runs.values() {
+        if let Some(r) = seg.strip_prefix("row:").and_then(|rest| {
+            rest.find(":sushi").map(|i| &rest[..i])
+        }) {
+            *runs_per_recipe.entry(r).or_insert(0.0) += 1.0;
+        }
+    }
 
-    for (seg, belt) in &seg_belt {
+    for (seg, belt) in runs.values() {
         // segment_id shape: `row:{recipe}:sushi:{item}` — recover the recipe.
         let recipe = seg.strip_prefix("row:").and_then(|rest| {
             rest.find(":sushi").map(|i| &rest[..i])
@@ -194,6 +234,9 @@ pub fn check_sushi_saturation(
             .filter(|m| m.recipe == recipe)
             .flat_map(|m| m.outputs.iter().filter(|o| !o.is_fluid).map(move |o| o.rate * m.count))
             .sum();
+        // Each physical run carries its share of the recipe's output.
+        let share = runs_per_recipe.get(recipe).copied().unwrap_or(1.0).max(1.0);
+        let total = total / share;
         let cap = belt_throughput(belt);
         if total > cap + 1e-6 {
             issues.push(ValidationIssue::new(
@@ -240,6 +283,78 @@ mod tests {
             ..Default::default()
         }
     }
+    /// Two PHYSICAL sushi runs that share one segment string — what
+    /// `place_rows` produces whenever a scrap-recycling recipe needs more
+    /// machines than one row can carry.
+    ///
+    /// Each run carries half the recipe's output and each is within its own
+    /// belt's capacity, so nothing is jammed. Keying on the segment id
+    /// collapsed both into one entry and compared the recipe's WHOLE output
+    /// against a single belt, reporting a jam that does not exist.
+    #[test]
+    fn split_rows_are_judged_per_physical_run() {
+        let solver = SolverResult {
+            machines: vec![MachineSpec {
+                recipe: "scrap-recycling".into(),
+                count: 8.0,
+                outputs: vec![ItemFlow {
+                    item: "iron-plate".into(),
+                    // 8 x 1.5 = 12/s recipe-wide, 6/s per run.
+                    rate: 1.5,
+                    is_fluid: false,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        // Yellow belt: 15/s. Each run at 6/s is fine; 12/s against one belt
+        // would also be fine, so make the belts red-tier-free and the total
+        // large enough that only the collapsed comparison could trip.
+        let mut entities = Vec::new();
+        for x in 0..4 {
+            entities.push(sushi_belt(x, 0, EntityDirection::East));
+        }
+        // Second run, far away — a separate physical belt, same segment id.
+        for x in 0..4 {
+            entities.push(sushi_belt(x, 40, EntityDirection::East));
+        }
+        let layout = LayoutResult { entities, width: 10, height: 50, ..Default::default() };
+
+        let issues = check_sushi_saturation(&layout, &solver);
+        assert!(
+            issues.is_empty(),
+            "two runs at 6/s each on a 15/s belt are not saturated: {issues:?}"
+        );
+    }
+
+    /// The converse: a genuinely over-capacity run must still be reported, so
+    /// the per-run split cannot silently excuse a real jam.
+    #[test]
+    fn a_genuinely_saturated_run_is_still_reported() {
+        let solver = SolverResult {
+            machines: vec![MachineSpec {
+                recipe: "scrap-recycling".into(),
+                count: 8.0,
+                // 8 x 4.0 = 32/s recipe-wide, 32/s on the single run.
+                outputs: vec![ItemFlow {
+                    item: "iron-plate".into(),
+                    rate: 4.0,
+                    is_fluid: false,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let entities: Vec<PlacedEntity> =
+            (0..4).map(|x| sushi_belt(x, 0, EntityDirection::East)).collect();
+        let layout = LayoutResult { entities, width: 10, height: 10, ..Default::default() };
+        let issues = check_sushi_saturation(&layout, &solver);
+        assert_eq!(issues.len(), 1, "32/s on one 15/s belt must report: {issues:?}");
+        assert_eq!(issues[0].category, "sushi-saturation");
+    }
+
     fn plain_belt(x: i32, y: i32, dir: EntityDirection, item: &str) -> PlacedEntity {
         PlacedEntity {
             name: "transport-belt".into(),

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1398,10 +1398,11 @@ fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
         blocks_overlap, build_manifold_nets, compact_axis, compact_island_axis,
         extract_rigid_islands, extract_route_nets, machine_blocks, occupied_bbox,
-        strip_empty_columns, undergroundify_straight_belts, CompactAxis, CompactIr,
-        PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
+        compact_transport_geometry, CompactAxis, CompactIr, PlacedMachineSignature,
+        ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
+    use spaghettio_core::density::score_density;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
     for label in ["mega-chain-usp2raw", "mega-chain-chem5raw", "mega-chain-pu4raw", "chain-mil5ore"] {
@@ -1513,8 +1514,7 @@ fn rfc057_machine_constraint_baseline() {
             manifolds.iter().map(|manifold| manifold.required_belts(45.0)).max().unwrap_or(0),
         );
 
-        let runnable =
-            strip_empty_columns(&undergroundify_straight_belts(&layout));
+        let runnable = compact_transport_geometry(&layout);
         assert_eq!(
             PlacedMachineSignature::from_layout(&runnable),
             placed,
@@ -1529,6 +1529,11 @@ fn rfc057_machine_constraint_baseline() {
             .filter(|issue| issue.severity == Severity::Error)
             .collect();
         assert!(errors.is_empty(), "{label}: runnable post-pass errors: {errors:?}");
+        let underground_warnings = issues.iter()
+            .filter(|issue| {
+                issue.severity != Severity::Error && issue.category == "underground-belt"
+            })
+            .count();
         let source_belts = layout.entities.iter()
             .filter(|entity| is_belt_entity(&entity.name))
             .count();
@@ -1541,6 +1546,20 @@ fn rfc057_machine_constraint_baseline() {
             source_belts, compact_belts,
             (compact_belts as f64 / source_belts as f64 - 1.0) * 100.0,
         );
+        println!("{label}: underground warnings={underground_warnings}");
+        let source_density = score_density(&layout, (1, 1));
+        let compact_density = score_density(&runnable, (1, 1));
+        println!(
+            "{label}: occupied tiles={} -> {} ({:+.1}%), content area={} -> {}",
+            source_density.filled_tiles,
+            compact_density.filled_tiles,
+            (compact_density.filled_tiles as f64 / source_density.filled_tiles as f64 - 1.0)
+                * 100.0,
+            u64::from(source_density.content_bbox_width)
+                * u64::from(source_density.content_bbox_height),
+            u64::from(compact_density.content_bbox_width)
+                * u64::from(compact_density.content_bbox_height),
+        );
     }
 }
 
@@ -1549,8 +1568,8 @@ fn rfc057_machine_constraint_baseline() {
 fn rfc057_strip_empty_columns_mil5ore() {
     use spaghettio_core::bus::compaction::{
         compact_island_axis, extract_rigid_islands, extract_route_nets, occupied_bbox,
-        strip_empty_columns, undergroundify_straight_belts, CompactAxis,
-        PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
+        compact_transport_geometry, strip_empty_columns, CompactAxis, PlacedMachineSignature,
+        ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
@@ -1564,8 +1583,7 @@ fn rfc057_strip_empty_columns_mil5ore() {
     ).unwrap();
     let source = fixture.compose_layout();
     let compacted = strip_empty_columns(&source);
-    let underground_compacted =
-        strip_empty_columns(&undergroundify_straight_belts(&source));
+    let underground_compacted = compact_transport_geometry(&source);
     let production = ProductionSignature::from_solver(&sr).unwrap();
     let nets = extract_route_nets(&source);
     let islands = extract_rigid_islands(&source);
@@ -1664,6 +1682,44 @@ fn rfc057_strip_empty_columns_mil5ore() {
         println!(
             "  net {}: segments={} entities={} terminals={}",
             net.item, net.segments.len(), net.entity_indices.len(), net.terminals.len(),
+        );
+    }
+}
+
+#[test]
+#[ignore = "RFC-057 compacted artifact producer"]
+fn export_rfc057_compacted_candidates() {
+    use spaghettio_core::bus::compaction::compact_transport_geometry;
+
+    std::fs::create_dir_all("target/tmp").unwrap();
+    for fixture_label in [
+        "mega-chain-chem5raw",
+        "mega-chain-pu4raw",
+        "mega-chain-usp2raw",
+    ] {
+        let fixture = SimFixture::find(fixture_label);
+        let inputs: FxHashSet<String> =
+            fixture.inputs.iter().map(|item| item.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        let control = fixture.compose_layout();
+        let compacted = compact_transport_geometry(&control);
+        for (variant, layout) in [("control", &control), ("compact", &compacted)] {
+            let label = format!("rfc057-{fixture_label}-{variant}");
+            let (bp, manifest) =
+                spaghettio_core::blueprint::export_with_manifest(layout, &sr, &label);
+            std::fs::write(format!("target/tmp/{label}.bp"), bp).unwrap();
+            std::fs::write(
+                format!("target/tmp/{label}.manifest.json"),
+                serde_json::to_string_pretty(&manifest).unwrap(),
+            ).unwrap();
+        }
+        println!(
+            "{fixture_label}: {}x{} / {} entities -> {}x{} / {} entities",
+            control.width, control.height, control.entities.len(),
+            compacted.width, compacted.height, compacted.entities.len(),
         );
     }
 }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3713,6 +3713,47 @@ fn probe_pole_connectivity_census() {
         ) else { continue };
         let base = fixture.compose_layout();
         let compact = compact_validated_geometry(&base, &sr);
+        // `disconnected_poles` counts "unreachable from pole[0]", which is a
+        // poor progress metric: merging two components that both exclude
+        // pole[0] leaves the count unchanged while ADDING the bridge, so real
+        // repair can read as regression. Component count is the honest one.
+        let components = |l: &spaghettio_core::models::LayoutResult| -> usize {
+            let poles: Vec<(f64, f64, f64)> = l
+                .entities
+                .iter()
+                .filter_map(|e| {
+                    spaghettio_core::power_wires::wire_reach(
+                        &e.name,
+                        e.quality.unwrap_or_default(),
+                    )
+                    .map(|r| {
+                        let (cx, cy) = spaghettio_core::power_wires::pole_center(&e.name, e.x, e.y);
+                        (cx, cy, r)
+                    })
+                })
+                .collect();
+            let n = poles.len();
+            let mut parent: Vec<usize> = (0..n).collect();
+            fn find(p: &mut [usize], mut x: usize) -> usize {
+                while p[x] != x { p[x] = p[p[x]]; x = p[x]; }
+                x
+            }
+            for i in 0..n {
+                for j in (i + 1)..n {
+                    let (ax, ay, ar) = poles[i];
+                    let (bx, by, br) = poles[j];
+                    let (dx, dy) = (ax - bx, ay - by);
+                    let reach = ar.min(br);
+                    if dx * dx + dy * dy <= reach * reach {
+                        let (ri, rj) = (find(&mut parent, i), find(&mut parent, j));
+                        if ri != rj { parent[ri] = rj; }
+                    }
+                }
+            }
+            let mut roots = std::collections::BTreeSet::new();
+            for i in 0..n { let r = find(&mut parent, i); roots.insert(r); }
+            roots.len()
+        };
         let count = |l: &spaghettio_core::models::LayoutResult| {
             let n = l.entities.iter()
                 .filter(|e| e.name.ends_with("electric-pole") || e.name == "substation")
@@ -3726,9 +3767,12 @@ fn probe_pole_connectivity_census() {
         let added = spaghettio_core::bus::layout::repair_pole_network(&mut repaired);
         let (rn, rd) = count(&repaired);
         println!(
-            "{label:<22} composed {bd:>3}/{bn:<4}   compacted {cd:>3}/{cn:<4}   \
-             after repair {rd:>3}/{rn:<4} (+{added} bridges)",
+            "{label:<22} composed {bd:>4}/{bn:<4} in {:>4} networks   \
+             after repair {rd:>4}/{rn:<4} in {:>4} networks (+{added} bridges)",
+            components(&base),
+            components(&repaired),
         );
+        let _ = (cd, cn);
     }
 }
 

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1396,8 +1396,10 @@ fn export_rfc055_factorio_candidates() {
 #[ignore = "RFC-057 coarse machine compaction potential"]
 fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
-        blocks_overlap, compact_axis, machine_blocks, occupied_bbox, CompactAxis,
-        PlacedMachineSignature, ProductionSignature,
+        blocks_overlap, build_manifold_nets, compact_axis, compact_island_axis,
+        extract_rigid_islands, extract_route_nets, machine_blocks, occupied_bbox,
+        CompactAxis, CompactIr, PlacedMachineSignature, ProductionSignature,
+        RouteTerminalKind,
     };
 
     for label in ["mega-chain-usp2raw", "mega-chain-chem5raw", "mega-chain-pu4raw", "chain-mil5ore"] {
@@ -1411,8 +1413,25 @@ fn rfc057_machine_constraint_baseline() {
         let layout = fixture.compose_layout();
         let production = ProductionSignature::from_solver(&sr).unwrap();
         let placed = PlacedMachineSignature::from_layout(&layout);
+        let nets = extract_route_nets(&layout);
+        let islands = extract_rigid_islands(&layout);
         assert!(!production.machines.is_empty());
         assert!(!placed.0.is_empty());
+        for edge in production.edges.iter().filter(|edge| !edge.is_fluid) {
+            assert!(nets.iter().any(|net| {
+                net.item == edge.item
+                    && net.terminals.iter().any(|terminal| {
+                        terminal.kind == RouteTerminalKind::ProducerDrop
+                            && terminal.recipe.as_ref().is_some_and(|recipe| {
+                                edge.producer_recipes.contains(recipe)
+                            })
+                    })
+                    && net.terminals.iter().any(|terminal| {
+                        terminal.kind == RouteTerminalKind::ConsumerPickup
+                            && terminal.recipe.as_deref() == Some(edge.consumer_recipe.as_str())
+                    })
+            }), "{label}: no route intent covers {edge:?}");
+        }
 
         let original = machine_blocks(&layout);
         let original_bbox = occupied_bbox(&original);
@@ -1433,6 +1452,41 @@ fn rfc057_machine_constraint_baseline() {
             "{label}: machines={} machine-bbox={}x{} -> {}x{} ({:+.1}%)",
             original.len(), original_bbox.0, original_bbox.1,
             compact_bbox.0, compact_bbox.1,
+            (after as f64 / before as f64 - 1.0) * 100.0,
+        );
+
+        let island_source = occupied_bbox(
+            &islands.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+        );
+        let mut island_compacted = islands.clone();
+        for _ in 0..8 {
+            island_compacted = compact_island_axis(&island_compacted, CompactAxis::X, 1);
+            island_compacted = compact_island_axis(&island_compacted, CompactAxis::Y, 1);
+        }
+        let island_after = occupied_bbox(
+            &island_compacted.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+        );
+        let ir = CompactIr { islands: islands.clone(), route_nets: nets.clone() };
+        let manifolds = build_manifold_nets(&ir, &island_compacted).unwrap();
+        for manifold in &manifolds {
+            assert!(
+                manifold.producers().next().is_some(),
+                "{label}: {} manifold has no producer/input",
+                manifold.item,
+            );
+            assert!(
+                manifold.consumers().next().is_some(),
+                "{label}: {} manifold has no consumer/output",
+                manifold.item,
+            );
+        }
+        let before = i64::from(island_source.0) * i64::from(island_source.1);
+        let after = i64::from(island_after.0) * i64::from(island_after.1);
+        println!(
+            "{label}: islands={} terminals={} manifolds={} island-bbox={}x{} -> {}x{} ({:+.1}%)",
+            islands.len(), islands.iter().map(|island| island.terminals.len()).sum::<usize>(),
+            manifolds.len(),
+            island_source.0, island_source.1, island_after.0, island_after.1,
             (after as f64 / before as f64 - 1.0) * 100.0,
         );
     }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1392,6 +1392,52 @@ fn export_rfc055_factorio_candidates() {
     }
 }
 
+#[test]
+#[ignore = "RFC-057 coarse machine compaction potential"]
+fn rfc057_machine_constraint_baseline() {
+    use spaghettio_core::bus::compaction::{
+        blocks_overlap, compact_axis, machine_blocks, occupied_bbox, CompactAxis,
+        PlacedMachineSignature, ProductionSignature,
+    };
+
+    for label in ["mega-chain-usp2raw", "mega-chain-chem5raw", "mega-chain-pu4raw", "chain-mil5ore"] {
+        let fixture = SimFixture::find(label);
+        let inputs: FxHashSet<String> =
+            fixture.inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        let layout = fixture.compose_layout();
+        let production = ProductionSignature::from_solver(&sr).unwrap();
+        let placed = PlacedMachineSignature::from_layout(&layout);
+        assert!(!production.machines.is_empty());
+        assert!(!placed.0.is_empty());
+
+        let original = machine_blocks(&layout);
+        let original_bbox = occupied_bbox(&original);
+        let mut compacted = original.clone();
+        for _ in 0..8 {
+            compacted = compact_axis(&compacted, CompactAxis::X, 1);
+            compacted = compact_axis(&compacted, CompactAxis::Y, 1);
+        }
+        for (i, a) in compacted.iter().enumerate() {
+            for b in &compacted[i + 1..] {
+                assert!(!blocks_overlap(a, b), "{label}: blocks {} and {} overlap", a.id, b.id);
+            }
+        }
+        let compact_bbox = occupied_bbox(&compacted);
+        let before = i64::from(original_bbox.0) * i64::from(original_bbox.1);
+        let after = i64::from(compact_bbox.0) * i64::from(compact_bbox.1);
+        println!(
+            "{label}: machines={} machine-bbox={}x{} -> {}x{} ({:+.1}%)",
+            original.len(), original_bbox.0, original_bbox.1,
+            compact_bbox.0, compact_bbox.1,
+            (after as f64 / before as f64 - 1.0) * 100.0,
+        );
+    }
+}
+
 /// Artifact producer for the increment-2 sim run.
 #[test]
 #[ignore = "artifact producer"]

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3721,9 +3721,13 @@ fn probe_pole_connectivity_census() {
         };
         let (bn, bd) = count(&base);
         let (cn, cd) = count(&compact);
+        // Can the pipeline's own repair close the gap on composed output?
+        let mut repaired = base.clone();
+        let added = spaghettio_core::bus::layout::repair_pole_network(&mut repaired);
+        let (rn, rd) = count(&repaired);
         println!(
-            "{label:<22} composed {bd:>3}/{bn:<4} disconnected   compacted {cd:>3}/{cn:<4}{}",
-            if cd > bd { "   <-- COMPACTION MADE IT WORSE" } else { "" }
+            "{label:<22} composed {bd:>3}/{bn:<4}   compacted {cd:>3}/{cn:<4}   \
+             after repair {rd:>3}/{rn:<4} (+{added} bridges)",
         );
     }
 }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1398,8 +1398,9 @@ fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
         blocks_overlap, build_manifold_nets, compact_axis, compact_island_axis,
         compact_transport_geometry, estimated_manifold_wirelength, extract_rigid_islands,
-        extract_route_nets, machine_blocks, occupied_bbox, place_recipe_clusters, CompactAxis,
-        CompactIr, PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
+        extract_route_nets, machine_blocks, occupied_bbox, place_recipe_clusters,
+        plan_local_manifolds, CompactAxis, CompactIr, PlacedMachineSignature,
+        ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
     use spaghettio_core::density::score_density;
@@ -1475,6 +1476,7 @@ fn rfc057_machine_constraint_baseline() {
         let manifolds = build_manifold_nets(&ir, &island_compacted).unwrap();
         let (clustered_islands, clusters) = place_recipe_clusters(&ir, 1);
         let clustered_manifolds = build_manifold_nets(&ir, &clustered_islands).unwrap();
+        let local_plans = plan_local_manifolds(&clustered_islands, &clustered_manifolds, 1);
         let clustered_bbox = occupied_bbox(
             &clustered_islands
                 .iter()
@@ -1537,6 +1539,26 @@ fn rfc057_machine_constraint_baseline() {
             estimated_manifold_wirelength(&manifolds),
             estimated_manifold_wirelength(&clustered_manifolds),
         );
+        println!(
+            "{label}: local hubs={} lanes={} merger-ready={} distributor-ready={}",
+            local_plans.len(),
+            local_plans.iter().map(|plan| plan.belt_count).sum::<u32>(),
+            local_plans.iter().filter(|plan| plan.all_mergers_stampable).count(),
+            local_plans.iter().filter(|plan| plan.all_distributors_stampable).count(),
+        );
+        assert_eq!(local_plans.len(), clustered_manifolds.len());
+        for (plan, manifold) in local_plans.iter().zip(&clustered_manifolds) {
+            assert!(plan.all_mergers_stampable, "{label}: {} merger hierarchy not stampable", plan.item);
+            assert!(plan.all_distributors_stampable, "{label}: {} distributor hierarchy not stampable", plan.item);
+            assert_eq!(
+                plan.lane_groups.iter().map(|group| group.producers.len()).sum::<usize>(),
+                manifold.producers().count(),
+            );
+            assert_eq!(
+                plan.lane_groups.iter().map(|group| group.consumers.len()).sum::<usize>(),
+                manifold.consumers().count(),
+            );
+        }
 
         let runnable = compact_transport_geometry(&layout);
         assert_eq!(

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1398,12 +1398,12 @@ fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
         blocks_overlap, build_local_manifold_graph, build_manifold_nets, compact_axis, compact_island_axis,
         compact_transport_geometry, estimated_manifold_wirelength, extract_rigid_islands,
-        extract_route_nets, machine_blocks, occupied_bbox, place_recipe_clusters,
-        plan_local_manifolds, CompactAxis, CompactIr, PlacedMachineSignature,
-        ProductionSignature, RouteTerminalKind,
+        extract_route_nets, machine_blocks, occupied_bbox, place_local_manifold_nodes,
+        place_recipe_clusters, plan_local_manifolds, CompactAxis, CompactIr,
+        PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
-    use spaghettio_core::density::score_density;
+    use spaghettio_core::density::{entity_footprint, score_density};
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
     for label in ["mega-chain-usp2raw", "mega-chain-chem5raw", "mega-chain-pu4raw", "chain-mil5ore"] {
@@ -1481,6 +1481,21 @@ fn rfc057_machine_constraint_baseline() {
             .iter()
             .map(build_local_manifold_graph)
             .collect();
+        let placed_hubs = place_local_manifold_nodes(&clustered_islands, &local_graphs, 1);
+        let mut hub_tiles = FxHashSet::default();
+        for hub in &placed_hubs {
+            for entity in &hub.entities {
+                let (width, height) = entity_footprint(entity);
+                for x in entity.x..entity.x + width as i32 {
+                    for y in entity.y..entity.y + height as i32 {
+                        assert!(
+                            hub_tiles.insert((x, y)),
+                            "{label}: stamped hub entity overlap at ({x},{y})",
+                        );
+                    }
+                }
+            }
+        }
         let clustered_bbox = occupied_bbox(
             &clustered_islands
                 .iter()
@@ -1549,6 +1564,11 @@ fn rfc057_machine_constraint_baseline() {
             local_plans.iter().map(|plan| plan.belt_count).sum::<u32>(),
             local_plans.iter().filter(|plan| plan.all_mergers_stampable).count(),
             local_plans.iter().filter(|plan| plan.all_distributors_stampable).count(),
+        );
+        println!(
+            "{label}: stamped hub nodes={} entities={}",
+            placed_hubs.iter().map(|hub| hub.nodes.len()).sum::<usize>(),
+            placed_hubs.iter().map(|hub| hub.entities.len()).sum::<usize>(),
         );
         assert_eq!(local_plans.len(), clustered_manifolds.len());
         for ((plan, graph), manifold) in local_plans

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1397,9 +1397,9 @@ fn export_rfc055_factorio_candidates() {
 fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
         blocks_overlap, build_manifold_nets, compact_axis, compact_island_axis,
-        extract_rigid_islands, extract_route_nets, machine_blocks, occupied_bbox,
-        compact_transport_geometry, CompactAxis, CompactIr, PlacedMachineSignature,
-        ProductionSignature, RouteTerminalKind,
+        compact_transport_geometry, estimated_manifold_wirelength, extract_rigid_islands,
+        extract_route_nets, machine_blocks, occupied_bbox, place_recipe_clusters, CompactAxis,
+        CompactIr, PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
     use spaghettio_core::density::score_density;
@@ -1473,6 +1473,24 @@ fn rfc057_machine_constraint_baseline() {
         assert_eq!(ir.islands, islands);
         assert_eq!(ir.route_nets, nets);
         let manifolds = build_manifold_nets(&ir, &island_compacted).unwrap();
+        let (clustered_islands, clusters) = place_recipe_clusters(&ir, 1);
+        let clustered_manifolds = build_manifold_nets(&ir, &clustered_islands).unwrap();
+        let clustered_bbox = occupied_bbox(
+            &clustered_islands
+                .iter()
+                .map(|island| island.block.clone())
+                .collect::<Vec<_>>(),
+        );
+        for (idx, island) in clustered_islands.iter().enumerate() {
+            for other in &clustered_islands[idx + 1..] {
+                assert!(
+                    !blocks_overlap(&island.block, &other.block),
+                    "{label}: clustered islands {} and {} overlap",
+                    island.id,
+                    other.id,
+                );
+            }
+        }
         let mut non_monotone = Vec::new();
         for manifold in &manifolds {
             assert!(
@@ -1512,6 +1530,12 @@ fn rfc057_machine_constraint_baseline() {
             "{label}: express manifold lanes total={} max={}",
             manifolds.iter().map(|manifold| manifold.required_belts(45.0)).sum::<u32>(),
             manifolds.iter().map(|manifold| manifold.required_belts(45.0)).max().unwrap_or(0),
+        );
+        println!(
+            "{label}: recipe clusters={} bbox={}x{}, weighted-wirelength={} -> {}",
+            clusters.len(), clustered_bbox.0, clustered_bbox.1,
+            estimated_manifold_wirelength(&manifolds),
+            estimated_manifold_wirelength(&clustered_manifolds),
         );
 
         let runnable = compact_transport_geometry(&layout);

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3520,6 +3520,132 @@ fn export_fold_pair_for_sim() {
     }
 }
 
+/// Dump source-vs-folded geometry as JSON for the visual report.
+///
+/// One character per tile, classified by entity family, so the renderer can
+/// colour belts, machines, pipes and the rest differently without shipping
+/// per-entity records for tens of thousands of entities.
+#[test]
+#[ignore = "report export — feeds the fold visualisation"]
+fn export_fold_report_json() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, search_snake_fold};
+    use spaghettio_core::models::LayoutResult;
+
+    fn class_of(name: &str) -> char {
+        use spaghettio_core::common::*;
+        if is_machine_entity(name) {
+            'm'
+        } else if is_splitter(name) {
+            's'
+        } else if is_ug_belt(name) {
+            'u'
+        } else if is_belt_entity(name) {
+            'b'
+        } else if is_inserter(name) {
+            'i'
+        } else if name.starts_with("pipe") {
+            'p'
+        } else if name.ends_with("electric-pole") || name == "substation" {
+            'e'
+        } else {
+            'o'
+        }
+    }
+
+    fn grid(l: &LayoutResult) -> String {
+        let (w, h) = (l.width.max(1) as usize, l.height.max(1) as usize);
+        let mut g = vec![b'.'; w * h];
+        for e in &l.entities {
+            let (ew, eh) = spaghettio_core::common::entity_size(&e.name);
+            let c = class_of(&e.name) as u8;
+            for dx in 0..(ew as i32).max(1) {
+                for dy in 0..(eh as i32).max(1) {
+                    let (x, y) = (e.x + dx, e.y + dy);
+                    if x >= 0 && y >= 0 && (x as usize) < w && (y as usize) < h {
+                        let i = y as usize * w + x as usize;
+                        // machines win over belts so footprints read clearly
+                        if g[i] == b'.' || c == b'm' {
+                            g[i] = c;
+                        }
+                    }
+                }
+            }
+        }
+        String::from_utf8(g).unwrap()
+    }
+
+    fn counts(l: &LayoutResult) -> String {
+        let mut m = std::collections::BTreeMap::new();
+        for e in &l.entities {
+            *m.entry(class_of(&e.name)).or_insert(0usize) += 1;
+        }
+        m.iter()
+            .map(|(k, v)| format!("\"{k}\":{v}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    struct Case {
+        label: &'static str,
+        arch: &'static str,
+        item: &'static str,
+        rate: f64,
+        inputs: &'static [&'static str],
+        machine: &'static str,
+        cell: bool,
+    }
+    let cases = [
+        Case { label: "chain-mil5ore", arch: "cell", item: "military-science-pack", rate: 5.0,
+               inputs: &["iron-ore", "copper-ore", "stone", "coal"], machine: "assembling-machine-3", cell: true },
+        Case { label: "gear15-ore", arch: "bus", item: "iron-gear-wheel", rate: 15.0,
+               inputs: &["iron-ore"], machine: "assembling-machine-2", cell: false },
+        Case { label: "ec10-ore", arch: "bus", item: "electronic-circuit", rate: 10.0,
+               inputs: &["iron-ore", "copper-ore"], machine: "assembling-machine-1", cell: false },
+    ];
+
+    let mut out = String::from("[\n");
+    for (n, c) in cases.iter().enumerate() {
+        let inputs_set: FxHashSet<String> = c.inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            c.item, c.rate, &inputs_set, &MachinePalette::default(), c.machine,
+            &FxHashSet::default(), QualityTier::Normal,
+        )
+        .unwrap();
+        let base = if c.cell {
+            SimFixture::find(c.label).compose_layout()
+        } else {
+            layout::build_bus_layout(&sr, layout::LayoutOptions::default()).unwrap()
+        };
+        let compact = compact_validated_geometry(&base, &sr);
+        let search = search_snake_fold(&compact, &sr, 4);
+        let Some(found) = &search.best else {
+            println!("{}: no fold, skipped", c.label);
+            continue;
+        };
+        let f = &found.layout;
+        if n > 0 {
+            out.push_str(",\n");
+        }
+        out.push_str(&format!(
+            "{{\"label\":\"{}\",\"arch\":\"{}\",\"item\":\"{}\",\"rate\":{},\"folds\":{:?},\n\
+             \"src\":{{\"w\":{},\"h\":{},\"n\":{},\"counts\":{{{}}},\"grid\":\"{}\"}},\n\
+             \"fold\":{{\"w\":{},\"h\":{},\"n\":{},\"counts\":{{{}}},\"grid\":\"{}\"}}}}",
+            c.label, c.arch, c.item, c.rate, found.folds,
+            compact.width, compact.height, compact.entities.len(), counts(&compact), grid(&compact),
+            f.width, f.height, f.entities.len(), counts(f), grid(f),
+        ));
+        println!(
+            "{}: {}x{} -> {}x{} ({} -> {} entities)",
+            c.label, compact.width, compact.height, f.width, f.height,
+            compact.entities.len(), f.entities.len()
+        );
+    }
+    out.push_str("\n]\n");
+    std::fs::create_dir_all("target/tmp").unwrap();
+    std::fs::write("target/tmp/fold-report.json", out).unwrap();
+    println!("wrote target/tmp/fold-report.json");
+}
+
 /// Does the fold work on BUS layouts, not just cell chains?
 ///
 /// Every fold measurement so far has been on `compose_chain_*` output — the

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1438,6 +1438,74 @@ fn rfc057_machine_constraint_baseline() {
     }
 }
 
+#[test]
+#[ignore = "RFC-057 runnable whitespace-compaction baseline"]
+fn rfc057_strip_empty_columns_mil5ore() {
+    use spaghettio_core::bus::compaction::{
+        extract_route_nets, strip_empty_columns, PlacedMachineSignature,
+        ProductionSignature, RouteTerminalKind,
+    };
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+
+    let fixture = SimFixture::find("chain-mil5ore");
+    let inputs: FxHashSet<String> =
+        fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let source = fixture.compose_layout();
+    let compacted = strip_empty_columns(&source);
+    let production = ProductionSignature::from_solver(&sr).unwrap();
+    let nets = extract_route_nets(&source);
+    for edge in production.edges.iter().filter(|edge| !edge.is_fluid) {
+        assert!(nets.iter().any(|net| {
+            net.item == edge.item
+                && net.terminals.iter().any(|terminal| {
+                    terminal.kind == RouteTerminalKind::ProducerDrop
+                        && terminal.recipe.as_ref().is_some_and(|recipe| {
+                            edge.producer_recipes.contains(recipe)
+                        })
+                })
+                && net.terminals.iter().any(|terminal| {
+                    terminal.kind == RouteTerminalKind::ConsumerPickup
+                        && terminal.recipe.as_deref() == Some(edge.consumer_recipe.as_str())
+                })
+        }), "no extracted route net covers edge {edge:?}");
+    }
+    assert_eq!(
+        PlacedMachineSignature::from_layout(&source),
+        PlacedMachineSignature::from_layout(&compacted),
+    );
+    let issues = match validate::validate(&compacted, Some(&sr), LayoutStyle::Bus) {
+        Ok(v) => v,
+        Err(e) => e.issues,
+    };
+    let errors: Vec<_> = issues.iter()
+        .filter(|issue| issue.severity == Severity::Error)
+        .collect();
+    assert!(errors.is_empty(), "stripped candidate errors: {errors:?}");
+    std::fs::create_dir_all("target/tmp").unwrap();
+    for (label, layout) in [
+        ("rfc057-mil5ore-control", &source),
+        ("rfc057-mil5ore-strip", &compacted),
+    ] {
+        let (bp, manifest) =
+            spaghettio_core::blueprint::export_with_manifest(layout, &sr, label);
+        std::fs::write(format!("target/tmp/{label}.bp"), bp).unwrap();
+        std::fs::write(
+            format!("target/tmp/{label}.manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        ).unwrap();
+    }
+    println!(
+        "chain-mil5ore: {}x{} -> {}x{}; entities={}",
+        source.width, source.height, compacted.width, compacted.height,
+        compacted.entities.len(),
+    );
+    println!("extracted {} replaceable route nets", nets.len());
+}
+
 /// Artifact producer for the increment-2 sim run.
 #[test]
 #[ignore = "artifact producer"]

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1400,6 +1400,7 @@ fn rfc057_machine_constraint_baseline() {
         compact_transport_geometry, estimated_manifold_wirelength, extract_rigid_islands,
         extract_route_nets, machine_blocks, occupied_bbox,
         place_distributed_local_manifold_nodes, place_recipe_clusters, plan_local_manifolds,
+        legalize_manifold_routes, materialize_legalized_manifold_routes,
         route_local_manifold_edges, CompactAxis, CompactIr,
         PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
@@ -1483,7 +1484,7 @@ fn rfc057_machine_constraint_baseline() {
             .map(build_local_manifold_graph)
             .collect();
         let placed_hubs =
-            place_distributed_local_manifold_nodes(&clustered_islands, &local_graphs, 1)
+            place_distributed_local_manifold_nodes(&clustered_islands, &local_graphs, 3)
                 .unwrap();
         if label == "chain-mil5ore" {
             let routed =
@@ -1497,6 +1498,47 @@ fn rfc057_machine_constraint_baseline() {
             );
             assert_eq!(routed.routes.len(), edge_count);
             assert!(routed.routes.iter().all(|route| route.path.len() >= 2));
+            let legalized = legalize_manifold_routes(&routed.routes);
+            assert_eq!(legalized.routes.len(), routed.routes.len());
+            if legalized.unresolved_routes == 0 {
+                assert!(materialize_legalized_manifold_routes(&legalized.routes).is_ok());
+            } else {
+                assert!(materialize_legalized_manifold_routes(&legalized.routes).is_err());
+            }
+            let mut crossed_merge_edges = 0usize;
+            let mut crossed_distribute_edges = 0usize;
+            for route in routed.routes.iter().filter(|route| !route.crossings.is_empty()) {
+                let graph = local_graphs
+                    .iter()
+                    .find(|graph| graph.item == route.item)
+                    .unwrap();
+                let touches_role = |endpoint: &spaghettio_core::bus::compaction::ManifoldEndpoint,
+                                    role| match endpoint {
+                    spaghettio_core::bus::compaction::ManifoldEndpoint::NodeInput { node, .. }
+                    | spaghettio_core::bus::compaction::ManifoldEndpoint::NodeOutput { node, .. } => {
+                        graph.nodes[*node].role == role
+                    }
+                    _ => false,
+                };
+                if touches_role(
+                    &route.edge.from,
+                    spaghettio_core::bus::compaction::BalancerNodeRole::Merge,
+                ) || touches_role(
+                    &route.edge.to,
+                    spaghettio_core::bus::compaction::BalancerNodeRole::Merge,
+                ) {
+                    crossed_merge_edges += 1;
+                }
+                if touches_role(
+                    &route.edge.from,
+                    spaghettio_core::bus::compaction::BalancerNodeRole::Distribute,
+                ) || touches_role(
+                    &route.edge.to,
+                    spaghettio_core::bus::compaction::BalancerNodeRole::Distribute,
+                ) {
+                    crossed_distribute_edges += 1;
+                }
+            }
             let mut occupied_axes = FxHashMap::<(i32, i32), u8>::default();
             let mut same_axis_tiles = 0usize;
             let mut perpendicular_tiles = 0usize;
@@ -1520,13 +1562,18 @@ fn rfc057_machine_constraint_baseline() {
             }
             println!(
                 "{label}: routed {} manifold edges, {} paths cross prior paths, \
-                 conflicts={same_axis_tiles} same-axis/{perpendicular_tiles} perpendicular tiles",
+                 conflicts={same_axis_tiles} same-axis/{perpendicular_tiles} perpendicular tiles; \
+                 legalization={} UG spans, {} residual routes/{} tiles; \
+                 crossed roles={crossed_merge_edges} merge/{crossed_distribute_edges} distribute",
                 routed.routes.len(),
                 routed
                     .routes
                     .iter()
                     .filter(|route| !route.crossings.is_empty())
                     .count(),
+                legalized.underground_spans,
+                legalized.unresolved_routes,
+                legalized.unresolved_tiles,
             );
         }
         let mut hub_tiles = FxHashSet::default();

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1312,6 +1312,86 @@ fn rfc055_compact_usp_real_geometry() {
         compact.width, compact.height, compact.entities.len());
 }
 
+#[test]
+#[ignore = "RFC-055 acceptance-corpus experiment"]
+fn rfc055_compact_acceptance_corpus() {
+    use spaghettio_core::bus::cells::chain::{compose_chain_compact, compose_chain_with_capacity};
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+
+    for (label, target, rate, raw) in [
+        ("usp2raw", "utility-science-pack", 2.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"][..]),
+        ("chem5raw", "chemical-science-pack", 5.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
+        ("pu4raw", "processing-unit", 4.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
+        ("mil5ore", "military-science-pack", 5.0,
+            &["iron-ore", "copper-ore", "stone", "coal"][..]),
+    ] {
+        let inputs: FxHashSet<String> = raw.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            target, rate, &inputs, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        let control = compose_chain_with_capacity(&sr, 0)
+            .unwrap_or_else(|e| panic!("{label} control: {e}"));
+        let compact = compose_chain_compact(&sr, 0)
+            .unwrap_or_else(|e| panic!("{label} compact: {e}"));
+        let issues = match validate::validate(&compact, Some(&sr), LayoutStyle::Bus) {
+            Ok(v) => v,
+            Err(e) => e.issues,
+        };
+        let errors = issues.iter().filter(|i| i.severity == Severity::Error).count();
+        assert_eq!(errors, 0, "{label} compact has errors: {issues:?}");
+        let belts = |l: &spaghettio_core::models::LayoutResult| l.entities.iter()
+            .filter(|e| e.name.contains("transport-belt") || e.name.contains("splitter"))
+            .count();
+        let corridors = |l: &spaghettio_core::models::LayoutResult| l.entities.iter()
+            .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("corr:")))
+            .count();
+        println!("{label}: control={}x{} entities={} belts={} corr={} compact={}x{} entities={} belts={} corr={}",
+            control.width, control.height, control.entities.len(), belts(&control), corridors(&control),
+            compact.width, compact.height, compact.entities.len(), belts(&compact), corridors(&compact));
+    }
+}
+
+#[test]
+#[ignore = "RFC-055 Factorio artifact producer"]
+fn export_rfc055_factorio_candidates() {
+    use spaghettio_core::blueprint::export_with_manifest;
+    use spaghettio_core::bus::cells::chain::{compose_chain_compact, compose_chain_with_capacity};
+
+    std::fs::create_dir_all("target/tmp/rfc055").unwrap();
+    for (label, target, rate, raw) in [
+        ("usp2raw", "utility-science-pack", 2.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"][..]),
+        ("chem5raw", "chemical-science-pack", 5.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
+        ("pu4raw", "processing-unit", 4.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
+    ] {
+        let inputs: FxHashSet<String> = raw.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            target, rate, &inputs, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ).unwrap();
+        for (variant, layout) in [
+            ("control", compose_chain_with_capacity(&sr, 0).unwrap()),
+            ("compact", compose_chain_compact(&sr, 0).unwrap()),
+        ] {
+            let artifact = format!("rfc055-{label}-{variant}");
+            let (bp, manifest) = export_with_manifest(&layout, &sr, &artifact);
+            std::fs::write(format!("target/tmp/rfc055/{artifact}.bp"), bp).unwrap();
+            std::fs::write(
+                format!("target/tmp/rfc055/{artifact}.manifest.json"),
+                serde_json::to_string_pretty(&manifest).unwrap(),
+            ).unwrap();
+            println!("wrote {artifact}: {}x{}, {} entities",
+                layout.width, layout.height, layout.entities.len());
+        }
+    }
+}
+
 /// Artifact producer for the increment-2 sim run.
 #[test]
 #[ignore = "artifact producer"]

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3475,21 +3475,20 @@ fn fold_routing_headroom_for(label: &str) {
     }
 }
 
-/// Fold search: try different numbers of folds and positions on the
-/// compacted mil5-ore layout, validate each, report the squarest valid.
+/// Export the compacted control and its folded counterpart for the sim
+/// harness. Belt lane semantics are the thing folding is most likely to
+/// break — a corner that is a 90° turn carries both lanes, one that has
+/// become a sideload carries one — and only Factorio adjudicates that.
 #[test]
-#[ignore = "exploration probe — fold search"]
-fn probe_fold_search_mil5() {
+#[ignore = "sim export — run spaghettio-sim against the written artifacts"]
+fn export_fold_pair_for_sim() {
     use spaghettio_core::bus::compaction::{compact_validated_geometry, fold_snake};
-    use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
-    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "stone", "coal"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let fixture = SimFixture::find("chain-mil5ore");
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "military-science-pack",
-        5.0,
+        fixture.target,
+        fixture.rate,
         &inputs,
         &MachinePalette::default(),
         "assembling-machine-3",
@@ -3497,265 +3496,219 @@ fn probe_fold_search_mil5() {
         QualityTier::Normal,
     )
     .unwrap();
+    let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
+    let folded =
+        fold_snake(&compact, &[compact.width / 2]).expect("midpoint fold must succeed");
 
-    let bus = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
-        .expect("mil5-ore must compose");
-    let compact = compact_validated_geometry(&bus, &sr);
+    std::fs::create_dir_all("target/tmp").unwrap();
+    for (tag, l) in [("mil5-compact", &compact), ("mil5-fold1", &folded)] {
+        let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(l, &sr, tag);
+        std::fs::write(format!("target/tmp/{tag}.bp"), &bp).unwrap();
+        std::fs::write(
+            format!("target/tmp/{tag}.manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        println!(
+            "wrote target/tmp/{tag}.bp — {}x{}, {} entities, {} in / {} out",
+            l.width,
+            l.height,
+            l.entities.len(),
+            l.boundary_inputs.len(),
+            l.boundary_outputs.len(),
+        );
+    }
+}
+
+/// What is actually blocking a fold? Fold `chain-mil5ore` at its midpoint
+/// and group every validation issue by category, rather than sampling the
+/// first few as the fold search does.
+#[test]
+#[ignore = "exploration probe — fold error breakdown"]
+fn probe_fold_error_breakdown_mil5() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, fold_snake};
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    use std::collections::BTreeMap;
+
+    let fixture = SimFixture::find("chain-mil5ore");
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        fixture.target,
+        fixture.rate,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+    let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
     println!(
-        "compact baseline: {}x{} = {} tiles, {} entities",
+        "compact baseline: {}x{}, {} entities",
         compact.width,
         compact.height,
-        compact.width * compact.height,
-        compact.entities.len(),
+        compact.entities.len()
     );
-    // Diag: show South-facing belts near x=274
-    for e in compact.entities.iter() {
-        if e.x == 274 && e.direction == spaghettio_core::models::EntityDirection::South {
-            println!("  DIAG: South belt at (274,{}) name={}", e.y, e.name);
-        }
-    }
-    // Show max y
-    let max_y = compact.entities.iter().map(|e| e.y).max().unwrap_or(0);
-    println!("  DIAG: max_y={max_y} height={}", compact.height);
-    // Check what's at (274, 32) in the original — should be nothing
-    let at_274_32: Vec<_> = compact
-        .entities
-        .iter()
-        .filter(|e| e.x == 274 && e.y == 32)
-        .collect();
-    println!("  DIAG: entities at (274,32): {}", at_274_32.len());
-    // Validate the compact baseline
-    let base_issues = validate::validate(&compact, Some(&sr), LayoutStyle::Bus).unwrap();
-    let base_errors = base_issues
-        .iter()
-        .filter(|i| i.severity == Severity::Error)
-        .count();
-    println!("  DIAG: compact baseline errors={base_errors}");
 
-    // DIAG: check what's at (158,8) in original compact
-    for e in compact.entities.iter() {
-        if e.x == 158 && e.y == 8 {
-            println!(
-                "  DIAG: orig(158,8): name={} dir={:?} io={:?}",
-                e.name, e.direction, e.io_type
-            );
-        }
+    // Control: whatever the compacted source already warns about is not
+    // something folding introduced.
+    let base = validate::validate(&compact, Some(&sr), LayoutStyle::Bus).unwrap();
+    let mut base_cat: BTreeMap<String, usize> = BTreeMap::new();
+    for i in &base {
+        *base_cat.entry(i.category.clone()).or_default() += 1;
     }
+    println!("  unfolded control: {} issues {:?}", base.len(), base_cat);
 
-    // DIAG: check UG belts at x=139 (fold boundary for f=140)
-    for e in compact.entities.iter() {
-        if e.x == 139 && e.y == 15 && spaghettio_core::common::is_ug_belt(&e.name) {
+    println!(
+        "legal fold columns: {} of {}",
+        spaghettio_core::bus::compaction::legal_fold_columns(&compact).len(),
+        compact.width - 1
+    );
+
+    // The validated search: only folds that match the control's issue
+    // profile are admitted.
+    match spaghettio_core::bus::compaction::search_snake_fold(&compact, &sr, 5) {
+        Some(found) => {
+            let l = &found.layout;
             println!(
-                "  DIAG: UG at (139,15): name={} dir={:?} io={:?}",
-                e.name, e.direction, e.io_type
+                "\nSEARCH WINNER: folds={:?} -> {}x{} (aspect {:.2}), {} entities                  [source {}x{} aspect {:.2}, {} entities]",
+                found.folds,
+                l.width,
+                l.height,
+                l.width.max(l.height) as f64 / l.width.min(l.height) as f64,
+                l.entities.len(),
+                compact.width,
+                compact.height,
+                compact.width as f64 / compact.height as f64,
+                compact.entities.len(),
             );
-        }
-    }
-    // Check what's at x=140..143, y=15 (search range for express)
-    for x in 140..=148 {
-        for e in compact.entities.iter() {
-            if e.x == x && e.y == 15 && spaghettio_core::common::is_ug_belt(&e.name) {
-                println!(
-                    "  DIAG: UG at ({x},15): name={} dir={:?} io={:?}",
-                    e.name, e.direction, e.io_type
-                );
+            let mut why: BTreeMap<String, usize> = BTreeMap::new();
+            for (_, reason) in &found.refusals {
+                *why.entry(format!("{reason:?}").split(' ').next().unwrap().to_string())
+                    .or_default() += 1;
             }
+            println!("  refusals during search: {why:?}");
         }
+        None => println!("\nSEARCH: no fold preserved the control issue profile"),
     }
 
-    let w = compact.width;
-    let mut best: Option<(i32, i32, usize, Vec<i32>)> = None;
-
-    // First: exhaustive 1-fold search to find all valid fold positions.
-    println!("\n--- Exhaustive 1-fold search ---");
-    for f in 1..w {
-        let folds = vec![f];
-        let Some(folded) = fold_snake(&compact, &folds) else {
-            continue;
+    let ladder: Vec<Vec<i32>> = (1..=5)
+        .filter_map(|k| spaghettio_core::bus::compaction::even_legal_folds(&compact, k, 30))
+        .collect();
+    for folds in ladder {
+        println!("\n=== folds={folds:?} ===");
+        let folded = match fold_snake(&compact, &folds) {
+            Ok(f) => f,
+            Err(reason) => {
+                println!("  fold_snake refused: {reason:?}");
+                continue;
+            }
         };
+        println!(
+            "  folded: {}x{}, {} entities",
+            folded.width,
+            folded.height,
+            folded.entities.len()
+        );
         let issues = match validate::validate(&folded, Some(&sr), LayoutStyle::Bus) {
             Ok(v) => v,
-            Err(_) => continue,
-        };
-        let errors = issues
-            .iter()
-            .filter(|i| i.severity == Severity::Error)
-            .count();
-        if errors == 0 {
-            let area = folded.width * folded.height;
-            let aspect = if folded.height > folded.width {
-                folded.height as f64 / folded.width as f64
-            } else {
-                folded.width as f64 / folded.height as f64
-            };
-            println!(
-                "  f={f}: {}x{} = {} tiles, {} entities, aspect={:.2}",
-                folded.width,
-                folded.height,
-                area,
-                folded.entities.len(),
-                aspect,
-            );
-            let best_aspect = best
-                .as_ref()
-                .map(|b| {
-                    if b.1 > b.0 {
-                        b.1 as f64 / b.0 as f64
+            Err(e) => {
+                // A hard refusal carries its findings in the message body.
+                let msg = format!("{e}");
+                let mut by_kind: BTreeMap<String, usize> = BTreeMap::new();
+                for line in msg.lines().skip(1) {
+                    let kind = if line.contains("has no receiver") {
+                        "dead-end belt"
+                    } else if line.contains("but feeds into") {
+                        "item mismatch on feed"
+                    } else if line.contains("overlap") {
+                        "entity overlap"
                     } else {
-                        b.0 as f64 / b.1 as f64
-                    }
-                })
-                .unwrap_or(f64::MAX);
-            if aspect < best_aspect {
-                best = Some((
-                    folded.width,
-                    folded.height,
-                    folded.entities.len(),
-                    folds.clone(),
-                ));
-            }
-        }
-    }
-
-    for n_folds in 2..=4u32 {
-        let ideal: Vec<i32> = (1..=n_folds)
-            .map(|i| w * i as i32 / (n_folds + 1) as i32)
-            .collect();
-        println!("\n--- {n_folds} folds: ideal positions {ideal:?} ---");
-
-        let max_tries = 1000u32;
-        let mut tried = 0u32;
-
-        // Try fold positions near the ideal, plus all valid columns.
-        let mut candidates: Vec<Vec<i32>> = Vec::new();
-        // Single-delta search around ideal.
-        for delta in -30..=30 {
-            let folds: Vec<i32> = ideal.iter().map(|&p| p + delta).collect();
-            let valid =
-                folds.iter().all(|&f| f > 0 && f < w) && folds.windows(2).all(|w| w[1] > w[0]);
-            if valid {
-                candidates.push(folds);
-            }
-        }
-
-        // Filter to pairs with reasonable segment widths (≥50 tiles each).
-        let reasonable: Vec<Vec<i32>> = candidates
-            .into_iter()
-            .filter(|folds| {
-                let mut bounds = vec![0];
-                bounds.extend(folds);
-                bounds.push(w);
-                bounds.windows(2).all(|b| b[1] - b[0] >= 30)
-            })
-            .collect();
-        println!(
-            "  {n_folds}-fold: {} reasonable candidates",
-            reasonable.len()
-        );
-        for folds in &reasonable {
-            tried += 1;
-            if tried > max_tries {
-                break;
-            }
-            let Some(folded) = fold_snake(&compact, folds) else {
-                if tried <= 10 {
-                    println!("  folds={folds:?}: fold_snake None (multi-tile entity cut?)");
+                        "other"
+                    };
+                    *by_kind.entry(kind.to_string()).or_default() += 1;
                 }
-                continue;
-            };
-            let issues = match validate::validate(&folded, Some(&sr), LayoutStyle::Bus) {
-                Ok(v) => v,
-                Err(e) => {
-                    if tried <= 10 {
-                        let msg = format!("{e}");
-                        let first = msg.lines().next().unwrap_or("");
-                        println!("  folds={folds:?}: validate Err: {first}");
-                        for line in msg.lines().skip(1).take(15) {
-                            println!("    {line}");
-                        }
-                    }
-                    if folds == &vec![158_i32, 341] {
-                        for e in folded.entities.iter().filter(|e| e.x == 158 && e.y == 8) {
+                println!("  REFUSED, {} findings:", msg.lines().count() - 1);
+                for (kind, n) in &by_kind {
+                    println!("    {n:>5}  {kind}");
+                }
+                for line in msg.lines().skip(1).take(4) {
+                    println!("    e.g. {}", line.trim());
+                }
+                // Dump the neighbourhood of the first reported coordinate so
+                // the cause is visible instead of inferred.
+                if let Some(coord) = msg
+                    .lines()
+                    .skip(1)
+                    .find_map(|l| l.split(" at (").nth(1))
+                    .and_then(|rest| rest.split(')').next())
+                {
+                    let nums: Vec<i32> = coord
+                        .split(',')
+                        .filter_map(|n| n.trim().parse().ok())
+                        .collect();
+                    if let [ex, ey] = nums[..] {
+                        println!("    --- around ({ex},{ey}) ---");
+                        let mut near: Vec<_> = folded
+                            .entities
+                            .iter()
+                            .filter(|e| (e.x - ex).abs() <= 3 && (e.y - ey).abs() <= 3)
+                            .collect();
+                        near.sort_by_key(|e| (e.y, e.x));
+                        for e in near {
                             println!(
-                                "    DIAG(158,8): name={} dir={:?} io={:?}",
-                                e.name, e.direction, e.io_type
+                                "      ({},{}) {} dir={:?} io={:?} carries={:?}",
+                                e.x, e.y, e.name, e.direction, e.io_type, e.carries
                             );
                         }
-                        for e in folded.entities.iter().filter(|e| e.x == 157 && e.y == 8) {
-                            println!("    DIAG(157,8): name={} dir={:?}", e.name, e.direction);
-                        }
                     }
-                    continue;
                 }
-            };
-            let errors = issues
-                .iter()
-                .filter(|i| i.severity == Severity::Error)
-                .count();
-            let area = folded.width * folded.height;
-            let aspect = if folded.height > folded.width {
-                folded.height as f64 / folded.width as f64
-            } else {
-                folded.width as f64 / folded.height as f64
-            };
-
-            if errors == 0 {
-                let tag = if aspect < 1.5 { " SQUARE" } else { "" };
-                println!(
-                    "  folds={folds:?}: {}x{} = {} tiles, {} entities, aspect={:.2}{tag}",
-                    folded.width,
-                    folded.height,
-                    area,
-                    folded.entities.len(),
-                    aspect,
-                );
-                let best_aspect = best
-                    .as_ref()
-                    .map(|b| {
-                        if b.1 > b.0 {
-                            b.1 as f64 / b.0 as f64
-                        } else {
-                            b.0 as f64 / b.1 as f64
-                        }
-                    })
-                    .unwrap_or(f64::MAX);
-                let best_area = best
-                    .as_ref()
-                    .map(|b| (b.0 * b.1) as i64)
-                    .unwrap_or(i64::MAX);
-                let better = best.is_none()
-                    || aspect < best_aspect
-                    || (aspect < 1.5 && (area as i64) < best_area);
-                if better {
-                    best = Some((
-                        folded.width,
-                        folded.height,
-                        folded.entities.len(),
-                        folds.clone(),
-                    ));
-                }
-            } else if tried <= 3 || folds == &vec![158_i32, 341] {
-                for i in issues.iter().take(3) {
-                    println!("    [{:?}] {}", i.severity, i.message);
-                }
-                if folds == &vec![158_i32, 341] {
-                    for e in folded.entities.iter().filter(|e| e.x == 158 && e.y == 8) {
-                        println!("    DIAG(158,8): name={} dir={:?}", e.name, e.direction);
+                continue;
+            }
+        };
+        let mut by_cat: BTreeMap<(String, String), usize> = BTreeMap::new();
+        for i in &issues {
+            *by_cat
+                .entry((format!("{:?}", i.severity), i.category.clone()))
+                .or_default() += 1;
+        }
+        println!("  {} issues:", issues.len());
+        for ((sev, cat), n) in &by_cat {
+            println!("    {n:>5}  [{sev}] {cat}");
+        }
+        if let Some(w) = issues
+            .iter()
+            .find(|i| i.category == "belt-flow-reachability")
+        {
+            if let Some(coord) = w.message.split(" at (").nth(1).and_then(|r| r.split(')').next()) {
+                let nums: Vec<i32> = coord
+                    .split(',')
+                    .filter_map(|n| n.trim().parse().ok())
+                    .collect();
+                if let [ex, ey] = nums[..] {
+                    println!("    --- feed side of ({ex},{ey}) ---");
+                    let mut near: Vec<_> = folded
+                        .entities
+                        .iter()
+                        .filter(|e| (e.x - ex).abs() <= 4 && (e.y - ey).abs() <= 4)
+                        .collect();
+                    near.sort_by_key(|e| (e.y, e.x));
+                    for e in near {
+                        println!(
+                            "      ({},{}) {} dir={:?} io={:?} carries={:?}",
+                            e.x, e.y, e.name, e.direction, e.io_type, e.carries
+                        );
                     }
                 }
             }
         }
-    }
-
-    if let Some((w, h, n, folds)) = best {
-        println!(
-            "\n=== BEST: folds={folds:?} -> {}x{} = {} tiles, {} entities ===",
-            w,
-            h,
-            w * h,
-            n,
-        );
-    } else {
-        println!("\n=== No valid fold found ===");
+        let mut shown: BTreeMap<String, usize> = BTreeMap::new();
+        for i in &issues {
+            let n = shown.entry(i.category.clone()).or_default();
+            if *n < 2 {
+                println!("    e.g. [{}] {}", i.category, i.message);
+            }
+            *n += 1;
+        }
     }
 }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -622,6 +622,29 @@ impl SimFixture {
 /// mega-chain exporters keep the identical defect after the first version
 /// of this gate landed, because a coverage gap was indistinguishable from
 /// a deliberate exclusion.
+/// Which registry pins have moved, all of them, without aborting on the first.
+///
+/// Deliberately a separate probe rather than a flag on the gate above: a real
+/// gate that turns into a no-op when an environment variable is set is one
+/// stray CI export away from protecting nothing.
+#[test]
+#[ignore = "survey — re-blessing aid, reports every moved pin"]
+fn probe_registry_pin_survey() {
+    use spaghettio_core::bus::cells::registry::{entries, geometry_hash};
+    for e in entries() {
+        let candidates: Vec<(&str, String)> = SIM_FIXTURES
+            .iter()
+            .filter(|f| f.target == e.target && (f.rate - e.rate).abs() < 1e-9)
+            .map(|f| (f.label, format!("{:016x}", geometry_hash(&f.compose_layout()))))
+            .collect();
+        let ok = candidates.iter().any(|(_, h)| *h == e.geometry_hash);
+        println!(
+            "{:<24}@{:<5} {}  blessed={} fresh={:?}",
+            e.target, e.rate, if ok { "OK   " } else { "MOVED" }, e.geometry_hash, candidates
+        );
+    }
+}
+
 #[test]
 fn chain_fixture_geometry_matches_registry() {
     use spaghettio_core::bus::cells::registry::{entries, geometry_hash};
@@ -3644,6 +3667,40 @@ fn export_fold_report_json() {
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/fold-report.json", out).unwrap();
     println!("wrote target/tmp/fold-report.json");
+}
+
+/// Export `mega-chain-chem5raw` at its registry-declared capacity, for
+/// re-blessing its pinned geometry after a change.
+///
+/// The registry pin carries a SIM-VERIFIED claim, so moving the hash without
+/// re-measuring would attach yesterday's evidence to today's factory — the
+/// exact failure its own assert message warns about.
+#[test]
+#[ignore = "sim export — re-bless the chem5 registry pin"]
+fn export_chem5_for_rebless() {
+    let fixture = SimFixture::find("mega-chain-chem5raw");
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    )
+    .unwrap();
+    let mut l = fixture.compose_layout();
+    // Registry entry declares inserter_capacity 2 / stacking 1.
+    l.inserter_capacity = 2;
+    let tag = "chem5-rebless";
+    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, tag);
+    std::fs::create_dir_all("target/tmp").unwrap();
+    std::fs::write(format!("target/tmp/{tag}.bp"), &bp).unwrap();
+    std::fs::write(
+        format!("target/tmp/{tag}.manifest.json"),
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    ).unwrap();
+    println!(
+        "wrote target/tmp/{tag}.bp — {}x{}, {} entities, hash {:016x}",
+        l.width, l.height, l.entities.len(),
+        spaghettio_core::bus::cells::registry::geometry_hash(&l),
+    );
 }
 
 /// How often does the NORMAL pipeline emit a fragmented pole network?

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3646,6 +3646,88 @@ fn export_fold_report_json() {
     println!("wrote target/tmp/fold-report.json");
 }
 
+/// How often does the NORMAL pipeline emit a fragmented pole network?
+///
+/// Decides whether `check_pole_network_connectivity` can be promoted from
+/// Warning to Error: a factory whose poles form two islands does not run, but
+/// promoting a check that already fires on ordinary output would just break
+/// every build. Measures rather than assumes.
+#[test]
+#[ignore = "measurement probe — pole connectivity across the pipeline"]
+fn probe_pole_connectivity_census() {
+    use spaghettio_core::bus::compaction::compact_validated_geometry;
+    use spaghettio_core::power_wires::{disconnected_poles, wires_for};
+
+    let cases: &[(&str, &str, f64, &[&str], &str)] = &[
+        ("gear15-ore", "iron-gear-wheel", 15.0, &["iron-ore"], "assembling-machine-2"),
+        ("gear15-plate", "iron-gear-wheel", 15.0, &["iron-plate"], "assembling-machine-2"),
+        ("ec10-ore", "electronic-circuit", 10.0, &["iron-ore", "copper-ore"], "assembling-machine-1"),
+        ("ec15-plate", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"], "assembling-machine-2"),
+        ("belt5-ore", "transport-belt", 5.0, &["iron-ore"], "assembling-machine-2"),
+        ("insert3-ore", "inserter", 3.0, &["iron-ore", "copper-ore"], "assembling-machine-2"),
+        ("sci2-ore", "logistic-science-pack", 2.0, &["iron-ore", "copper-ore"], "assembling-machine-2"),
+        ("plastic10", "plastic-bar", 10.0, &["coal", "petroleum-gas"], "chemical-plant"),
+    ];
+
+    let mut dirty_raw = 0;
+    let mut dirty_compact = 0;
+    let mut total = 0;
+    for (label, item, rate, inputs, machine) in cases {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let Ok(sr) = solver::solve_with_palette_exclusions_and_quality(
+            item, *rate, &inputs_set, &MachinePalette::default(), machine,
+            &FxHashSet::default(), QualityTier::Normal,
+        ) else { println!("{label}: solver refused"); continue };
+        let Ok(bus) = layout::build_bus_layout(&sr, layout::LayoutOptions::default()) else {
+            println!("{label}: layout refused"); continue
+        };
+        let poles = |l: &spaghettio_core::models::LayoutResult| {
+            let n = l.entities.iter()
+                .filter(|e| e.name.ends_with("electric-pole") || e.name == "substation")
+                .count();
+            (n, disconnected_poles(&l.entities, &wires_for(l)).len())
+        };
+        let (bn, bd) = poles(&bus);
+        let compact = compact_validated_geometry(&bus, &sr);
+        let (cn, cd) = poles(&compact);
+        total += 1;
+        if bd > 0 { dirty_raw += 1; }
+        if cd > 0 { dirty_compact += 1; }
+        println!(
+            "{label:<14} bus {bd:>3}/{bn:<4} disconnected   compacted {cd:>3}/{cn:<4}{}",
+            if cd > bd { "   <-- COMPACTION MADE IT WORSE" } else { "" }
+        );
+    }
+    println!("\n{dirty_raw}/{total} raw bus layouts have a fragmented pole network");
+    println!("{dirty_compact}/{total} compacted layouts do");
+
+    // Cell composition is the other producer of layouts, and the one whose
+    // compacted mil5 control carries 2 disconnected poles.
+    println!("\n--- cell-composed fixtures ---");
+    for label in ["chain-mil5ore", "mega-chain-chem5raw", "mega-chain-pu4raw", "mega-chain-usp2raw"] {
+        let fixture = SimFixture::find(label);
+        let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+        let Ok(sr) = solver::solve_with_palette_exclusions_and_quality(
+            fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
+            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+        ) else { continue };
+        let base = fixture.compose_layout();
+        let compact = compact_validated_geometry(&base, &sr);
+        let count = |l: &spaghettio_core::models::LayoutResult| {
+            let n = l.entities.iter()
+                .filter(|e| e.name.ends_with("electric-pole") || e.name == "substation")
+                .count();
+            (n, disconnected_poles(&l.entities, &wires_for(l)).len())
+        };
+        let (bn, bd) = count(&base);
+        let (cn, cd) = count(&compact);
+        println!(
+            "{label:<22} composed {bd:>3}/{bn:<4} disconnected   compacted {cd:>3}/{cn:<4}{}",
+            if cd > bd { "   <-- COMPACTION MADE IT WORSE" } else { "" }
+        );
+    }
+}
+
 /// Does the fold work on BUS layouts, not just cell chains?
 ///
 /// Every fold measurement so far has been on `compose_chain_*` output — the

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3520,6 +3520,102 @@ fn export_fold_pair_for_sim() {
     }
 }
 
+/// Does the fold work on BUS layouts, not just cell chains?
+///
+/// Every fold measurement so far has been on `compose_chain_*` output — the
+/// cell architecture. The only wired-up consumer of this module,
+/// `LayoutOptions::compact_layout`, sits on the bus path, so bus layouts are
+/// the case with a real caller and no evidence.
+#[test]
+#[ignore = "exploration probe — fold search over bus layouts"]
+fn probe_fold_bus_layouts() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, search_snake_fold};
+    use spaghettio_core::validate::{self, LayoutStyle};
+    use std::collections::BTreeMap;
+
+    let cases: &[(&str, &str, f64, &[&str], &str)] = &[
+        ("gear15-ore", "iron-gear-wheel", 15.0, &["iron-ore"], "assembling-machine-2"),
+        ("ec10-ore", "electronic-circuit", 10.0, &["iron-ore", "copper-ore"], "assembling-machine-1"),
+        ("ec15-plate", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"], "assembling-machine-2"),
+        ("belt5-ore", "transport-belt", 5.0, &["iron-ore"], "assembling-machine-2"),
+        ("insert3-ore", "inserter", 3.0, &["iron-ore", "copper-ore"], "assembling-machine-2"),
+        ("sci2-ore", "logistic-science-pack", 2.0, &["iron-ore", "copper-ore"], "assembling-machine-2"),
+    ];
+
+    for (label, item, rate, inputs, machine) in cases {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let Ok(sr) = solver::solve_with_palette_exclusions_and_quality(
+            item,
+            *rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            machine,
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        ) else {
+            println!("{label}: solver refused");
+            continue;
+        };
+        let Ok(bus) = layout::build_bus_layout(&sr, layout::LayoutOptions::default()) else {
+            println!("{label}: bus layout refused");
+            continue;
+        };
+        let compact = compact_validated_geometry(&bus, &sr);
+        let asp = compact.width.max(compact.height) as f64 / compact.width.min(compact.height) as f64;
+
+        let search = search_snake_fold(&compact, &sr, 3);
+        let mut why: BTreeMap<String, usize> = BTreeMap::new();
+        for (_, r) in &search.refusals {
+            *why.entry(format!("{r:?}").split(' ').next().unwrap().into()).or_default() += 1;
+        }
+        match &search.best {
+            Some(found) => {
+                let l = &found.layout;
+                let fasp = l.width.max(l.height) as f64 / l.width.min(l.height) as f64;
+                println!(
+                    "{label}: bus {}x{} ({asp:.1}:1, {} ent) -> folds={:?} {}x{} ({fasp:.2}:1, {} ent)",
+                    compact.width, compact.height, compact.entities.len(),
+                    found.folds, l.width, l.height, l.entities.len(),
+                );
+            }
+            None => {
+                println!(
+                    "{label}: bus {}x{} ({asp:.1}:1) -> NO fold | legal={} refusals={why:?} rejected={}",
+                    compact.width, compact.height, search.legal_columns,
+                    search.rejected_by_validation
+                );
+                // A candidate that folds but validates worse is a different
+                // animal from one that refuses; show what it broke.
+                if search.rejected_by_validation > 0 {
+                    let legal = spaghettio_core::bus::compaction::legal_fold_columns(&compact);
+                    let mid = legal
+                        .iter()
+                        .copied()
+                        .min_by_key(|f| (f - compact.width / 2).abs());
+                    if let Some(f) = mid {
+                        if let Ok(folded) =
+                            spaghettio_core::bus::compaction::fold_snake(&compact, &[f])
+                        {
+                            let prof = |l: &spaghettio_core::models::LayoutResult| {
+                                let mut m: BTreeMap<String, usize> = BTreeMap::new();
+                                if let Ok(v) = validate::validate(l, Some(&sr), LayoutStyle::Bus) {
+                                    for i in &v {
+                                        *m.entry(i.category.clone()).or_default() += 1;
+                                    }
+                                }
+                                m
+                            };
+                            let (a, b) = (prof(&compact), prof(&folded));
+                            println!("     control={a:?}");
+                            println!("     fold@{f}={b:?}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Does the fold generalise beyond the fixture it was developed on?
 /// Runs the validated search over the whole RFC-057 corpus and reports what
 /// each fixture yields, plus why candidates were refused.

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3148,6 +3148,333 @@ fn probe_mil5_errors() {
     }
 }
 
+/// Manhattan MST over a terminal set — an obstacle-free lower bound on the
+/// belt tiles a perfect shared-trunk router would need for one commodity.
+/// Prim's, O(n²); nets here are tens of terminals, not thousands.
+fn manhattan_mst_cost(points: &[(i32, i32)]) -> i64 {
+    if points.len() < 2 {
+        return 0;
+    }
+    let n = points.len();
+    let mut in_tree = vec![false; n];
+    let mut best = vec![i64::MAX; n];
+    best[0] = 0;
+    let mut total = 0i64;
+    for _ in 0..n {
+        let mut pick = usize::MAX;
+        for i in 0..n {
+            if !in_tree[i] && (pick == usize::MAX || best[i] < best[pick]) {
+                pick = i;
+            }
+        }
+        in_tree[pick] = true;
+        total += best[pick];
+        let (px, py) = points[pick];
+        for i in 0..n {
+            if in_tree[i] {
+                continue;
+            }
+            let (qx, qy) = points[i];
+            let d = i64::from((px - qx).abs()) + i64::from((py - qy).abs());
+            if d < best[i] {
+                best[i] = d;
+            }
+        }
+    }
+    total
+}
+
+/// Map a point through the snake-fold coordinate transform.
+///
+/// `bounds` is the fold partition (`[0, f1, .., fk, width]`). Even segments
+/// keep their X orientation, odd segments mirror; each segment drops by
+/// `height + gap`. This is `fold_snake`'s transform with the U-turn and
+/// reconnection machinery removed — geometry only.
+///
+/// `y_mirror` additionally flips odd segments vertically. `fold_snake` does
+/// not do this, and it should matter: an X-only fold puts the *bottom* edge
+/// of segment k against the *top* edge of segment k+1, so structures that sat
+/// at the same height in the ribbon (a trunk, say) end up `height + gap`
+/// apart. Flipping alternate segments in Y makes them meet instead — which is
+/// what a two-sided main bus actually looks like.
+fn fold_point(
+    x: i32,
+    y: i32,
+    bounds: &[i32],
+    height: i32,
+    gap: i32,
+    y_mirror: bool,
+) -> (i32, i32) {
+    let n_segs = bounds.len() - 1;
+    let seg = (0..n_segs)
+        .find(|&k| x >= bounds[k] && x < bounds[k + 1])
+        .unwrap_or(n_segs - 1);
+    let odd = seg % 2 == 1;
+    let nx = if odd {
+        bounds[seg + 1] - 1 - x
+    } else {
+        x - bounds[seg]
+    };
+    let local_y = if odd && y_mirror { height - 1 - y } else { y };
+    (nx, local_y + (seg as i32) * (height + gap))
+}
+
+/// Does folding actually shorten the *routing problem*?
+///
+/// `probe_fold_search_mil5` measures fold-as-implemented, which can only add
+/// entities (it preserves every belt and adds U-turns). That says nothing
+/// about fold-as-a-stage followed by a re-router. This probe removes the
+/// reconnection machinery entirely and asks the prior question: under a pure
+/// fold coordinate transform, does the idealized cost of connecting each
+/// commodity's terminals go down?
+///
+/// The metric is the sum over commodity nets of the Manhattan MST over that
+/// net's terminals. It ignores obstacles, so it is a *lower bound* on what a
+/// real router achieves — but it is measured identically before and after,
+/// so the ratio is the honest screen. If MST does not improve, no downstream
+/// shortcut search can pay for the fold.
+///
+/// Run over the whole RFC-057 corpus, because the fold's cost is fixed
+/// (`height + gap` of vertical separation per fold) while its benefit scales
+/// with width — so the answer should depend on aspect ratio, and mil5 is the
+/// thinnest fixture of the four.
+#[test]
+#[ignore = "exploration probe — fold routing headroom"]
+fn probe_fold_routing_headroom() {
+    for label in [
+        "chain-mil5ore",
+        "mega-chain-chem5raw",
+        "mega-chain-pu4raw",
+        "mega-chain-usp2raw",
+    ] {
+        println!("\n========== {label} ==========");
+        fold_routing_headroom_for(label);
+    }
+}
+
+fn fold_routing_headroom_for(label: &str) {
+    use spaghettio_core::bus::compaction::{
+        build_manifold_nets, compact_validated_geometry, CompactIr, RouteTerminalKind,
+    };
+
+    let fixture = SimFixture::find(label);
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        fixture.target,
+        fixture.rate,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+
+    let bus = fixture.compose_layout();
+    let compact = compact_validated_geometry(&bus, &sr);
+    let belt_entities = compact
+        .entities
+        .iter()
+        .filter(|e| spaghettio_core::common::is_belt_entity(&e.name))
+        .count();
+    println!(
+        "compact baseline: {}x{} = {} tiles, {} entities ({} belts)",
+        compact.width,
+        compact.height,
+        compact.width * compact.height,
+        compact.entities.len(),
+        belt_entities,
+    );
+
+    // One net extraction, then two coordinate mappings — the terminal set is
+    // identical in both cases, so the comparison is apples-to-apples.
+    let ir = CompactIr::from_source(&compact, &sr);
+    let nets = build_manifold_nets(&ir, &ir.islands).expect("identity placement must build nets");
+
+    let w = compact.width;
+    let h = compact.height;
+    let gap = 2;
+
+    // Two metrics, because they fail in opposite directions.
+    //
+    // MST forces every terminal of a commodity into ONE tree. Real delivery
+    // is a forest: smelter bank A feeds the consumers beside A and never
+    // connects to bank B. That is why MST here exceeds the actual belt count
+    // — it pays for inter-cluster links the factory never builds. Folding
+    // shortens exactly those links, so MST alone would flatter the result.
+    //
+    // `nearest-source` is the honest one: for every consuming terminal, the
+    // distance to the closest producing terminal of that item. It is
+    // forest-shaped like real delivery, and it measures the thing the
+    // shortcut hypothesis actually claims — that folding puts consumers
+    // nearer their producers.
+    let cost_at = |bounds: &[i32], y_mirror: bool| -> (i64, i64, i64, i32, i32) {
+        let mut mst_total = 0i64;
+        let mut near_total = 0i64;
+        let mut near_weighted = 0i64;
+        let (mut max_x, mut max_y) = (0i32, 0i32);
+        for net in &nets {
+            let mut all = Vec::with_capacity(net.terminals.len());
+            let mut sources = Vec::new();
+            let mut sinks = Vec::new();
+            for t in &net.terminals {
+                let p = fold_point(t.x, t.y, bounds, h, gap, y_mirror);
+                max_x = max_x.max(p.0);
+                max_y = max_y.max(p.1);
+                all.push(p);
+                match t.kind {
+                    RouteTerminalKind::ProducerDrop | RouteTerminalKind::BoundaryInput => {
+                        sources.push(p)
+                    }
+                    RouteTerminalKind::ConsumerPickup | RouteTerminalKind::BoundaryOutput => {
+                        sinks.push(p)
+                    }
+                }
+            }
+            mst_total += manhattan_mst_cost(&all);
+
+            let mut net_near = 0i64;
+            for &(sx, sy) in &sinks {
+                let closest = sources
+                    .iter()
+                    .map(|&(px, py)| i64::from((sx - px).abs()) + i64::from((sy - py).abs()))
+                    .min();
+                if let Some(d) = closest {
+                    net_near += d;
+                }
+            }
+            near_total += net_near;
+            // planned_rate is fixed-point; scale down so the weighted total
+            // stays readable rather than exact.
+            near_weighted += net_near * net.planned_rate.max(1) / 1000;
+        }
+        (mst_total, near_total, near_weighted, max_x + 1, max_y + 1)
+    };
+
+    let flat: Vec<i32> = vec![0, w];
+    let (base_mst, base_near, base_weighted, base_w, base_h) = cost_at(&flat, false);
+    let terminal_count: usize = nets.iter().map(|net| net.terminals.len()).sum();
+    println!(
+        "unfolded: MST={base_mst}  nearest-source={base_near}  \
+         rate-weighted={base_weighted}  terminal-bbox={base_w}x{base_h}"
+    );
+    println!(
+        "  ({} nets, {terminal_count} terminals, {belt_entities} actual belts)",
+        nets.len()
+    );
+
+    for y_mirror in [false, true] {
+        println!(
+            "\n--- even folds ({}) ---",
+            if y_mirror {
+                "X-mirror + Y-mirror on odd segments"
+            } else {
+                "X-mirror only — what fold_snake does"
+            }
+        );
+        for k in 1..=6usize {
+            let mut bounds = vec![0];
+            for i in 1..=k {
+                bounds.push(w * i as i32 / (k + 1) as i32);
+            }
+            bounds.push(w);
+            let (mst, near, weighted, fw, fh) = cost_at(&bounds, y_mirror);
+            println!(
+                "  {k} fold(s): MST {:+.1}%  nearest-source {:+.1}%  \
+                 rate-weighted {:+.1}%  bbox={fw}x{fh} aspect={:.2}",
+                (mst as f64 / base_mst as f64 - 1.0) * 100.0,
+                (near as f64 / base_near as f64 - 1.0) * 100.0,
+                (weighted as f64 / base_weighted as f64 - 1.0) * 100.0,
+                if fh > fw {
+                    fh as f64 / fw as f64
+                } else {
+                    fw as f64 / fh as f64
+                },
+            );
+        }
+    }
+
+    // Even splits are an arbitrary choice of fold line, and the erratic
+    // rate-weighted numbers above look like the consequence: a fold that
+    // happens to cut between a high-rate producer and its consumer pays for
+    // that pair, one that lands in a quiet seam does not. Choosing fold
+    // columns to minimise the rate-weighted cost is the fair test of the
+    // idea. Greedy, because this is a screen and not the final placer.
+    // Rate-weighted nearest-source only — no MST. The greedy sweep evaluates
+    // this thousands of times and MST is O(n²) per net, which is unaffordable
+    // on the 1,000-plus-terminal fixtures.
+    let weighted_only = |bounds: &[i32], y_mirror: bool| -> i64 {
+        let mut total = 0i64;
+        for net in &nets {
+            let mut sources = Vec::new();
+            let mut sinks = Vec::new();
+            for t in &net.terminals {
+                let p = fold_point(t.x, t.y, bounds, h, gap, y_mirror);
+                match t.kind {
+                    RouteTerminalKind::ProducerDrop | RouteTerminalKind::BoundaryInput => {
+                        sources.push(p)
+                    }
+                    RouteTerminalKind::ConsumerPickup | RouteTerminalKind::BoundaryOutput => {
+                        sinks.push(p)
+                    }
+                }
+            }
+            let mut net_near = 0i64;
+            for &(sx, sy) in &sinks {
+                if let Some(d) = sources
+                    .iter()
+                    .map(|&(px, py)| i64::from((sx - px).abs()) + i64::from((sy - py).abs()))
+                    .min()
+                {
+                    net_near += d;
+                }
+            }
+            total += net_near * net.planned_rate.max(1) / 1000;
+        }
+        total
+    };
+
+    println!("\n--- greedily placed folds (best of X-only / X+Y mirror) ---");
+    // ~40 candidate columns regardless of fixture width, so the sweep costs
+    // the same on a 550-wide layout and a 2,400-wide one.
+    let step = ((w / 40).max(4)) as usize;
+    for k in 1..=4usize {
+        let mut chosen: Vec<i32> = Vec::new();
+        let mut best_cost = base_weighted;
+        let mut best_mirror = false;
+        for _ in 0..k {
+            let mut round: Option<(i64, i32, bool)> = None;
+            for f in (10..w - 10).step_by(step) {
+                if chosen.contains(&f) {
+                    continue;
+                }
+                let mut trial = chosen.clone();
+                trial.push(f);
+                trial.sort();
+                let mut bounds = vec![0];
+                bounds.extend_from_slice(&trial);
+                bounds.push(w);
+                for y_mirror in [false, true] {
+                    let weighted = weighted_only(&bounds, y_mirror);
+                    if round.is_none() || weighted < round.unwrap().0 {
+                        round = Some((weighted, f, y_mirror));
+                    }
+                }
+            }
+            let Some((cost, f, mirror)) = round else { break };
+            chosen.push(f);
+            chosen.sort();
+            best_cost = cost;
+            best_mirror = mirror;
+        }
+        println!(
+            "  {k} fold(s) at {chosen:?}{}: rate-weighted {:+.1}%",
+            if best_mirror { " (Y-mirrored)" } else { "" },
+            (best_cost as f64 / base_weighted as f64 - 1.0) * 100.0,
+        );
+    }
+}
+
 /// Fold search: try different numbers of folds and positions on the
 /// compacted mil5-ore layout, validate each, report the squarest valid.
 #[test]

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1282,6 +1282,36 @@ fn export_mega_usp_for_sim() {
     println!("wrote mega-chain-usp2raw.bp ({} in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
 }
 
+/// RFC-055 real-geometry experiment. Kept opt-in while compact ordering is
+/// speculative; unlike the placement estimator, this composes and validates
+/// both complete routed factories.
+#[test]
+#[ignore = "RFC-055 compact-order experiment"]
+fn rfc055_compact_usp_real_geometry() {
+    use spaghettio_core::bus::cells::chain::{compose_chain_compact, compose_chain_with_capacity};
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+
+    let inputs: FxHashSet<String> =
+        ["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]
+            .iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "utility-science-pack", 2.0, &inputs, &MachinePalette::default(),
+        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
+    ).unwrap();
+    let control = compose_chain_with_capacity(&sr, 0).expect("control composes");
+    let compact = compose_chain_compact(&sr, 0).expect("compact composes");
+    let issues = match validate::validate(&compact, Some(&sr), LayoutStyle::Bus) {
+        Ok(v) => v,
+        Err(e) => e.issues,
+    };
+    let errors: Vec<_> = issues.iter()
+        .filter(|i| i.severity == Severity::Error).collect();
+    assert!(errors.is_empty(), "compact USP errors: {errors:?}");
+    println!("control={}x{} entities={} compact={}x{} entities={}",
+        control.width, control.height, control.entities.len(),
+        compact.width, compact.height, compact.entities.len());
+}
+
 /// Artifact producer for the increment-2 sim run.
 #[test]
 #[ignore = "artifact producer"]

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1568,8 +1568,8 @@ fn rfc057_machine_constraint_baseline() {
 fn rfc057_strip_empty_columns_mil5ore() {
     use spaghettio_core::bus::compaction::{
         compact_island_axis, extract_rigid_islands, extract_route_nets, occupied_bbox,
-        compact_transport_geometry, strip_empty_columns, CompactAxis, PlacedMachineSignature,
-        ProductionSignature, RouteTerminalKind,
+        compact_transport_geometry, compact_validated_geometry, strip_empty_columns,
+        CompactAxis, PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
@@ -1584,6 +1584,7 @@ fn rfc057_strip_empty_columns_mil5ore() {
     let source = fixture.compose_layout();
     let compacted = strip_empty_columns(&source);
     let underground_compacted = compact_transport_geometry(&source);
+    let cut_compacted = compact_validated_geometry(&source, &sr);
     let production = ProductionSignature::from_solver(&sr).unwrap();
     let nets = extract_route_nets(&source);
     let islands = extract_rigid_islands(&source);
@@ -1610,9 +1611,14 @@ fn rfc057_strip_empty_columns_mil5ore() {
         PlacedMachineSignature::from_layout(&source),
         PlacedMachineSignature::from_layout(&underground_compacted),
     );
+    assert_eq!(
+        PlacedMachineSignature::from_layout(&source),
+        PlacedMachineSignature::from_layout(&cut_compacted),
+    );
     for (label, candidate) in [
         ("stripped", &compacted),
         ("underground-compacted", &underground_compacted),
+        ("cut-compacted", &cut_compacted),
     ] {
         let issues = match validate::validate(candidate, Some(&sr), LayoutStyle::Bus) {
             Ok(v) => v,
@@ -1628,6 +1634,7 @@ fn rfc057_strip_empty_columns_mil5ore() {
         ("rfc057-mil5ore-control", &source),
         ("rfc057-mil5ore-strip", &compacted),
         ("rfc057-mil5ore-underground", &underground_compacted),
+        ("rfc057-mil5ore-cut", &cut_compacted),
     ] {
         let (bp, manifest) =
             spaghettio_core::blueprint::export_with_manifest(layout, &sr, label);
@@ -1653,6 +1660,10 @@ fn rfc057_strip_empty_columns_mil5ore() {
         underground_compacted.width, underground_compacted.height,
         underground_compacted.entities.len(), underground_belts,
         (underground_belts as f64 / source_belts as f64 - 1.0) * 100.0,
+    );
+    println!(
+        "validated-cut candidate: {}x{} entities={}",
+        cut_compacted.width, cut_compacted.height, cut_compacted.entities.len(),
     );
     println!("extracted {} replaceable route nets", nets.len());
     println!(
@@ -1689,7 +1700,7 @@ fn rfc057_strip_empty_columns_mil5ore() {
 #[test]
 #[ignore = "RFC-057 compacted artifact producer"]
 fn export_rfc057_compacted_candidates() {
-    use spaghettio_core::bus::compaction::compact_transport_geometry;
+    use spaghettio_core::bus::compaction::compact_validated_geometry;
 
     std::fs::create_dir_all("target/tmp").unwrap();
     for fixture_label in [
@@ -1705,7 +1716,7 @@ fn export_rfc057_compacted_candidates() {
             "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
         ).unwrap();
         let control = fixture.compose_layout();
-        let compacted = compact_transport_geometry(&control);
+        let compacted = compact_validated_geometry(&control, &sr);
         for (variant, layout) in [("control", &control), ("compact", &compacted)] {
             let label = format!("rfc057-{fixture_label}-{variant}");
             let (bp, manifest) =

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1396,7 +1396,7 @@ fn export_rfc055_factorio_candidates() {
 #[ignore = "RFC-057 coarse machine compaction potential"]
 fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
-        blocks_overlap, build_manifold_nets, compact_axis, compact_island_axis,
+        blocks_overlap, build_local_manifold_graph, build_manifold_nets, compact_axis, compact_island_axis,
         compact_transport_geometry, estimated_manifold_wirelength, extract_rigid_islands,
         extract_route_nets, machine_blocks, occupied_bbox, place_recipe_clusters,
         plan_local_manifolds, CompactAxis, CompactIr, PlacedMachineSignature,
@@ -1477,6 +1477,10 @@ fn rfc057_machine_constraint_baseline() {
         let (clustered_islands, clusters) = place_recipe_clusters(&ir, 1);
         let clustered_manifolds = build_manifold_nets(&ir, &clustered_islands).unwrap();
         let local_plans = plan_local_manifolds(&clustered_islands, &clustered_manifolds, 1);
+        let local_graphs: Vec<_> = local_plans
+            .iter()
+            .map(build_local_manifold_graph)
+            .collect();
         let clustered_bbox = occupied_bbox(
             &clustered_islands
                 .iter()
@@ -1547,7 +1551,11 @@ fn rfc057_machine_constraint_baseline() {
             local_plans.iter().filter(|plan| plan.all_distributors_stampable).count(),
         );
         assert_eq!(local_plans.len(), clustered_manifolds.len());
-        for (plan, manifold) in local_plans.iter().zip(&clustered_manifolds) {
+        for ((plan, graph), manifold) in local_plans
+            .iter()
+            .zip(&local_graphs)
+            .zip(&clustered_manifolds)
+        {
             assert!(plan.all_mergers_stampable, "{label}: {} merger hierarchy not stampable", plan.item);
             assert!(plan.all_distributors_stampable, "{label}: {} distributor hierarchy not stampable", plan.item);
             assert_eq!(
@@ -1558,6 +1566,22 @@ fn rfc057_machine_constraint_baseline() {
                 plan.lane_groups.iter().map(|group| group.consumers.len()).sum::<usize>(),
                 manifold.consumers().count(),
             );
+            for terminal in manifold.producers() {
+                assert!(graph.edges.iter().any(|edge| {
+                    edge.from
+                        == spaghettio_core::bus::compaction::ManifoldEndpoint::Terminal(
+                            terminal.clone(),
+                        )
+                }));
+            }
+            for terminal in manifold.consumers() {
+                assert!(graph.edges.iter().any(|edge| {
+                    edge.to
+                        == spaghettio_core::bus::compaction::ManifoldEndpoint::Terminal(
+                            terminal.clone(),
+                        )
+                }));
+            }
         }
 
         let runnable = compact_transport_geometry(&layout);

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -31,22 +31,44 @@ use spaghettio_core::solver;
 fn cell_composed_ec15_zero_errors() {
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
     let (esr, l) = compose_pairs_calibrated(3);
-    println!("calibrated EC@15: {}x{} = {} tiles, {} entities", l.width, l.height, l.width * l.height, l.entities.len());
+    println!(
+        "calibrated EC@15: {}x{} = {} tiles, {} entities",
+        l.width,
+        l.height,
+        l.width * l.height,
+        l.entities.len()
+    );
     // Phase-A parity pins: the lift must reproduce the Phase-1 geometry
     // bit-for-bit (RFC-051 verification plan).
-    assert_eq!((l.width, l.height), (110, 22), "parity: sim-verified artifact dims");
-    assert_eq!(l.entities.len(), 461, "parity: sim-verified artifact entity count");
+    assert_eq!(
+        (l.width, l.height),
+        (110, 22),
+        "parity: sim-verified artifact dims"
+    );
+    assert_eq!(
+        l.entities.len(),
+        461,
+        "parity: sim-verified artifact entity count"
+    );
     let issues = validate::validate(&l, Some(&esr), LayoutStyle::Bus)
         .unwrap_or_else(|e| panic!("composed EC@15 must validate: {e}"));
-    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .collect();
     assert!(errors.is_empty(), "composed EC@15 errors: {errors:?}");
     assert!(
-        issues.iter().all(|i| i.category == "inserter-item-throughput"),
+        issues
+            .iter()
+            .all(|i| i.category == "inserter-item-throughput"),
         "only the sim-disproven attribution warnings are tolerated: {issues:?}"
     );
     // The 6 specific warnings were sim-adjudicated; more of the same
     // category would be NEW unadjudicated claims — trip on growth.
-    assert!(issues.len() <= 6, "warning count grew past the adjudicated 6: {issues:?}");
+    assert!(
+        issues.len() <= 6,
+        "warning count grew past the adjudicated 6: {issues:?}"
+    );
 }
 
 /// PERMANENT GATE (RFC-048 Phase 1; Phase-A parity pin): the
@@ -59,8 +81,13 @@ fn cell_composed_plastic_zero_issues() {
     let (sr, comp) = compose_plastic_calibrated();
     let issues = validate::validate(&comp, Some(&sr), LayoutStyle::Bus)
         .unwrap_or_else(|e| panic!("composed plastic must validate: {e}"));
-    println!("composed plastic (calibrated): {}x{}, {} entities, {} issues",
-        comp.width, comp.height, comp.entities.len(), issues.len());
+    println!(
+        "composed plastic (calibrated): {}x{}, {} entities, {} issues",
+        comp.width,
+        comp.height,
+        comp.entities.len(),
+        issues.len()
+    );
     assert!(issues.is_empty(), "composed plastic issues: {issues:?}");
 }
 
@@ -71,18 +98,25 @@ fn cell_composed_plastic_zero_issues() {
 fn probe_cell_source_geometry() {
     for (label, item, rate, inputs) in [
         ("cable", "copper-cable", 15.0, &["copper-plate"][..]),
-        ("ec", "electronic-circuit", 5.0, &["iron-plate", "copper-cable"][..]),
+        (
+            "ec",
+            "electronic-circuit",
+            5.0,
+            &["iron-plate", "copper-cable"][..],
+        ),
     ] {
         let (sr, l) = generate_cell_layout(item, rate, inputs);
-        println!("== {label}: {}x{}, {} entities ==", l.width, l.height, l.entities.len());
+        println!(
+            "== {label}: {}x{}, {} entities ==",
+            l.width,
+            l.height,
+            l.entities.len()
+        );
         for m in &sr.machines {
             println!("   spec {} x{:.2}", m.recipe, m.count);
         }
         for e in &l.entities {
-            let edge = e.x <= 1
-                || e.x >= l.width - 2
-                || e.y <= 1
-                || e.y >= l.height - 2;
+            let edge = e.x <= 1 || e.x >= l.width - 2 || e.y <= 1 || e.y >= l.height - 2;
             if edge && spaghettio_core::common::is_belt_entity(&e.name) {
                 println!(
                     "   edge belt ({},{}) {} dir={:?} carries={:?} seg={:?}",
@@ -99,13 +133,29 @@ fn probe_cell_source_geometry() {
 fn probe_extracted_cells() {
     for (label, item, rate, inputs) in [
         ("cable", "copper-cable", 15.0, &["copper-plate"][..]),
-        ("ec", "electronic-circuit", 5.0, &["iron-plate", "copper-cable"][..]),
+        (
+            "ec",
+            "electronic-circuit",
+            5.0,
+            &["iron-plate", "copper-cable"][..],
+        ),
     ] {
         let (_sr, l) = generate_cell_layout(item, rate, inputs);
         let c = extract_cell(&l);
-        println!("== {label} cell: {}x{}, {} entities ==", c.width, c.height, c.entities.len());
+        println!(
+            "== {label} cell: {}x{}, {} entities ==",
+            c.width,
+            c.height,
+            c.entities.len()
+        );
         for p in &c.ports {
-            println!("   port {} y={} {} {}", p.edge, p.y, p.item, if p.inbound { "IN" } else { "OUT" });
+            println!(
+                "   port {} y={} {} {}",
+                p.edge,
+                p.y,
+                p.item,
+                if p.inbound { "IN" } else { "OUT" }
+            );
         }
         for e in &c.entities {
             if spaghettio_core::common::is_belt_entity(&e.name) {
@@ -123,7 +173,8 @@ fn probe_extracted_cells() {
 #[ignore = "artifact producer for the sim step"]
 fn export_composed_ec15_for_sim() {
     let (esr, l) = compose_pairs_calibrated(3);
-    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &esr, "rfc048-ec15-composed");
+    let (bp, manifest) =
+        spaghettio_core::blueprint::export_with_manifest(&l, &esr, "rfc048-ec15-composed");
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/rfc048-ec15.bp", &bp).unwrap();
     std::fs::write(
@@ -145,18 +196,40 @@ fn export_composed_ec15_for_sim() {
 #[ignore = "measurement probe"]
 fn probe_axis_growth_machine_tier() {
     for machine in ["assembling-machine-2", "assembling-machine-3"] {
-        let inputs: FxHashSet<String> =
-            ["iron-plate", "copper-cable"].iter().map(|s| s.to_string()).collect();
+        let inputs: FxHashSet<String> = ["iron-plate", "copper-cable"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            "electronic-circuit", 5.0, &inputs, &MachinePalette::default(),
-            machine, &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            "electronic-circuit",
+            5.0,
+            &inputs,
+            &MachinePalette::default(),
+            machine,
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default()).unwrap();
         let c = extract_cell(&l);
-        println!("== {machine}: cell {}x{}, {} entities ==", c.width, c.height, c.entities.len());
-        for m in &sr.machines { println!("   spec {} x{:.2}", m.recipe, m.count); }
+        println!(
+            "== {machine}: cell {}x{}, {} entities ==",
+            c.width,
+            c.height,
+            c.entities.len()
+        );
+        for m in &sr.machines {
+            println!("   spec {} x{:.2}", m.recipe, m.count);
+        }
         for p in &c.ports {
-            println!("   port {} ({},{}) {} {}", p.edge, p.x, p.y, p.item, if p.inbound { "IN" } else { "OUT" });
+            println!(
+                "   port {} ({},{}) {} {}",
+                p.edge,
+                p.x,
+                p.y,
+                p.item,
+                if p.inbound { "IN" } else { "OUT" }
+            );
         }
     }
 }
@@ -167,14 +240,34 @@ fn probe_axis_growth_machine_tier() {
 fn probe_fluid_cell_geometry() {
     let (sr, l) = generate_cell_layout("plastic-bar", 2.0, &["petroleum-gas", "coal"]);
     let c = extract_cell(&l);
-    println!("== plastic cell {}x{}, {} entities ==", c.width, c.height, c.entities.len());
-    for m in &sr.machines { println!("   spec {} x{:.2}", m.recipe, m.count); }
-    for port in &c.ports { println!("   port {} ({},{}) {} {}", port.edge, port.x, port.y, port.item, if port.inbound { "IN" } else { "OUT" }); }
+    println!(
+        "== plastic cell {}x{}, {} entities ==",
+        c.width,
+        c.height,
+        c.entities.len()
+    );
+    for m in &sr.machines {
+        println!("   spec {} x{:.2}", m.recipe, m.count);
+    }
+    for port in &c.ports {
+        println!(
+            "   port {} ({},{}) {} {}",
+            port.edge,
+            port.x,
+            port.y,
+            port.item,
+            if port.inbound { "IN" } else { "OUT" }
+        );
+    }
     let mut segs: std::collections::BTreeSet<String> = Default::default();
     for e in &c.entities {
-        if let Some(seg) = e.segment_id.as_deref() { segs.insert(format!("{seg} [{}]", e.name)); }
+        if let Some(seg) = e.segment_id.as_deref() {
+            segs.insert(format!("{seg} [{}]", e.name));
+        }
     }
-    for s in &segs { println!("   seg {s}"); }
+    for s in &segs {
+        println!("   seg {s}");
+    }
 }
 
 /// Artifact producer for the sim: composed plastic blueprint + manifest.
@@ -182,11 +275,15 @@ fn probe_fluid_cell_geometry() {
 #[ignore = "artifact producer — run explicitly when exporting for the sim"]
 fn export_composed_plastic_for_sim() {
     let (sr, comp) = compose_plastic_calibrated();
-    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&comp, &sr, "rfc048-plastic-composed");
+    let (bp, manifest) =
+        spaghettio_core::blueprint::export_with_manifest(&comp, &sr, "rfc048-plastic-composed");
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/rfc048-plastic.bp", &bp).unwrap();
-    std::fs::write("target/tmp/rfc048-plastic.manifest.json",
-        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+    std::fs::write(
+        "target/tmp/rfc048-plastic.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
     println!("wrote target/tmp/rfc048-plastic.bp + manifest");
 }
 
@@ -208,7 +305,10 @@ fn probe_plastic_pipes() {
     let c = extract_cell(&l);
     for e in &c.entities {
         if e.name.contains("pipe") {
-            println!("{} ({},{}) dir={:?} io={:?} seg={:?}", e.name, e.x, e.y, e.direction, e.io_type, e.segment_id);
+            println!(
+                "{} ({},{}) dir={:?} io={:?} seg={:?}",
+                e.name, e.x, e.y, e.direction, e.io_type, e.segment_id
+            );
         }
     }
 }
@@ -219,12 +319,19 @@ fn probe_plastic_pipes() {
 #[ignore = "artifact producer"]
 fn export_engine_plastic_for_sim() {
     let (sr, l) = generate_cell_layout("plastic-bar", 2.0, &["petroleum-gas", "coal"]);
-    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "rfc048-engine-plastic");
+    let (bp, manifest) =
+        spaghettio_core::blueprint::export_with_manifest(&l, &sr, "rfc048-engine-plastic");
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/rfc048-engine-plastic.bp", &bp).unwrap();
-    std::fs::write("target/tmp/rfc048-engine-plastic.manifest.json",
-        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-    println!("wrote engine plastic artifacts ({} boundary in)", l.boundary_inputs.len());
+    std::fs::write(
+        "target/tmp/rfc048-engine-plastic.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+    println!(
+        "wrote engine plastic artifacts ({} boundary in)",
+        l.boundary_inputs.len()
+    );
 }
 
 /// Phase-B dev probe: the chain auto-placer on the two dev fixtures.
@@ -234,29 +341,61 @@ fn probe_chain_autoplace() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
     for (label, item, rate, inputs) in [
-        ("ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
-        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+        (
+            "ec15",
+            "electronic-circuit",
+            15.0,
+            &["iron-plate", "copper-plate"][..],
+        ),
+        (
+            "ac1",
+            "advanced-circuit",
+            1.0,
+            &["iron-plate", "copper-plate", "plastic-bar"][..],
+        ),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            item, rate, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            item,
+            rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         println!("== {label}: {} specs ==", sr.machines.len());
-        for m in &sr.machines { println!("   {} x{:.2} out {:.2}/s", m.recipe, m.count, m.outputs[0].rate); }
+        for m in &sr.machines {
+            println!(
+                "   {} x{:.2} out {:.2}/s",
+                m.recipe, m.count, m.outputs[0].rate
+            );
+        }
         match compose_chain(&sr) {
             Ok(l) => {
-                println!("   composed {}x{} = {} tiles, {} entities", l.width, l.height, l.width * l.height, l.entities.len());
+                println!(
+                    "   composed {}x{} = {} tiles, {} entities",
+                    l.width,
+                    l.height,
+                    l.width * l.height,
+                    l.entities.len()
+                );
                 match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
                     Ok(issues) => {
-                        let e = issues.iter().filter(|i| i.severity == Severity::Error).count();
+                        let e = issues
+                            .iter()
+                            .filter(|i| i.severity == Severity::Error)
+                            .count();
                         println!("   validation: {} errors / {} issues", e, issues.len());
                         for i in issues.iter().take(15) {
                             println!("     [{:?}] {} {}", i.severity, i.category, i.message);
                         }
                     }
                     Err(er) => {
-                        for line in format!("{er}").lines().take(12) { println!("     {line}"); }
+                        for line in format!("{er}").lines().take(12) {
+                            println!("     {line}");
+                        }
                     }
                 }
             }
@@ -298,48 +437,135 @@ struct SimFixture {
 }
 
 const SIM_FIXTURES: &[SimFixture] = &[
-    SimFixture { label: "chain-ac1", target: "advanced-circuit", rate: 1.0,
+    SimFixture {
+        label: "chain-ac1",
+        target: "advanced-circuit",
+        rate: 1.0,
         inputs: &["iron-plate", "copper-plate", "plastic-bar"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[0] },
-    SimFixture { label: "chain-ec15", target: "electronic-circuit", rate: 15.0,
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[0],
+    },
+    SimFixture {
+        label: "chain-ec15",
+        target: "electronic-circuit",
+        rate: 15.0,
         inputs: &["iron-plate", "copper-plate"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[1, 2, 3, 5, 7] },
-    SimFixture { label: "chain-ec30", target: "electronic-circuit", rate: 30.0,
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[1, 2, 3, 5, 7],
+    },
+    SimFixture {
+        label: "chain-ec30",
+        target: "electronic-circuit",
+        rate: 30.0,
         inputs: &["iron-plate", "copper-plate"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[1, 2, 3, 5, 7] },
-    SimFixture { label: "chain-mil5ore", target: "military-science-pack", rate: 5.0,
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[1, 2, 3, 5, 7],
+    },
+    SimFixture {
+        label: "chain-mil5ore",
+        target: "military-science-pack",
+        rate: 5.0,
         inputs: &["iron-ore", "copper-ore", "stone", "coal"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[0, 2, 3, 7] },
-    SimFixture { label: "chain-mil5plates", target: "military-science-pack", rate: 5.0,
-        inputs: &["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[0, 2] },
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[0, 2, 3, 7],
+    },
+    SimFixture {
+        label: "chain-mil5plates",
+        target: "military-science-pack",
+        rate: 5.0,
+        inputs: &[
+            "iron-plate",
+            "copper-plate",
+            "steel-plate",
+            "stone-brick",
+            "coal",
+        ],
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[0, 2],
+    },
     // Mega chains. Same `compose_chain` path as the rows above, so they
     // carried the identical ambient-default defect; they export once
     // under a bare label rather than at declared levels.
-    SimFixture { label: "mega-chain-ac2raw", target: "advanced-circuit", rate: 2.0,
+    SimFixture {
+        label: "mega-chain-ac2raw",
+        target: "advanced-circuit",
+        rate: 2.0,
         inputs: &["iron-ore", "copper-ore", "crude-oil", "water", "coal"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[] },
-    SimFixture { label: "mega-chain-chem5raw", target: "chemical-science-pack", rate: 5.0,
-        inputs: &["iron-ore", "copper-ore", "crude-oil", "water", "coal",
-                  "iron-plate", "copper-plate", "steel-plate"],
-        compose: Compose::Chain, geo_cap: 2, levels: &[] },
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[],
+    },
+    SimFixture {
+        label: "mega-chain-chem5raw",
+        target: "chemical-science-pack",
+        rate: 5.0,
+        inputs: &[
+            "iron-ore",
+            "copper-ore",
+            "crude-oil",
+            "water",
+            "coal",
+            "iron-plate",
+            "copper-plate",
+            "steel-plate",
+        ],
+        compose: Compose::Chain,
+        geo_cap: 2,
+        levels: &[],
+    },
     // Not registry-blessed: their measurements live in #453 (USP@2,
     // -57.0%) and #437 (PU@4, -27.3%), both recorded before #431. Pinned
     // to L0 so those recorded numbers keep describing this geometry.
-    SimFixture { label: "mega-chain-usp2raw", target: "utility-science-pack", rate: 2.0,
-        inputs: &["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[] },
-    SimFixture { label: "mega-chain-pu4raw", target: "processing-unit", rate: 4.0,
+    SimFixture {
+        label: "mega-chain-usp2raw",
+        target: "utility-science-pack",
+        rate: 2.0,
+        inputs: &[
+            "iron-ore",
+            "copper-ore",
+            "crude-oil",
+            "water",
+            "coal",
+            "stone",
+        ],
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[],
+    },
+    SimFixture {
+        label: "mega-chain-pu4raw",
+        target: "processing-unit",
+        rate: 4.0,
         inputs: &["iron-ore", "copper-ore", "crude-oil", "water", "coal"],
-        compose: Compose::Chain, geo_cap: 0, levels: &[] },
+        compose: Compose::Chain,
+        geo_cap: 0,
+        levels: &[],
+    },
     // Mega CELLS: a different composer, unaffected by the capacity
     // default, but covered here so the gate has no blind spot.
-    SimFixture { label: "mega-plastic2", target: "plastic-bar", rate: 2.0,
+    SimFixture {
+        label: "mega-plastic2",
+        target: "plastic-bar",
+        rate: 2.0,
         inputs: &["crude-oil", "water", "coal"],
-        compose: Compose::MegaCell, geo_cap: 0, levels: &[] },
-    SimFixture { label: "mega-sulfur2", target: "sulfur", rate: 2.0,
+        compose: Compose::MegaCell,
+        geo_cap: 0,
+        levels: &[],
+    },
+    SimFixture {
+        label: "mega-sulfur2",
+        target: "sulfur",
+        rate: 2.0,
         inputs: &["crude-oil", "water"],
-        compose: Compose::MegaCell, geo_cap: 0, levels: &[] },
+        compose: Compose::MegaCell,
+        geo_cap: 0,
+        levels: &[],
+    },
 ];
 
 impl SimFixture {
@@ -349,14 +575,24 @@ impl SimFixture {
         match self.compose {
             Compose::MegaCell => {
                 spaghettio_core::bus::cells::mega::compose_mega_calibrated(
-                    self.target, self.rate, self.inputs,
-                ).unwrap_or_else(|e| panic!("{}: mega cell must compose: {e}", self.label)).1
+                    self.target,
+                    self.rate,
+                    self.inputs,
+                )
+                .unwrap_or_else(|e| panic!("{}: mega cell must compose: {e}", self.label))
+                .1
             }
             Compose::Chain => {
                 let sr = solver::solve_with_palette_exclusions_and_quality(
-                    self.target, self.rate, &inputs, &MachinePalette::default(),
-                    "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-                ).unwrap_or_else(|e| panic!("{}: must solve: {e:?}", self.label));
+                    self.target,
+                    self.rate,
+                    &inputs,
+                    &MachinePalette::default(),
+                    "assembling-machine-3",
+                    &FxHashSet::default(),
+                    QualityTier::Normal,
+                )
+                .unwrap_or_else(|e| panic!("{}: must solve: {e:?}", self.label));
                 spaghettio_core::bus::cells::chain::compose_chain_with_capacity(&sr, self.geo_cap)
                     .unwrap_or_else(|e| panic!("{}: chain must compose: {e}", self.label))
             }
@@ -364,7 +600,9 @@ impl SimFixture {
     }
 
     fn find(label: &str) -> &'static SimFixture {
-        SIM_FIXTURES.iter().find(|f| f.label == label)
+        SIM_FIXTURES
+            .iter()
+            .find(|f| f.label == label)
             .unwrap_or_else(|| panic!("no SIM_FIXTURES row for {label}"))
     }
 }
@@ -396,19 +634,32 @@ fn chain_fixture_geometry_matches_registry() {
         let candidates: Vec<(&str, String)> = SIM_FIXTURES
             .iter()
             .filter(|f| f.target == e.target && (f.rate - e.rate).abs() < 1e-9)
-            .map(|f| (f.label, format!("{:016x}", geometry_hash(&f.compose_layout()))))
+            .map(|f| {
+                (
+                    f.label,
+                    format!("{:016x}", geometry_hash(&f.compose_layout())),
+                )
+            })
             .collect();
-        assert!(!candidates.is_empty(),
+        assert!(
+            !candidates.is_empty(),
             "{}@{}: registry entry has no SIM_FIXTURES row, so no gate covers the exporter \
              that writes it — add the row. A silent skip here is exactly how the mega-chain \
              exporters kept the ambient-default defect.",
-            e.target, e.rate);
-        assert!(candidates.iter().any(|(_, h)| *h == e.geometry_hash),
+            e.target,
+            e.rate
+        );
+        assert!(
+            candidates.iter().any(|(_, h)| *h == e.geometry_hash),
             "{}@{}: registered geometry {} is no longer produced by any sim fixture at its \
              blessed capacity (fresh: {:?}). The exporter would write a DIFFERENT factory \
              under the same label, and every sim/meter number taken against this baseline \
              would silently compare two layouts — re-bless deliberately, never ignore.",
-            e.target, e.rate, e.geometry_hash, candidates);
+            e.target,
+            e.rate,
+            e.geometry_hash,
+            candidates
+        );
     }
 }
 
@@ -436,9 +687,15 @@ fn export_chain_fixtures_for_sim() {
         let (label, sr) = (f.label, {
             let inputs_set: FxHashSet<String> = f.inputs.iter().map(|s| s.to_string()).collect();
             solver::solve_with_palette_exclusions_and_quality(
-                f.target, f.rate, &inputs_set, &MachinePalette::default(),
-                "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-            ).unwrap()
+                f.target,
+                f.rate,
+                &inputs_set,
+                &MachinePalette::default(),
+                "assembling-machine-3",
+                &FxHashSet::default(),
+                QualityTier::Normal,
+            )
+            .unwrap()
         });
         for &lvl in f.levels {
             let mut l = f.compose_layout();
@@ -447,10 +704,16 @@ fn export_chain_fixtures_for_sim() {
             let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, &tag);
             std::fs::create_dir_all("target/tmp").unwrap();
             std::fs::write(format!("target/tmp/{tag}.bp"), &bp).unwrap();
-            std::fs::write(format!("target/tmp/{tag}.manifest.json"),
-                serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-            println!("wrote target/tmp/{tag}.bp ({} boundary in / {} out)",
-                l.boundary_inputs.len(), l.boundary_outputs.len());
+            std::fs::write(
+                format!("target/tmp/{tag}.manifest.json"),
+                serde_json::to_string_pretty(&manifest).unwrap(),
+            )
+            .unwrap();
+            println!(
+                "wrote target/tmp/{tag}.bp ({} boundary in / {} out)",
+                l.boundary_inputs.len(),
+                l.boundary_outputs.len()
+            );
         }
     }
 }
@@ -465,24 +728,81 @@ fn probe_differential_scoreboard() {
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
     let fixtures: &[(&str, &str, f64, &[&str])] = &[
         ("gear15", "iron-gear-wheel", 15.0, &["iron-plate"]),
-        ("ec5", "electronic-circuit", 5.0, &["iron-plate", "copper-plate"]),
-        ("ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"]),
-        ("ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"]),
-        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"]),
-        ("ac2", "advanced-circuit", 2.0, &["iron-plate", "copper-plate", "plastic-bar"]),
+        (
+            "ec5",
+            "electronic-circuit",
+            5.0,
+            &["iron-plate", "copper-plate"],
+        ),
+        (
+            "ec15",
+            "electronic-circuit",
+            15.0,
+            &["iron-plate", "copper-plate"],
+        ),
+        (
+            "ec30",
+            "electronic-circuit",
+            30.0,
+            &["iron-plate", "copper-plate"],
+        ),
+        (
+            "ac1",
+            "advanced-circuit",
+            1.0,
+            &["iron-plate", "copper-plate", "plastic-bar"],
+        ),
+        (
+            "ac2",
+            "advanced-circuit",
+            2.0,
+            &["iron-plate", "copper-plate", "plastic-bar"],
+        ),
         // Package-2 targets: the scaling-wall class + from-ore chains
         // (furnace cells; fan-out >2 on shared plates).
-        ("ec15-ore", "electronic-circuit", 15.0, &["iron-ore", "copper-ore"]),
-        ("mil5-plates", "military-science-pack", 5.0, &["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"]),
-        ("mil5-ore", "military-science-pack", 5.0, &["iron-ore", "copper-ore", "stone", "coal"]),
-        ("ec60", "electronic-circuit", 60.0, &["iron-plate", "copper-plate"]),
+        (
+            "ec15-ore",
+            "electronic-circuit",
+            15.0,
+            &["iron-ore", "copper-ore"],
+        ),
+        (
+            "mil5-plates",
+            "military-science-pack",
+            5.0,
+            &[
+                "iron-plate",
+                "copper-plate",
+                "steel-plate",
+                "stone-brick",
+                "coal",
+            ],
+        ),
+        (
+            "mil5-ore",
+            "military-science-pack",
+            5.0,
+            &["iron-ore", "copper-ore", "stone", "coal"],
+        ),
+        (
+            "ec60",
+            "electronic-circuit",
+            60.0,
+            &["iron-plate", "copper-plate"],
+        ),
     ];
     for (label, item, rate, inputs) in fixtures {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            item, *rate, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            item,
+            *rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         // Explicit Off — the DEFAULT is Candidate post-flip, and the bus
         // column must measure the bus.
         let bus_opts = layout::LayoutOptions {
@@ -493,10 +813,23 @@ fn probe_differential_scoreboard() {
         let bus_desc = match &bus {
             Ok(Ok(l)) => match validate::validate(l, Some(&sr), LayoutStyle::Bus) {
                 Ok(issues) => {
-                    let e = issues.iter().filter(|i| i.severity == Severity::Error).count();
-                    format!("{}x{}={} tiles, {} errors / {} warnings", l.width, l.height, l.width * l.height, e, issues.len() - e)
+                    let e = issues
+                        .iter()
+                        .filter(|i| i.severity == Severity::Error)
+                        .count();
+                    format!(
+                        "{}x{}={} tiles, {} errors / {} warnings",
+                        l.width,
+                        l.height,
+                        l.width * l.height,
+                        e,
+                        issues.len() - e
+                    )
                 }
-                Err(er) => format!("validate() Err: {}", format!("{er}").lines().next().unwrap_or("")),
+                Err(er) => format!(
+                    "validate() Err: {}",
+                    format!("{er}").lines().next().unwrap_or("")
+                ),
             },
             Ok(Err(e)) => format!("REFUSED: {}", e.lines().next().unwrap_or("")),
             Err(_) => "PANICKED".into(),
@@ -506,10 +839,23 @@ fn probe_differential_scoreboard() {
             Ok(()) => match compose_chain(&sr) {
                 Ok(l) => match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
                     Ok(issues) => {
-                        let e = issues.iter().filter(|i| i.severity == Severity::Error).count();
-                        format!("{}x{}={} tiles, {} errors / {} warnings", l.width, l.height, l.width * l.height, e, issues.len() - e)
+                        let e = issues
+                            .iter()
+                            .filter(|i| i.severity == Severity::Error)
+                            .count();
+                        format!(
+                            "{}x{}={} tiles, {} errors / {} warnings",
+                            l.width,
+                            l.height,
+                            l.width * l.height,
+                            e,
+                            issues.len() - e
+                        )
                     }
-                    Err(er) => format!("validate() Err: {}", format!("{er}").lines().next().unwrap_or("")),
+                    Err(er) => format!(
+                        "validate() Err: {}",
+                        format!("{er}").lines().next().unwrap_or("")
+                    ),
                 },
                 Err(e) => format!("REFUSED: {e}"),
             },
@@ -546,12 +892,20 @@ fn probe_differential_scoreboard() {
 fn cell_candidate_resolves_ec15_refusal() {
     use spaghettio_core::bus::cells::CellComposition;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
-    let inputs: FxHashSet<String> =
-        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "electronic-circuit", 15.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "electronic-circuit",
+        15.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
 
     // Flag OFF (explicit — the DEFAULT is Candidate since the flip
     // decision): the bus refusal stands.
@@ -566,7 +920,10 @@ fn cell_candidate_resolves_ec15_refusal() {
     let opts = layout::LayoutOptions::default();
     let l = layout::build_bus_layout(&sr, opts).expect("candidate must resolve the refusal");
     let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).unwrap();
-    let errors = issues.iter().filter(|i| i.severity == Severity::Error).count();
+    let errors = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .count();
     assert_eq!(errors, 0, "composed candidate errors: {issues:?}");
     // **2026-07-25 (#448):** `row-input-belt-margin` joins the tolerated
     // set, and this fixture is the check's own motivating measurement —
@@ -592,7 +949,10 @@ fn cell_candidate_resolves_ec15_refusal() {
         "only the adjudicated categories tolerated: {issues:?}"
     );
     assert_eq!(
-        issues.iter().filter(|i| i.category == "row-input-belt-margin").count(),
+        issues
+            .iter()
+            .filter(|i| i.category == "row-input-belt-margin")
+            .count(),
         1,
         "expected exactly the one measured copper-cable input finding: {issues:?}"
     );
@@ -600,7 +960,10 @@ fn cell_candidate_resolves_ec15_refusal() {
     // budget (2.0 × 7.5 = 15.0/s) — any lane-budget warning here would
     // be a new, unadjudicated claim.
     assert_eq!(
-        issues.iter().filter(|i| i.category == "row-output-lane-budget").count(),
+        issues
+            .iter()
+            .filter(|i| i.category == "row-output-lane-budget")
+            .count(),
         0,
         "row-output-lane-budget should not fire at the recalibrated budget: {issues:?}"
     );
@@ -613,35 +976,90 @@ fn probe_registry_hashes() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::bus::cells::registry::geometry_hash;
     for (label, item, rate, inputs) in [
-        ("chain-ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..]),
-        ("chain-ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
-        ("chain-ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..]),
-        ("chain-mil5ore", "military-science-pack", 5.0, &["iron-ore", "copper-ore", "stone", "coal"][..]),
-        ("chain-mil5plates", "military-science-pack", 5.0, &["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"][..]),
+        (
+            "chain-ec15",
+            "electronic-circuit",
+            15.0,
+            &["iron-plate", "copper-plate"][..],
+        ),
+        (
+            "chain-ac1",
+            "advanced-circuit",
+            1.0,
+            &["iron-plate", "copper-plate", "plastic-bar"][..],
+        ),
+        (
+            "chain-ec30",
+            "electronic-circuit",
+            30.0,
+            &["iron-plate", "copper-plate"][..],
+        ),
+        (
+            "chain-mil5ore",
+            "military-science-pack",
+            5.0,
+            &["iron-ore", "copper-ore", "stone", "coal"][..],
+        ),
+        (
+            "chain-mil5plates",
+            "military-science-pack",
+            5.0,
+            &[
+                "iron-plate",
+                "copper-plate",
+                "steel-plate",
+                "stone-brick",
+                "coal",
+            ][..],
+        ),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            item, rate, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            item,
+            rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         let l = compose_chain(&sr).unwrap();
         println!("{label}: {:016x}", geometry_hash(&l));
     }
     for (label, item, rate, inputs) in [
-        ("mega-plastic2", "plastic-bar", 2.0, &["crude-oil", "water", "coal"][..]),
+        (
+            "mega-plastic2",
+            "plastic-bar",
+            2.0,
+            &["crude-oil", "water", "coal"][..],
+        ),
         ("mega-sulfur2", "sulfur", 2.0, &["crude-oil", "water"][..]),
     ] {
-        let (_sr, l) = spaghettio_core::bus::cells::mega::compose_mega_calibrated(item, rate, inputs).unwrap();
+        let (_sr, l) =
+            spaghettio_core::bus::cells::mega::compose_mega_calibrated(item, rate, inputs).unwrap();
         println!("{label}: {:016x}", geometry_hash(&l));
     }
     {
         let inputs_set: FxHashSet<String> =
-            ["iron-ore", "copper-ore", "crude-oil", "water", "coal"].iter().map(|s| s.to_string()).collect();
+            ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            "advanced-circuit", 2.0, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
-        println!("mega-chain-ac2raw: {:016x}", geometry_hash(&compose_chain(&sr).unwrap()));
+            "advanced-circuit",
+            2.0,
+            &inputs_set,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
+        println!(
+            "mega-chain-ac2raw: {:016x}",
+            geometry_hash(&compose_chain(&sr).unwrap())
+        );
     }
 }
 
@@ -665,22 +1083,35 @@ fn probe_registry_hashes() {
 fn chain_capacity_reaches_the_placer() {
     use spaghettio_core::bus::cells::chain::{compose_chain, compose_chain_with_capacity};
     use spaghettio_core::bus::cells::registry::geometry_hash;
-    let inputs: FxHashSet<String> =
-        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "electronic-circuit", 15.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "electronic-circuit",
+        15.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let plain = compose_chain(&sr).unwrap();
     let default_explicit =
-        compose_chain_with_capacity(&sr, spaghettio_core::common::DEFAULT_INSERTER_CAPACITY).unwrap();
+        compose_chain_with_capacity(&sr, spaghettio_core::common::DEFAULT_INSERTER_CAPACITY)
+            .unwrap();
     assert_eq!(
-        geometry_hash(&plain), geometry_hash(&default_explicit),
+        geometry_hash(&plain),
+        geometry_hash(&default_explicit),
         "plain compose_chain must equal the DEFAULT_INSERTER_CAPACITY build"
     );
     let l0 = compose_chain_with_capacity(&sr, 0).unwrap();
     let l7 = compose_chain_with_capacity(&sr, 7).unwrap();
-    assert_eq!(l7.inserter_capacity, 7, "composed layout must declare its capacity");
+    assert_eq!(
+        l7.inserter_capacity, 7,
+        "composed layout must declare its capacity"
+    );
     assert_ne!(
         geometry_hash(&l0), geometry_hash(&l7),
         "declared L7 must change composed geometry (ladder-resized hands) —          identical hashes mean the option died on the way to the placer again (#383)"
@@ -698,12 +1129,20 @@ fn ec15_chain_inserter_clean_at_default_capacity() {
     use spaghettio_core::bus::cells::registry::geometry_hash;
     use spaghettio_core::common::DEFAULT_INSERTER_CAPACITY;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
-    let inputs: FxHashSet<String> =
-        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "electronic-circuit", 15.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "electronic-circuit",
+        15.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     // Geometry-regression lock on the L2 DEFAULT path — the geometry
     // production actually builds, which the registry gate (rebuilt at
     // explicit L0) does not cover (PR #431 review finding). Not sim-blessed
@@ -750,12 +1189,20 @@ fn ec15_chain_inserter_clean_at_default_capacity() {
 #[test]
 fn mega_chain_composes_at_declared_capacity() {
     use spaghettio_core::bus::cells::chain::compose_chain_with_capacity;
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal"].iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "advanced-circuit", 2.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "advanced-circuit",
+        2.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     // L7 composes (no refusal, no clamp) and DECLARES its requested level —
     // the non-mega cells thread it; the mega interior stays L0 internally.
     let l7 = compose_chain_with_capacity(&sr, 7).expect("mega chain composes at L7");
@@ -787,18 +1234,79 @@ fn cell_registry_hashes_current() {
     // real L2 geometry and must reproduce at L2. Re-deriving everything
     // at one capacity would falsely fail one group or the other.
     let configs: &[(&str, f64, &[&str], &str, u8)] = &[
-        ("advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"], "chain", 0),
-        ("electronic-circuit", 15.0, &["iron-plate", "copper-plate"], "chain", 0),
-        ("electronic-circuit", 30.0, &["iron-plate", "copper-plate"], "chain", 0),
-        ("military-science-pack", 5.0, &["iron-ore", "copper-ore", "stone", "coal"], "chain", 0),
-        ("military-science-pack", 5.0, &["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"], "chain", 0),
-        ("plastic-bar", 2.0, &["crude-oil", "water", "coal"], "mega", 0),
+        (
+            "advanced-circuit",
+            1.0,
+            &["iron-plate", "copper-plate", "plastic-bar"],
+            "chain",
+            0,
+        ),
+        (
+            "electronic-circuit",
+            15.0,
+            &["iron-plate", "copper-plate"],
+            "chain",
+            0,
+        ),
+        (
+            "electronic-circuit",
+            30.0,
+            &["iron-plate", "copper-plate"],
+            "chain",
+            0,
+        ),
+        (
+            "military-science-pack",
+            5.0,
+            &["iron-ore", "copper-ore", "stone", "coal"],
+            "chain",
+            0,
+        ),
+        (
+            "military-science-pack",
+            5.0,
+            &[
+                "iron-plate",
+                "copper-plate",
+                "steel-plate",
+                "stone-brick",
+                "coal",
+            ],
+            "chain",
+            0,
+        ),
+        (
+            "plastic-bar",
+            2.0,
+            &["crude-oil", "water", "coal"],
+            "mega",
+            0,
+        ),
         ("sulfur", 2.0, &["crude-oil", "water"], "mega", 0),
-        ("advanced-circuit", 2.0, &["iron-ore", "copper-ore", "crude-oil", "water", "coal"], "chain", 0),
+        (
+            "advanced-circuit",
+            2.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"],
+            "chain",
+            0,
+        ),
         // First post-#431 registration: blessed at the L2 default.
-        ("chemical-science-pack", 5.0,
-         &["iron-ore", "copper-ore", "crude-oil", "water", "coal",
-           "iron-plate", "copper-plate", "steel-plate"], "chain", 2),
+        (
+            "chemical-science-pack",
+            5.0,
+            &[
+                "iron-ore",
+                "copper-ore",
+                "crude-oil",
+                "water",
+                "coal",
+                "iron-plate",
+                "copper-plate",
+                "steel-plate",
+            ],
+            "chain",
+            2,
+        ),
     ];
     assert!(!entries().is_empty(), "registry must not be empty");
     for e in entries() {
@@ -809,14 +1317,22 @@ fn cell_registry_hashes_current() {
                 let l = match *kind {
                     "mega" => {
                         spaghettio_core::bus::cells::mega::compose_mega_calibrated(t, *r, inputs)
-                            .unwrap().1
+                            .unwrap()
+                            .1
                     }
                     _ => {
-                        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+                        let inputs_set: FxHashSet<String> =
+                            inputs.iter().map(|s| s.to_string()).collect();
                         let sr = solver::solve_with_palette_exclusions_and_quality(
-                            t, *r, &inputs_set, &MachinePalette::default(),
-                            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-                        ).unwrap();
+                            t,
+                            *r,
+                            &inputs_set,
+                            &MachinePalette::default(),
+                            "assembling-machine-3",
+                            &FxHashSet::default(),
+                            QualityTier::Normal,
+                        )
+                        .unwrap();
                         // Re-derive at the capacity this config was BLESSED at
                         // (never the ambient engine default, which moves) — see
                         // the per-config `u8` above for why the two groups differ.
@@ -826,9 +1342,12 @@ fn cell_registry_hashes_current() {
                 format!("{:016x}", geometry_hash(&l))
             })
             .collect();
-        assert!(!candidates.is_empty(),
+        assert!(
+            !candidates.is_empty(),
             "{}@{}: registry entry has no re-derivable fixture config in this gate — add it",
-            e.target, e.rate);
+            e.target,
+            e.rate
+        );
         assert!(candidates.contains(&e.geometry_hash),
             "{}@{} (declared capacity {}): composed geometry no longer matches the registered hash {} (fresh: {:?}) — re-verify in the sim and update cell-sim-registry.json",
             e.target, e.rate, e.declared_inserter_capacity, e.geometry_hash, candidates);
@@ -849,30 +1368,80 @@ fn cell_registry_hashes_current() {
 fn cell_quantization_copy_counts() {
     use spaghettio_core::bus::cells::chain::{chain_eligible, required_copies};
     for (label, item, rate, inputs, want_k) in [
-        ("ec15", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"][..], 1),
-        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..], 1),
-        ("ec5", "electronic-circuit", 5.0, &["iron-plate", "copper-plate"][..], 1),
+        (
+            "ec15",
+            "electronic-circuit",
+            15.0,
+            &["iron-plate", "copper-plate"][..],
+            1,
+        ),
+        (
+            "ac1",
+            "advanced-circuit",
+            1.0,
+            &["iron-plate", "copper-plate", "plastic-bar"][..],
+            1,
+        ),
+        (
+            "ec5",
+            "electronic-circuit",
+            5.0,
+            &["iron-plate", "copper-plate"][..],
+            1,
+        ),
         // pre-quantization these two REFUSED on the 45/s corridor cap
-        ("ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..], 2),
-        ("ec60", "electronic-circuit", 60.0, &["iron-plate", "copper-plate"][..], 4),
+        (
+            "ec30",
+            "electronic-circuit",
+            30.0,
+            &["iron-plate", "copper-plate"][..],
+            2,
+        ),
+        (
+            "ec60",
+            "electronic-circuit",
+            60.0,
+            &["iron-plate", "copper-plate"][..],
+            4,
+        ),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            item, rate, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            item,
+            rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         assert_eq!(required_copies(&sr), want_k, "{label}: copy count");
-        assert!(chain_eligible(&sr).is_ok(), "{label}: must be chain-eligible");
+        assert!(
+            chain_eligible(&sr).is_ok(),
+            "{label}: must be chain-eligible"
+        );
     }
     // Past K_MAX=12 the chain refuses loudly (ec600 → cable 1800/s → K=40).
-    let inputs_set: FxHashSet<String> =
-        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let inputs_set: FxHashSet<String> = ["iron-plate", "copper-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "electronic-circuit", 600.0, &inputs_set, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "electronic-circuit",
+        600.0,
+        &inputs_set,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let err = chain_eligible(&sr).unwrap_err();
-    assert!(err.contains("quantized copies"), "K_MAX refusal, got: {err}");
+    assert!(
+        err.contains("quantized copies"),
+        "K_MAX refusal, got: {err}"
+    );
 }
 
 /// PERMANENT GATE (belt-tier constraint): composed corridors are
@@ -887,30 +1456,52 @@ fn cell_quantization_copy_counts() {
 fn cell_candidate_respects_belt_tier_cap() {
     use spaghettio_core::bus::cells::registry::geometry_hash;
     use spaghettio_core::bus::cells::CellComposition;
-    let inputs: FxHashSet<String> =
-        ["iron-plate", "copper-plate"].iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "electronic-circuit", 15.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "electronic-circuit",
+        15.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     // EC@15 is chain-eligible, so only the tier guard keeps the
     // candidate out under a red cap.
     let build = |cc: CellComposition| {
-        layout::build_bus_layout(&sr, layout::LayoutOptions {
-            max_belt_tier: Some("fast-transport-belt".into()),
-            cell_composition: cc,
-            ..Default::default()
-        })
+        layout::build_bus_layout(
+            &sr,
+            layout::LayoutOptions {
+                max_belt_tier: Some("fast-transport-belt".into()),
+                cell_composition: cc,
+                ..Default::default()
+            },
+        )
     };
-    match (build(CellComposition::Candidate), build(CellComposition::Off)) {
+    match (
+        build(CellComposition::Candidate),
+        build(CellComposition::Off),
+    ) {
         (Ok(on), Ok(off)) => {
-            assert_eq!(geometry_hash(&on), geometry_hash(&off),
-                "sub-express cap: Candidate must be inert (bit-identical to Off)");
-            assert!(!on.entities.iter().any(|e| e.name.starts_with("express")),
-                "sub-express cap: no express entity may appear");
+            assert_eq!(
+                geometry_hash(&on),
+                geometry_hash(&off),
+                "sub-express cap: Candidate must be inert (bit-identical to Off)"
+            );
+            assert!(
+                !on.entities.iter().any(|e| e.name.starts_with("express")),
+                "sub-express cap: no express entity may appear"
+            );
         }
-        (on, off) => assert_eq!(on.is_err(), off.is_err(),
-            "sub-express cap: Candidate must not flip a refusal"),
+        (on, off) => assert_eq!(
+            on.is_err(),
+            off.is_err(),
+            "sub-express cap: Candidate must not flip a refusal"
+        ),
     }
     // Express cap (explicit) still composes the #336 refusal.
     let opts = layout::LayoutOptions {
@@ -932,15 +1523,36 @@ fn cell_candidate_respects_belt_tier_cap() {
 fn cell_candidate_never_displaces_a_succeeding_bus() {
     for (label, item, rate, inputs) in [
         ("gear15", "iron-gear-wheel", 15.0, &["iron-plate"][..]),
-        ("ec5", "electronic-circuit", 5.0, &["iron-plate", "copper-plate"][..]),
-        ("ac1", "advanced-circuit", 1.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
-        ("ac2", "advanced-circuit", 2.0, &["iron-plate", "copper-plate", "plastic-bar"][..]),
+        (
+            "ec5",
+            "electronic-circuit",
+            5.0,
+            &["iron-plate", "copper-plate"][..],
+        ),
+        (
+            "ac1",
+            "advanced-circuit",
+            1.0,
+            &["iron-plate", "copper-plate", "plastic-bar"][..],
+        ),
+        (
+            "ac2",
+            "advanced-circuit",
+            2.0,
+            &["iron-plate", "copper-plate", "plastic-bar"][..],
+        ),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            item, rate, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            item,
+            rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
             .unwrap_or_else(|e| panic!("{label}: bus-succeeding fixture must lay out: {e}"));
         assert!(
@@ -963,24 +1575,43 @@ fn cell_candidate_never_displaces_a_succeeding_bus() {
 #[test]
 fn cell_candidate_composes_mil5_ore() {
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "stone", "coal"].iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "stone", "coal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "military-science-pack", 5.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "military-science-pack",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     // Bus-only arm still refuses — composition is doing the winning.
-    let off = layout::build_bus_layout(&sr, layout::LayoutOptions {
-        cell_composition: spaghettio_core::bus::cells::CellComposition::Off,
-        ..Default::default()
-    });
-    assert!(off.is_err(), "bus-only mil5-ore must still refuse (else move this fixture to the bus ladder)");
+    let off = layout::build_bus_layout(
+        &sr,
+        layout::LayoutOptions {
+            cell_composition: spaghettio_core::bus::cells::CellComposition::Off,
+            ..Default::default()
+        },
+    );
+    assert!(
+        off.is_err(),
+        "bus-only mil5-ore must still refuse (else move this fixture to the bus ladder)"
+    );
     let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
         .expect("mil5-ore must compose");
-    assert!(l.warnings.iter().any(|w| w.starts_with("cell-composed:")),
-        "the composed candidate must be the winner");
+    assert!(
+        l.warnings.iter().any(|w| w.starts_with("cell-composed:")),
+        "the composed candidate must be the winner"
+    );
     let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).unwrap();
-    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .collect();
     assert!(errors.is_empty(), "composed mil5-ore errors: {errors:?}");
 }
 
@@ -993,19 +1624,37 @@ fn cell_candidate_composes_mil5_ore() {
 #[test]
 fn cell_candidate_wins_mil5_plates_over_broken_native() {
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
-    let inputs: FxHashSet<String> =
-        ["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = [
+        "iron-plate",
+        "copper-plate",
+        "steel-plate",
+        "stone-brick",
+        "coal",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "military-science-pack", 5.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "military-science-pack",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
         .expect("mil5-plates must lay out");
-    assert!(l.warnings.iter().any(|w| w.starts_with("cell-composed:")),
-        "the clean composed candidate must win over the validation-broken native");
+    assert!(
+        l.warnings.iter().any(|w| w.starts_with("cell-composed:")),
+        "the clean composed candidate must win over the validation-broken native"
+    );
     let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).unwrap();
-    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .collect();
     assert!(errors.is_empty(), "winner must validate clean: {errors:?}");
 }
 
@@ -1018,18 +1667,39 @@ fn cell_candidate_wins_mil5_plates_over_broken_native() {
 /// own self-check replay.
 #[test]
 fn selection_tier_validation_never_leaks_trace_events() {
-    let inputs: FxHashSet<String> =
-        ["iron-plate", "copper-plate", "steel-plate", "stone-brick", "coal"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = [
+        "iron-plate",
+        "copper-plate",
+        "steel-plate",
+        "stone-brick",
+        "coal",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "military-science-pack", 5.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "military-science-pack",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let l = layout::build_bus_layout_traced(&sr, layout::LayoutOptions::default())
         .expect("mil5-plates must lay out");
-    let n_validation_events = l.trace.as_ref().expect("traced build carries trace")
+    let n_validation_events = l
+        .trace
+        .as_ref()
+        .expect("traced build carries trace")
         .iter()
-        .filter(|e| matches!(e, spaghettio_core::trace::TraceEvent::ValidationCompleted { .. }))
+        .filter(|e| {
+            matches!(
+                e,
+                spaghettio_core::trace::TraceEvent::ValidationCompleted { .. }
+            )
+        })
         .count();
     assert_eq!(n_validation_events, 1,
         "only the winner's own validation may appear in the trace (leaked tier validations corrupt the web timing log)");
@@ -1050,8 +1720,18 @@ fn mega_cell_plastic_from_crude_zero_issues() {
     // All three Phase-A fixtures gate here (#401 review note: probe-only
     // coverage of plastic@5/sulfur@2 wouldn't catch a regression).
     for (label, item, rate, inputs) in [
-        ("plastic@2", "plastic-bar", 2.0, &["crude-oil", "water", "coal"][..]),
-        ("plastic@5", "plastic-bar", 5.0, &["crude-oil", "water", "coal"][..]),
+        (
+            "plastic@2",
+            "plastic-bar",
+            2.0,
+            &["crude-oil", "water", "coal"][..],
+        ),
+        (
+            "plastic@5",
+            "plastic-bar",
+            5.0,
+            &["crude-oil", "water", "coal"][..],
+        ),
         ("sulfur@2", "sulfur", 2.0, &["crude-oil", "water"][..]),
     ] {
         let (sr, l) = compose_mega_calibrated(item, rate, inputs)
@@ -1059,8 +1739,14 @@ fn mega_cell_plastic_from_crude_zero_issues() {
         // Kit-pitch invariant: boundary heads >= 4 apart, all at y=0,
         // sorted west→east (#363).
         let xs: Vec<i32> = l.boundary_inputs.iter().map(|b| b.x).collect();
-        assert!(xs.windows(2).all(|w| w[1] - w[0] >= 4), "{label}: feed heads must sit at >=4 pitch: {xs:?}");
-        assert!(l.boundary_inputs.iter().all(|b| b.y == 0), "{label}: feed heads at the north edge");
+        assert!(
+            xs.windows(2).all(|w| w[1] - w[0] >= 4),
+            "{label}: feed heads must sit at >=4 pitch: {xs:?}"
+        );
+        assert!(
+            l.boundary_inputs.iter().all(|b| b.y == 0),
+            "{label}: feed heads at the north edge"
+        );
         let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus)
             .unwrap_or_else(|e| panic!("{label}: mega must validate: {e}"));
         assert!(issues.is_empty(), "{label}: mega issues: {issues:?}");
@@ -1073,17 +1759,28 @@ fn mega_cell_plastic_from_crude_zero_issues() {
 fn export_mega_fixtures_for_sim() {
     use spaghettio_core::bus::cells::mega::compose_mega_calibrated;
     for (label, item, rate, inputs) in [
-        ("mega-plastic2", "plastic-bar", 2.0, &["crude-oil", "water", "coal"][..]),
+        (
+            "mega-plastic2",
+            "plastic-bar",
+            2.0,
+            &["crude-oil", "water", "coal"][..],
+        ),
         ("mega-sulfur2", "sulfur", 2.0, &["crude-oil", "water"][..]),
     ] {
         let (sr, l) = compose_mega_calibrated(item, rate, inputs).unwrap();
         let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, label);
         std::fs::create_dir_all("target/tmp").unwrap();
         std::fs::write(format!("target/tmp/{label}.bp"), &bp).unwrap();
-        std::fs::write(format!("target/tmp/{label}.manifest.json"),
-            serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-        println!("wrote target/tmp/{label}.bp ({} in / {} out)",
-            l.boundary_inputs.len(), l.boundary_outputs.len());
+        std::fs::write(
+            format!("target/tmp/{label}.manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        println!(
+            "wrote target/tmp/{label}.bp ({} in / {} out)",
+            l.boundary_inputs.len(),
+            l.boundary_outputs.len()
+        );
     }
 }
 
@@ -1100,17 +1797,28 @@ fn mega_chain_ac_from_raw_zero_issues() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
     for rate in [1.0, 2.0, 4.0] {
-        let inputs: FxHashSet<String> =
-            ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
-                .iter().map(|s| s.to_string()).collect();
+        let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            "advanced-circuit", rate, &inputs, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
-        let l = compose_chain(&sr).unwrap_or_else(|e| panic!("AC@{rate} from raw must compose: {e}"));
+            "advanced-circuit",
+            rate,
+            &inputs,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
+        let l =
+            compose_chain(&sr).unwrap_or_else(|e| panic!("AC@{rate} from raw must compose: {e}"));
         let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus)
             .unwrap_or_else(|e| panic!("AC@{rate} from raw must validate: {e}"));
-        let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+        let errors: Vec<_> = issues
+            .iter()
+            .filter(|i| i.severity == Severity::Error)
+            .collect();
         assert!(errors.is_empty(), "AC@{rate} from raw errors: {errors:?}");
         // AC@4's cable cell outputs 40/s. Under the old bridged express
         // budget (1.733 × 22.5 = 39.0/s) that was a 1/s shortfall and
@@ -1135,20 +1843,40 @@ fn mega_chain_ac_from_raw_zero_issues() {
 fn mega_chain_chem5_resolves_bus_failure() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal",
-         "iron-plate", "copper-plate", "steel-plate"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = [
+        "iron-ore",
+        "copper-ore",
+        "crude-oil",
+        "water",
+        "coal",
+        "iron-plate",
+        "copper-plate",
+        "steel-plate",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "chemical-science-pack", 5.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "chemical-science-pack",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let l = compose_chain(&sr).expect("chem5 from raw must compose");
     let issues = validate::validate(&l, Some(&sr), LayoutStyle::Bus).expect("must validate");
-    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .collect();
     assert!(errors.is_empty(), "chem5 errors: {errors:?}");
     assert!(
-        issues.iter().all(|i| matches!(i.category.as_str(), "inserter-item-throughput" | "power")),
+        issues
+            .iter()
+            .all(|i| matches!(i.category.as_str(), "inserter-item-throughput" | "power")),
         "only adjudicated categories tolerated: {issues:?}"
     );
 }
@@ -1164,13 +1892,20 @@ fn mega_chain_chem5_resolves_bus_failure() {
 fn mega_chain_pu4_resolves_bus_failure() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "processing-unit", 4.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "processing-unit",
+        4.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let plan = spaghettio_core::bus::cells::mega::mega_subgraph(&sr)
         .expect("subgraph")
         .expect("PU chain has a fluid subgraph");
@@ -1184,7 +1919,10 @@ fn mega_chain_pu4_resolves_bus_failure() {
         Ok(v) => v,
         Err(e) => e.issues,
     };
-    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .collect();
     assert!(errors.is_empty(), "PU@4 errors: {errors:?}");
     assert!(
         issues.iter().all(|i| matches!(
@@ -1219,13 +1957,27 @@ fn mega_chain_pu4_resolves_bus_failure() {
 fn mega_chain_usp2_resolves_bus_failure() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = [
+        "iron-ore",
+        "copper-ore",
+        "crude-oil",
+        "water",
+        "coal",
+        "stone",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "utility-science-pack", 2.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "utility-science-pack",
+        2.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let plan = spaghettio_core::bus::cells::mega::mega_subgraph(&sr)
         .expect("subgraph")
         .expect("USP chain has a fluid subgraph");
@@ -1258,7 +2010,10 @@ fn mega_chain_usp2_resolves_bus_failure() {
         Ok(v) => v,
         Err(e) => e.issues,
     };
-    let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .collect();
     assert!(errors.is_empty(), "USP@2 errors: {errors:?}");
 }
 
@@ -1266,20 +2021,42 @@ fn mega_chain_usp2_resolves_bus_failure() {
 #[test]
 #[ignore = "artifact producer"]
 fn export_mega_usp_for_sim() {
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = [
+        "iron-ore",
+        "copper-ore",
+        "crude-oil",
+        "water",
+        "coal",
+        "stone",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "utility-science-pack", 2.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "utility-science-pack",
+        2.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let l = SimFixture::find("mega-chain-usp2raw").compose_layout();
-    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-usp2raw");
+    let (bp, manifest) =
+        spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-usp2raw");
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/mega-chain-usp2raw.bp", &bp).unwrap();
-    std::fs::write("target/tmp/mega-chain-usp2raw.manifest.json",
-        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-    println!("wrote mega-chain-usp2raw.bp ({} in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
+    std::fs::write(
+        "target/tmp/mega-chain-usp2raw.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+    println!(
+        "wrote mega-chain-usp2raw.bp ({} in / {} out)",
+        l.boundary_inputs.len(),
+        l.boundary_outputs.len()
+    );
 }
 
 /// RFC-055 real-geometry experiment. Kept opt-in while compact ordering is
@@ -1291,25 +2068,47 @@ fn rfc055_compact_usp_real_geometry() {
     use spaghettio_core::bus::cells::chain::{compose_chain_compact, compose_chain_with_capacity};
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = [
+        "iron-ore",
+        "copper-ore",
+        "crude-oil",
+        "water",
+        "coal",
+        "stone",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "utility-science-pack", 2.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "utility-science-pack",
+        2.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let control = compose_chain_with_capacity(&sr, 0).expect("control composes");
     let compact = compose_chain_compact(&sr, 0).expect("compact composes");
     let issues = match validate::validate(&compact, Some(&sr), LayoutStyle::Bus) {
         Ok(v) => v,
         Err(e) => e.issues,
     };
-    let errors: Vec<_> = issues.iter()
-        .filter(|i| i.severity == Severity::Error).collect();
+    let errors: Vec<_> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .collect();
     assert!(errors.is_empty(), "compact USP errors: {errors:?}");
-    println!("control={}x{} entities={} compact={}x{} entities={}",
-        control.width, control.height, control.entities.len(),
-        compact.width, compact.height, compact.entities.len());
+    println!(
+        "control={}x{} entities={} compact={}x{} entities={}",
+        control.width,
+        control.height,
+        control.entities.len(),
+        compact.width,
+        compact.height,
+        compact.entities.len()
+    );
 }
 
 #[test]
@@ -1319,36 +2118,78 @@ fn rfc055_compact_acceptance_corpus() {
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
     for (label, target, rate, raw) in [
-        ("usp2raw", "utility-science-pack", 2.0,
-            &["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"][..]),
-        ("chem5raw", "chemical-science-pack", 5.0,
-            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
-        ("pu4raw", "processing-unit", 4.0,
-            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
-        ("mil5ore", "military-science-pack", 5.0,
-            &["iron-ore", "copper-ore", "stone", "coal"][..]),
+        (
+            "usp2raw",
+            "utility-science-pack",
+            2.0,
+            &[
+                "iron-ore",
+                "copper-ore",
+                "crude-oil",
+                "water",
+                "coal",
+                "stone",
+            ][..],
+        ),
+        (
+            "chem5raw",
+            "chemical-science-pack",
+            5.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..],
+        ),
+        (
+            "pu4raw",
+            "processing-unit",
+            4.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..],
+        ),
+        (
+            "mil5ore",
+            "military-science-pack",
+            5.0,
+            &["iron-ore", "copper-ore", "stone", "coal"][..],
+        ),
     ] {
         let inputs: FxHashSet<String> = raw.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            target, rate, &inputs, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
-        let control = compose_chain_with_capacity(&sr, 0)
-            .unwrap_or_else(|e| panic!("{label} control: {e}"));
-        let compact = compose_chain_compact(&sr, 0)
-            .unwrap_or_else(|e| panic!("{label} compact: {e}"));
+            target,
+            rate,
+            &inputs,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
+        let control =
+            compose_chain_with_capacity(&sr, 0).unwrap_or_else(|e| panic!("{label} control: {e}"));
+        let compact =
+            compose_chain_compact(&sr, 0).unwrap_or_else(|e| panic!("{label} compact: {e}"));
         let issues = match validate::validate(&compact, Some(&sr), LayoutStyle::Bus) {
             Ok(v) => v,
             Err(e) => e.issues,
         };
-        let errors = issues.iter().filter(|i| i.severity == Severity::Error).count();
+        let errors = issues
+            .iter()
+            .filter(|i| i.severity == Severity::Error)
+            .count();
         assert_eq!(errors, 0, "{label} compact has errors: {issues:?}");
-        let belts = |l: &spaghettio_core::models::LayoutResult| l.entities.iter()
-            .filter(|e| e.name.contains("transport-belt") || e.name.contains("splitter"))
-            .count();
-        let corridors = |l: &spaghettio_core::models::LayoutResult| l.entities.iter()
-            .filter(|e| e.segment_id.as_deref().is_some_and(|s| s.starts_with("corr:")))
-            .count();
+        let belts = |l: &spaghettio_core::models::LayoutResult| {
+            l.entities
+                .iter()
+                .filter(|e| e.name.contains("transport-belt") || e.name.contains("splitter"))
+                .count()
+        };
+        let corridors = |l: &spaghettio_core::models::LayoutResult| {
+            l.entities
+                .iter()
+                .filter(|e| {
+                    e.segment_id
+                        .as_deref()
+                        .is_some_and(|s| s.starts_with("corr:"))
+                })
+                .count()
+        };
         println!("{label}: control={}x{} entities={} belts={} corr={} compact={}x{} entities={} belts={} corr={}",
             control.width, control.height, control.entities.len(), belts(&control), corridors(&control),
             compact.width, compact.height, compact.entities.len(), belts(&compact), corridors(&compact));
@@ -1363,18 +2204,43 @@ fn export_rfc055_factorio_candidates() {
 
     std::fs::create_dir_all("target/tmp/rfc055").unwrap();
     for (label, target, rate, raw) in [
-        ("usp2raw", "utility-science-pack", 2.0,
-            &["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"][..]),
-        ("chem5raw", "chemical-science-pack", 5.0,
-            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
-        ("pu4raw", "processing-unit", 4.0,
-            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..]),
+        (
+            "usp2raw",
+            "utility-science-pack",
+            2.0,
+            &[
+                "iron-ore",
+                "copper-ore",
+                "crude-oil",
+                "water",
+                "coal",
+                "stone",
+            ][..],
+        ),
+        (
+            "chem5raw",
+            "chemical-science-pack",
+            5.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..],
+        ),
+        (
+            "pu4raw",
+            "processing-unit",
+            4.0,
+            &["iron-ore", "copper-ore", "crude-oil", "water", "coal"][..],
+        ),
     ] {
         let inputs: FxHashSet<String> = raw.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            target, rate, &inputs, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            target,
+            rate,
+            &inputs,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         for (variant, layout) in [
             ("control", compose_chain_with_capacity(&sr, 0).unwrap()),
             ("compact", compose_chain_compact(&sr, 0).unwrap()),
@@ -1385,9 +2251,14 @@ fn export_rfc055_factorio_candidates() {
             std::fs::write(
                 format!("target/tmp/rfc055/{artifact}.manifest.json"),
                 serde_json::to_string_pretty(&manifest).unwrap(),
-            ).unwrap();
-            println!("wrote {artifact}: {}x{}, {} entities",
-                layout.width, layout.height, layout.entities.len());
+            )
+            .unwrap();
+            println!(
+                "wrote {artifact}: {}x{}, {} entities",
+                layout.width,
+                layout.height,
+                layout.entities.len()
+            );
         }
     }
 }
@@ -1396,26 +2267,36 @@ fn export_rfc055_factorio_candidates() {
 #[ignore = "RFC-057 coarse machine compaction potential"]
 fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
-        blocks_overlap, build_local_manifold_graph, build_manifold_nets, compact_axis, compact_island_axis,
-        compact_transport_geometry, estimated_manifold_wirelength, extract_rigid_islands,
-        extract_route_nets, machine_blocks, occupied_bbox,
+        blocks_overlap, build_local_manifold_graph, build_manifold_nets, compact_axis,
+        compact_island_axis, compact_transport_geometry, estimated_manifold_wirelength,
+        extract_rigid_islands, extract_route_nets, legalize_manifold_routes, machine_blocks,
+        materialize_legalized_manifold_routes, occupied_bbox,
         place_distributed_local_manifold_nodes, place_recipe_clusters, plan_local_manifolds,
-        legalize_manifold_routes, materialize_legalized_manifold_routes,
-        route_local_manifold_edges, CompactAxis, CompactIr,
-        PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
+        route_local_manifold_edges, CompactAxis, CompactIr, PlacedMachineSignature,
+        ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
     use spaghettio_core::density::{entity_footprint, score_density};
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
-    for label in ["mega-chain-usp2raw", "mega-chain-chem5raw", "mega-chain-pu4raw", "chain-mil5ore"] {
+    for label in [
+        "mega-chain-usp2raw",
+        "mega-chain-chem5raw",
+        "mega-chain-pu4raw",
+        "chain-mil5ore",
+    ] {
         let fixture = SimFixture::find(label);
-        let inputs: FxHashSet<String> =
-            fixture.inputs.iter().map(|s| s.to_string()).collect();
+        let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            fixture.target,
+            fixture.rate,
+            &inputs,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         let layout = fixture.compose_layout();
         let production = ProductionSignature::from_solver(&sr).unwrap();
         let placed = PlacedMachineSignature::from_layout(&layout);
@@ -1424,19 +2305,23 @@ fn rfc057_machine_constraint_baseline() {
         assert!(!production.machines.is_empty());
         assert!(!placed.0.is_empty());
         for edge in production.edges.iter().filter(|edge| !edge.is_fluid) {
-            assert!(nets.iter().any(|net| {
-                net.item == edge.item
-                    && net.terminals.iter().any(|terminal| {
-                        terminal.kind == RouteTerminalKind::ProducerDrop
-                            && terminal.recipe.as_ref().is_some_and(|recipe| {
-                                edge.producer_recipes.contains(recipe)
-                            })
-                    })
-                    && net.terminals.iter().any(|terminal| {
-                        terminal.kind == RouteTerminalKind::ConsumerPickup
-                            && terminal.recipe.as_deref() == Some(edge.consumer_recipe.as_str())
-                    })
-            }), "{label}: no route intent covers {edge:?}");
+            assert!(
+                nets.iter().any(|net| {
+                    net.item == edge.item
+                        && net.terminals.iter().any(|terminal| {
+                            terminal.kind == RouteTerminalKind::ProducerDrop
+                                && terminal
+                                    .recipe
+                                    .as_ref()
+                                    .is_some_and(|recipe| edge.producer_recipes.contains(recipe))
+                        })
+                        && net.terminals.iter().any(|terminal| {
+                            terminal.kind == RouteTerminalKind::ConsumerPickup
+                                && terminal.recipe.as_deref() == Some(edge.consumer_recipe.as_str())
+                        })
+                }),
+                "{label}: no route intent covers {edge:?}"
+            );
         }
 
         let original = machine_blocks(&layout);
@@ -1448,7 +2333,12 @@ fn rfc057_machine_constraint_baseline() {
         }
         for (i, a) in compacted.iter().enumerate() {
             for b in &compacted[i + 1..] {
-                assert!(!blocks_overlap(a, b), "{label}: blocks {} and {} overlap", a.id, b.id);
+                assert!(
+                    !blocks_overlap(a, b),
+                    "{label}: blocks {} and {} overlap",
+                    a.id,
+                    b.id
+                );
             }
         }
         let compact_bbox = occupied_bbox(&compacted);
@@ -1456,13 +2346,19 @@ fn rfc057_machine_constraint_baseline() {
         let after = i64::from(compact_bbox.0) * i64::from(compact_bbox.1);
         println!(
             "{label}: machines={} machine-bbox={}x{} -> {}x{} ({:+.1}%)",
-            original.len(), original_bbox.0, original_bbox.1,
-            compact_bbox.0, compact_bbox.1,
+            original.len(),
+            original_bbox.0,
+            original_bbox.1,
+            compact_bbox.0,
+            compact_bbox.1,
             (after as f64 / before as f64 - 1.0) * 100.0,
         );
 
         let island_source = occupied_bbox(
-            &islands.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+            &islands
+                .iter()
+                .map(|island| island.block.clone())
+                .collect::<Vec<_>>(),
         );
         let mut island_compacted = islands.clone();
         for _ in 0..8 {
@@ -1470,7 +2366,10 @@ fn rfc057_machine_constraint_baseline() {
             island_compacted = compact_island_axis(&island_compacted, CompactAxis::Y, 1);
         }
         let island_after = occupied_bbox(
-            &island_compacted.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+            &island_compacted
+                .iter()
+                .map(|island| island.block.clone())
+                .collect::<Vec<_>>(),
         );
         let ir = CompactIr::from_source(&layout, &sr);
         assert_eq!(ir.islands, islands);
@@ -1479,13 +2378,9 @@ fn rfc057_machine_constraint_baseline() {
         let (clustered_islands, clusters) = place_recipe_clusters(&ir, 1);
         let clustered_manifolds = build_manifold_nets(&ir, &clustered_islands).unwrap();
         let local_plans = plan_local_manifolds(&clustered_islands, &clustered_manifolds, 1);
-        let local_graphs: Vec<_> = local_plans
-            .iter()
-            .map(build_local_manifold_graph)
-            .collect();
+        let local_graphs: Vec<_> = local_plans.iter().map(build_local_manifold_graph).collect();
         let placed_hubs =
-            place_distributed_local_manifold_nodes(&clustered_islands, &local_graphs, 3)
-                .unwrap();
+            place_distributed_local_manifold_nodes(&clustered_islands, &local_graphs, 3).unwrap();
         if label == "chain-mil5ore" {
             let routed =
                 route_local_manifold_edges(&clustered_islands, &local_graphs, &placed_hubs)
@@ -1507,19 +2402,29 @@ fn rfc057_machine_constraint_baseline() {
             }
             let mut crossed_merge_edges = 0usize;
             let mut crossed_distribute_edges = 0usize;
-            for route in routed.routes.iter().filter(|route| !route.crossings.is_empty()) {
+            for route in routed
+                .routes
+                .iter()
+                .filter(|route| !route.crossings.is_empty())
+            {
                 let graph = local_graphs
                     .iter()
                     .find(|graph| graph.item == route.item)
                     .unwrap();
-                let touches_role = |endpoint: &spaghettio_core::bus::compaction::ManifoldEndpoint,
-                                    role| match endpoint {
-                    spaghettio_core::bus::compaction::ManifoldEndpoint::NodeInput { node, .. }
-                    | spaghettio_core::bus::compaction::ManifoldEndpoint::NodeOutput { node, .. } => {
-                        graph.nodes[*node].role == role
-                    }
-                    _ => false,
-                };
+                let touches_role =
+                    |endpoint: &spaghettio_core::bus::compaction::ManifoldEndpoint, role| {
+                        match endpoint {
+                            spaghettio_core::bus::compaction::ManifoldEndpoint::NodeInput {
+                                node,
+                                ..
+                            }
+                            | spaghettio_core::bus::compaction::ManifoldEndpoint::NodeOutput {
+                                node,
+                                ..
+                            } => graph.nodes[*node].role == role,
+                            _ => false,
+                        }
+                    };
                 if touches_role(
                     &route.edge.from,
                     spaghettio_core::bus::compaction::BalancerNodeRole::Merge,
@@ -1590,6 +2495,7 @@ fn rfc057_machine_constraint_baseline() {
                 }
             }
         }
+
         let clustered_bbox = occupied_bbox(
             &clustered_islands
                 .iter()
@@ -1618,12 +2524,18 @@ fn rfc057_machine_constraint_baseline() {
                 "{label}: {} manifold has no consumer/output",
                 manifold.item,
             );
-            assert!(manifold.planned_rate > 0, "{label}: {} has no planned rate", manifold.item);
-            let producer_max = manifold.producers()
+            assert!(
+                manifold.planned_rate > 0,
+                "{label}: {} has no planned rate",
+                manifold.item
+            );
+            let producer_max = manifold
+                .producers()
                 .filter(|terminal| terminal.island_id.is_some())
                 .map(|terminal| terminal.x)
                 .max();
-            let consumer_min = manifold.consumers()
+            let consumer_min = manifold
+                .consumers()
                 .filter(|terminal| terminal.island_id.is_some())
                 .map(|terminal| terminal.x)
                 .min();
@@ -1635,20 +2547,36 @@ fn rfc057_machine_constraint_baseline() {
         let after = i64::from(island_after.0) * i64::from(island_after.1);
         println!(
             "{label}: islands={} terminals={} manifolds={} island-bbox={}x{} -> {}x{} ({:+.1}%)",
-            islands.len(), islands.iter().map(|island| island.terminals.len()).sum::<usize>(),
+            islands.len(),
+            islands
+                .iter()
+                .map(|island| island.terminals.len())
+                .sum::<usize>(),
             manifolds.len(),
-            island_source.0, island_source.1, island_after.0, island_after.1,
+            island_source.0,
+            island_source.1,
+            island_after.0,
+            island_after.1,
             (after as f64 / before as f64 - 1.0) * 100.0,
         );
         println!("{label}: non-monotone manifolds={non_monotone:?}");
         println!(
             "{label}: express manifold lanes total={} max={}",
-            manifolds.iter().map(|manifold| manifold.required_belts(45.0)).sum::<u32>(),
-            manifolds.iter().map(|manifold| manifold.required_belts(45.0)).max().unwrap_or(0),
+            manifolds
+                .iter()
+                .map(|manifold| manifold.required_belts(45.0))
+                .sum::<u32>(),
+            manifolds
+                .iter()
+                .map(|manifold| manifold.required_belts(45.0))
+                .max()
+                .unwrap_or(0),
         );
         println!(
             "{label}: recipe clusters={} bbox={}x{}, weighted-wirelength={} -> {}",
-            clusters.len(), clustered_bbox.0, clustered_bbox.1,
+            clusters.len(),
+            clustered_bbox.0,
+            clustered_bbox.1,
             estimated_manifold_wirelength(&manifolds),
             estimated_manifold_wirelength(&clustered_manifolds),
         );
@@ -1656,13 +2584,22 @@ fn rfc057_machine_constraint_baseline() {
             "{label}: local hubs={} lanes={} merger-ready={} distributor-ready={}",
             local_plans.len(),
             local_plans.iter().map(|plan| plan.belt_count).sum::<u32>(),
-            local_plans.iter().filter(|plan| plan.all_mergers_stampable).count(),
-            local_plans.iter().filter(|plan| plan.all_distributors_stampable).count(),
+            local_plans
+                .iter()
+                .filter(|plan| plan.all_mergers_stampable)
+                .count(),
+            local_plans
+                .iter()
+                .filter(|plan| plan.all_distributors_stampable)
+                .count(),
         );
         println!(
             "{label}: stamped hub nodes={} entities={}",
             placed_hubs.iter().map(|hub| hub.nodes.len()).sum::<usize>(),
-            placed_hubs.iter().map(|hub| hub.entities.len()).sum::<usize>(),
+            placed_hubs
+                .iter()
+                .map(|hub| hub.entities.len())
+                .sum::<usize>(),
         );
         assert_eq!(local_plans.len(), clustered_manifolds.len());
         for ((plan, graph), manifold) in local_plans
@@ -1670,14 +2607,28 @@ fn rfc057_machine_constraint_baseline() {
             .zip(&local_graphs)
             .zip(&clustered_manifolds)
         {
-            assert!(plan.all_mergers_stampable, "{label}: {} merger hierarchy not stampable", plan.item);
-            assert!(plan.all_distributors_stampable, "{label}: {} distributor hierarchy not stampable", plan.item);
+            assert!(
+                plan.all_mergers_stampable,
+                "{label}: {} merger hierarchy not stampable",
+                plan.item
+            );
+            assert!(
+                plan.all_distributors_stampable,
+                "{label}: {} distributor hierarchy not stampable",
+                plan.item
+            );
             assert_eq!(
-                plan.lane_groups.iter().map(|group| group.producers.len()).sum::<usize>(),
+                plan.lane_groups
+                    .iter()
+                    .map(|group| group.producers.len())
+                    .sum::<usize>(),
                 manifold.producers().count(),
             );
             assert_eq!(
-                plan.lane_groups.iter().map(|group| group.consumers.len()).sum::<usize>(),
+                plan.lane_groups
+                    .iter()
+                    .map(|group| group.consumers.len())
+                    .sum::<usize>(),
                 manifold.consumers().count(),
             );
             for terminal in manifold.producers() {
@@ -1712,22 +2663,34 @@ fn rfc057_machine_constraint_baseline() {
             .iter()
             .filter(|issue| issue.severity == Severity::Error)
             .collect();
-        assert!(errors.is_empty(), "{label}: runnable post-pass errors: {errors:?}");
-        let underground_warnings = issues.iter()
+        assert!(
+            errors.is_empty(),
+            "{label}: runnable post-pass errors: {errors:?}"
+        );
+        let underground_warnings = issues
+            .iter()
             .filter(|issue| {
                 issue.severity != Severity::Error && issue.category == "underground-belt"
             })
             .count();
-        let source_belts = layout.entities.iter()
+        let source_belts = layout
+            .entities
+            .iter()
             .filter(|entity| is_belt_entity(&entity.name))
             .count();
-        let compact_belts = runnable.entities.iter()
+        let compact_belts = runnable
+            .entities
+            .iter()
             .filter(|entity| is_belt_entity(&entity.name))
             .count();
         println!(
             "{label}: runnable={}x{} -> {}x{}, belts={} -> {} ({:+.1}%)",
-            layout.width, layout.height, runnable.width, runnable.height,
-            source_belts, compact_belts,
+            layout.width,
+            layout.height,
+            runnable.width,
+            runnable.height,
+            source_belts,
+            compact_belts,
             (compact_belts as f64 / source_belts as f64 - 1.0) * 100.0,
         );
         println!("{label}: underground warnings={underground_warnings}");
@@ -1751,20 +2714,25 @@ fn rfc057_machine_constraint_baseline() {
 #[ignore = "RFC-057 runnable whitespace-compaction baseline"]
 fn rfc057_strip_empty_columns_mil5ore() {
     use spaghettio_core::bus::compaction::{
-        compact_island_axis, extract_rigid_islands, extract_route_nets, occupied_bbox,
-        compact_transport_geometry, compact_validated_geometry, strip_empty_columns,
-        CompactAxis, PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
+        compact_island_axis, compact_transport_geometry, compact_validated_geometry,
+        extract_rigid_islands, extract_route_nets, occupied_bbox, strip_empty_columns, CompactAxis,
+        PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
     let fixture = SimFixture::find("chain-mil5ore");
-    let inputs: FxHashSet<String> =
-        fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        fixture.target,
+        fixture.rate,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let source = fixture.compose_layout();
     let compacted = strip_empty_columns(&source);
     let underground_compacted = compact_transport_geometry(&source);
@@ -1773,19 +2741,23 @@ fn rfc057_strip_empty_columns_mil5ore() {
     let nets = extract_route_nets(&source);
     let islands = extract_rigid_islands(&source);
     for edge in production.edges.iter().filter(|edge| !edge.is_fluid) {
-        assert!(nets.iter().any(|net| {
-            net.item == edge.item
-                && net.terminals.iter().any(|terminal| {
-                    terminal.kind == RouteTerminalKind::ProducerDrop
-                        && terminal.recipe.as_ref().is_some_and(|recipe| {
-                            edge.producer_recipes.contains(recipe)
-                        })
-                })
-                && net.terminals.iter().any(|terminal| {
-                    terminal.kind == RouteTerminalKind::ConsumerPickup
-                        && terminal.recipe.as_deref() == Some(edge.consumer_recipe.as_str())
-                })
-        }), "no extracted route net covers edge {edge:?}");
+        assert!(
+            nets.iter().any(|net| {
+                net.item == edge.item
+                    && net.terminals.iter().any(|terminal| {
+                        terminal.kind == RouteTerminalKind::ProducerDrop
+                            && terminal
+                                .recipe
+                                .as_ref()
+                                .is_some_and(|recipe| edge.producer_recipes.contains(recipe))
+                    })
+                    && net.terminals.iter().any(|terminal| {
+                        terminal.kind == RouteTerminalKind::ConsumerPickup
+                            && terminal.recipe.as_deref() == Some(edge.consumer_recipe.as_str())
+                    })
+            }),
+            "no extracted route net covers edge {edge:?}"
+        );
     }
     assert_eq!(
         PlacedMachineSignature::from_layout(&source),
@@ -1808,7 +2780,8 @@ fn rfc057_strip_empty_columns_mil5ore() {
             Ok(v) => v,
             Err(e) => e.issues,
         };
-        let errors: Vec<_> = issues.iter()
+        let errors: Vec<_> = issues
+            .iter()
             .filter(|issue| issue.severity == Severity::Error)
             .collect();
         assert!(errors.is_empty(), "{label} candidate errors: {errors:?}");
@@ -1820,45 +2793,69 @@ fn rfc057_strip_empty_columns_mil5ore() {
         ("rfc057-mil5ore-underground", &underground_compacted),
         ("rfc057-mil5ore-cut", &cut_compacted),
     ] {
-        let (bp, manifest) =
-            spaghettio_core::blueprint::export_with_manifest(layout, &sr, label);
+        let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(layout, &sr, label);
         std::fs::write(format!("target/tmp/{label}.bp"), bp).unwrap();
         std::fs::write(
             format!("target/tmp/{label}.manifest.json"),
             serde_json::to_string_pretty(&manifest).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
     }
     println!(
         "chain-mil5ore: {}x{} -> {}x{}; entities={}",
-        source.width, source.height, compacted.width, compacted.height,
+        source.width,
+        source.height,
+        compacted.width,
+        compacted.height,
         compacted.entities.len(),
     );
-    let source_belts = source.entities.iter()
+    let source_belts = source
+        .entities
+        .iter()
         .filter(|entity| is_belt_entity(&entity.name))
         .count();
-    let underground_belts = underground_compacted.entities.iter()
+    let underground_belts = underground_compacted
+        .entities
+        .iter()
         .filter(|entity| is_belt_entity(&entity.name))
         .count();
     println!(
         "underground candidate: {}x{} entities={} belts={} ({:+.1}% belts)",
-        underground_compacted.width, underground_compacted.height,
-        underground_compacted.entities.len(), underground_belts,
+        underground_compacted.width,
+        underground_compacted.height,
+        underground_compacted.entities.len(),
+        underground_belts,
         (underground_belts as f64 / source_belts as f64 - 1.0) * 100.0,
     );
     println!(
         "validated-cut candidate: {}x{} entities={}",
-        cut_compacted.width, cut_compacted.height, cut_compacted.entities.len(),
+        cut_compacted.width,
+        cut_compacted.height,
+        cut_compacted.entities.len(),
     );
     println!("extracted {} replaceable route nets", nets.len());
     println!(
         "extracted {} rigid production islands: entities={} terminals={} largest={}",
         islands.len(),
-        islands.iter().map(|island| island.entity_indices.len()).sum::<usize>(),
-        islands.iter().map(|island| island.terminals.len()).sum::<usize>(),
-        islands.iter().map(|island| island.entity_indices.len()).max().unwrap_or(0),
+        islands
+            .iter()
+            .map(|island| island.entity_indices.len())
+            .sum::<usize>(),
+        islands
+            .iter()
+            .map(|island| island.terminals.len())
+            .sum::<usize>(),
+        islands
+            .iter()
+            .map(|island| island.entity_indices.len())
+            .max()
+            .unwrap_or(0),
     );
     let source_island_bbox = occupied_bbox(
-        &islands.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+        &islands
+            .iter()
+            .map(|island| island.block.clone())
+            .collect::<Vec<_>>(),
     );
     let mut placed_islands = islands.clone();
     for _ in 0..8 {
@@ -1866,17 +2863,22 @@ fn rfc057_strip_empty_columns_mil5ore() {
         placed_islands = compact_island_axis(&placed_islands, CompactAxis::Y, 1);
     }
     let placed_island_bbox = occupied_bbox(
-        &placed_islands.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+        &placed_islands
+            .iter()
+            .map(|island| island.block.clone())
+            .collect::<Vec<_>>(),
     );
     println!(
         "rigid-island bbox: {}x{} -> {}x{}",
-        source_island_bbox.0, source_island_bbox.1,
-        placed_island_bbox.0, placed_island_bbox.1,
+        source_island_bbox.0, source_island_bbox.1, placed_island_bbox.0, placed_island_bbox.1,
     );
     for net in nets.iter().take(12) {
         println!(
             "  net {}: segments={} entities={} terminals={}",
-            net.item, net.segments.len(), net.entity_indices.len(), net.terminals.len(),
+            net.item,
+            net.segments.len(),
+            net.entity_indices.len(),
+            net.terminals.len(),
         );
     }
 }
@@ -1896,9 +2898,15 @@ fn export_rfc057_compacted_candidates() {
         let inputs: FxHashSet<String> =
             fixture.inputs.iter().map(|item| item.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            fixture.target, fixture.rate, &inputs, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            fixture.target,
+            fixture.rate,
+            &inputs,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         let control = fixture.compose_layout();
         let compacted = compact_validated_geometry(&control, &sr);
         for (variant, layout) in [("control", &control), ("compact", &compacted)] {
@@ -1909,12 +2917,17 @@ fn export_rfc057_compacted_candidates() {
             std::fs::write(
                 format!("target/tmp/{label}.manifest.json"),
                 serde_json::to_string_pretty(&manifest).unwrap(),
-            ).unwrap();
+            )
+            .unwrap();
         }
         println!(
             "{fixture_label}: {}x{} / {} entities -> {}x{} / {} entities",
-            control.width, control.height, control.entities.len(),
-            compacted.width, compacted.height, compacted.entities.len(),
+            control.width,
+            control.height,
+            control.entities.len(),
+            compacted.width,
+            compacted.height,
+            compacted.entities.len(),
         );
     }
 }
@@ -1923,62 +2936,114 @@ fn export_rfc057_compacted_candidates() {
 #[test]
 #[ignore = "artifact producer"]
 fn export_mega_pu_for_sim() {
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "processing-unit", 4.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "processing-unit",
+        4.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let l = SimFixture::find("mega-chain-pu4raw").compose_layout();
-    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-pu4raw");
+    let (bp, manifest) =
+        spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-pu4raw");
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/mega-chain-pu4raw.bp", &bp).unwrap();
-    std::fs::write("target/tmp/mega-chain-pu4raw.manifest.json",
-        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-    println!("wrote mega-chain-pu4raw.bp ({} in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
+    std::fs::write(
+        "target/tmp/mega-chain-pu4raw.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+    println!(
+        "wrote mega-chain-pu4raw.bp ({} in / {} out)",
+        l.boundary_inputs.len(),
+        l.boundary_outputs.len()
+    );
 }
 
 /// Artifact producer for the kill-2 sim run.
 #[test]
 #[ignore = "artifact producer"]
 fn export_mega_chem_for_sim() {
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal",
-         "iron-plate", "copper-plate", "steel-plate"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = [
+        "iron-ore",
+        "copper-ore",
+        "crude-oil",
+        "water",
+        "coal",
+        "iron-plate",
+        "copper-plate",
+        "steel-plate",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "chemical-science-pack", 5.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "chemical-science-pack",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let l = SimFixture::find("mega-chain-chem5raw").compose_layout();
-    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-chem5raw");
+    let (bp, manifest) =
+        spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-chem5raw");
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/mega-chain-chem5raw.bp", &bp).unwrap();
-    std::fs::write("target/tmp/mega-chain-chem5raw.manifest.json",
-        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-    println!("wrote mega-chain-chem5raw.bp ({} in / {} out)", l.boundary_inputs.len(), l.boundary_outputs.len());
+    std::fs::write(
+        "target/tmp/mega-chain-chem5raw.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+    println!(
+        "wrote mega-chain-chem5raw.bp ({} in / {} out)",
+        l.boundary_inputs.len(),
+        l.boundary_outputs.len()
+    );
 }
 
 /// Artifact producer for the Phase-B flagship sim run.
 #[test]
 #[ignore = "artifact producer"]
 fn export_mega_chain_for_sim() {
-    let inputs: FxHashSet<String> =
-        ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
-            .iter().map(|s| s.to_string()).collect();
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "crude-oil", "water", "coal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let sr = solver::solve_with_palette_exclusions_and_quality(
-        "advanced-circuit", 2.0, &inputs, &MachinePalette::default(),
-        "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-    ).unwrap();
+        "advanced-circuit",
+        2.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
     let l = SimFixture::find("mega-chain-ac2raw").compose_layout();
-    let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-ac2raw");
+    let (bp, manifest) =
+        spaghettio_core::blueprint::export_with_manifest(&l, &sr, "mega-chain-ac2raw");
     std::fs::create_dir_all("target/tmp").unwrap();
     std::fs::write("target/tmp/mega-chain-ac2raw.bp", &bp).unwrap();
-    std::fs::write("target/tmp/mega-chain-ac2raw.manifest.json",
-        serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
-    println!("wrote target/tmp/mega-chain-ac2raw.bp ({} in / {} out)",
-        l.boundary_inputs.len(), l.boundary_outputs.len());
+    std::fs::write(
+        "target/tmp/mega-chain-ac2raw.manifest.json",
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+    println!(
+        "wrote target/tmp/mega-chain-ac2raw.bp ({} in / {} out)",
+        l.boundary_inputs.len(),
+        l.boundary_outputs.len()
+    );
 }
 
 #[test]
@@ -1987,8 +3052,18 @@ fn probe_mega_cells() {
     use spaghettio_core::bus::cells::mega::compose_mega_calibrated;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
     for (label, item, rate, inputs) in [
-        ("plastic2", "plastic-bar", 2.0, &["crude-oil", "water", "coal"][..]),
-        ("plastic5", "plastic-bar", 5.0, &["crude-oil", "water", "coal"][..]),
+        (
+            "plastic2",
+            "plastic-bar",
+            2.0,
+            &["crude-oil", "water", "coal"][..],
+        ),
+        (
+            "plastic5",
+            "plastic-bar",
+            5.0,
+            &["crude-oil", "water", "coal"][..],
+        ),
         ("sulfur2", "sulfur", 2.0, &["crude-oil", "water"][..]),
     ] {
         match compose_mega_calibrated(item, rate, inputs) {
@@ -1997,12 +3072,26 @@ fn probe_mega_cells() {
                 match d {
                     Ok(is) => {
                         let e = is.iter().filter(|i| i.severity == Severity::Error).count();
-                        println!("{label}: {}x{} {} entities, {} errors / {} warnings; feeds {:?}",
-                            l.width, l.height, l.entities.len(), e, is.len() - e,
-                            l.boundary_inputs.iter().map(|b| (b.item.clone(), b.x)).collect::<Vec<_>>());
-                        for i in is.iter().take(8) { println!("   [{:?}] {} {}", i.severity, i.category, i.message); }
+                        println!(
+                            "{label}: {}x{} {} entities, {} errors / {} warnings; feeds {:?}",
+                            l.width,
+                            l.height,
+                            l.entities.len(),
+                            e,
+                            is.len() - e,
+                            l.boundary_inputs
+                                .iter()
+                                .map(|b| (b.item.clone(), b.x))
+                                .collect::<Vec<_>>()
+                        );
+                        for i in is.iter().take(8) {
+                            println!("   [{:?}] {} {}", i.severity, i.category, i.message);
+                        }
                     }
-                    Err(er) => println!("{label}: validate ERR {}", format!("{er}").lines().next().unwrap_or("")),
+                    Err(er) => println!(
+                        "{label}: validate ERR {}",
+                        format!("{er}").lines().next().unwrap_or("")
+                    ),
                 }
             }
             Err(e) => println!("{label}: REFUSED {e}"),
@@ -2016,25 +3105,330 @@ fn probe_mil5_errors() {
     use spaghettio_core::bus::cells::chain::compose_chain;
     use spaghettio_core::validate::{self, LayoutStyle};
     for (label, item, rate, inputs) in [
-        ("mil5-ore", "military-science-pack", 5.0, &["iron-ore", "copper-ore", "stone", "coal"][..]),
-        ("ec30", "electronic-circuit", 30.0, &["iron-plate", "copper-plate"][..]),
+        (
+            "mil5-ore",
+            "military-science-pack",
+            5.0,
+            &["iron-ore", "copper-ore", "stone", "coal"][..],
+        ),
+        (
+            "ec30",
+            "electronic-circuit",
+            30.0,
+            &["iron-plate", "copper-plate"][..],
+        ),
     ] {
         let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve_with_palette_exclusions_and_quality(
-            item, rate, &inputs_set, &MachinePalette::default(),
-            "assembling-machine-3", &FxHashSet::default(), QualityTier::Normal,
-        ).unwrap();
+            item,
+            rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
         println!("== {label}: {} specs ==", sr.machines.len());
         match compose_chain(&sr) {
             Ok(l) => match validate::validate(&l, Some(&sr), LayoutStyle::Bus) {
                 Ok(_) => println!("   validates OK"),
                 Err(er) => {
-                    for line in format!("{er}").lines().filter(|l| l.contains("error")).take(8) {
+                    for line in format!("{er}")
+                        .lines()
+                        .filter(|l| l.contains("error"))
+                        .take(8)
+                    {
                         println!("   {line}");
                     }
                 }
             },
             Err(e) => println!("   REFUSED: {e}"),
         }
+    }
+}
+
+/// Fold search: try different numbers of folds and positions on the
+/// compacted mil5-ore layout, validate each, report the squarest valid.
+#[test]
+#[ignore = "exploration probe — fold search"]
+fn probe_fold_search_mil5() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, fold_snake};
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+
+    let inputs: FxHashSet<String> = ["iron-ore", "copper-ore", "stone", "coal"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "military-science-pack",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+
+    let bus = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
+        .expect("mil5-ore must compose");
+    let compact = compact_validated_geometry(&bus, &sr);
+    println!(
+        "compact baseline: {}x{} = {} tiles, {} entities",
+        compact.width,
+        compact.height,
+        compact.width * compact.height,
+        compact.entities.len(),
+    );
+    // Diag: show South-facing belts near x=274
+    for e in compact.entities.iter() {
+        if e.x == 274 && e.direction == spaghettio_core::models::EntityDirection::South {
+            println!("  DIAG: South belt at (274,{}) name={}", e.y, e.name);
+        }
+    }
+    // Show max y
+    let max_y = compact.entities.iter().map(|e| e.y).max().unwrap_or(0);
+    println!("  DIAG: max_y={max_y} height={}", compact.height);
+    // Check what's at (274, 32) in the original — should be nothing
+    let at_274_32: Vec<_> = compact
+        .entities
+        .iter()
+        .filter(|e| e.x == 274 && e.y == 32)
+        .collect();
+    println!("  DIAG: entities at (274,32): {}", at_274_32.len());
+    // Validate the compact baseline
+    let base_issues = validate::validate(&compact, Some(&sr), LayoutStyle::Bus).unwrap();
+    let base_errors = base_issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .count();
+    println!("  DIAG: compact baseline errors={base_errors}");
+
+    // DIAG: check what's at (158,8) in original compact
+    for e in compact.entities.iter() {
+        if e.x == 158 && e.y == 8 {
+            println!(
+                "  DIAG: orig(158,8): name={} dir={:?} io={:?}",
+                e.name, e.direction, e.io_type
+            );
+        }
+    }
+
+    // DIAG: check UG belts at x=139 (fold boundary for f=140)
+    for e in compact.entities.iter() {
+        if e.x == 139 && e.y == 15 && spaghettio_core::common::is_ug_belt(&e.name) {
+            println!(
+                "  DIAG: UG at (139,15): name={} dir={:?} io={:?}",
+                e.name, e.direction, e.io_type
+            );
+        }
+    }
+    // Check what's at x=140..143, y=15 (search range for express)
+    for x in 140..=148 {
+        for e in compact.entities.iter() {
+            if e.x == x && e.y == 15 && spaghettio_core::common::is_ug_belt(&e.name) {
+                println!(
+                    "  DIAG: UG at ({x},15): name={} dir={:?} io={:?}",
+                    e.name, e.direction, e.io_type
+                );
+            }
+        }
+    }
+
+    let w = compact.width;
+    let mut best: Option<(i32, i32, usize, Vec<i32>)> = None;
+
+    // First: exhaustive 1-fold search to find all valid fold positions.
+    println!("\n--- Exhaustive 1-fold search ---");
+    for f in 1..w {
+        let folds = vec![f];
+        let Some(folded) = fold_snake(&compact, &folds) else {
+            continue;
+        };
+        let issues = match validate::validate(&folded, Some(&sr), LayoutStyle::Bus) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let errors = issues
+            .iter()
+            .filter(|i| i.severity == Severity::Error)
+            .count();
+        if errors == 0 {
+            let area = folded.width * folded.height;
+            let aspect = if folded.height > folded.width {
+                folded.height as f64 / folded.width as f64
+            } else {
+                folded.width as f64 / folded.height as f64
+            };
+            println!(
+                "  f={f}: {}x{} = {} tiles, {} entities, aspect={:.2}",
+                folded.width,
+                folded.height,
+                area,
+                folded.entities.len(),
+                aspect,
+            );
+            let best_aspect = best
+                .as_ref()
+                .map(|b| {
+                    if b.1 > b.0 {
+                        b.1 as f64 / b.0 as f64
+                    } else {
+                        b.0 as f64 / b.1 as f64
+                    }
+                })
+                .unwrap_or(f64::MAX);
+            if aspect < best_aspect {
+                best = Some((
+                    folded.width,
+                    folded.height,
+                    folded.entities.len(),
+                    folds.clone(),
+                ));
+            }
+        }
+    }
+
+    for n_folds in 2..=4u32 {
+        let ideal: Vec<i32> = (1..=n_folds)
+            .map(|i| w * i as i32 / (n_folds + 1) as i32)
+            .collect();
+        println!("\n--- {n_folds} folds: ideal positions {ideal:?} ---");
+
+        let max_tries = 1000u32;
+        let mut tried = 0u32;
+
+        // Try fold positions near the ideal, plus all valid columns.
+        let mut candidates: Vec<Vec<i32>> = Vec::new();
+        // Single-delta search around ideal.
+        for delta in -30..=30 {
+            let folds: Vec<i32> = ideal.iter().map(|&p| p + delta).collect();
+            let valid =
+                folds.iter().all(|&f| f > 0 && f < w) && folds.windows(2).all(|w| w[1] > w[0]);
+            if valid {
+                candidates.push(folds);
+            }
+        }
+
+        // Filter to pairs with reasonable segment widths (≥50 tiles each).
+        let reasonable: Vec<Vec<i32>> = candidates
+            .into_iter()
+            .filter(|folds| {
+                let mut bounds = vec![0];
+                bounds.extend(folds);
+                bounds.push(w);
+                bounds.windows(2).all(|b| b[1] - b[0] >= 30)
+            })
+            .collect();
+        println!(
+            "  {n_folds}-fold: {} reasonable candidates",
+            reasonable.len()
+        );
+        for folds in &reasonable {
+            tried += 1;
+            if tried > max_tries {
+                break;
+            }
+            let Some(folded) = fold_snake(&compact, folds) else {
+                if tried <= 10 {
+                    println!("  folds={folds:?}: fold_snake None (multi-tile entity cut?)");
+                }
+                continue;
+            };
+            let issues = match validate::validate(&folded, Some(&sr), LayoutStyle::Bus) {
+                Ok(v) => v,
+                Err(e) => {
+                    if tried <= 10 {
+                        let msg = format!("{e}");
+                        let first = msg.lines().next().unwrap_or("");
+                        println!("  folds={folds:?}: validate Err: {first}");
+                        for line in msg.lines().skip(1).take(15) {
+                            println!("    {line}");
+                        }
+                    }
+                    if folds == &vec![158_i32, 341] {
+                        for e in folded.entities.iter().filter(|e| e.x == 158 && e.y == 8) {
+                            println!(
+                                "    DIAG(158,8): name={} dir={:?} io={:?}",
+                                e.name, e.direction, e.io_type
+                            );
+                        }
+                        for e in folded.entities.iter().filter(|e| e.x == 157 && e.y == 8) {
+                            println!("    DIAG(157,8): name={} dir={:?}", e.name, e.direction);
+                        }
+                    }
+                    continue;
+                }
+            };
+            let errors = issues
+                .iter()
+                .filter(|i| i.severity == Severity::Error)
+                .count();
+            let area = folded.width * folded.height;
+            let aspect = if folded.height > folded.width {
+                folded.height as f64 / folded.width as f64
+            } else {
+                folded.width as f64 / folded.height as f64
+            };
+
+            if errors == 0 {
+                let tag = if aspect < 1.5 { " SQUARE" } else { "" };
+                println!(
+                    "  folds={folds:?}: {}x{} = {} tiles, {} entities, aspect={:.2}{tag}",
+                    folded.width,
+                    folded.height,
+                    area,
+                    folded.entities.len(),
+                    aspect,
+                );
+                let best_aspect = best
+                    .as_ref()
+                    .map(|b| {
+                        if b.1 > b.0 {
+                            b.1 as f64 / b.0 as f64
+                        } else {
+                            b.0 as f64 / b.1 as f64
+                        }
+                    })
+                    .unwrap_or(f64::MAX);
+                let best_area = best
+                    .as_ref()
+                    .map(|b| (b.0 * b.1) as i64)
+                    .unwrap_or(i64::MAX);
+                let better = best.is_none()
+                    || aspect < best_aspect
+                    || (aspect < 1.5 && (area as i64) < best_area);
+                if better {
+                    best = Some((
+                        folded.width,
+                        folded.height,
+                        folded.entities.len(),
+                        folds.clone(),
+                    ));
+                }
+            } else if tried <= 3 || folds == &vec![158_i32, 341] {
+                for i in issues.iter().take(3) {
+                    println!("    [{:?}] {}", i.severity, i.message);
+                }
+                if folds == &vec![158_i32, 341] {
+                    for e in folded.entities.iter().filter(|e| e.x == 158 && e.y == 8) {
+                        println!("    DIAG(158,8): name={} dir={:?}", e.name, e.direction);
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some((w, h, n, folds)) = best {
+        println!(
+            "\n=== BEST: folds={folds:?} -> {}x{} = {} tiles, {} entities ===",
+            w,
+            h,
+            w * h,
+            n,
+        );
+    } else {
+        println!("\n=== No valid fold found ===");
     }
 }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3520,6 +3520,67 @@ fn export_fold_pair_for_sim() {
     }
 }
 
+/// Does the fold generalise beyond the fixture it was developed on?
+/// Runs the validated search over the whole RFC-057 corpus and reports what
+/// each fixture yields, plus why candidates were refused.
+#[test]
+#[ignore = "exploration probe — fold search across the corpus"]
+fn probe_fold_corpus() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, search_snake_fold};
+    use std::collections::BTreeMap;
+
+    for label in [
+        "chain-mil5ore",
+        "mega-chain-chem5raw",
+        "mega-chain-pu4raw",
+        "mega-chain-usp2raw",
+    ] {
+        let fixture = SimFixture::find(label);
+        let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            fixture.target,
+            fixture.rate,
+            &inputs,
+            &MachinePalette::default(),
+            "assembling-machine-3",
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap();
+        let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
+        let src_aspect = compact.width as f64 / compact.height as f64;
+
+        match search_snake_fold(&compact, &sr, 4) {
+            Some(found) => {
+                let l = &found.layout;
+                let asp = l.width.max(l.height) as f64 / l.width.min(l.height) as f64;
+                println!(
+                    "{label}: {}x{} ({:.1}:1, {} ent) -> folds={:?} {}x{} ({:.2}:1, {} ent)",
+                    compact.width,
+                    compact.height,
+                    src_aspect,
+                    compact.entities.len(),
+                    found.folds,
+                    l.width,
+                    l.height,
+                    asp,
+                    l.entities.len(),
+                );
+                let mut why: BTreeMap<String, usize> = BTreeMap::new();
+                for (_, r) in &found.refusals {
+                    *why.entry(format!("{r:?}").split(' ').next().unwrap().into())
+                        .or_default() += 1;
+                }
+                println!("   refusals: {why:?}");
+            }
+            None => println!(
+                "{label}: {}x{} ({:.1}:1) -> NO function-preserving fold",
+                compact.width, compact.height, src_aspect
+            ),
+        }
+    }
+}
+
 /// What is actually blocking a fold? Fold `chain-mil5ore` at its midpoint
 /// and group every validation issue by category, rather than sampling the
 /// first few as the fold search does.
@@ -3527,7 +3588,7 @@ fn export_fold_pair_for_sim() {
 #[ignore = "exploration probe — fold error breakdown"]
 fn probe_fold_error_breakdown_mil5() {
     use spaghettio_core::bus::compaction::{compact_validated_geometry, fold_snake};
-    use spaghettio_core::validate::{self, LayoutStyle, Severity};
+    use spaghettio_core::validate::{self, LayoutStyle};
     use std::collections::BTreeMap;
 
     let fixture = SimFixture::find("chain-mil5ore");

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1398,9 +1398,11 @@ fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
         blocks_overlap, build_manifold_nets, compact_axis, compact_island_axis,
         extract_rigid_islands, extract_route_nets, machine_blocks, occupied_bbox,
-        CompactAxis, CompactIr, PlacedMachineSignature, ProductionSignature,
-        RouteTerminalKind,
+        strip_empty_columns, undergroundify_straight_belts, CompactAxis, CompactIr,
+        PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
+    use spaghettio_core::common::is_belt_entity;
+    use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
     for label in ["mega-chain-usp2raw", "mega-chain-chem5raw", "mega-chain-pu4raw", "chain-mil5ore"] {
         let fixture = SimFixture::find(label);
@@ -1466,8 +1468,11 @@ fn rfc057_machine_constraint_baseline() {
         let island_after = occupied_bbox(
             &island_compacted.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
         );
-        let ir = CompactIr { islands: islands.clone(), route_nets: nets.clone() };
+        let ir = CompactIr::from_source(&layout, &sr);
+        assert_eq!(ir.islands, islands);
+        assert_eq!(ir.route_nets, nets);
         let manifolds = build_manifold_nets(&ir, &island_compacted).unwrap();
+        let mut non_monotone = Vec::new();
         for manifold in &manifolds {
             assert!(
                 manifold.producers().next().is_some(),
@@ -1479,6 +1484,18 @@ fn rfc057_machine_constraint_baseline() {
                 "{label}: {} manifold has no consumer/output",
                 manifold.item,
             );
+            assert!(manifold.planned_rate > 0, "{label}: {} has no planned rate", manifold.item);
+            let producer_max = manifold.producers()
+                .filter(|terminal| terminal.island_id.is_some())
+                .map(|terminal| terminal.x)
+                .max();
+            let consumer_min = manifold.consumers()
+                .filter(|terminal| terminal.island_id.is_some())
+                .map(|terminal| terminal.x)
+                .min();
+            if producer_max.zip(consumer_min).is_some_and(|(p, c)| p > c) {
+                non_monotone.push(manifold.item.clone());
+            }
         }
         let before = i64::from(island_source.0) * i64::from(island_source.1);
         let after = i64::from(island_after.0) * i64::from(island_after.1);
@@ -1489,6 +1506,41 @@ fn rfc057_machine_constraint_baseline() {
             island_source.0, island_source.1, island_after.0, island_after.1,
             (after as f64 / before as f64 - 1.0) * 100.0,
         );
+        println!("{label}: non-monotone manifolds={non_monotone:?}");
+        println!(
+            "{label}: express manifold lanes total={} max={}",
+            manifolds.iter().map(|manifold| manifold.required_belts(45.0)).sum::<u32>(),
+            manifolds.iter().map(|manifold| manifold.required_belts(45.0)).max().unwrap_or(0),
+        );
+
+        let runnable =
+            strip_empty_columns(&undergroundify_straight_belts(&layout));
+        assert_eq!(
+            PlacedMachineSignature::from_layout(&runnable),
+            placed,
+            "{label}: runnable post-pass changed machines",
+        );
+        let issues = match validate::validate(&runnable, Some(&sr), LayoutStyle::Bus) {
+            Ok(issues) => issues,
+            Err(error) => error.issues,
+        };
+        let errors: Vec<_> = issues
+            .iter()
+            .filter(|issue| issue.severity == Severity::Error)
+            .collect();
+        assert!(errors.is_empty(), "{label}: runnable post-pass errors: {errors:?}");
+        let source_belts = layout.entities.iter()
+            .filter(|entity| is_belt_entity(&entity.name))
+            .count();
+        let compact_belts = runnable.entities.iter()
+            .filter(|entity| is_belt_entity(&entity.name))
+            .count();
+        println!(
+            "{label}: runnable={}x{} -> {}x{}, belts={} -> {} ({:+.1}%)",
+            layout.width, layout.height, runnable.width, runnable.height,
+            source_belts, compact_belts,
+            (compact_belts as f64 / source_belts as f64 - 1.0) * 100.0,
+        );
     }
 }
 
@@ -1497,9 +1549,10 @@ fn rfc057_machine_constraint_baseline() {
 fn rfc057_strip_empty_columns_mil5ore() {
     use spaghettio_core::bus::compaction::{
         compact_island_axis, extract_rigid_islands, extract_route_nets, occupied_bbox,
-        strip_empty_columns, CompactAxis, PlacedMachineSignature, ProductionSignature,
-        RouteTerminalKind,
+        strip_empty_columns, undergroundify_straight_belts, CompactAxis,
+        PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
+    use spaghettio_core::common::is_belt_entity;
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
     let fixture = SimFixture::find("chain-mil5ore");
@@ -1511,6 +1564,8 @@ fn rfc057_strip_empty_columns_mil5ore() {
     ).unwrap();
     let source = fixture.compose_layout();
     let compacted = strip_empty_columns(&source);
+    let underground_compacted =
+        strip_empty_columns(&undergroundify_straight_belts(&source));
     let production = ProductionSignature::from_solver(&sr).unwrap();
     let nets = extract_route_nets(&source);
     let islands = extract_rigid_islands(&source);
@@ -1533,18 +1588,28 @@ fn rfc057_strip_empty_columns_mil5ore() {
         PlacedMachineSignature::from_layout(&source),
         PlacedMachineSignature::from_layout(&compacted),
     );
-    let issues = match validate::validate(&compacted, Some(&sr), LayoutStyle::Bus) {
-        Ok(v) => v,
-        Err(e) => e.issues,
-    };
-    let errors: Vec<_> = issues.iter()
-        .filter(|issue| issue.severity == Severity::Error)
-        .collect();
-    assert!(errors.is_empty(), "stripped candidate errors: {errors:?}");
+    assert_eq!(
+        PlacedMachineSignature::from_layout(&source),
+        PlacedMachineSignature::from_layout(&underground_compacted),
+    );
+    for (label, candidate) in [
+        ("stripped", &compacted),
+        ("underground-compacted", &underground_compacted),
+    ] {
+        let issues = match validate::validate(candidate, Some(&sr), LayoutStyle::Bus) {
+            Ok(v) => v,
+            Err(e) => e.issues,
+        };
+        let errors: Vec<_> = issues.iter()
+            .filter(|issue| issue.severity == Severity::Error)
+            .collect();
+        assert!(errors.is_empty(), "{label} candidate errors: {errors:?}");
+    }
     std::fs::create_dir_all("target/tmp").unwrap();
     for (label, layout) in [
         ("rfc057-mil5ore-control", &source),
         ("rfc057-mil5ore-strip", &compacted),
+        ("rfc057-mil5ore-underground", &underground_compacted),
     ] {
         let (bp, manifest) =
             spaghettio_core::blueprint::export_with_manifest(layout, &sr, label);
@@ -1558,6 +1623,18 @@ fn rfc057_strip_empty_columns_mil5ore() {
         "chain-mil5ore: {}x{} -> {}x{}; entities={}",
         source.width, source.height, compacted.width, compacted.height,
         compacted.entities.len(),
+    );
+    let source_belts = source.entities.iter()
+        .filter(|entity| is_belt_entity(&entity.name))
+        .count();
+    let underground_belts = underground_compacted.entities.iter()
+        .filter(|entity| is_belt_entity(&entity.name))
+        .count();
+    println!(
+        "underground candidate: {}x{} entities={} belts={} ({:+.1}% belts)",
+        underground_compacted.width, underground_compacted.height,
+        underground_compacted.entities.len(), underground_belts,
+        (underground_belts as f64 / source_belts as f64 - 1.0) * 100.0,
     );
     println!("extracted {} replaceable route nets", nets.len());
     println!(

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -9,7 +9,7 @@
 //! orientation) were dropped in the lift; their findings live in the
 //! RFC-048 decision log.
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use spaghettio_core::bus::cells::compose::{compose_pairs_calibrated, compose_plastic_calibrated};
 use spaghettio_core::bus::cells::extract::{extract_cell, generate_cell_layout};
 use spaghettio_core::bus::layout;
@@ -1398,8 +1398,9 @@ fn rfc057_machine_constraint_baseline() {
     use spaghettio_core::bus::compaction::{
         blocks_overlap, build_local_manifold_graph, build_manifold_nets, compact_axis, compact_island_axis,
         compact_transport_geometry, estimated_manifold_wirelength, extract_rigid_islands,
-        extract_route_nets, machine_blocks, occupied_bbox, place_local_manifold_nodes,
-        place_recipe_clusters, plan_local_manifolds, CompactAxis, CompactIr,
+        extract_route_nets, machine_blocks, occupied_bbox,
+        place_distributed_local_manifold_nodes, place_recipe_clusters, plan_local_manifolds,
+        route_local_manifold_edges, CompactAxis, CompactIr,
         PlacedMachineSignature, ProductionSignature, RouteTerminalKind,
     };
     use spaghettio_core::common::is_belt_entity;
@@ -1481,7 +1482,53 @@ fn rfc057_machine_constraint_baseline() {
             .iter()
             .map(build_local_manifold_graph)
             .collect();
-        let placed_hubs = place_local_manifold_nodes(&clustered_islands, &local_graphs, 1);
+        let placed_hubs =
+            place_distributed_local_manifold_nodes(&clustered_islands, &local_graphs, 1)
+                .unwrap();
+        if label == "chain-mil5ore" {
+            let routed =
+                route_local_manifold_edges(&clustered_islands, &local_graphs, &placed_hubs)
+                    .unwrap();
+            let edge_count: usize = local_graphs.iter().map(|graph| graph.edges.len()).sum();
+            assert!(
+                routed.unroutable.is_empty(),
+                "{label}: {} manifold edges could not be routed",
+                routed.unroutable.len(),
+            );
+            assert_eq!(routed.routes.len(), edge_count);
+            assert!(routed.routes.iter().all(|route| route.path.len() >= 2));
+            let mut occupied_axes = FxHashMap::<(i32, i32), u8>::default();
+            let mut same_axis_tiles = 0usize;
+            let mut perpendicular_tiles = 0usize;
+            for route in &routed.routes {
+                let mut route_axes = FxHashMap::<(i32, i32), u8>::default();
+                for pair in route.path.windows(2) {
+                    let axis = if pair[0].0 == pair[1].0 { 1 } else { 2 };
+                    *route_axes.entry(pair[0]).or_default() |= axis;
+                    *route_axes.entry(pair[1]).or_default() |= axis;
+                }
+                for (tile, axis) in route_axes {
+                    if let Some(previous) = occupied_axes.get(&tile) {
+                        if previous & axis != 0 {
+                            same_axis_tiles += 1;
+                        } else {
+                            perpendicular_tiles += 1;
+                        }
+                    }
+                    *occupied_axes.entry(tile).or_default() |= axis;
+                }
+            }
+            println!(
+                "{label}: routed {} manifold edges, {} paths cross prior paths, \
+                 conflicts={same_axis_tiles} same-axis/{perpendicular_tiles} perpendicular tiles",
+                routed.routes.len(),
+                routed
+                    .routes
+                    .iter()
+                    .filter(|route| !route.crossings.is_empty())
+                    .count(),
+            );
+        }
         let mut hub_tiles = FxHashSet::default();
         for hub in &placed_hubs {
             for entity in &hub.entities {

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1504,6 +1504,12 @@ fn rfc057_strip_empty_columns_mil5ore() {
         compacted.entities.len(),
     );
     println!("extracted {} replaceable route nets", nets.len());
+    for net in nets.iter().take(12) {
+        println!(
+            "  net {}: segments={} entities={} terminals={}",
+            net.item, net.segments.len(), net.entity_indices.len(), net.terminals.len(),
+        );
+    }
 }
 
 /// Artifact producer for the increment-2 sim run.

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3887,6 +3887,9 @@ fn probe_fold_error_breakdown_mil5() {
         *base_cat.entry(i.category.clone()).or_default() += 1;
     }
     println!("  unfolded control: {} issues {:?}", base.len(), base_cat);
+    for i in &base {
+        println!("      control: [{}] {}", i.category, i.message);
+    }
 
     println!(
         "legal fold columns: {} of {}",

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3550,7 +3550,13 @@ fn probe_fold_corpus() {
         let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
         let src_aspect = compact.width as f64 / compact.height as f64;
 
-        match search_snake_fold(&compact, &sr, 4) {
+        let search = search_snake_fold(&compact, &sr, 4);
+        let mut why: BTreeMap<String, usize> = BTreeMap::new();
+        for (_, r) in &search.refusals {
+            *why.entry(format!("{r:?}").split(' ').next().unwrap().into())
+                .or_default() += 1;
+        }
+        match &search.best {
             Some(found) => {
                 let l = &found.layout;
                 let asp = l.width.max(l.height) as f64 / l.width.min(l.height) as f64;
@@ -3566,17 +3572,24 @@ fn probe_fold_corpus() {
                     asp,
                     l.entities.len(),
                 );
-                let mut why: BTreeMap<String, usize> = BTreeMap::new();
-                for (_, r) in &found.refusals {
-                    *why.entry(format!("{r:?}").split(' ').next().unwrap().into())
-                        .or_default() += 1;
-                }
-                println!("   refusals: {why:?}");
+                println!(
+                    "   legal columns={}, refusals={why:?}, rejected-by-validation={}",
+                    search.legal_columns, search.rejected_by_validation
+                );
             }
-            None => println!(
-                "{label}: {}x{} ({:.1}:1) -> NO function-preserving fold",
-                compact.width, compact.height, src_aspect
-            ),
+            None => {
+                println!(
+                    "{label}: {}x{} ({:.1}:1) -> NO function-preserving fold",
+                    compact.width, compact.height, src_aspect
+                );
+                println!(
+                    "   legal columns={} of {}, refusals={why:?}, \
+                     rejected-by-validation={}",
+                    search.legal_columns,
+                    compact.width - 1,
+                    search.rejected_by_validation
+                );
+            }
         }
     }
 }
@@ -3661,7 +3674,8 @@ fn probe_fold_error_breakdown_mil5() {
 
     // The validated search: only folds that match the control's issue
     // profile are admitted.
-    match spaghettio_core::bus::compaction::search_snake_fold(&compact, &sr, 5) {
+    let search5 = spaghettio_core::bus::compaction::search_snake_fold(&compact, &sr, 5);
+    match &search5.best {
         Some(found) => {
             let l = &found.layout;
             println!(
@@ -3677,7 +3691,7 @@ fn probe_fold_error_breakdown_mil5() {
                 compact.entities.len(),
             );
             let mut why: BTreeMap<String, usize> = BTreeMap::new();
-            for (_, reason) in &found.refusals {
+            for (_, reason) in &search5.refusals {
                 *why.entry(format!("{reason:?}").split(' ').next().unwrap().to_string())
                     .or_default() += 1;
             }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1442,8 +1442,9 @@ fn rfc057_machine_constraint_baseline() {
 #[ignore = "RFC-057 runnable whitespace-compaction baseline"]
 fn rfc057_strip_empty_columns_mil5ore() {
     use spaghettio_core::bus::compaction::{
-        extract_route_nets, strip_empty_columns, PlacedMachineSignature,
-        ProductionSignature, RouteTerminalKind,
+        compact_island_axis, extract_rigid_islands, extract_route_nets, occupied_bbox,
+        strip_empty_columns, CompactAxis, PlacedMachineSignature, ProductionSignature,
+        RouteTerminalKind,
     };
     use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
@@ -1458,6 +1459,7 @@ fn rfc057_strip_empty_columns_mil5ore() {
     let compacted = strip_empty_columns(&source);
     let production = ProductionSignature::from_solver(&sr).unwrap();
     let nets = extract_route_nets(&source);
+    let islands = extract_rigid_islands(&source);
     for edge in production.edges.iter().filter(|edge| !edge.is_fluid) {
         assert!(nets.iter().any(|net| {
             net.item == edge.item
@@ -1504,6 +1506,29 @@ fn rfc057_strip_empty_columns_mil5ore() {
         compacted.entities.len(),
     );
     println!("extracted {} replaceable route nets", nets.len());
+    println!(
+        "extracted {} rigid production islands: entities={} terminals={} largest={}",
+        islands.len(),
+        islands.iter().map(|island| island.entity_indices.len()).sum::<usize>(),
+        islands.iter().map(|island| island.terminals.len()).sum::<usize>(),
+        islands.iter().map(|island| island.entity_indices.len()).max().unwrap_or(0),
+    );
+    let source_island_bbox = occupied_bbox(
+        &islands.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+    );
+    let mut placed_islands = islands.clone();
+    for _ in 0..8 {
+        placed_islands = compact_island_axis(&placed_islands, CompactAxis::X, 1);
+        placed_islands = compact_island_axis(&placed_islands, CompactAxis::Y, 1);
+    }
+    let placed_island_bbox = occupied_bbox(
+        &placed_islands.iter().map(|island| island.block.clone()).collect::<Vec<_>>()
+    );
+    println!(
+        "rigid-island bbox: {}x{} -> {}x{}",
+        source_island_bbox.0, source_island_bbox.1,
+        placed_island_bbox.0, placed_island_bbox.1,
+    );
     for net in nets.iter().take(12) {
         println!(
             "  net {}: segments={} entities={} terminals={}",

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3550,6 +3550,39 @@ fn probe_fold_error_breakdown_mil5() {
         compact.entities.len()
     );
 
+    {
+        println!("  --- boundaries: source vs folded ---");
+        for b in &compact.boundary_inputs {
+            println!("      IN  src {} ({},{}) dir={:?}", b.item, b.x, b.y, b.direction);
+        }
+        for b in &compact.boundary_outputs {
+            println!("      OUT src {} ({},{}) dir={:?}", b.item, b.x, b.y, b.direction);
+        }
+        if let Ok(f) = spaghettio_core::bus::compaction::fold_snake(&compact, &[compact.width / 2]) {
+            for b in &f.boundary_inputs {
+                println!("      IN  fold {} ({},{}) dir={:?}", b.item, b.x, b.y, b.direction);
+            }
+            for b in &f.boundary_outputs {
+                println!("      OUT fold {} ({},{}) dir={:?}", b.item, b.x, b.y, b.direction);
+            }
+        } else {
+            println!("      (fold currently refused; boundaries unavailable)");
+        }
+        println!("  --- source around (489,8) ---");
+        let mut near: Vec<_> = compact
+            .entities
+            .iter()
+            .filter(|e| (e.x - 489).abs() <= 5 && (e.y - 8).abs() <= 2)
+            .collect();
+        near.sort_by_key(|e| (e.y, e.x));
+        for e in near {
+            println!(
+                "      ({},{}) {} dir={:?} io={:?} carries={:?}",
+                e.x, e.y, e.name, e.direction, e.io_type, e.carries
+            );
+        }
+    }
+
     // Control: whatever the compacted source already warns about is not
     // something folding introduced.
     let base = validate::validate(&compact, Some(&sr), LayoutStyle::Bus).unwrap();

--- a/crates/core/tests/solver_netflow_parity.rs
+++ b/crates/core/tests/solver_netflow_parity.rs
@@ -467,9 +467,9 @@ fn golden_rocket_fuel_free_mode_zero_surplus() {
 }
 
 /// Regression for #476: lubricant forces advanced oil processing into the
-/// utility-science chain. Its unavoidable petroleum-gas co-product must
-/// displace basic oil processing rather than stack on top of it as an
-/// unroutable surplus that blocks the advanced refineries in-game.
+/// utility-science chain. Its co-products must displace basic oil
+/// processing and be fully consumed by ordinary recipes; vanilla Factorio
+/// has no ordinary fluid void.
 #[test]
 fn utility_science_credits_advanced_oil_petroleum_before_basic_oil() {
     let inputs = set(&["iron-ore", "copper-ore", "crude-oil", "water", "coal", "stone"]);
@@ -493,14 +493,13 @@ fn utility_science_credits_advanced_oil_petroleum_before_basic_oil() {
         "advanced oil's petroleum must displace basic oil; got {recipes:?}"
     );
     assert!(
-        r.surplus_outputs.iter().all(|f| f.item != "petroleum-gas"),
-        "petroleum gas must be consumed, not stranded: {:?}",
+        r.surplus_outputs.iter().all(|f| !f.is_fluid),
+        "all fluid co-products must be consumed, not stranded: {:?}",
         r.surplus_outputs
     );
     assert!(
-        r.surplus_outputs.iter().any(|f| f.item == "heavy-oil" && f.is_fluid),
-        "advanced-only plan must expose unavoidable heavy-oil surplus for physical routing: {:?}",
-        r.surplus_outputs
+        recipes.contains(&"heavy-oil-cracking"),
+        "heavy-oil excess must be consumed by a real recipe; got {recipes:?}"
     );
 }
 

--- a/crates/meter/examples/measure.rs
+++ b/crates/meter/examples/measure.rs
@@ -16,11 +16,20 @@ use std::time::Instant;
 
 use spaghettio_meter::{Factory, Manifest};
 
-const WARMUP: u64 = 60 * 60 * 2; // 2 game-minutes
-const WINDOW: u64 = 60 * 60 * 3; // 3 game-minutes
+const DEFAULT_WARMUP: u64 = 60 * 60 * 2; // 2 game-minutes
+const DEFAULT_WINDOW: u64 = 60 * 60 * 3; // 3 game-minutes
 
 fn main() {
-    let want = std::env::args().nth(1);
+    let args: Vec<String> = std::env::args().collect();
+    let want = args.get(1).cloned();
+    let warmup = args
+        .get(2)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_WARMUP);
+    let window = args
+        .get(3)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_WINDOW);
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../core/target/tmp");
     let Ok(entries) = std::fs::read_dir(&dir) else {
         eprintln!("no fixtures at {dir:?} — generate them first (see module docs)");
@@ -59,7 +68,7 @@ fn main() {
             }
         };
         let entities = f.net.len() + f.machines.len() + f.inserters.len();
-        let report = f.measure(WARMUP, WINDOW);
+        let report = f.measure(warmup, window);
         let wall = started.elapsed();
 
         println!(
@@ -68,7 +77,7 @@ fn main() {
             f.machines.len(),
             f.inserters.len(),
             wall.as_secs_f64(),
-            WARMUP + WINDOW
+            warmup + window
         );
         let _ = entities;
 
@@ -87,7 +96,10 @@ fn main() {
             .collect();
         rows.sort_by(|a, b| a.3.partial_cmp(&b.3).unwrap_or(std::cmp::Ordering::Equal));
 
-        println!("  {:<26} {:>9} {:>9} {:>8}", "item", "planned/s", "meter/s", "d%");
+        println!(
+            "  {:<26} {:>9} {:>9} {:>8}",
+            "item", "planned/s", "meter/s", "d%"
+        );
         for (item, planned, got, delta) in &rows {
             println!("  {item:<26} {planned:>9.2} {got:>9.2} {delta:>7.1}%");
         }

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -106,6 +106,11 @@ fn layout_options(
             Some("off") => spaghettio_core::bus::cells::CellComposition::Off,
             _ => spaghettio_core::bus::cells::CellComposition::Candidate,
         },
+        // RFC-057 post-layout compaction: experimental, and deliberately not
+        // reachable from the web surface yet. It is an opt-in post-pass over
+        // an already-validated layout, so exposing it is a UI decision, not a
+        // fallback-semantics one — hard-false until that decision is made.
+        compact_layout: false,
         // No `..Default::default()`: adding `direct_insertion` completed
         // the field list, and a no-op struct update is a clippy error
         // under the workspace's `-D warnings`. A field added to

--- a/docs/rfc-055-compact-cell-chain.md
+++ b/docs/rfc-055-compact-cell-chain.md
@@ -276,3 +276,12 @@ and search budget.
   says they share one order for deterministic identical copies.
 - Which cell transforms are valuable enough to cache eagerly?
 
+## Decision log
+
+- **2026-07-26 — Phase 1 foundation implemented.** Added the shared
+  geometry-independent placement graph and candidate metrics in
+  `bus::cells::placement`. Consumer edges are weighted by total planned
+  demand, linear candidates report rate-weighted distance, maximum distance,
+  backward rate, weighted cuts, and estimated footprint, and the first
+  deterministic competitor performs best-improving adjacent swaps to a local
+  optimum. Tile routing remains unchanged.

--- a/docs/rfc-055-compact-cell-chain.md
+++ b/docs/rfc-055-compact-cell-chain.md
@@ -1,6 +1,6 @@
 # RFC-055: Compact cell chains — flow-weighted ordering and validated orientation
 
-Status: Design  
+Status: Experiment complete — selected over RFC-056
 Tracking: #456  
 Competes with: RFC-056
 
@@ -257,6 +257,46 @@ RFC-056 reuses:
 RFC-055 ships independently if it clears its gates. RFC-056 is accepted only
 if folding materially outperforms RFC-055 after controlling for orientation
 and search budget.
+
+## Decision — 2026-07-26
+
+The bounded linear-order experiment is the winner of the RFC-055/RFC-056
+comparison. This is an architecture selection, not production enablement:
+the implementation remains on the local speculative branch and the current
+composer remains the default.
+
+The experiment added deterministic best-improving relocation plus adjacent
+swap search and made the existing chain router order-independent for
+westbound fan branches and compact adjacent fan-outs. Complete routed compact
+layouts validate at zero errors across the four acceptance fixtures.
+
+All figures below use real extracted-cell dimensions. Belt counts include
+transport belts, underground belts, and splitters; corridor counts include
+entities whose segment is a chain corridor.
+
+| Fixture | weighted distance | critical path | belts | corridor entities |
+|---|---:|---:|---:|---:|
+| `usp2raw` | 46,461 → 30,908 (−33.5%) | 3,254 → 2,233 (−31.4%) | 43,041 → 46,704 (+8.5%) | 37,383 → 41,478 (+11.0%) |
+| `chem5raw` | 24,950 → 20,875 (−16.3%) | 589 → 513 (−12.9%) | 9,744 → 8,720 (−10.5%) | 6,420 → 5,296 (−17.5%) |
+| `pu4raw` | 57,293 → 34,598 (−39.6%) | 3,000 → 422 (−85.9%) | 22,824 → 20,512 (−10.1%) | 16,320 → 14,176 (−13.1%) |
+| `mil5ore` | 4,728 → 3,175 (−32.8%) | 261 → 243 (−6.9%) | 3,642 → 3,012 (−17.3%) | 2,442 → 1,748 (−28.4%) |
+
+The primary USP weighted-distance gate and its alternate critical-path gate
+both clear. Three of four fixtures also use fewer belts; USP is the exception,
+because supporting its many westbound edges requires more bypass rows. This
+is why the result selects the linear architecture but does not yet justify
+making it the production default.
+
+A long-warmup Factorio control run for `chem5raw` delivered 4.03/s against
+5.0/s planned and remained non-converged (4.03–4.47/s recent windows). The
+matching compact run was stopped at the user's request, along with further
+Factorio testing. Consequently the Factorio and time-to-90% acceptance gates
+are explicitly **not adjudicated** here; production promotion requires a
+separate implementation/verification phase.
+
+Validated rotated cell variants were not needed by the winning candidate and
+remain future search-space expansion. No unchecked entity rotation was
+introduced.
 
 ## Phases
 

--- a/docs/rfc-056-folded-cell-chain.md
+++ b/docs/rfc-056-folded-cell-chain.md
@@ -242,3 +242,11 @@ Evidence against escalation:
   routing across rows? Duplication is out of scope here but should be measured.
 - Should K replicas be tiled in a grid after each replica is folded?
 
+## Decision log
+
+- **2026-07-26 — Phase 1 foundation implemented.** The shared placement
+  model can score contiguous multi-row layouts using Manhattan macro-centre
+  distance and explicit weighted inter-row cuts. The first RFC-056 competitor
+  evaluates every non-empty two-row split of a fixed order and compares
+  serpentine with same-direction rows deterministically. It is a fold
+  simulator only; no folded tile geometry is emitted yet.

--- a/docs/rfc-056-folded-cell-chain.md
+++ b/docs/rfc-056-folded-cell-chain.md
@@ -1,6 +1,6 @@
 # RFC-056: Folded cell chains — cut-aware multi-row macro placement
 
-Status: Design  
+Status: Experiment complete — rejected in favour of RFC-055
 Tracking: #456  
 Competes with: RFC-055
 
@@ -250,3 +250,26 @@ Evidence against escalation:
   evaluates every non-empty two-row split of a fixed order and compares
   serpentine with same-direction rows deterministically. It is a fold
   simulator only; no folded tile geometry is emitted yet.
+- **2026-07-26 — Rejected at the admission gate.** Using the winning
+  RFC-055 order and real extracted-cell dimensions, the exact two-row search
+  evaluated every non-empty cut in both same-direction and serpentine modes.
+  Results relative to RFC-055 were:
+
+  | Fixture | RFC-055 weighted distance | best two-row | delta | critical-path delta |
+  |---|---:|---:|---:|---:|
+  | `usp2raw` | 30,908 | 30,060 | −2.7% | +51.0% |
+  | `chem5raw` | 20,875 | 17,625 | −15.6% | −40.4% |
+  | `pu4raw` | 34,598 | 38,434 | +11.1% | +78.7% |
+  | `mil5ore` | 3,175 | 3,156 | −0.6% | −22.6% |
+
+  Only chemistry clears the material-improvement threshold. USP gains almost
+  nothing in the primary metric while its critical path becomes much longer,
+  and processing units regress in both metrics. Optimizing cuts solely for
+  critical path does not produce a second qualifying deep fixture.
+
+  RFC-056 therefore does not earn the physical-composer phases. Implementing
+  row trunks, rotated variants, and multi-row power corridors would add
+  architecture and routing complexity without satisfying the RFC's own
+  prerequisite evidence. RFC-055 is selected; general 2D placement remains a
+  possible later RFC if a different constraint model provides stronger
+  evidence.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -587,3 +587,32 @@ make either experimental composer a production default.
   estimates of 20,269 tiles for military science and 146,773 for USP because
   every inserter was dragged to a distant global band. The active router uses
   local, flow-sized manifolds interleaved with their production clusters.
+
+- **2026-07-26 — Axis-symmetric transport fixed point.** The runnable
+  compactor now undergrounds both horizontal and vertical straight runs,
+  strips empty rows as well as columns, and repeats to a fixed point. The
+  expanded candidates retain exact machine signatures, have no underground
+  pairing warnings and validate cleanly:
+
+  | Fixture | belt delta | occupied-tile delta |
+  |---|---:|---:|
+  | `mega-chain-usp2raw` | −63.8% | −54.0% |
+  | `mega-chain-chem5raw` | −36.8% | −20.5% |
+  | `mega-chain-pu4raw` | −55.7% | −38.8% |
+  | `chain-mil5ore` | −41.2% | −27.0% |
+
+  This clears the 35% belt gate on chemistry and processing units. USP also
+  clears the 40% occupied-tile gate; PU is close. Chemistry and military
+  science demonstrate why route-entity reduction alone is not completion:
+  immutable machines/inserters dominate their remaining filled tiles, and
+  local island placement must remove more interfaces.
+
+  The updated military candidate meters at 2.13/s produced and 1.91/s
+  delivered versus the control's 1.73/s and 1.28/s. Processing units improve
+  electronic circuits from 64.27/s to 91.20/s at the standard window.
+  Chemistry's standard-window cable rate falls from 38.29/s to 27.64/s, but
+  neither artifact has a meaningful long-window chemistry result: without
+  fluid-boundary simulation both eventually fill downstream buffers and
+  report zero cable/EC production. This is a meter capability boundary, not
+  evidence of a steady-state loss; chemistry requires Factorio adjudication
+  once the candidate is otherwise final.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -653,3 +653,13 @@ make either experimental composer a production default.
   A focused end-to-end test proves the default path is inert, the option
   preserves the exact placed-machine signature, never increases either
   dimension and returns a fully valid layout.
+
+- **2026-07-26 — Debug-segment identity removed from seam constraints.**
+  Coordinate cuts may now coalesce surface belts when item, tier and
+  direction agree even if the incumbent `segment_id` differs. Segment IDs
+  describe row/corridor provenance, not independent production topology; the
+  earlier equality guard unnecessarily preserved those interfaces. On
+  military science this topology-free seam move reduces the final candidate
+  from 568×32 / 2,078 meter belt tiles to 552×32 / 2,024, while improving
+  delivered science from 1.90/s to 1.93/s. Full validation remains the
+  transactional admission gate.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -722,3 +722,27 @@ make either experimental composer a production default.
 
   Terminal and inter-node graph edges are still unrouted; therefore these
   stamps are not exported as factory candidates yet.
+
+- **2026-07-26 — First negotiated manifold routing pass.** Every typed graph
+  edge can now be A*-routed around rigid islands and exact stamped hub
+  footprints; endpoints are resolved from terminal, balancer-port and
+  capacity-lane identities rather than inferred coordinates. Provisional
+  paths remain separate from entities and explicitly report crossings, so
+  unresolved ghost overlap cannot be exported as a valid factory.
+
+  The military fixture routed all 500 edges after replacing the binary-only
+  hierarchy with bounded direct `(n,1)` / `(1,m)` primitives. A fan-four
+  bound was materially better than either extreme: it reduced the military
+  hub from 1,404 to 1,059 entities, while fan ten grew it to 2,928 entities
+  because the throughput-unlimited 1→10 template is internally expensive.
+  Distributed placement now puts merger/distributor sub-hubs near the
+  terminals they serve and leaves only the capacity lanes at the commodity
+  median.
+
+  This is not yet a runnable candidate. On military science, 485 of 500
+  provisional paths touch an earlier path; the current best placement has
+  9,694 same-axis and 1,510 perpendicular conflicting tile claims.
+  Perpendicular crossings can be legalised with underground pairs, but
+  same-axis overlaps require negotiated rerouting or shared-segment graph
+  rewriting. The result rejects direct materialisation and makes crossing
+  legality the next admission gate.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -1,6 +1,6 @@
 # RFC-057: Topology-preserving dense factory repacking
 
-Registry: [`rfcs.md`](rfcs.md). Status: **Design**.
+Registry: [`rfcs.md`](rfcs.md). Status: **Active prototype**.
 
 ## Summary
 
@@ -616,3 +616,31 @@ make either experimental composer a production default.
   report zero cable/EC production. This is a meter capability boundary, not
   evidence of a steady-state loss; chemistry requires Factorio adjudication
   once the candidate is otherwise final.
+
+- **2026-07-26 — Transactional X/Y coordinate compaction implemented.**
+  After transport resynthesis, the compactor now attempts occupied coordinate
+  cuts on both axes. A cut shifts the entire downstream half-plane, coalesces
+  only physically equivalent seam belts, refuses multi-tile footprint
+  collisions, recomputes the authoritative copper-wire graph and commits only
+  if full layout validation remains error-free. X and Y alternate to a fixed
+  point.
+
+  Final validated geometry on the representative artifacts is:
+
+  | Fixture | source | compacted | entity count |
+  |---|---:|---:|---:|
+  | `mega-chain-usp2raw` | 2214×193 | 1966×192 | 47,875 → 19,443 |
+  | `mega-chain-chem5raw` | 834×56 | 710×55 | 5,707 → 4,078 |
+  | `mega-chain-pu4raw` | 2704×90 | 2397×87 | 27,634 → 14,530 |
+  | `chain-mil5ore` | 720×34 | 568×32 | 4,550 → 2,846 |
+
+  Military science remains meter-stable after the extra coordinate cuts:
+  2.16/s produced and 1.90/s delivered versus 2.13/s and 1.91/s for the
+  transport-only incumbent, with 2,078 meter belt tiles versus 3,754 in the
+  control. The cut search therefore adds real footprint reduction without
+  undoing the transport gain.
+
+  This lands the deterministic, explainable #456 baseline as a working
+  compaction system. It does not yet implement topology-free local manifolds,
+  rotations or annealed island reordering; those remain the higher-risk
+  competitors for the occupied-tile gate.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -683,3 +683,17 @@ make either experimental composer a production default.
   rows with compact 2D production geometry while also shortening the
   rate-weighted commodity spans. The next phase must materialise those spans
   as local flow-sized manifolds and refuse any candidate that cannot route.
+
+- **2026-07-26 — Local manifold capacity and hierarchy planning.** Each
+  commodity now receives the minimum number of express capacity lanes from
+  its exact solver rate (28 total on USP, 14 chemistry, 30 processing units,
+  14 military science). Producer and consumer terminals are distributed
+  evenly across those lanes. Each lane is reduced through a ragged binary
+  `(2,1)` merger tree and expanded through an exact-leaf `(1,2)` distributor
+  tree, avoiding the unavailable giant `(n,1)` / `(1,m)` templates.
+
+  All producer and consumer hierarchies for all four representative fixtures
+  decompose entirely into stampable library primitives. Hubs are placed near
+  their terminal medians and reserve collision-free rectangles against both
+  production islands and previously placed hubs. Rendering must now stamp
+  these nodes and route their explicit inter-stage/terminal edges.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -663,3 +663,23 @@ make either experimental composer a production default.
   from 568×32 / 2,078 meter belt tiles to 552×32 / 2,024, while improving
   delivered science from 1.90/s to 1.93/s. Full validation remains the
   transactional admission gate.
+
+- **2026-07-26 — Topology-free recipe-cluster placement implemented.**
+  Rigid machine/inserter islands are now shelf-packed into recipe banks; the
+  banks are placed in 2D by solver-rate-weighted production adjacency.
+  Incumbent row order, corridor positions and segment provenance do not enter
+  the placement. Every resulting island rectangle is pairwise disjoint and
+  all manifold terminals move with its island.
+
+  | Fixture | recipe clusters | clustered rigid bbox | rate-weighted manifold span delta |
+  |---|---:|---:|---:|
+  | `mega-chain-usp2raw` | 22 | 195×110 | −54.1% |
+  | `mega-chain-chem5raw` | 10 | 109×83 | −40.2% |
+  | `mega-chain-pu4raw` | 10 | 163×173 | −63.9% |
+  | `chain-mil5ore` | 9 | 67×77 | −18.0% |
+
+  These are route-ready placements, not yet emitted factories. The result is
+  especially strong on the deep mixed fixtures: it replaces kilometre-wide
+  rows with compact 2D production geometry while also shortening the
+  rate-weighted commodity spans. The next phase must materialise those spans
+  as local flow-sized manifolds and refuse any candidate that cannot route.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -455,3 +455,31 @@ rearrangement.
 
 RFC-057 supersedes RFC-055/056 as the density research direction. It does not
 make either experimental composer a production default.
+
+## Decision log
+
+- **2026-07-26 — Phase 1 signature and constraint baseline implemented.**
+  `ProductionSignature` canonically freezes machines, fixed-point rates,
+  item producer sets, consumers, external inputs, targets and surplus.
+  `PlacedMachineSignature` independently freezes the exact emitted machine
+  multiset while ignoring coordinates and entity ordering. Multiple oil
+  producers are represented explicitly rather than forced through the
+  single-producer assumption used by solid cell chains.
+
+  The first exact per-axis longest-path compactor preserves the relative
+  order of rectangles whose cross-axis footprints overlap. Eight alternating
+  X/Y passes over the current physical machine rectangles produced:
+
+  | Fixture | machines | source machine bbox | compacted bbox | area delta |
+  |---|---:|---:|---:|---:|
+  | `mega-chain-usp2raw` | 495 | 2202×118 | 1667×49 | −68.6% |
+  | `mega-chain-chem5raw` | 184 | 817×32 | 607×17 | −60.5% |
+  | `mega-chain-pu4raw` | 640 | 2684×63 | 2239×25 | −66.9% |
+  | `chain-mil5ore` | 146 | 706×5 | 583×3 | −50.5% |
+
+  Every resulting machine rectangle is pairwise non-overlapping. These are
+  coarse potential bounds, not factory candidates: inserters, route endpoints,
+  pipes, power and logistics have not yet been re-embedded. Their purpose is
+  to answer whether the source contains enough positional slack to justify
+  the router work. A 50–69% machine-bbox reduction says yes and clears that
+  continuation gate by a wide margin.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -504,3 +504,21 @@ make either experimental composer a production default.
   logistics capacity without changing production. It recovers 13 commodity
   nets on `chain-mil5ore` and proves every solved solid production edge has
   producer-drop and consumer-pickup terminals.
+
+- **2026-07-26 — Rigid production islands extracted.** `CompactIR` now
+  separates movable production islands from replaceable commodity routes.
+  Each recipe-bearing machine retains every inserter that touches it. An
+  inserter whose two ends touch machines unions them into one island, so
+  direct insertion remains physical geometry rather than being accidentally
+  converted into a belt edge. Belt-facing inserters expose item-labelled,
+  island-relative pickup/drop terminals for the new router.
+
+  `chain-mil5ore` yields 146 islands containing 508 machines/inserters and
+  362 route terminals; the largest island contains five entities. Its rigid
+  machine-plus-inserter bbox compacts from 706×7 to 583×5 under the existing
+  alternating constraint pass (41.0% less bbox area). This is still a routing
+  bound, not a runnable candidate, but unlike the earlier machine-only bound
+  it reserves the complete inserter geometry the router must serve.
+  Applying a proposed island placement is transactional and preserves the
+  exact placed-machine signature; incumbent belts are explicitly left for
+  rip-up/reroute rather than silently translated.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -496,8 +496,11 @@ make either experimental composer a production default.
   refusals. Each 18,000-tick measurement took 0.40s.
 
   Route-intent extraction now groups physical belt provenance into commodity
-  nets by `(item, capacity replica)` rather than by debug segment. The latter
-  was falsified immediately: one real copper-plate delivery spans row, fan and
-  corridor segment IDs. The corrected extractor finds 39 replaceable solid
-  route nets on `chain-mil5ore`, and every solved solid production edge has
-  both a producer-drop and consumer-pickup terminal in at least one net.
+  nets by item rather than by debug segment. Segment identity was falsified
+  immediately: one real copper-plate delivery spans row, fan and corridor
+  IDs. Capacity-copy suffixes were also rejected as net identity because
+  corridors carry them while the row segments containing machine terminals
+  do not. The corrected extractor permits the new router to repartition
+  logistics capacity without changing production. It recovers 13 commodity
+  nets on `chain-mil5ore` and proves every solved solid production edge has
+  producer-drop and consumer-pickup terminals.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -775,3 +775,63 @@ make either experimental composer a production default.
   belts and collision-checks all emitted footprints. The current military
   result correctly fails that gate. Residual negotiated rip-up/reroute is
   therefore still required before blueprint export or meter testing.
+
+- **2026-07-29 — Snake folding measured; ~20% routing ceiling, and the
+  transform in the tree is the wrong one.** An unlanded `fold_snake`
+  prototype (Strategy C) snake-folds the validated Strategy-A output to trade
+  a kilometre-wide ribbon for a squarer factory. Measuring fold-as-implemented
+  is not the right test — it preserves every entity and adds U-turns, so it
+  can only grow occupied tiles. The question that decides the direction is
+  whether folding makes the *routing problem* easier, which a later shortcut
+  pass could then collect.
+
+  `probe_fold_routing_headroom` answers it directly: extract commodity nets
+  once, then apply the fold as a pure coordinate transform with no
+  reconnection, and compare idealized routing cost before and after. Two
+  metrics, because they fail in opposite directions. Per-commodity MST was
+  rejected as the headline number — it exceeds the actual belt count (4,897
+  vs 2,020 on military science) because it forces one tree per item where
+  real delivery is a forest of local clusters, and folding shortens exactly
+  the inter-cluster links a factory never builds. The reported metric is
+  rate-weighted nearest-source: for each consuming terminal, distance to the
+  nearest producer of that item, weighted by planned rate.
+
+  | Fixture | compacted | X-mirror only | + Y-mirror | greedy fold positions |
+  |---|---:|---:|---:|---:|
+  | `chain-mil5ore` | 552×32 | −11.6% | −17.3% | −15.0% |
+  | `mega-chain-chem5raw` | 700×55 | −14.1% | −20.7% | −22.6% |
+  | `mega-chain-pu4raw` | 2381×87 | −0.9% | −18.9% | −18.9% |
+  | `mega-chain-usp2raw` | 1939×192 | −4.6% | −19.0% | −19.9% |
+
+  Two findings. First, `fold_snake`'s transform is wrong: mirroring only in X
+  puts one segment's bottom edge against the next segment's top edge, so
+  structures that shared a height in the ribbon end up `height + gap` apart.
+  Mirroring alternate segments in Y as well makes them meet — the two-sided
+  main bus — and that is the difference between −0.9% and −18.9% on the
+  deepest fixture. Second, ~20% is a firm ceiling: it survives both mirror
+  variants, 1–6 folds, even splits, and fold positions chosen greedily to
+  minimise rate-weighted cost. Because the metric is obstacle-free, ~20% is
+  an *upper* bound on what a perfect post-fold shortcut router could collect
+  from folding; a real router realizes less.
+
+  **Decision: folding is refused as a density lever and retained as a shape
+  transform.** The 35%-belt / 40%-tile gates in this RFC cannot be reached
+  from a 20% ceiling, and 10–20% is the band this RFC already declares a
+  rejection. But the shape result is large and independent — `pu4raw` goes
+  from 2381×87 (27:1) to 476×443 (1.07:1), `usp2raw` from 1939×192 to
+  646×580 — and on three of four fixtures the near-square fold count is also
+  where the ~19–21% routing gain lands. A kilometres-wide ribbon is not a
+  factory anyone builds; that is worth having on its own terms, under gates
+  about buildability rather than density. Any continuation belongs in its own
+  RFC with those gates, not under RFC-057's.
+
+  Prerequisites for that continuation, diagnosed but not fixed: `fold_snake`
+  reconnects an even-indexed fold's U-turn at `seg_w_k - 1` when the
+  X-mirrored continuation belt is at `seg_w_{k+1} - 1`, so the connector
+  overshoots into empty space (dead-end belts) or lands inside the next
+  segment and sideloads into a belt carrying a different item. Extra entities
+  scale with the width mismatch — +1 at exactly equal halves, +446 at a 74-
+  tile mismatch — and only 4 of 549 single folds and 0 of 61 multi-folds
+  validate today. The gap-bridge step also chains unrelated bottom-edge belts
+  into one shared line, and straddling underground pairs are refilled only on
+  the entrance side.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -864,6 +864,33 @@ make either experimental composer a production default.
   adds zero bridges here, because compaction has removed precisely the free
   tiles a bridge pole needs. That is the open problem.
 
+  **RESOLVED (2026-07-29, same day): the fold's power network is whole, and
+  Factorio agrees.** `replace_poles` had been stripping every pole and
+  re-placing from scratch, on the reasoning that pole positions depend on
+  final geometry. Wrong for this transform: a fold is a RIGID MOTION per
+  segment, so poles inside a segment keep their relative positions and a
+  connected source network stays connected within each segment — only the
+  seams break. Stripping discarded a good network and rebuilt a worse one with
+  `place_poles`, which is shaped for row layouts. Keeping the transformed
+  poles and bridging only the seams takes `chain-mil5ore` from 89 unreachable
+  poles to **zero**.
+
+  Two earlier fixes had to land before this was even visible: the cell
+  composer's pole repair (so the source network is connected at all — the
+  control went from 1 power warning to 0), and the de-aggregated connectivity
+  check (without which 2 and 89 both read as `{"power": 1}`).
+
+  | | geometry | aspect | produced | delivered | machines | pole networks | verdict |
+  |---|---|---|---:|---:|---:|---:|---|
+  | control | 553×32 | 17.28:1 | 5.00/s | 5.00/s | 146 | 1 | PASS |
+  | folded | 277×66 | 4.20:1 | 5.00/s* | 5.02/s | 146 | **1** | PASS |
+
+  \* the reported −1.6% is sampling phase: the window series alternates
+  4.92/5.08 with a mean of exactly 5.00, and every intermediate item measures
+  at plan. `power: 1 pole network` is the number that matters here — the
+  harness energises each network separately, so anything above 1 would have
+  been masked.
+
   The decisive finding is a **validator blind spot**. An earlier version of
   that same fold validated at exact control parity and produced *nothing* in
   Factorio: 0.00/s, 36 of 146 machines working, 110 with `full_output`, rates

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -705,3 +705,20 @@ make either experimental composer a production default.
   terminal appears exactly as a graph source and every consumer terminal as a
   graph sink on all four representative fixtures. The remaining renderer no
   longer needs to infer branch semantics from coordinates or debug metadata.
+
+- **2026-07-26 — Balancer nodes materialised.** Every graph node is now
+  stamped from the existing express `(2,1)` / `(1,2)` balancer templates.
+  Nodes are arranged by lane, role and tree level; capacity handoff belts are
+  stamped between merge/distribution halves. Hubs expand to their real
+  template footprint and relocate around production islands and earlier
+  hubs. Exhaustive footprint checks find no hub-entity overlap across:
+
+  | Fixture | balancer nodes | stamped hub entities |
+  |---|---:|---:|
+  | `mega-chain-usp2raw` | 1,105 | 4,476 |
+  | `mega-chain-chem5raw` | 568 | 2,300 |
+  | `mega-chain-pu4raw` | 1,388 | 5,612 |
+  | `chain-mil5ore` | 344 | 1,404 |
+
+  Terminal and inter-node graph edges are still unrouted; therefore these
+  stamps are not exported as factory candidates yet.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -746,3 +746,32 @@ make either experimental composer a production default.
   same-axis overlaps require negotiated rerouting or shared-segment graph
   rewriting. The result rejects direct materialisation and makes crossing
   legality the next admission gate.
+
+- **2026-07-26 — Underground-aware routing and rotation competitor.** The
+  router now searches surface steps and express-underground jumps together.
+  Machinery and prior route entities block underground endpoints but not
+  their interiors, so going beneath a machine or belt is a first-class
+  routing decision rather than a post-pass accident. Fixed balancer ports
+  reserve direction-correct access sockets; a second pass releases unused
+  sockets after successful routes commit.
+
+  Local `(n,m)` templates may now rotate north/east/south/west with
+  footprint-correct splitter geometry, rotated ports and entity directions.
+  Nodes select the cardinal direction from their aggregate source toward
+  their capacity lane or descendant consumers. Three tiles of sub-hub
+  clearance was the measured routing optimum on military science; larger
+  clearances lengthened paths without reducing the residual.
+
+  On the military fixture all 500 graph edges still receive paths, but only
+  about 95 now require ghost fallback. Raw conflicting claims fell from
+  11,437 tiles in the adjacent-step router to roughly 2,300; bounded
+  underground legalization leaves roughly 1,200 residual tiles, an
+  approximately 90% reduction. An admissible underground entity-distance
+  heuristic also reduces this routing experiment from roughly 21 seconds to
+  13 seconds.
+
+  A strict materializer now emits surface/underground entities only when
+  every route has zero unresolved claims, omits already stamped fixed-port
+  belts and collision-checks all emitted footprints. The current military
+  result correctly fails that gate. Residual negotiated rip-up/reroute is
+  therefore still required before blueprint export or meter testing.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -644,3 +644,12 @@ make either experimental composer a production default.
   compaction system. It does not yet implement topology-free local manifolds,
   rotations or annealed island reordering; those remain the higher-risk
   competitors for the occupied-tile gate.
+
+- **2026-07-26 — Normal pipeline integration.** `LayoutOptions` now exposes
+  `compact_layout`, default `false`. When explicitly enabled,
+  `build_bus_layout` runs the validated RFC-057 fixed point on the winning
+  decomposition before returning it; candidate decompositions themselves
+  remain uncompacted so selection scoring and retry logic are unchanged.
+  A focused end-to-end test proves the default path is inert, the option
+  preserves the exact placed-machine signature, never increases either
+  dimension and returns a fully valid layout.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -835,3 +835,56 @@ make either experimental composer a production default.
   validate today. The gap-bridge step also chains unrelated bottom-edge belts
   into one shared line, and straddling underground pairs are refilled only on
   the entrance side.
+
+- **2026-07-29 — Single fold repaired and measured in Factorio; validation
+  found to give a false pass.** The prototype's defects above are fixed and
+  `chain-mil5ore` now folds from 552×32 (17.25:1) to 276×66 (4.18:1) with an
+  issue profile identical to the unfolded control. Factorio agrees: 5.00/s
+  military science averaged over a stable window, **146 of 146 machines
+  working — the control's exact census**.
+
+  The decisive finding is a **validator blind spot**. An earlier version of
+  that same fold validated at exact control parity and produced *nothing* in
+  Factorio: 0.00/s, 36 of 146 machines working, 110 with `full_output`, rates
+  decaying 1.80 → 2.05 → 1.22 → 0.10 → 0.00. `chain-mil5ore` emits science on
+  its bottom edge facing south; folding puts that edge against an
+  inter-segment gap, so the exit belt is rerouted along a gap lane to the
+  bounding box — but the `boundary_outputs` *record* stayed on the machine's
+  folded tile. Output was produced into a tile nothing drained, every producer
+  upstream backed up, and the line stalled. Validation checks geometry and
+  never asks whether a boundary record still describes where output arrives,
+  so it passed a factory that cannot run. **Any transform that relocates a
+  boundary must move its record, and geometry-only validation cannot be the
+  admission gate for one.**
+
+  The transform changes that mattered, in rough order of impact:
+
+  | Change | Why it was wrong before |
+  |---|---|
+  | 180° rotation, not X mirror | A reflection flips chirality: swaps splitter left/right priorities, invalidates fluid-box `mirror`. The rotation also composes with the U-turn's two right turns so lane handedness survives (B11). |
+  | Fold boundary records | Only X was shifted, so every record pointed at an unrelated tile once a segment moved. |
+  | Reconnect underground halves | Matching only surface belts left runs severed; the symptom was a starved machine elsewhere, not a junction error. Took a 3-fold from 91 issues to 3. |
+  | Nest junction spans | A leg crosses an earlier chain's vertical run only if further out AND its rows fall inside that span. Ordering by span width (not landing row — west crossings run upward) makes it unsatisfiable. |
+  | Exits to the real bbox edge | Runs stopped at the segment edge, which junction columns had since made interior. |
+
+  Refusals are now typed (`FoldRefusal`) rather than a bare `None`, which had
+  made the common causes indistinguishable and every fix guesswork. Corners
+  are checked to be single-feeder turns rather than sideloads (B8 vs B11);
+  fold columns may not sever inserter reach, splitter adjacency or pipe
+  contact; a continuity invariant refuses any fold where a belt that handed
+  off, or was fed, no longer is. `search_snake_fold` admits a candidate only
+  when it validates no worse than its source.
+
+  Two unbounded reconnection loops allocated ~20 GB each until the OOM killer
+  fired; because that OOM was global it killed unrelated processes, including
+  the editor session, four times. Bounded ranges plus an entity-count backstop
+  now; long-running probes are worth running under
+  `systemd-run --user --scope -p MemoryMax=8G`.
+
+  **Multi-fold remains unproven.** Three folds reach 152×132 (1.15:1) with two
+  residual `belt-flow-reachability` warnings, and two folds 211×100 with 45.
+  Given that a two-warning margin has already concealed a total failure once,
+  multi-fold is not claimed to work on validator evidence; it needs the same
+  Factorio adjudication the single fold just received. This does not change
+  the 2026-07-29 refusal of folding as a *density* lever — the ~20% routing
+  ceiling stands, and the single fold costs 277 entities (2820 → 3097).

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -522,3 +522,13 @@ make either experimental composer a production default.
   Applying a proposed island placement is transactional and preserves the
   exact placed-machine signature; incumbent belts are explicitly left for
   rip-up/reroute rather than silently translated.
+
+- **2026-07-26 — Existing-router reuse boundary identified.** The current
+  `route_bus_ghost` entry point is coupled to `BusLane`, `RowSpan`, pre-stamped
+  south-flowing trunks and output-row mergers, so treating dense islands as
+  synthetic bus rows would reintroduce the architecture this RFC is trying to
+  escape. RFC-057 will instead reuse its lower-level proven pieces:
+  `ghost_astar` for negotiated paths, `render_path` for underground
+  materialisation, and the junction solver for remaining crossings. A small
+  manifold adapter will own multi-terminal commodity nets and shared-trunk /
+  `(n,m)` selection.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -843,6 +843,27 @@ make either experimental composer a production default.
   military science averaged over a stable window, **146 of 146 machines
   working — the control's exact census**.
 
+  **CORRECTION (2026-07-29, later the same day): the parity claim above is
+  wrong.** Adversarial review found the fold takes `chain-mil5ore` from **2
+  disconnected power poles to 89**, and both sides reported `{"power": 1}`
+  because `check_pole_network_connectivity` packed the magnitude into message
+  text while `search_snake_fold` compares issue *counts*. The Factorio run did
+  not catch it either: the harness creates one electric energy interface **per
+  pole network**, so it energised both islands and reported 146/146 machines
+  working. A player pasting that blueprint gets two dead halves.
+
+  The throughput result stands — 5.00/s produced, machine census matched — but
+  the layout's own power graph was never verified by it. **A green sim says
+  nothing about a blueprint's internal wire connectivity.** The check now emits
+  one issue per unreachable pole, and with that the mil5 fold is correctly
+  REFUSED. Folding genuinely fragments the power network; it only looked like
+  parity because nothing could see it.
+
+  `replace_poles` was additionally skipping `repair_pole_connectivity`, which
+  `build_bus_layout` always runs. Calling it is necessary but not sufficient: it
+  adds zero bridges here, because compaction has removed precisely the free
+  tiles a bridge pole needs. That is the open problem.
+
   The decisive finding is a **validator blind spot**. An earlier version of
   that same fold validated at exact control parity and produced *nothing* in
   Factorio: 0.00/s, 36 of 146 machines working, 110 with `full_output`, rates

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -532,3 +532,21 @@ make either experimental composer a production default.
   materialisation, and the junction solver for remaining crossings. A small
   manifold adapter will own multi-terminal commodity nets and shared-trunk /
   `(n,m)` selection.
+
+- **2026-07-26 — Cross-layout `CompactIR` gate passed.** Solid production-edge
+  terminal coverage and manifold construction now pass on the four
+  representative layouts. With complete machine-plus-inserter islands
+  reserved, the alternating placement bound is:
+
+  | Fixture | islands | terminals | commodity manifolds | source bbox | compacted bbox | area delta |
+  |---|---:|---:|---:|---:|---:|---:|
+  | `mega-chain-usp2raw` | 495 | 1,149 | 20 | 2202×120 | 1715×57 | −63.0% |
+  | `mega-chain-chem5raw` | 184 | 582 | 13 | 817×34 | 607×23 | −49.7% |
+  | `mega-chain-pu4raw` | 640 | 1,416 | 11 | 2684×65 | 2239×33 | −57.6% |
+  | `chain-mil5ore` | 146 | 362 | 13 | 706×7 | 583×5 | −41.0% |
+
+  `build_manifold_nets` now materialises every island-relative terminal at a
+  proposed placement and joins it with external input/output terminals by
+  commodity. Every resulting manifold on these fixtures has at least one
+  producer/input and consumer/output. This is the typed input to the new
+  shared-trunk router; coordinates no longer depend on the source belt paths.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -550,3 +550,40 @@ make either experimental composer a production default.
   commodity. Every resulting manifold on these fixtures has at least one
   producer/input and consumer/output. This is the typed input to the new
   shared-trunk router; coordinates no longer depend on the source belt paths.
+
+- **2026-07-26 — Flow-sized manifolds and first runnable belt compactor.**
+  `CompactIR` now carries exact fixed-point commodity flow requirements from
+  the solver. The representative express-belt requirements are only 28 total
+  lanes (maximum three for one item) on USP, 14 (maximum two) on chemistry,
+  30 (maximum eight) on processing units and 14 (maximum two) on military
+  science. This disproves “one route per inserter” as the manifold shape:
+  hundreds of terminals must aggregate into a small number of capacity lanes
+  through local `(n,m)` structures.
+
+  A conservative runnable post-pass now replaces uninterrupted horizontal
+  surface-belt spans with maximal legal underground pairs, protects
+  inserter/boundary/junction tiles, normalises pairs collapsed to adjacency
+  during coordinate stripping, and then removes globally empty columns.
+  Every representative candidate preserves the exact placed-machine
+  signature and passes full structural validation:
+
+  | Fixture | source → compacted | belt entities | belt delta |
+  |---|---:|---:|---:|
+  | `mega-chain-usp2raw` | 2214×193 → 2166×193 | 44,031 → 28,998 | −34.1% |
+  | `mega-chain-chem5raw` | 834×56 → 800×56 | 4,202 → 3,182 | −24.3% |
+  | `mega-chain-pu4raw` | 2704×90 → 2624×90 | 23,128 → 15,504 | −33.0% |
+  | `chain-mil5ore` | 720×34 → 670×34 | 3,750 → 2,308 | −38.5% |
+
+  The fast meter measured the military-science control at 1.73/s produced
+  and 1.28/s delivered. The underground candidate improved that to 2.18/s
+  produced and 1.79/s delivered while reducing meter wall time from 0.35s to
+  0.24s. Thus the first real candidate clears the 35% belt gate and improves,
+  rather than trades away, throughput. Chemistry and processing units remain
+  below the RFC's 35% gate, so this primitive is retained as a strong
+  incumbent but does not complete RFC-057.
+
+  A competing global-band sketch was rejected before implementation: placing
+  one commodity trunk band below all compacted islands produced coarse route
+  estimates of 20,269 tiles for military science and 146,773 for USP because
+  every inserter was dragged to a distant global band. The active router uses
+  local, flow-sized manifolds interleaved with their production clusters.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -697,3 +697,11 @@ make either experimental composer a production default.
   their terminal medians and reserve collision-free rectangles against both
   production islands and previously placed hubs. Rendering must now stamp
   these nodes and route their explicit inter-stage/terminal edges.
+
+- **2026-07-26 — Explicit local-manifold flow graphs.** Hierarchy plans now
+  expand into typed graph nodes and edges: producer terminal → `(2,1)` input,
+  merger output → next merger, root → capacity lane, lane → `(1,2)` input,
+  distributor output → next distributor/consumer terminal. Every producer
+  terminal appears exactly as a graph source and every consumer terminal as a
+  graph sink on all four representative fixtures. The remaining renderer no
+  longer needs to infer branch semantics from coordinates or debug metadata.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -1,0 +1,457 @@
+# RFC-057: Topology-preserving dense factory repacking
+
+Registry: [`rfcs.md`](rfcs.md). Status: **Design**.
+
+## Summary
+
+Increase factory density by moving the existing machines into compact
+two-dimensional production islands and synthesizing all transport geometry
+again.
+
+The production topology is already solved and is immutable:
+
+- the recipe and machine multiset;
+- machine counts, qualities and modules;
+- producer→item→consumer relationships;
+- planned rates and external inputs;
+- surplus and target outputs;
+- direct-insertion eligibility.
+
+The physical realization is deliberately **not** immutable. The repacker may:
+
+- translate, rotate and mirror machines where their port contract validates;
+- replace every belt, underground belt, splitter, merger and balancer;
+- choose new belt lanes and underground spans;
+- share trunks between consumers of the same item;
+- use `(n,m)` balancers to distribute a producer bank evenly;
+- replace a belt edge with direct insertion when the existing production edge
+  is eligible;
+- regenerate pipes and power infrastructure around the new placement.
+
+This is the **spaghettifier** proposed in
+[#456](https://github.com/storkme/spaghettio/issues/456): a post-pass over a
+known-correct factory, not another from-scratch generator or cell-ordering
+RFC. Cells are optional seeds and reusable local patterns, not indivisible
+placement units.
+
+## Motivation
+
+RFC-055 demonstrated the limit of macro reordering. It reduced estimated
+rate-weighted distance by 16–40% and reduced belts on three fixtures, but the
+physical belt reduction was only 10–17% on the deep winners and USP grew by
+8.5%. RFC-056's contiguous folds did not materially improve two of the three
+deep fixtures.
+
+The retained architecture dominates the result:
+
+- each edge receives a mostly private corridor;
+- K capacity replicas duplicate feeds, corridors and poles;
+- producers and consumers retain full cell boundary adapters even when they
+  could form one local island;
+- long belts are routed around macro rectangles whose internal slack the
+  placer cannot use;
+- arbitrary 2D adjacency and shared item trunks are unavailable.
+
+Shuffling rectangles cannot remove interfaces. RFC-057 is allowed to remove
+and rebuild those interfaces while preserving what the factory produces.
+
+## Topology invariant
+
+Define a canonical `ProductionSignature` before placement:
+
+```text
+ProductionSignature {
+    machines: multiset(recipe, entity, quality, modules, count),
+    edges: multiset(producer_recipe, item, consumer_recipe, planned_rate),
+    external_inputs: multiset(item, rate, fluid),
+    target_outputs: multiset(item, rate),
+    surplus_outputs: multiset(item, rate, fluid),
+}
+```
+
+Every emitted candidate reconstructs the same signature from its placed
+machines and transport reachability. A mismatch is a hard refusal.
+
+This distinguishes two meanings of topology:
+
+- **Production topology is fixed.** Copper cable still comes from the same
+  cable machines and supplies the same circuit consumers.
+- **Logistics topology is free.** That edge may be a direct inserter, a short
+  manifold, a balanced shared trunk, or a belt/underground route around other
+  machinery.
+
+The invariant is checked mechanically; it is not an assumption carried from
+the source layout.
+
+The source layout's belt graph is also not part of the signature. Preserving
+it would preserve the dominant source of sprawl. A candidate may change
+splitter count, branching order, underground spans, route homotopy and shared
+trunks as long as every production edge remains physically reachable at the
+required capacity.
+
+## Starting artifact and topological IR
+
+The pass consumes a validated `LayoutResult` plus its `SolverResult`. It does
+not modify the source in place.
+
+Extract a new `CompactIR` containing:
+
+- movable machine/pattern blocks and validated orientation variants;
+- fixed production edges from `ProductionSignature`;
+- external feed and drain terminals;
+- inserter reach/face constraints;
+- fluid-port constraints;
+- power requirements;
+- existing routes as an initial topological embedding only.
+
+The existing geometry supplies a guaranteed incumbent and useful routing
+intent (`carries`, segment ids and boundary records). The compactor may use
+that engine IR. The meter remains independent and sees only the exported
+blueprint and manifest.
+
+`CompactIR` separates three things the current layout conflates:
+
+1. production edges that must survive;
+2. relative-placement constraints required by direct insertion and fluid
+   ports;
+3. replaceable logistics routes.
+
+## Constraint-graph compaction baseline
+
+The first competitor is the exact polynomial baseline from #456 and VLSI
+layout compaction.
+
+For one axis, construct a directed separation graph:
+
+```text
+A ── minimum_clearance(A,B) ──> B
+```
+
+An edge records the minimum coordinate difference needed to prevent entity
+footprint overlap or to retain a deliberately reserved face/channel. Longest
+paths in the resulting DAG give the minimum legal coordinates for that
+ordering.
+
+Run:
+
+```text
+compact X → reroute → compact Y → reroute
+```
+
+until occupied area no longer improves. Alternate once more after any
+orientation or ordering move.
+
+This competitor is important even if the later search wins:
+
+- it establishes how much empty coordinate slack exists without changing
+  relative order;
+- every move is explainable by a named separation constraint;
+- it supplies a deterministic compact incumbent;
+- it distinguishes "the rows were padded" from "the architecture needs a
+  different embedding."
+
+The constraint graph must not encode every existing belt tile as required
+clearance. It reserves endpoints, machine faces and channels needed by the
+current topological embedding; the route is then re-embedded and may use
+underground transit beneath otherwise occupied surface tiles.
+
+## Rubber-band routing and move set
+
+Constraint compaction alone cannot move a producer through its consumer or
+choose a better side of an obstacle. The second competitor uses a topological
+routing IR and bounded search.
+
+Each route initially records:
+
+- source and destination terminals;
+- ordered obstacle-side decisions;
+- required branch/merge semantics;
+- belt tier and capacity;
+- shared-trunk membership, if any.
+
+After blocks move, the router re-embeds that intent onto tiles. It may also
+propose a different embedding—changing obstacle sides, introducing an
+underground crossing, or joining a shared trunk. Existing route homotopy is an
+incumbent, not a correctness constraint.
+
+Initial flow-preserving moves:
+
+- translate one block or island;
+- swap two blocks;
+- rotate/mirror through a validated variant;
+- move a machine between compatible rows;
+- bind/unbind a direct-insertion pattern;
+- merge/split production islands;
+- replace private edges with one shared item trunk;
+- replace a serial fan with an `(n,m)` balancer;
+- rip up and reroute one net inside a bounded box;
+- change a surface span into a legal underground span.
+
+Every move is transactional: place, reroute affected nets, validate the
+production signature and physical layout, meter if it survives, otherwise
+restore the incumbent.
+
+## Placement unit
+
+The primitive placement unit is a machine with typed face demand:
+
+```text
+MachineNode {
+    recipe,
+    entity,
+    footprint,
+    orientation_variants,
+    item_inputs,
+    fluid_inputs,
+    outputs,
+    inserter_slots,
+    pipe_ports,
+    power_demand,
+}
+```
+
+The search may bind several nodes into a temporary rigid pattern when doing so
+is useful:
+
+- direct-insertion producer/consumer sandwiches from RFC-053;
+- smelting columns;
+- one producer bank plus an `(n,m)` output balancer;
+- fluid machinery whose pipe-port geometry is already validated;
+- a known-good cell used as an initial incumbent.
+
+Patterns are conveniences, not permanent boundaries. Solid rows may be broken
+apart when a denser placement meters better.
+
+## Production islands
+
+Build islands around high-rate dependencies rather than dependency order.
+
+1. Weight every production edge by planned rate and belt inventory cost.
+2. Seed clusters with direct-insertion pairs and the highest-weight edges.
+3. Grow clusters while local faces and route capacity remain feasible.
+4. Place consumers around their dominant producer banks.
+5. Give each island a small number of shared raw/intermediate interfaces.
+6. Place islands in 2D and route the remaining inter-island edges.
+
+For utility science, likely islands include:
+
+- copper plate + plastic + steel → low-density structures;
+- engines + electric engines + batteries → flying robot frames;
+- circuits + processing units;
+- final utility-science assembly.
+
+The clustering is proposed by the algorithm and judged by realized geometry
+and meter output; these examples are not hard-coded recipe knowledge.
+
+## Logistics synthesis
+
+Routing starts from an empty logistics layer.
+
+### Local delivery
+
+In priority order:
+
+1. validated machine→machine direct insertion;
+2. short balanced manifold beside the consumer bank;
+3. shared item trunk with balanced taps;
+4. private point-to-point route as fallback.
+
+The router may use ordinary and underground belts interchangeably. Underground
+belts are routing edges with endpoint occupancy and a maximum span, not copies
+of the source layout's underground choices.
+
+### Shared trunks
+
+One item with several consumers should normally have one owned distribution
+network. The producer bank feeds an `(n,m)` balancer selected from the existing
+library; its outputs serve consumer manifolds with planned-rate capacity.
+
+The fast meter, not a priority heuristic, decides whether a smaller serial tap
+is acceptable. A topology that only becomes fair after upstream consumers
+back up is expected to lose on startup and trailing delivery.
+
+### Crossings
+
+The router may:
+
+- cross surface belts with underground pairs;
+- tunnel beneath machines where the underground endpoints remain outside the
+  footprint and the span is legal;
+- reserve multi-item routing channels only where congestion requires them;
+- change route direction and entry face when the machine variant permits it.
+
+Machine footprints remain hard obstacles. Underground transit tiles are not
+surface occupancy, but their endpoints and same-axis pairing constraints are.
+
+### Fluids
+
+The first physical slice keeps each validated fluid mega-block rigid while
+moving it as one island member. Its solid adapters may be rerouted freely.
+
+A later slice may repack fluid machines individually only after pipe-port
+identity, pipe-to-ground orientation and recipe fluid-box validation are part
+of the candidate gate. There is no fluid-void escape hatch.
+
+## Search
+
+Use a staged, deterministic search:
+
+1. **Topology extraction.** Freeze and hash `ProductionSignature`.
+2. **Exact compaction incumbent.** Alternate constraint-graph X/Y compaction
+   with route re-embedding.
+3. **Incumbents.** Exact compacted source, RFC-055 order, and existing DI
+   patterns.
+4. **Island proposals.** Weighted graph clustering with several deterministic
+   thresholds.
+5. **Coarse placement.** Seeded annealing or large-neighbourhood search over
+   node position, orientation, cluster membership and bounded route rip-up.
+6. **Route synthesis.** Route high-rate edges first, then shared trunks,
+   local manifolds and remaining edges.
+7. **Static gate.** Production signature, entity overlap, belts, undergrounds,
+   inserters, fluids, item isolation, power and blueprint round trip.
+8. **Fast-meter gate.** Export the actual blueprint and meter it; no IR-only
+   approximation enters the score.
+9. **Factorio finalist.** Run only the control and final candidate when the
+   meter predicts a material win or exposes uncertainty.
+
+The cheap search objective is:
+
+```text
+score =
+    occupied_tiles
+  + belt_weight × belt_entities
+  + inventory_weight × rate_weighted_route_length
+  + congestion_weight × reserved_channel_area
+  + interface_weight × logistics_boundary_count
+```
+
+After routing, candidates are ranked lexicographically:
+
+1. meet the throughput floor;
+2. maximize delivered target rate per occupied tile;
+3. minimize occupied tiles;
+4. minimize belt entities and startup inventory;
+5. minimize search/runtime cost.
+
+Density may never buy a slower factory and call itself a win.
+
+## Fast-meter loop
+
+`spaghettio_meter::Factory` consumes the exported blueprint and manifest, so
+candidate evaluation remains independent of the engine's derived rate model.
+
+For each statically valid candidate:
+
+1. export blueprint + manifest;
+2. build a meter `Factory`;
+3. run a short screening window;
+4. discard candidates below 95% of the incumbent's delivered target rate;
+5. run survivors to meter convergence;
+6. record target delivery, time series, machine census and boundary refusals.
+
+The search may cache by blueprint geometry hash. Meter notes are candidate
+refusals when they concern unsupported physics on the target path.
+
+Factorio remains the oracle. Meter results rank candidates; they do not bless
+new mechanics.
+
+## Metrics
+
+Report for every finalist:
+
+- bounding-box area;
+- occupied footprint tiles;
+- target throughput per occupied tile;
+- belt, underground-belt, splitter and inserter counts;
+- pipe and pipe-to-ground counts;
+- rate-weighted route length;
+- estimated in-flight item inventory;
+- production-island count;
+- shared-trunk and private-edge counts;
+- logistics interfaces crossed per produced target item;
+- fast-meter final target rate, convergence and startup curve;
+- Factorio final target rate and time to 90%, when run;
+- placement, routing and meter runtime.
+
+Occupied tiles, not bounding box alone, is the primary spatial denominator:
+deliberate routing courtyards should not look dense merely because a rectangle
+around them is narrow.
+
+## Acceptance gates
+
+Corpus:
+
+- `mega-chain-usp2raw`;
+- `mega-chain-chem5raw`;
+- `mega-chain-pu4raw`;
+- `chain-mil5ore`;
+- one direct-insertion-rich solid control.
+
+Correctness:
+
+- production signature exactly preserved;
+- zero validator errors and no new item/fluid isolation warnings;
+- deterministic geometry hash for fixed seed and budget;
+- blueprint export→parse preserves machines, recipes, modules, qualities and
+  boundary records;
+- no simulator-only fluid void.
+
+Density:
+
+- at least 35% fewer belt/splitter entities on two deep fixtures;
+- at least 40% fewer occupied tiles on two deep fixtures;
+- at least 2× target throughput per occupied tile on one deep fixture and
+  at least 1.5× on a second;
+- no deep fixture may grow occupied area by more than 5%.
+
+Performance:
+
+- no candidate loses more than 2% fast-meter target throughput;
+- at least two deep fixtures improve meter time-to-90% by 20%;
+- Factorio target throughput is no worse within measurement noise for the
+  final candidate;
+- any meter/Factorio ranking disagreement is recorded before promotion.
+
+These thresholds intentionally demand a step change. Results in RFC-055's
+10–17% belt-reduction range reject the approach as another marginal
+rearrangement.
+
+## Phases
+
+1. Production-signature and `CompactIR` extractor.
+2. Alternating X/Y constraint-graph compactor with route re-embedding.
+3. Transactional boxed moves and underground-aware rip-up/reroute.
+4. Metrics-only island clustering and machine-level 2D placement.
+5. Solid local manifold/shared-trunk router with `(n,m)` balancers.
+6. Blueprint export, full validation and fast-meter ranking.
+7. Rigid fluid-block integration and deep-fixture comparison.
+8. Factorio control/finalist adjudication and accept/reject decision.
+
+## Kill criteria
+
+- If preserving machine-level topology prevents a 35% belt reduction on both
+  chemistry and processing units, stop and investigate topology-changing
+  production plans rather than relaxing the density gate.
+- If shared trunks repeatedly lose meter throughput to private corridors,
+  keep island placement but reject shared logistics as the default.
+- If routing consumes more than half of total candidate-search time before
+  producing four meterable candidates, introduce incremental routing or
+  stronger placement feasibility constraints.
+- If compact candidates depend on unsupported meter mechanics, do not tune
+  around the meter; adjudicate the mechanic in Factorio or refuse it.
+- If fluid-block rigidity dominates remaining area after solid compaction,
+  open a dedicated fluid-repacking RFC rather than silently weakening port
+  validation.
+
+## Relationship to earlier RFCs
+
+- RFC-053 supplies validated direct-insertion patterns.
+- RFC-054 supplies the candidate-ranking instrument.
+- RFC-055 supplies the linear incumbent and demonstrated that ordering alone
+  is insufficient.
+- RFC-056 supplies negative evidence against contiguous folding.
+- Existing `(n,m)` balancer templates are logistics primitives, not placement
+  constraints.
+
+RFC-057 supersedes RFC-055/056 as the density research direction. It does not
+make either experimental composer a production default.

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -483,3 +483,21 @@ make either experimental composer a production default.
   to answer whether the source contains enough positional slack to justify
   the router work. A 50–69% machine-bbox reduction says yes and clears that
   continuation gate by a wide margin.
+
+- **2026-07-26 — First runnable post-pass and route-intent extraction.**
+  Global empty-column stripping preserves every entity, remaps functional
+  boundaries and only shortens horizontal underground spans. On
+  `chain-mil5ore` it validates cleanly and reduces 720×34 to 712×34 (1.1%),
+  confirming that whitespace removal alone is safe but immaterial.
+
+  The fast meter measured the source and stripped artifacts identically:
+  1.73/s military science produced, 1.28/s delivered, the same per-item
+  rates, 136 working / 10 ingredient-short machines and 68,748 boundary
+  refusals. Each 18,000-tick measurement took 0.40s.
+
+  Route-intent extraction now groups physical belt provenance into commodity
+  nets by `(item, capacity replica)` rather than by debug segment. The latter
+  was falsified immediately: one real copper-plate delivery spans row, fan and
+  corridor segment IDs. The corrected extractor finds 39 replaceable solid
+  route nets on `chain-mil5ore`, and every solved solid production edge has
+  both a producer-drop and consumer-pickup terminal in at least one net.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -68,6 +68,6 @@ backfill the status next time the doc is touched.
 | RFC-054 | 2026-07-25 | [`rfc-054-fast-meter.md`](rfc-054-fast-meter.md) | Design (circulated for review) |
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
-| RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Design |
+| RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
 
 Next number: **RFC-058**.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -68,5 +68,6 @@ backfill the status next time the doc is touched.
 | RFC-054 | 2026-07-25 | [`rfc-054-fast-meter.md`](rfc-054-fast-meter.md) | Design (circulated for review) |
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
+| RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Design |
 
-Next number: **RFC-057**.
+Next number: **RFC-058**.

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -72,17 +72,28 @@ Reward: 3-fold reaches 152×132 (1.15:1) on mil5.
 ### 2. Three of four corpus fixtures find no fold
 
 `mega-chain-chem5raw`, `mega-chain-pu4raw` and `mega-chain-usp2raw` all yield
-nothing. `search_snake_fold` now reports legal-column count, refusals by
-cause, and validation rejections for the not-found path — read those before
-theorising. Untested hypotheses:
+nothing. `search_snake_fold` reports legal-column count, refusals by cause,
+and validation rejections for the not-found path — read those before
+theorising.
 
-Measured for `chem5raw` (700×55): **275 of 699 columns are legal**, refusals
-`InputStranded` 132, `ExitLaneConflict` 22, `JunctionBlocked` 15, and *zero*
-rejected by validation. The pipe-adjacency hypothesis is therefore **wrong** —
-columns are not the constraint. Since a single fold cannot strand inputs, the
-`InputStranded` count is all from k≥2, and chem's one-fold candidates die on
-`ExitLaneConflict`: chemistry emits several *different* items on its bottom
-edge, and a gap has one lane per side.
+Measured across the corpus (`probe_fold_corpus`):
+
+| fixture | legal cols | ExitLane | InputStranded | JunctionBlocked | rejected-by-validation |
+|---|---:|---:|---:|---:|---:|
+| `chain-mil5ore` | 251/551 | 21 | 121 | 29 | 9 → folds |
+| `mega-chain-chem5raw` | 275/699 | 22 | 132 | 15 | 0 |
+| `mega-chain-pu4raw` | 1052/2380 | **173** | **0** | 23 | 0 |
+| `mega-chain-usp2raw` | 888/1938 | 46 | 107 | 43 | 0 |
+
+Two things fall out. Legal columns are 40–50% everywhere, so column legality
+is **never** the binding constraint and the pipe-adjacency hypothesis for
+chem was wrong. And `pu4raw` records **zero** `InputStranded` — it fails on
+`ExitLaneConflict` alone. Since a single fold cannot strand an input, every
+fixture's one-fold candidates die the same way: several *different* items
+leave on the bottom edge, and a gap carries one lane per side.
+
+**`ExitLaneConflict` is therefore the highest-value fix in this backlog.** It
+alone blocks `pu4raw` completely, and it is a prerequisite for the other two.
 
 **Fix shape, shared with (1):** one lane per distinct item, gap height sized
 to fit. Sizing the gap is easy and was tried; the hard part is that a second

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -1,7 +1,9 @@
 # Snake-fold followups
 
-**Status (2026-07-29):** single fold works and is Factorio-verified on
-`chain-mil5ore`. Multi-fold and three of the four corpus fixtures do not
+**Status (2026-07-29):** single fold is verified for **throughput** on
+`chain-mil5ore` and **refused** on power — it fragments the pole network
+(2 disconnected poles to 89). See "The second trap" below before trusting any
+result in this document. Multi-fold and three of the four corpus fixtures do not
 fold; the causes below are diagnosed, not guessed. Owning design doc:
 [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md),
 whose decision log carries the measurements.
@@ -10,9 +12,21 @@ Folding is a **shape** transform, not a density one — RFC-057 refused it as a
 density lever on a measured ~20% routing ceiling. Its value is turning a
 kilometre-wide ribbon into something a human can place and inspect.
 
+## The second trap: a green sim proves nothing about power
+
+The harness creates one electric energy interface **per pole network**, so it
+energises every disconnected island it finds and reports every machine working.
+The mil5 fold measured 146/146 machines and PASS while splitting the factory
+into two power islands a player would paste as two dead halves.
+
+Between this and the boundary-record trap below, the rule for this transform
+is: **validator-clean and sim-green are each necessary and neither is
+sufficient.** Check the specific invariant you care about.
+
 ## What works
 
-`chain-mil5ore`, compacted, single fold at the midpoint:
+Throughput only — see the status line. `chain-mil5ore`, compacted, single fold
+at the midpoint:
 
 | | geometry | aspect | produced | delivered | machines | verdict |
 |---|---|---|---|---:|---:|---:|
@@ -104,7 +118,26 @@ row, and come back. An attempt that allocated lanes without solving the
 crossing regressed the verified single fold and was reverted; do not repeat it
 without the jog.
 
-### 3. Lower-confidence items
+### 3. Power network fragments across the fold (blocks the verified case)
+
+`replace_poles` places poles well but the two folded segments end up as
+separate networks: 89 of 174 poles unreachable from the first. The pipeline's
+own `repair_pole_connectivity` is now called (it was being skipped) and adds
+**zero** bridges — a compacted layout has had exactly the free tiles a bridge
+pole needs removed. Options, none tried: reserve bridge columns during folding,
+allow the repair to displace a belt tile, or run the fold before compaction
+rather than after.
+
+Adversarial review also raised two it could not exercise:
+
+- `replace_poles` passes an empty substation-target list, while
+  `build_bus_layout` computes real ones for deep interior geometry — precisely
+  what densification produces. Not exercised by mil5, which has no substations.
+- `InputStranded`'s edge test accepts any bounding-box edge, and is correct only
+  by coincidence of the current junction-column scheme. Adaptive gap sizing
+  (item 1) would invalidate that coincidence.
+
+### 4. Lower-confidence items
 
 - The continuity invariant (`RunSevered`) false-positived twice on splitter
   footprints — a 180° rotation swaps which physical tile the anchor names. It

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -1,9 +1,10 @@
 # Snake-fold followups
 
-**Status (2026-07-29):** single fold is verified for **throughput** on
-`chain-mil5ore` and **refused** on power — it fragments the pole network
-(2 disconnected poles to 89). See "The second trap" below before trusting any
-result in this document. Multi-fold and three of the four corpus fixtures do not
+**Status (2026-07-29):** single fold is verified on `chain-mil5ore` for
+throughput **and** power — 5.00/s, 146/146 machines, and one connected pole
+network, against a control that measures the same. The power fragmentation
+that previously blocked it is fixed. Read "The second trap" below anyway: it
+is why the fragmentation went unnoticed, and the reasoning generalises. Multi-fold and three of the four corpus fixtures do not
 fold; the causes below are diagnosed, not guessed. Owning design doc:
 [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md),
 whose decision log carries the measurements.

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -1,0 +1,122 @@
+# Snake-fold followups
+
+**Status (2026-07-29):** single fold works and is Factorio-verified on
+`chain-mil5ore`. Multi-fold and three of the four corpus fixtures do not
+fold; the causes below are diagnosed, not guessed. Owning design doc:
+[`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md),
+whose decision log carries the measurements.
+
+Folding is a **shape** transform, not a density one — RFC-057 refused it as a
+density lever on a measured ~20% routing ceiling. Its value is turning a
+kilometre-wide ribbon into something a human can place and inspect.
+
+## What works
+
+`chain-mil5ore`, compacted, single fold at the midpoint:
+
+| | geometry | aspect | produced | delivered | machines | verdict |
+|---|---|---|---|---:|---:|---:|
+| control | 552×32 | 17.25:1 | 5.00/s | 5.00/s | 146 | PASS |
+| folded | 276×66 | 4.18:1 | 5.00/s | 5.10/s | 146 | PASS |
+
+Factorio 2.0.77 headless, `--warmup 216000`, both `converged=true`. Cost is
+277 entities (2820 → 3097), all of it reconnection geometry.
+
+Entry point is `search_snake_fold`, which admits a candidate only when it
+validates no worse than its source. Prefer it to calling `fold_snake`
+directly — geometric legality is not sufficient (see below).
+
+## The trap: validation gives false passes here
+
+An earlier fold validated at **exact control parity** and produced 0.00/s in
+Factorio, with 110 machines showing `full_output` and rates decaying
+1.80 → 2.05 → 1.22 → 0.10 → 0.00.
+
+`chain-mil5ore` emits science on its bottom edge facing south. Folding puts
+that edge against an inter-segment gap, so the exit belt is rerouted along a
+gap lane to the bounding box — but the `boundary_outputs` *record* stayed on
+the machine's folded tile. Output went to a tile nothing drained.
+
+Validation checks geometry and never asks whether a boundary record still
+describes where output arrives. **Any transform that relocates a boundary must
+move its record, and a geometry-only gate cannot certify one.** Sim before
+believing a fold.
+
+## Open work
+
+### 1. Multi-fold: boundary inputs strand (`InputStranded`)
+
+Inputs are fed from outside the bounding box, so they only work on an edge.
+Segment parity decides where they land:
+
+- an unrotated segment keeps inputs on its **top** row;
+- a rotated segment carries them to its **bottom** row.
+
+With one fold both sets stay on the layout edge — segment 0's at the top,
+segment 1's rotated to the bottom — which is exactly why one fold works. From
+two folds up they land on interior gap rows.
+
+Because consecutive segments have opposite parity, each gap carries one
+segment's exits and the neighbour's inputs. Supplying the inputs needs one
+lane per item along a gap that already carries exits — roughly 8 lanes in 2
+rows for mil5's 3-fold.
+
+**Fix shape:** size gaps adaptively (`gap` is currently the constant 2) from
+the lane demand per gap, and route each item its own row. Needs per-segment Y
+offsets rather than the current `seg * (h + gap)`, threaded through the
+transform, junction and exit passes. Costs vertical space, which is
+acceptable — shape is the goal, not density.
+
+Reward: 3-fold reaches 152×132 (1.15:1) on mil5.
+
+### 2. Three of four corpus fixtures find no fold
+
+`mega-chain-chem5raw`, `mega-chain-pu4raw` and `mega-chain-usp2raw` all yield
+nothing. `search_snake_fold` now reports legal-column count, refusals by
+cause, and validation rejections for the not-found path — read those before
+theorising. Untested hypotheses:
+
+Measured for `chem5raw` (700×55): **275 of 699 columns are legal**, refusals
+`InputStranded` 132, `ExitLaneConflict` 22, `JunctionBlocked` 15, and *zero*
+rejected by validation. The pipe-adjacency hypothesis is therefore **wrong** —
+columns are not the constraint. Since a single fold cannot strand inputs, the
+`InputStranded` count is all from k≥2, and chem's one-fold candidates die on
+`ExitLaneConflict`: chemistry emits several *different* items on its bottom
+edge, and a gap has one lane per side.
+
+**Fix shape, shared with (1):** one lane per distinct item, gap height sized
+to fit. Sizing the gap is easy and was tried; the hard part is that a second
+item on the *same* side cannot reach its lane without crossing the first
+lane's belts — the exit sits adjacent to lane 0 only. That is channel routing:
+each additional item needs to travel out past the lanes' extent, jog to its
+row, and come back. An attempt that allocated lanes without solving the
+crossing regressed the verified single fold and was reverted; do not repeat it
+without the jog.
+
+### 3. Lower-confidence items
+
+- The continuity invariant (`RunSevered`) false-positived twice on splitter
+  footprints — a 180° rotation swaps which physical tile the anchor names. It
+  is footprint-aware in both directions now and the sim agrees with it, but it
+  has earned suspicion.
+- U-turn corners are checked to be single-feeder turns (both lanes, B11)
+  rather than sideloads (one lane, B8). The check is pass/fail; if it starts
+  refusing often on deeper fixtures, stagger junction columns per crossing
+  rather than weakening it.
+- `search_snake_fold` slides one comb of fold lines and snaps each to the
+  nearest legal column. Independent per-column search would explore more, at
+  combinatorial cost.
+
+## Guard rails worth keeping
+
+Every failure mode is a typed `FoldRefusal`, so a refusal names its cause
+rather than being a bare `None`: `CutsEntity`, `JunctionBlocked`,
+`ExitLaneConflict`, `CornerNotATurn`, `RunSevered`, `InputStranded`,
+`EntityExplosion`. `SPAGHETTIO_FOLD_DEBUG=1` lists every severed belt instead
+of just the first.
+
+Two unbounded reconnection loops once allocated ~20 GB each until the OOM
+killer fired; being a global OOM it killed unrelated processes including the
+editor session, four times over. Both are bounded ranges now plus an
+entity-count backstop. Long probes are worth running under
+`systemd-run --user --scope -p MemoryMax=8G` regardless.

--- a/docs/status.md
+++ b/docs/status.md
@@ -131,7 +131,12 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 PR #481 — RFC ACTIVE, not closed)**: a single fold is Factorio-verified.
 `chain-mil5ore` goes 552x32 (17.25:1) to 276x66 (4.18:1) at **5.00/s produced
 with 146 of 146 machines working** — the unfolded control's exact census, both
-runs converged at `--warmup 216000`. Bus layouts fold too: `gear15-ore` reaches
+runs converged at `--warmup 216000`. **Throughput only**: the same fold takes
+disconnected power poles from 2 to 89, which neither the validator (it
+aggregated the count into one warning) nor the sim (the harness energises every
+pole network separately) could see. With the validator fixed the fold is
+correctly refused. Do not read a green sim as evidence about a blueprint's own
+wire graph. Bus layouts fold too: `gear15-ore` reaches
 55x65 (1.18:1) on **three** folds. Folding stays refused as a *density* lever
 (measured routing headroom ~20%); its value is shape, since a 2,381-tile-wide
 ribbon is not a factory anyone builds. Reachable only from tests — deliberately

--- a/docs/status.md
+++ b/docs/status.md
@@ -131,12 +131,14 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 PR #481 — RFC ACTIVE, not closed)**: a single fold is Factorio-verified.
 `chain-mil5ore` goes 552x32 (17.25:1) to 276x66 (4.18:1) at **5.00/s produced
 with 146 of 146 machines working** — the unfolded control's exact census, both
-runs converged at `--warmup 216000`. **Throughput only**: the same fold takes
-disconnected power poles from 2 to 89, which neither the validator (it
-aggregated the count into one warning) nor the sim (the harness energises every
-pole network separately) could see. With the validator fixed the fold is
-correctly refused. Do not read a green sim as evidence about a blueprint's own
-wire graph. Bus layouts fold too: `gear15-ore` reaches
+runs converged at `--warmup 216000`, and the folded artifact measures **one
+pole network** — the whole factory on a single grid. Getting there needed three
+fixes that only made sense together: the cell composer's pole repair (the
+source network was itself in pieces), the de-aggregated connectivity check
+(2 and 89 unreachable poles both reported as one warning), and repairing the
+fold's seams rather than re-placing every pole. Standing lesson from the
+detour: the sim harness energises every pole network it finds, so a green sim
+is not evidence about a blueprint's own wire graph — check that separately. Bus layouts fold too: `gear15-ore` reaches
 55x65 (1.18:1) on **three** folds. Folding stays refused as a *density* lever
 (measured routing headroom ~20%); its value is shape, since a 2,381-tile-wide
 ribbon is not a factory anyone builds. Reachable only from tests — deliberately

--- a/docs/status.md
+++ b/docs/status.md
@@ -127,6 +127,23 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 
 ## Recent RFC close-outs
 
+**`rfc-057-topology-preserving-dense-repacking.md` snake fold (2026-07-29,
+PR #481 — RFC ACTIVE, not closed)**: a single fold is Factorio-verified.
+`chain-mil5ore` goes 552x32 (17.25:1) to 276x66 (4.18:1) at **5.00/s produced
+with 146 of 146 machines working** — the unfolded control's exact census, both
+runs converged at `--warmup 216000`. Bus layouts fold too: `gear15-ore` reaches
+55x65 (1.18:1) on **three** folds. Folding stays refused as a *density* lever
+(measured routing headroom ~20%); its value is shape, since a 2,381-tile-wide
+ribbon is not a factory anyone builds. Reachable only from tests — deliberately
+not wired to a `LayoutOptions` flag yet.
+
+Carries a **validator finding that outlives the fold**: an earlier version
+validated at exact control parity and produced 0.00/s in Factorio, because a
+relocated output belt left its `boundary_outputs` record behind. Geometry-only
+validation cannot certify a transform that moves a boundary. Fixed separately in
+PR #482. Open blockers and measured refusal causes:
+[`snake-fold-followups.md`](snake-fold-followups.md).
+
 **`rfc-053-direct-insertion-cells.md` Phase 0 (2026-07-25, PR #436 —
 RFC ACTIVE, not closed)**: machine→inserter→machine DI, the topology
 #429 asked for and the corpus overwhelmingly builds. Evidence is now


### PR DESCRIPTION
## Intent

Two things from [RFC-057](../blob/main/docs/rfc-057-topology-preserving-dense-repacking.md),
both post-passes over an already-validated layout:

1. **Compaction (Strategy A)** — make a factory smaller without changing what it
   produces: undergroundify straight belt runs, strip empty rows/columns, collapse
   coordinate cuts, each gated on full validation.
2. **Snake folding** — turn the resulting ribbon into something square. The layout
   engine emits factories 2,381 tiles wide; nobody builds that.

Retitled from *"Strategy A: validated coordinate cuts"*, which described only the
first commit and would have pointed a reviewer at the wrong third of the diff.

## Scope

- **In — compaction:** `compact_validated_geometry`, wired behind
  `LayoutOptions::compact_layout` (default off). Sim-verified: military science
  720x34 → 550x32, 4,548 → 2,816 entities, throughput unchanged.
- **In — snake folding:** `fold_snake` and `search_snake_fold`. Cuts into vertical
  segments, rotates alternates **180°** (a rotation, not a reflection — a
  reflection flips chirality and would swap splitter priorities and invalidate
  fluid-box mirror flags), reconnects severed runs with U-turns, re-places power
  poles, and refuses with a typed reason rather than emitting a broken factory.
- **Out — the fold is NOT wired into any pipeline.** Reachable only from tests, by
  choice: there is more development to do before it earns a `LayoutOptions` flag.
  It is inert and cannot regress the normal path.
- **Out — Strategy B** (topology-free island placement + negotiated re-routing),
  ~2,000 lines, is **present but wired into nothing and does not produce a valid
  layout**. Retained deliberately for a future iteration rather than deleted: its
  A*, route-net extraction and legalization are the reusable parts. Flagging it
  explicitly so it is not mistaken for working code.
- **Out — the boundary-record validator check**, split to #482. It is 141 lines
  with no dependency on this work and changes validation semantics for every
  layout, so it should be read on its own.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 1050 passed, 0 failed.
- [x] `cargo clippy --workspace -- -D warnings` — clean (the exact CI invocation).
- [ ] WASM rebuild + browser eyeball — N/A for the fold, which no UI path reaches.
- [x] **Factorio 2.0.77 headless**, `--warmup 216000`, both runs `converged=true`:

  | | geometry | aspect | produced | delivered | machines | verdict |
  |---|---|---|---:|---:|---:|---|
  | control | 552×32 | 17.25:1 | 5.00/s | 5.00/s | 146 | PASS |
  | folded | 276×66 | 4.18:1 | 5.00/s | 5.10/s | 146 | PASS |

  Identical production, identical machine census.

- [x] Corpus measured, not assumed: `probe_fold_corpus` and `probe_fold_bus_layouts`
      report legal-column counts and refusals by cause for every fixture.

### The finding that matters most

An earlier version of this fold **validated at exact control parity and produced
0.00/s in Factorio** — 110 machines with `full_output`, 36 of 146 working. A
relocated output belt left its `boundary_outputs` record behind, so output arrived
where nothing collected it. **Validation checks geometry and never asks whether a
boundary record still describes where output arrives.** Fixed here (records follow
their exits) and guarded generally in #482.

Treat validator-clean as insufficient evidence for anything in this diff.

## Deviations from intent

- **Folding is refused as a density lever**, which is what RFC-057 originally
  wanted it for. Measured routing headroom tops out near ~20% across four
  fixtures — the band the RFC itself declares a rejection. It is retained as a
  *shape* transform, which is worth having on its own terms. Decision log has the
  numbers.
- **Multi-fold works on bus layouts but not cell chains.** `gear15-ore` reaches
  1.18:1 on three folds; cell chains refuse with `InputStranded` because their
  inputs all sit on one edge. Diagnosed, not fixed —
  [`snake-fold-followups.md`](../blob/main/docs/snake-fold-followups.md).
- Two unbounded loops in the reconnection allocated ~20GB until the OOM killer
  fired, taking unrelated processes down with them. Both are bounded ranges now
  plus an entity-count backstop.

## Models / contracts touched

- `docs/rfc-057-*.md` decision log — measurements and the refusal of folding as a
  density lever.
- `docs/snake-fold-followups.md` — new; open blockers with measured causes.
- `docs/status.md` — RFC-057 was absent from the ledger entirely.
- `factorio-mechanics.md` B8/B11 are load-bearing here: U-turn corners are checked
  to be single-feeder **turns** (both lanes) rather than **sideloads** (one lane).
  No contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ