### PR TITLE
ci: re-enable the Claude review bot, pinned to Sonnet 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   claude-review:
-    # Temporarily disabled by user request (2026-07-26). Keep the workflow
-    # and job name in place so branch-protection/check wiring remains stable;
-    # remove this condition to re-enable automated reviews.
-    if: ${{ false }}
+    # Re-enabled 2026-07-29 (disabled 2026-07-26 by user request). While it
+    # was off the `claude-review` check reported "skipping" on every PR, which
+    # is indistinguishable at a glance from the silent-failure classes this
+    # workflow was hardened against — see docs/review-bot.md.
     runs-on: ubuntu-latest
     # `pull-requests`/`issues` must be WRITE: the review agent posts its
     # findings as a PR review + inline/summary comments. The stock template
@@ -66,7 +66,11 @@ jobs:
             already reviewed), do not end silently — post a one-line
             `gh pr comment` stating the skip and the reason. A silent
             end is indistinguishable from a crash and fails the check.
+          # Model pinned rather than left to the action's default: review
+          # quality and cost both depend on it, and an unpinned default can
+          # move under us without any change to this file.
           claude_args: |
+            --model claude-sonnet-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
 
       # Full session transcript (includes every permission denial) — the


### PR DESCRIPTION
## Intent

Re-enable automated PR review (disabled 2026-07-26 by user request) and pin the
model it runs on.

While it was off, the `claude-review` check reported **"skipping"** on every PR.
At a glance that is indistinguishable from the silent-failure classes this
workflow was specifically hardened against — and two substantial PRs (#481, #482)
went through with zero automated review because of it.

## Scope

- **In:** remove the `if: ${{ false }}` gate; add `--model claude-sonnet-5` to
  `claude_args`. Eight lines.
- **Out:** everything else. The write permissions, the `--comment` flag in the
  prompt, the harness note, the tool allowlist, and the zero-coverage guard are
  each individually load-bearing per [`docs/review-bot.md`](../blob/main/docs/review-bot.md),
  and `/install-github-app` has clobbered all of them at once before. Deliberately
  untouched.

### Why pin the model

It was unset, so the action's default applied. Review quality and cost both
depend on it, and an unpinned default can move without any change to this file —
which for a check whose entire failure history is *silent* degradation is worth
closing off.

## Verification

- [x] YAML parses; job has no `if` gate; permissions still
      `pull-requests: write` / `issues: write` (the read-only stock template was
      failure class 1 — it silently discarded every review).
- [x] Diff is 8 lines, confined to the gate and `claude_args`.
- [ ] Live behaviour: this PR is itself the test. Note it is a **workflow-file
      PR**, which the action self-skips by design (anti-hijack) and the guard
      carves out — so a skip here is expected and correct. First real exercise
      will be the next non-workflow PR.

## Deviations from intent

None.

## Models / contracts touched

[`docs/review-bot.md`](../blob/main/docs/review-bot.md) documents the failure
classes and the load-bearing pieces; no contract changed, and the piece this
touches (the enable gate) is the one that doc says to remove to re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ