### PR TITLE
ci(review): re-review new commits instead of skipping the PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,6 +66,22 @@ jobs:
             already reviewed), do not end silently — post a one-line
             `gh pr comment` stating the skip and the reason. A silent
             end is indistinguishable from a crash and fails the check.
+            — Re-review rule: "I already reviewed this PR" is NOT a valid
+            skip when new commits have landed since. This job fires on
+            every push, and the guard below only checks that the PR has
+            SOME review in its lifetime, so a skip here means the new
+            commits get no review at all — which is exactly how a PR that
+            was reviewed at its third commit merged at its ninth (#481,
+            2026-07-29: four real bugs found, then six further commits
+            including the fixes for those bugs went unreviewed). When
+            ${{ github.event.action }} is `synchronize`, review the
+            commits from ${{ github.event.before }} to
+            ${{ github.event.after }} — focus there, judge them in the
+            context of the whole PR, and say in your comment which range
+            you reviewed. Re-check that earlier findings were actually
+            addressed rather than assuming. Only the triviality gate
+            (genuinely no substantive change in the range) justifies a
+            skip, and it still needs the one-line comment.
           # Model pinned rather than left to the action's default: review
           # quality and cost both depend on it, and an unpinned default can
           # move under us without any change to this file.

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -19,6 +19,33 @@ changes.
   validation subagents → post. With `--comment` (which we pass —
   load-bearing) it posts inline comments on findings or a
   "No issues found" summary comment when clean.
+### Failure class 6: reviewed once, merged much later (2026-07-29)
+
+`claude-review` fires on every push, but two independent mechanisms conspire
+to make only the FIRST push get a review:
+
+- the plugin's own gate declines to re-review a PR Claude has already
+  commented on;
+- the guard below checks PR-**lifetime** coverage, so once any review exists
+  every later push passes trivially.
+
+Observed on #481: the bot reviewed the PR and found four real bugs, then six
+further commits — including the fixes for those four bugs and a substantial
+power-network change — landed and merged with no review of any of them. The
+check was green throughout, correctly by its own rules.
+
+The prompt now carries an explicit re-review rule: "already reviewed" is not a
+valid skip when new commits have landed, and on a `synchronize` event the run
+is told its `before..after` range and asked to name that range in its comment.
+Only the triviality gate justifies a skip, and it still requires the one-line
+notice.
+
+**Not yet done:** the guard is still PR-lifetime. Making it require coverage on
+the current head SHA would enforce this rather than merely asking for it, but
+that is only safe once the prompt change is observed working — otherwise it
+reds every follow-up push. Sequencing is deliberate: fix the behaviour, watch
+it, then tighten the gate.
+
 - [`clear-agent-reviewed.yml`](../.github/workflows/clear-agent-reviewed.yml)
   — drops the `agent-reviewed` label when new commits land, so a new head
   SHA gets re-reviewed.


### PR DESCRIPTION
## Intent

A PR only ever gets **one** review from `claude-review`, no matter how much it
changes afterwards. Two independent mechanisms cause it:

- the plugin's own gate declines to re-review a PR Claude has already
  commented on;
- the guard checks PR-**lifetime** coverage, so once any review exists every
  later push passes trivially.

Both are individually reasonable and together they leave a real hole.

**Observed on #481**, which prompted this: the bot reviewed and found four real
bugs — including one in shipped code. Six further commits then landed,
*including the fixes for those four bugs* and a substantial power-network
change, and merged with none of them reviewed. The check was green the whole
time, correctly by its own rules.

## Scope

- **In:** the prompt now states that "already reviewed" is not a valid skip
  when new commits have landed; hands the run its `before..after` range on a
  `synchronize` event; asks it to name the range it reviewed; and asks it to
  re-check that earlier findings were actually addressed rather than assumed.
- **Out — the guard is unchanged, deliberately.** Making it require coverage on
  the current head SHA would *enforce* this rather than asking for it, but that
  is only safe once the prompt change is observed working. Otherwise it reds
  every follow-up push — which is precisely why the guard was written
  PR-lifetime in the first place. Fix the behaviour, watch it, then tighten the
  gate.
- **Out:** the `agent-reviewed` label / `scripts/agent-watcher.sh` flow. That is
  a separate review path and is not currently running; this PR is scoped to the
  GitHub workflow path that is.
- **Out:** everything else in the file. The write permissions, `--comment`, the
  harness note, the allowlist and the guard are each individually load-bearing
  per `docs/review-bot.md`, and `/install-github-app` has clobbered all of them
  at once before.

## Verification

- [x] YAML parses; job still has no `if` gate; permissions still
      `pull-requests: write`.
- [x] Diff confined to the prompt block plus a `docs/review-bot.md` entry.
- [ ] Live behaviour cannot be tested here: this is a **workflow-file PR**,
      which the action self-skips by design (anti-hijack) and the guard carves
      out. The first real exercise is the next ordinary PR that gets a second
      push — worth watching that its comment names a commit range.

## Deviations from intent

None.

## Models / contracts touched

`docs/review-bot.md` gains failure class 6 with the #481 evidence, and records
that the guard tightening is deliberately deferred rather than forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ