### PR TITLE
fix(layout): bridge wide pole gaps; all composed fixtures reach one power network

### DIFF
--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -2136,8 +2136,38 @@ pub(crate) fn repair_pole_connectivity(
         // medium pole at top-left `p` (center via `pole_center`, reach medium),
         // so it wires to an endpoint iff their center distance ≤ min(medium,
         // endpoint reach) — the exact test `power_wires` will apply.
+        // Two seeds, tried in order, and the order matters for reasons
+        // beyond correctness.
+        //
+        // The midpoint is the original seed and works whenever the gap is at
+        // most `2 * reach`. Beyond that it sits further from either endpoint
+        // than a pole there could wire to, and the scan fails however wide its
+        // radius: measured on `mega-chain-usp2raw`, closest pair 40.3 tiles
+        // apart against reach 9, midpoint 20 from each end, repair gave up
+        // with 11 components still separate.
+        //
+        // Stepping `reach` from `pa` toward `pb` lands inside `pa`'s wire
+        // range by construction, so each iteration extends that component one
+        // reach-length closer and the loop walks a chain across an arbitrarily
+        // wide gap.
+        //
+        // The fallback is tried SECOND, and only when the midpoint scan finds
+        // nothing, so every layout the old seeding already handled keeps
+        // byte-identical geometry. Seeding from the endpoint unconditionally
+        // also works, but it perturbs pole positions corpus-wide and would
+        // invalidate three sim-verified registry pins to fix one fixture.
         let mid = ((pa.0 + pb.0) / 2, (pa.1 + pb.1) / 2);
+        let stepped = {
+            let (dx, dy) = (pb.0 - pa.0, pb.1 - pa.1);
+            let gap = (((dx * dx + dy * dy) as f64).sqrt()).max(1.0);
+            let step = medium_reach.min(gap / 2.0);
+            (
+                pa.0 + ((dx as f64) * step / gap).round() as i32,
+                pa.1 + ((dy as f64) * step / gap).round() as i32,
+            )
+        };
         let mut bridge: Option<(i32, i32)> = None;
+        for mid in [mid, stepped] {
         'scan: for r in 0i32..=scan_radius {
             for dy in -r..=r {
                 for dx in -r..=r {
@@ -2162,8 +2192,29 @@ pub(crate) fn repair_pole_connectivity(
                 }
             }
         }
+        if bridge.is_some() {
+            break;
+        }
+        }
 
-        let Some(p) = bridge else { return };
+        let Some(p) = bridge else {
+            if std::env::var("SPAGHETTIO_POWER_DEBUG").is_ok() {
+                let (ax, ay, _) = nodes[ia];
+                let (bx, by, _) = nodes[ib];
+                let gap = ((ax - bx).powi(2) + (ay - by).powi(2)).sqrt();
+                eprintln!(
+                    "repair gave up: {} components left, closest pair {:?}..{:?} gap {:.1} \
+                     (reach {:.1}, scan radius {scan_radius}) — no free tile within reach \
+                     of either endpoint",
+                    by_comp.len(),
+                    pa,
+                    pb,
+                    gap,
+                    medium_reach,
+                );
+            }
+            return;
+        };
         entities.push(make_pole(p.0, p.1));
         all_occupied.insert(p);
     }

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -2198,6 +2198,16 @@ pub(crate) fn repair_pole_connectivity(
         }
 
         let Some(p) = bridge else {
+            // Trace unconditionally, matching the budget-exhausted path
+            // below. This is the COMMON give-up — wide or obstructed gaps —
+            // and leaving it visible only under an env var meant the snapshot
+            // debugger and e2e diagnostics saw a repair that quietly did
+            // nothing. `CLAUDE.md` treats trace events as the reliable signal
+            // for confirming a failure mode; this one had none.
+            crate::trace::emit(crate::trace::TraceEvent::PolesPlaced {
+                count: by_comp.len(),
+                strategy: "repair-no-bridge-tile".to_string(),
+            });
             if std::env::var("SPAGHETTIO_POWER_DEBUG").is_ok() {
                 let (ax, ay, _) = nodes[ia];
                 let (bx, by, _) = nodes[ib];

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -119,7 +119,34 @@ row, and come back. An attempt that allocated lanes without solving the
 crossing regressed the verified single fold and was reverted; do not repeat it
 without the jog.
 
-### 3. Power network fragments across the fold (blocks the verified case)
+### 3. ~~Power network fragments across the fold~~ — DONE (2026-07-29)
+
+Fixed and Factorio-verified; kept here for the diagnosis, which generalises.
+
+Three separate causes, none sufficient alone:
+
+1. **The chain composer's spanning pole line** stepped by 8 on an absolute grid
+   against wire reach 9, and nudged forward past congestion without
+   compensating — orphaning the pole behind it. Now steps from the last pole
+   actually placed.
+2. **The fold re-placed poles from scratch.** A fold is a rigid motion per
+   segment, so poles keep their relative positions inside a segment and only
+   the seams break. Keeping the transformed poles and bridging the seams took
+   `chain-mil5ore` from 89 unreachable poles to 0.
+3. **`repair_pole_connectivity` seeded its bridge scan at the MIDPOINT** of the
+   two nearest components. That only works while the gap is at most
+   `2 * reach`; beyond it the midpoint is further from either endpoint than a
+   pole there could wire to, and the scan fails at any radius. Measured on
+   `usp2raw`: closest pair 40.3 tiles, reach 9, midpoint 20 from each end, gave
+   up with 11 components. Now falls back to stepping one reach-length from an
+   endpoint — as a FALLBACK, tried only when the midpoint scan finds nothing,
+   so every layout the old seeding handled keeps byte-identical geometry.
+   Seeding from the endpoint unconditionally also works but moves three
+   sim-verified registry pins to fix one fixture.
+
+Composed pole networks, all four fixtures: **1**.
+
+<!-- superseded detail retained below for the record -->
 
 `replace_poles` places poles well but the two folded segments end up as
 separate networks: 89 of 174 poles unreachable from the first. The pipeline's
@@ -138,7 +165,7 @@ Adversarial review also raised two it could not exercise:
   by coincidence of the current junction-column scheme. Adaptive gap sizing
   (item 1) would invalidate that coincidence.
 
-### 4. Lower-confidence items
+### 5. Lower-confidence items
 
 - The continuity invariant (`RunSevered`) false-positived twice on splitter
   footprints — a 180° rotation swaps which physical tile the anchor names. It


### PR DESCRIPTION
## Intent

`mega-chain-usp2raw` composed with its power network in 11 pieces — the last
holdout after the composer fixes earlier today. Closes that out: **all four
corpus fixtures now compose to a single connected pole network**.

## The bug

`repair_pole_connectivity` seeded its bridge search at the **midpoint** of the
two nearest components. That works while the gap is at most `2 * reach`; beyond
it the midpoint sits further from either endpoint than a pole placed there
could wire to, so the scan fails **at any radius** — the requirement scales
with the gap, so widening it does not help.

Measured, after two wrong guesses at the cause:

```
11 components left, closest pair (234,15)..(194,10) gap 40.3
(reach 9.0, scan radius 9) — no free tile within reach of either endpoint
```

Midpoint is 20 tiles from each end; nothing within radius 9 of it is within 9
of an endpoint. The existing comment anticipated needing to "step back toward
an endpoint" — the arithmetic never did.

## The fix, and why it is a fallback

Stepping one reach-length from `pa` toward `pb` lands inside `pa`'s wire range
by construction, so each iteration extends that component one step closer and
the loop walks a chain across an arbitrarily wide gap.

It is tried **only when the midpoint scan finds nothing**. Seeding from the
endpoint unconditionally fixes `usp2raw` equally well — I wrote that first —
but it perturbs pole positions corpus-wide and moved three sim-verified
registry pins (`plastic-bar@2`, `advanced-circuit@2`,
`chemical-science-pack@5`). That is three fresh Factorio runs owed, to fix one
fixture. As a fallback, every layout the old seeding already handled keeps
byte-identical geometry and **no pin moves**.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — **1054 passed, 0 failed**,
      including both registry-hash gates (the point of the fallback framing).
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] Composed pole networks, all four fixtures, zero repair give-ups:

  | fixture | before | after |
  |---|---:|---:|
  | `chain-mil5ore` | 3 | **1** |
  | `mega-chain-chem5raw` | 17 | **1** |
  | `mega-chain-pu4raw` | 41 | **1** |
  | `mega-chain-usp2raw` | 49 | **1** |

- [ ] No fresh sim: geometry is unchanged for every fixture except `usp2raw`,
      which is not registry-blessed. `chem5` was re-measured earlier today and
      its pin is untouched here.

## Deviations from intent

None.

## Models / contracts touched

`docs/snake-fold-followups.md` — the power blocker is closed out, with the
three-cause diagnosis retained because it generalises: heuristic placement
leaves islands, a rigid transform should repair rather than re-place, and a
midpoint seed is wrong for gaps wider than twice the wire reach.

Adds `SPAGHETTIO_POWER_DEBUG=1`, which reports component count, closest-pair
gap and reach when the repair gives up — that diagnostic produced the number
above after I had guessed wrong twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ