### PR TITLE
docs: land the fold-followups refresh on main

### DIFF
--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -150,12 +150,10 @@ Measured across the corpus (`probe_fold_corpus`, before per-item lanes):
 Two things fall out and still hold. Legal columns are 40–50% everywhere, so
 column legality is **never** the binding constraint — the pipe-adjacency
 hypothesis for chem was wrong. And `pu4raw` records **zero** `InputStranded`,
-failing with **zero** `InputStranded` — the only fixture where fixing the input
-side could not help at all, which is why the exit side was tackled first. (It
-still records 23 `JunctionBlocked`, so lane conflict is not its sole refusal —
-just its dominant one, and the only one input work could not touch.) By raw
-count `InputStranded` is the larger refusal on three of the four fixtures
-(121 vs 21, 132 vs 22, 107 vs 46); only `pu4raw` inverts that.
+failing on `ExitLaneConflict` (173) instead — the only fixture where fixing the
+input side could not help at all, which is why the exit side was tackled first.
+(It still records 23 `JunctionBlocked`, so lane conflict is not its sole
+refusal — just its dominant one, and the only one input work could not touch.)
 
 By raw count `InputStranded` is the larger refusal on three of the four
 fixtures (121 vs 21, 132 vs 22, 107 vs 46); only `pu4raw` inverts that. "Fix

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -4,8 +4,12 @@
 throughput **and** power — 5.00/s, 146/146 machines, and one connected pole
 network, against a control that measures the same. The power fragmentation
 that previously blocked it is fixed. Read "The second trap" below anyway: it
-is why the fragmentation went unnoticed, and the reasoning generalises. Multi-fold and three of the four corpus fixtures do not
-fold; the causes below are diagnosed, not guessed. Owning design doc:
+is why the fragmentation went unnoticed, and the reasoning generalises.
+
+Multi-fold is close but unfinished, on `feat/multifold-gap-lanes` (#492):
+`InputStranded` is resolved and the per-item lane machinery is built, leaving
+one crossing where two items share an input column. Every cause below is
+measured, not guessed. Owning design doc:
 [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md),
 whose decision log carries the measurements.
 
@@ -59,39 +63,58 @@ believing a fold.
 
 ## Open work
 
-### 1. Multi-fold: boundary inputs strand (`InputStranded`)
+### 1. Multi-fold: one crossing left (`ExitLaneConflict` at a shared column)
 
-Inputs are fed from outside the bounding box, so they only work on an edge.
-Segment parity decides where they land:
+Branch: `feat/multifold-gap-lanes`. `InputStranded` is **resolved**; what is
+left is a single, well-specified crossing.
 
-- an unrotated segment keeps inputs on its **top** row;
-- a rotated segment carries them to its **bottom** row.
+**Built.** A gap now carries one lane per distinct ITEM rather than one lane
+per side, which is what capped every layout at one item each way:
 
-With one fold both sets stay on the layout edge — segment 0's at the top,
-segment 1's rotated to the bottom — which is exactly why one fold works. From
-two folds up they land on interior gap rows.
+- gap height is sized from lane demand instead of the constant 2;
+- both exits and input feeds get per-item lanes, with boundary records
+  following their relocated terminus — the same discipline that a stale
+  `boundary_outputs` record taught by producing 0.00/s;
+- lane assignment is ordered by column, which makes the descent from a source
+  row to a non-adjacent lane provably free. A lane spans `[edge, x]`, so
+  ascending order means an earlier lane never covers the column a later one
+  descends through. Verified offline before implementing: ascending gives 0
+  blocked descents over a 5-exit sample, descending 10, arbitrary 5. The input
+  side inverts — it fills from the far side and climbs the other way, so the
+  deepest row needs the largest column.
 
-Because consecutive segments have opposite parity, each gap carries one
-segment's exits and the neighbour's inputs. Supplying the inputs needs one
-lane per item along a gap that already carries exits — roughly 8 lanes in 2
-rows for mil5's 3-fold.
+**The remaining blocker**, measured rather than assumed:
 
-**Fix shape:** size gaps adaptively (`gap` is currently the constant 2) from
-the lane demand per gap, and route each item its own row. Needs per-segment Y
-offsets rather than the current `seg * (h + gap)`, threaded through the
-transform, junction and exit passes. Costs vertical space, which is
-acceptable — shape is the goal, not density.
+```
+input lane clash: lane=2 row=71 at (34,71) item=iron-ore span=[34,210]
+occupied by express-transport-belt dir=North carries=coal
+```
 
-Reward: 3-fold reaches 152×132 (1.15:1) on mil5.
+The occupied tile is another lane's **climb**, and both are at column 34 — two
+different items whose input belts share a column, one feeding the segment above
+the gap and one below. The ordering argument holds only for lanes at *distinct*
+columns; at a shared column one item's climb must cross the other's lane, and
+no assignment order avoids it.
+
+**Fix shape:** an underground dive where two lanes share a column — the
+standard belt-weaving technique (`factorio-mechanics.md` B12), which this pass
+does not yet synthesize. Reward: 3-fold reaches roughly 152×132 (1.15:1) on
+mil5.
+
+**Do not** retry a lane allocation that ignores the crossing. One was tried
+before the ordering rule existed, regressed the verified single fold, and was
+reverted.
 
 ### 2. Three of four corpus fixtures find no fold
 
-`mega-chain-chem5raw`, `mega-chain-pu4raw` and `mega-chain-usp2raw` all yield
-nothing. `search_snake_fold` reports legal-column count, refusals by cause,
-and validation rejections for the not-found path — read those before
-theorising.
+Superseded in part by (1): `ExitLaneConflict` was the dominant refusal and the
+per-item lanes address it. Re-run `probe_fold_corpus` on the branch before
+trusting the table below, which predates that work.
 
-Measured across the corpus (`probe_fold_corpus`):
+`search_snake_fold` reports legal-column count, refusals by cause, and
+validation rejections for the not-found path — read those before theorising.
+
+Measured across the corpus (`probe_fold_corpus`, before per-item lanes):
 
 | fixture | legal cols | ExitLane | InputStranded | JunctionBlocked | rejected-by-validation |
 |---|---:|---:|---:|---:|---:|
@@ -100,24 +123,11 @@ Measured across the corpus (`probe_fold_corpus`):
 | `mega-chain-pu4raw` | 1052/2380 | **173** | **0** | 23 | 0 |
 | `mega-chain-usp2raw` | 888/1938 | 46 | 107 | 43 | 0 |
 
-Two things fall out. Legal columns are 40–50% everywhere, so column legality
-is **never** the binding constraint and the pipe-adjacency hypothesis for
-chem was wrong. And `pu4raw` records **zero** `InputStranded` — it fails on
-`ExitLaneConflict` alone. Since a single fold cannot strand an input, every
-fixture's one-fold candidates die the same way: several *different* items
-leave on the bottom edge, and a gap carries one lane per side.
-
-**`ExitLaneConflict` is therefore the highest-value fix in this backlog.** It
-alone blocks `pu4raw` completely, and it is a prerequisite for the other two.
-
-**Fix shape, shared with (1):** one lane per distinct item, gap height sized
-to fit. Sizing the gap is easy and was tried; the hard part is that a second
-item on the *same* side cannot reach its lane without crossing the first
-lane's belts — the exit sits adjacent to lane 0 only. That is channel routing:
-each additional item needs to travel out past the lanes' extent, jog to its
-row, and come back. An attempt that allocated lanes without solving the
-crossing regressed the verified single fold and was reverted; do not repeat it
-without the jog.
+Two things fall out and still hold. Legal columns are 40–50% everywhere, so
+column legality is **never** the binding constraint — the pipe-adjacency
+hypothesis for chem was wrong. And `pu4raw` records **zero** `InputStranded`,
+failing on `ExitLaneConflict` alone, which is why that was the highest-value
+fix and why (1) went after it first.
 
 ### 3. ~~Power network fragments across the fold~~ — DONE (2026-07-29)
 

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -63,7 +63,7 @@ believing a fold.
 
 ## Open work
 
-### 1. Multi-fold: one crossing left (`ExitLaneConflict` at a shared column)
+### 1. Multi-fold: one crossing left (an INPUT lane at a shared column)
 
 Branch: `feat/multifold-gap-lanes`. `InputStranded` is **resolved**; what is
 left is a single, well-specified crossing.
@@ -98,7 +98,12 @@ no assignment order avoids it.
 
 **Fix shape:** an underground dive where two lanes share a column — the
 standard belt-weaving technique (`factorio-mechanics.md` B12), which this pass
-does not yet synthesize. Reward: 3-fold reaches roughly 152×132 (1.15:1) on
+does not yet synthesize.
+
+Note the clash surfaces under the `ExitLaneConflict` refusal even though it is
+an *input*-side collision: the input feed pass reuses that variant. A misnomer
+that sends the reader to the wrong pass — renamed to `GapLaneConflict` on the
+work branch. Reward: 3-fold reaches roughly 152×132 (1.15:1) on
 mil5.
 
 **Do not** retry a lane allocation that ignores the crossing. One was tried
@@ -107,9 +112,9 @@ reverted.
 
 ### 2. Three of four corpus fixtures find no fold
 
-Superseded in part by (1): `ExitLaneConflict` was the dominant refusal and the
-per-item lanes address it. Re-run `probe_fold_corpus` on the branch before
-trusting the table below, which predates that work.
+Superseded in part by (1), which addresses both refusal classes with per-item
+lanes. Re-run `probe_fold_corpus` on the branch before trusting the table
+below, which predates that work.
 
 `search_snake_fold` reports legal-column count, refusals by cause, and
 validation rejections for the not-found path — read those before theorising.
@@ -126,8 +131,13 @@ Measured across the corpus (`probe_fold_corpus`, before per-item lanes):
 Two things fall out and still hold. Legal columns are 40–50% everywhere, so
 column legality is **never** the binding constraint — the pipe-adjacency
 hypothesis for chem was wrong. And `pu4raw` records **zero** `InputStranded`,
-failing on `ExitLaneConflict` alone, which is why that was the highest-value
-fix and why (1) went after it first.
+failing on `ExitLaneConflict` alone — the one fixture where a single class
+blocks everything, which is why the exit side was tackled first.
+
+By raw count `InputStranded` is the larger refusal on three of the four
+fixtures (121 vs 21, 132 vs 22, 107 vs 46); only `pu4raw` inverts that. "Fix
+the exits first" was a judgement about `pu4raw` being unblockable any other
+way, not a claim that exits dominated the corpus.
 
 ### 3. ~~Power network fragments across the fold~~ — DONE (2026-07-29)
 

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -83,6 +83,15 @@ per side, which is what capped every layout at one item each way:
   side inverts — it fills from the far side and climbs the other way, so the
   deepest row needs the largest column.
 
+`InputStranded` no longer fires on any multi-fold — **verified rather than
+inferred**, because "the check went quiet" is not evidence on its own, and item
+5 below predicted that adaptive gap sizing would invalidate the edge test this
+check relies on. Instrumenting every evaluation across the fold ladder: 504
+input checks, of which **82 are interior** (`on_edge=false`) and **all 82 are
+`supplied=true`** — the same 82. The interior branch still fires, and those
+cases pass because the feed pass genuinely supplies them, not because the test
+stopped discriminating. `SPAGHETTIO_FOLD_DEBUG=1` reproduces it.
+
 **The remaining blocker**, measured rather than assumed:
 
 ```
@@ -182,8 +191,13 @@ Adversarial review also raised two it could not exercise:
   `build_bus_layout` computes real ones for deep interior geometry — precisely
   what densification produces. Not exercised by mil5, which has no substations.
 - `InputStranded`'s edge test accepts any bounding-box edge, and is correct only
-  by coincidence of the current junction-column scheme. Adaptive gap sizing
-  (item 1) would invalidate that coincidence.
+  by coincidence of the current junction-column scheme. This predicted that
+  adaptive gap sizing (item 1) would invalidate that coincidence. **Tested when
+  that landed: it did not** — 82 interior inputs are still detected as interior,
+  every one supplied. Gap height is vertical; the edge test's fragility is
+  horizontal (junction columns), so adaptive sizing does not touch it. The
+  looseness itself remains a latent risk: re-run that measurement if
+  junction-column *placement* ever changes.
 
 ### 5. Lower-confidence items
 

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -83,14 +83,24 @@ per side, which is what capped every layout at one item each way:
   side inverts — it fills from the far side and climbs the other way, so the
   deepest row needs the largest column.
 
-`InputStranded` no longer fires on any multi-fold — **verified rather than
-inferred**, because "the check went quiet" is not evidence on its own, and item
-5 below predicted that adaptive gap sizing would invalidate the edge test this
-check relies on. Instrumenting every evaluation across the fold ladder: 504
-input checks, of which **82 are interior** (`on_edge=false`) and **all 82 are
-`supplied=true`** — the same 82. The interior branch still fires, and those
-cases pass because the feed pass genuinely supplies them, not because the test
-stopped discriminating. `SPAGHETTIO_FOLD_DEBUG=1` reproduces it.
+`InputStranded` no longer fires on **candidates that clear the gap-lane pass**.
+That scoping matters: `fold_snake` returns on a `GapLaneConflict` some 200 lines
+before the stranding check runs, so a candidate that dies on a lane clash is
+never measured. The stranding-prone candidates may be exactly the ones dying
+earlier — this does not establish anything about them.
+
+What it does establish, instrumenting every evaluation across the fold ladder:
+504 input checks, of which **82 are interior** (`on_edge=false`) and **all 82
+are `supplied=true`** — the same 82. So among candidates that get that far, the
+interior branch still fires and passes because the feed pass genuinely supplies
+them, not because the test stopped discriminating. That was worth checking,
+because "the check went quiet" is not evidence on its own, and the retained note
+in item 3 predicted adaptive gap sizing would invalidate this very edge test.
+`SPAGHETTIO_FOLD_DEBUG=1` reproduces it.
+
+Re-measure once the shared-column crossing is fixed and lane clashes stop
+refusing candidates — that is when the excluded population finally reaches the
+check.
 
 **The remaining blocker**, measured rather than assumed:
 
@@ -140,8 +150,12 @@ Measured across the corpus (`probe_fold_corpus`, before per-item lanes):
 Two things fall out and still hold. Legal columns are 40–50% everywhere, so
 column legality is **never** the binding constraint — the pipe-adjacency
 hypothesis for chem was wrong. And `pu4raw` records **zero** `InputStranded`,
-failing on `ExitLaneConflict` alone — the one fixture where a single class
-blocks everything, which is why the exit side was tackled first.
+failing with **zero** `InputStranded` — the only fixture where fixing the input
+side could not help at all, which is why the exit side was tackled first. (It
+still records 23 `JunctionBlocked`, so lane conflict is not its sole refusal —
+just its dominant one, and the only one input work could not touch.) By raw
+count `InputStranded` is the larger refusal on three of the four fixtures
+(121 vs 21, 132 vs 22, 107 vs 46); only `pu4raw` inverts that.
 
 By raw count `InputStranded` is the larger refusal on three of the four
 fixtures (121 vs 21, 132 vs 22, 107 vs 46); only `pu4raw` inverts that. "Fix
@@ -199,7 +213,7 @@ Adversarial review also raised two it could not exercise:
   looseness itself remains a latent risk: re-run that measurement if
   junction-column *placement* ever changes.
 
-### 5. Lower-confidence items
+### 4. Lower-confidence items
 
 - The continuity invariant (`RunSevered`) false-positived twice on splitter
   footprints — a 180° rotation swaps which physical tile the anchor names. It


### PR DESCRIPTION
## Intent

`docs/snake-fold-followups.md` on `main` still names `InputStranded` as the
multi-fold blocker and describes the fix as unattempted. Both are stale — it is
resolved and the per-item lane machinery is built (#492).

The refresh was committed to `feat/multifold-gap-lanes`, which means it is
correct only for someone already working on that branch — i.e. the one person
who does not need it. Anyone picking this up cold from `main` would have spent
their first hours re-solving a solved problem, which is exactly the failure a
followups doc exists to prevent.

## Scope

- **In:** doc only. Same content as the branch copy, plus the #492 reference so
  the WIP is findable without knowing the branch name.
- **Out:** the code on `feat/multifold-gap-lanes` — still WIP, tracked in #492.

## Models / contracts touched

None. Doc-only change: no models, no contracts, no public API.

## Verification

- [x] Doc-only change; no code touched.
- [x] Content matches `feat/multifold-gap-lanes` at `b9bf4d9b`.

## Deviations from intent

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ
