### PR TITLE
docs: record the reporting-shape failure mode in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ Layout bugs are easy to get wrong — zero validation errors can mean the check 
 4. **Trace events are reliable signals** — `JunctionGrowthCapped`, `JunctionStrategyAttempt`, `GhostSpecFailed`, `CrossingZoneSkipped`, `BalancerStamped`, `TapBridgeUnbridgeable`, `LayoutRetried` are emitted by the pipeline and land in the snapshot's `trace.events`. Use them to confirm the specific failure mode before theorizing. (`RouteFailure` and `BridgeDropped` are declared in `trace.rs` but never emitted — don't wait for them.)
 5. **Don't trust an error-count drop alone** — if warnings go 5 → 0, ask *why*. Does the topology still make sense? Were belts actually re-routed, or did a check get silently skipped? Check the specific change caused the fix you wanted.
 6. **Clippy + WASM builds are checks, not nits** — a layout change that clippy-fails or breaks the WASM build is not done.
+7. **A check going quiet is not evidence the problem is fixed** — it is equally consistent with the check having stopped discriminating. Verify the specific invariant: instrument it and *count*, don't sample. When writing a check, emit one positioned issue per instance rather than a count inside a message — anything comparing issue counts by category cannot tell 2 from 218. This failure mode has recurred nine times; the rules and the evidence are in [`docs/validator-reporting.md`](docs/validator-reporting.md).
 
 ## Where to find X
 
@@ -179,6 +180,7 @@ Layout bugs are easy to get wrong — zero validation errors can mean the check 
 | Belt tier thresholds | `crates/core/src/common.rs` (`belt_entity_for_rate`, `ug_max_reach`) |
 | Entity sizes | `crates/core/src/common.rs` (`entity_size`) |
 | Validation checks | `crates/core/src/validate/` (36 checks, dispatched from `mod.rs`) |
+| How a check should report (and the nine times it didn't) | [`docs/validator-reporting.md`](docs/validator-reporting.md) |
 | Snapshot format | `crates/core/src/snapshot.rs` + [`docs/layout-snapshot-debugger.md`](docs/layout-snapshot-debugger.md) |
 | Sim measurement semantics + forensics | [`docs/sim-harness-forensics.md`](docs/sim-harness-forensics.md) (what each spaghettio-sim number means, artifact classes, debug playbook) |
 | Belt lane physics | [`docs/factorio-mechanics.md`](docs/factorio-mechanics.md) |

--- a/docs/validator-reporting.md
+++ b/docs/validator-reporting.md
@@ -3,7 +3,7 @@
 A check that runs, works, and finds the problem can still be useless — if the
 way it reports makes the problem invisible to whoever is reading. That failure
 mode hit this codebase **nine times**, was found in one day (2026-07-29), and
-three of the nine were written *while fixing the other six*. It is easy to
+three of the nine were written *while fixing five of the others*. It is easy to
 reintroduce, so it is written down.
 
 ## The shape
@@ -61,4 +61,7 @@ Kept as evidence that this is a pattern rather than a run of bad luck.
 | 8 | `claude-review` guard | asked "was this PR reviewed", not "was this code reviewed" |
 | 9 | a PR-watch monitor | reported `passing: 0` for CI that had not started |
 
-Numbers 6, 8 and 9 were written during the session that fixed 1–5.
+Numbers 6, 8 and 9 were written during the session that fixed 1–5. Number 7 was
+found in the same audit and is **not yet fixed on `main`** — the fix is in
+flight ([#491](https://github.com/storkme/spaghettio/pull/491)), tracked by
+[#490](https://github.com/storkme/spaghettio/issues/490).

--- a/docs/validator-reporting.md
+++ b/docs/validator-reporting.md
@@ -1,0 +1,64 @@
+# How a validation check should report
+
+A check that runs, works, and finds the problem can still be useless — if the
+way it reports makes the problem invisible to whoever is reading. That failure
+mode hit this codebase **nine times**, was found in one day (2026-07-29), and
+three of the nine were written *while fixing the other six*. It is easy to
+reintroduce, so it is written down.
+
+## The shape
+
+Consumers of validation compare **issue counts by category**: the fold's
+admission gate, the compaction gate, a human scanning a summary. A check that
+collapses N problems into one issue is therefore invisible to all of them —
+2 and 218 both read as `{"category": 1}`.
+
+## Rules for writing a check
+
+1. **One issue per instance, positioned.** Not one issue with a count in its
+   message text. `check_power_coverage` and `check_row_output_lane_budget` are
+   the reference shape; use `ValidationIssue::with_pos` so it can be found in
+   the snapshot debugger.
+2. **Measure an absolute property, not one relative to an arbitrary element.**
+   "Unreachable from element 0" is a fine boolean and a misleading magnitude:
+   it moves the wrong way when the layout genuinely improves. Count components.
+3. **Never truncate silently.** A cap, an early return, or an exhausted budget
+   must emit a trace event. A caller cannot otherwise distinguish "repaired"
+   from "gave up".
+4. **Cross-check derived metadata against the entities.** A `LayoutResult`
+   field is a claim, not a fact. `check_stranded_byproducts` is the model:
+   an exit record counts only if a real entity carrying that item sits at the
+   recorded tile.
+
+## Rules for reading validation
+
+5. **A check going quiet is not evidence the problem is fixed.** It is equally
+   consistent with the check having stopped discriminating. Verify the specific
+   invariant — instrument it and count.
+6. **Count, don't sample.** Summarising instrumentation by frequency
+   (`sort -rn`, `head`) surfaces the common case and hides the tail, which is
+   usually where the interesting minority lives.
+7. **Validator-clean and sim-green are each necessary and neither is
+   sufficient.** Two independent examples: a fold validated at exact parity
+   with its control and produced 0.00/s in Factorio (a relocated belt left its
+   boundary record behind); and the sim harness energises every pole network it
+   finds, so it reported 146/146 machines working for a blueprint that pastes
+   as two dead halves.
+
+## The nine
+
+Kept as evidence that this is a pattern rather than a run of bad luck.
+
+| # | Where | Shape |
+|---|---|---|
+| 1 | `boundary_outputs` | no check existed at all, while byproduct exits had one |
+| 2 | `check_pole_network_connectivity` | count in message text; 2 and 89 read alike |
+| 3 | `repair_pole_connectivity` | flat 20-bridge cap, silent on exhaustion |
+| 4 | `power_wires::disconnected_poles` | measured from `pole[0]`; a real repair read as regression |
+| 5 | `check_sushi_saturation` | N belts collapsed to one arbitrary entry |
+| 6 | bridge give-up path | traced only under an env var |
+| 7 | `check_belt_network_topology` | count in prose *and* origin-relative |
+| 8 | `claude-review` guard | asked "was this PR reviewed", not "was this code reviewed" |
+| 9 | a PR-watch monitor | reported `passing: 0` for CI that had not started |
+
+Numbers 6, 8 and 9 were written during the session that fixed 1–5.

--- a/docs/validator-reporting.md
+++ b/docs/validator-reporting.md
@@ -3,7 +3,7 @@
 A check that runs, works, and finds the problem can still be useless — if the
 way it reports makes the problem invisible to whoever is reading. That failure
 mode hit this codebase **nine times**, was found in one day (2026-07-29), and
-three of the nine were written *while fixing five of the others*. It is easy to
+three of the nine were written *while fixing the other six*. It is easy to
 reintroduce, so it is written down.
 
 ## The shape
@@ -62,6 +62,6 @@ Kept as evidence that this is a pattern rather than a run of bad luck.
 | 9 | a PR-watch monitor | reported `passing: 0` for CI that had not started |
 
 Numbers 6, 8 and 9 were written during the session that fixed 1–5. Number 7 was
-found in the same audit and is **not yet fixed on `main`** — the fix is in
-flight ([#491](https://github.com/storkme/spaghettio/pull/491)), tracked by
-[#490](https://github.com/storkme/spaghettio/issues/490).
+found in the same audit and fixed last, in
+[#491](https://github.com/storkme/spaghettio/pull/491) — so all six of the
+others are fixed on `main`.


### PR DESCRIPTION
## Intent

A check that runs, works and finds the problem can still be useless — if how it
reports makes the problem invisible to whoever reads it.

That shape hit this codebase **nine times**, all surfaced on 2026-07-29. Three
of the nine were written *while fixing the other six*, which is the argument for
writing it down rather than trusting it to be remembered.

## Scope

- **In — one CLAUDE.md protocol item.** Space there is expensive since it loads
  into every session, so it carries only the operative rules: a check going
  quiet is not evidence the problem is fixed; count rather than sample when
  verifying; emit one positioned issue per instance rather than a count inside a
  message, because anything comparing issue counts by category cannot tell 2
  from 218.
- **In — [`docs/validator-reporting.md`](../blob/docs/reporting-shape-lesson/docs/validator-reporting.md)**,
  67 lines: rules for writing a check (per-instance and positioned; absolute
  rather than origin-relative magnitudes; never truncate silently; cross-check
  derived metadata against entities), rules for reading validation output, and
  the table of nine as evidence it is a pattern.
- **Out:** no code. Instances 1-7 are fixed on `main` (#7 last, in #491);
  8 and 9 were tooling, fixed in place. The one remaining tracked item is
  #488, which is a *different* defect found by the same audit.

## Placement

Next to the existing "don't trust an error-count drop alone" item, which is
adjacent but distinct: that one is about a count falling for the wrong reason,
this one about a count that *cannot move*.

## The nine, for reviewers

| # | Where | Shape |
|---|---|---|
| 1 | `boundary_outputs` | no check at all, while byproduct exits had one |
| 2 | `check_pole_network_connectivity` | count in message text; 2 and 89 read alike |
| 3 | `repair_pole_connectivity` | flat 20-bridge cap, silent on exhaustion |
| 4 | `power_wires::disconnected_poles` | measured from `pole[0]`; a real repair read as a regression |
| 5 | `check_sushi_saturation` | N belts collapsed to one arbitrary entry |
| 6 | bridge give-up path | traced only under an env var |
| 7 | `check_belt_network_topology` | count in prose *and* origin-relative |
| 8 | `claude-review` guard | asked "was this PR reviewed", not "was this code reviewed" |
| 9 | a PR-watch monitor | reported `passing: 0` for CI that had not started |

## Models / contracts touched

None. Docs only: no models, no contracts, no public API, no code.

## Verification

- [x] Docs only; no code touched.
- [x] Every claim in the table traces to a merged PR or an open issue from that
      day.

## Deviations from intent

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ
