### PR TITLE
ci: do not cancel in-progress runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseding a PR push is fine — only the latest head matters. Superseding a
+  # push to main is not: every commit on main is a state someone can check out,
+  # and a cancelled run leaves it unverified while the run list still reads
+  # "success" from whichever doc-only merge landed next.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   changes:


### PR DESCRIPTION
## Intent

Verify every commit that lands on `main`. Right now several don't get verified,
and the run list doesn't show it.

Four PRs merged in quick succession today. Both of the code-carrying merges had
their `main` CI run **cancelled** by the next push landing on top of it:

| SHA | what | CI on main |
|---|---|---|
| `dde86638` | #489 — validator: pole connectivity is an Error | **cancelled** |
| `d769765c` | #491 — validator: per-network belt topology | **cancelled** |
| `059f93e2` | #493 — docs | success (Rust jobs skipped) |
| `608f7a3a` | #494 — docs | success (Rust jobs skipped) |

No CI run has compiled those two validator changes together. Each passed on a PR
branch whose base lacked the other — #491 merged first, so #489's green checks
were measured against a base that no longer existed at merge time.

The failure is quiet in the way this repo has spent the day cataloguing: `gh run
list --branch main` reads `success`, because the runs that succeeded are the two
doc merges, and doc merges skip the Rust jobs. Green there means "nothing ran."

## Scope

- **In:** scope `cancel-in-progress` to non-`main` refs in
  [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Cancelling is correct
  for PR pushes — only the latest head matters. It is wrong for `main`, where
  every commit is a state someone can check out and bisect through.
- **Out:** making `claude-review` a required status check, and re-reviewing on
  `edited` so body-scoped findings can be closed. Both are real gaps found in
  the same session; neither belongs in this diff.

## Models / contracts touched

None. CI configuration only.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` on `main` at
      `608f7a3a` — **1036 passed, 0 failed** (single invocation). This is the
      verification the cancelled runs owed us; the two validator changes do
      compose.
- [x] YAML parses (`yaml.safe_load`).
- [ ] The change only demonstrates itself on the next merge to `main` — the run
      should survive a subsequent push rather than reporting `cancelled`.

## Deviations from intent

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ