### PR TITLE
fix(review-bot): close the body-finding, merge-race, and repeat-finding gaps

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,23 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    # `edited` closes one specific hole: the bot files real findings against
+    # the PR *description* (missing template sections, body claims the diff
+    # contradicts), and fixing those means editing the body — which pushes
+    # nothing, so no `synchronize` fires and the finding is never confirmed
+    # closed. Observed 2026-07-29 on #493/#494: a template finding was fixed
+    # in the body, and the next round's summary still reported it "already on
+    # record and unchanged". The job's `if` below keeps this from turning
+    # every typo fix into an 11-minute review.
+    types: [opened, synchronize, ready_for_review, reopened, edited]
+
+# A review takes 8-11 minutes and fires per push, so a burst of pushes leaves
+# several runs racing over superseded heads. Cancelling is safe *because* the
+# guard enforces coverage on the CURRENT head: the surviving run reviews the
+# only SHA that can be merged. Keyed by PR so PRs never cancel each other.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
@@ -10,6 +26,15 @@ jobs:
     # was off the `claude-review` check reported "skipping" on every PR, which
     # is indistinguishable at a glance from the silent-failure classes this
     # workflow was hardened against — see docs/review-bot.md.
+    #
+    # `edited` fires on title, body, and base-branch changes alike. A title
+    # edit changes nothing reviewable; a body edit gets the cheap
+    # description-only re-check the prompt describes; a base change silently
+    # rewrites the whole diff and gets a full review.
+    if: >-
+      github.event.action != 'edited' ||
+      github.event.changes.body != null ||
+      github.event.changes.base != null
     runs-on: ubuntu-latest
     # `pull-requests`/`issues` must be WRITE: the review agent posts its
     # findings as a PR review + inline/summary comments. The stock template
@@ -82,6 +107,32 @@ jobs:
             addressed rather than assuming. Only the triviality gate
             (genuinely no substantive change in the range) justifies a
             skip, and it still needs the one-line comment.
+            — Description-edit runs: when ${{ github.event.action }} is
+            `edited`, the code has NOT changed — the PR description has.
+            Do NOT re-review the diff. Read the current description, then
+            re-check ONLY the findings that were scoped to it (missing
+            template sections, body claims the diff contradicts, stale
+            numbers). Post one short `gh pr comment` saying which
+            body-scoped findings are now resolved and which still stand.
+            This exists because a body edit pushes no commit, so without
+            it a description finding can never be confirmed fixed — and
+            the next round reports it as still open when it isn't.
+            — Repeat findings escalate. A finding raised in an earlier
+            round and still unaddressed must NOT be restated at the same
+            volume as a new one: it is stronger evidence than a first
+            sighting, because it has now survived a round of attention.
+            Lead your comment with a `**Unaddressed from N prior
+            round(s):** ...` line naming each one before any new
+            findings. Three consecutive identical restatements buried at
+            the bottom of a summary is the observed failure (#493,
+            2026-07-29) — the author fixed every inline finding and
+            stepped over the repeated one twice.
+            — Scope claims about mutable state to when you looked. Issue
+            and PR state changes under you: a finding that says "#490 is
+            open, so this isn't fixed" can invert within the hour if #490
+            merges, taking your recommended remedy with it. Write such
+            claims as "as of this review, #490 is open" and say what
+            would change the conclusion.
           # Model pinned rather than left to the action's default: review
           # quality and cost both depend on it, and an unpinned default can
           # move under us without any change to this file.
@@ -116,6 +167,15 @@ jobs:
           PUSH_BEFORE: ${{ github.event.before }}
         run: |
           set -uo pipefail
+          # Description-edit runs carry no new commit, so head-SHA coverage is
+          # owned by whichever push event produced that head — every SHA gets
+          # an `opened` or `synchronize` run. Enforcing here would red a PR for
+          # a body edit whose cheap re-check legitimately had nothing to post.
+          # Carving this out cannot lose coverage on any SHA.
+          if [ "${EVENT_ACTION:-}" = "edited" ]; then
+            echo "Description-edit run — no new head SHA; coverage is enforced by the push events."
+            exit 0
+          fi
           # Fail-open on API errors: the guard is a safety net, and its own
           # flakiness must never block a merge. It fails ONLY on confirmed
           # zero-coverage abandonment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,14 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   Live trap: re-running `/install-github-app` overwrites the repaired
   workflow files with the stock template — diff them against main before
   merging its PR. Failure-class history and forensics playbook:
-  [`docs/review-bot.md`](docs/review-bot.md). Local adversarial review (an
+  [`docs/review-bot.md`](docs/review-bot.md).
+  **Nothing blocks a merge while the review is still running** — `main` is
+  unprotected, so waiting is the merger's job. Use
+  `scripts/review-gate.sh wait <pr>`, never a hand-rolled poll: a running
+  check reports `IN_PROGRESS` (and the PR `UNSTABLE`), so the obvious
+  `!= "PENDING"` test passes instantly and merges mid-review.
+  Findings against the PR *description* are re-checked on body edits, so fix
+  them in the body and let the cheap `edited` run confirm them closed. Local adversarial review (an
   independent agent that re-runs gates and probes the claims) is the
   fallback when a PR isn't in play — and it remains **required in addition
   to the bot** for layout-engine or validator-semantics changes: the bot

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -9,8 +9,14 @@ changes.
 
 - [`.github/workflows/claude-code-review.yml`](../.github/workflows/claude-code-review.yml)
   — runs on every PR event (opened / synchronize / ready_for_review /
-  reopened): checkout → `anthropics/claude-code-action@v1` running the
-  `code-review` plugin → transcript artifact upload → silent-no-op guard.
+  reopened / edited): checkout → `anthropics/claude-code-action@v1` running
+  the `code-review` plugin → transcript artifact upload → silent-no-op guard.
+  Runs are debounced per PR (`concurrency` + `cancel-in-progress`): a review
+  costs 8–11 minutes, and a run against a superseded head is spend the guard
+  ignores anyway, since it enforces coverage on the *current* head.
+  `edited` runs are the description-only re-check (class 7 below) — they take
+  the cheap path in the prompt and are carved out of the guard, because a body
+  edit produces no new SHA whose coverage could be at stake.
 - **The plugin** (`code-review@claude-code-plugins`, from the
   anthropics/claude-code marketplace) is a multi-subagent orchestration:
   a haiku gate (skip closed / draft / trivial / already-reviewed PRs) → a
@@ -84,8 +90,10 @@ semantics below).
 
 ## Failure-class history
 
-Six classes, each individually sufficient to produce the same symptom —
-green check, nothing posted:
+Classes 1–6 share one symptom — green check, nothing posted — and each is
+individually sufficient to produce it. Classes 7–8, below the table, are a
+different family: the review runs and posts, but its findings can't be closed
+or don't land.
 
 | # | Cause | Symptom signature | Fixed |
 |---|-------|-------------------|-------|
@@ -96,9 +104,77 @@ green check, nothing posted:
 | 5 | Shape-sensitive denial starvation — the allowlist admits plain `gh pr/issue` commands but denies improvised *shapes* (env prefixes `GH_PAGER= gh …`, command substitution `$(…)`, `cd … &&` chains, `gh api`); enough denials and the orchestrator abandons mid-review without posting. Stochastic per run, worse on large PRs (more context wanted → more improvised commands). Diagnosed 2026-07-24 on PR #389 (two consecutive silent no-ops; PR #405 succeeded through 31 denials the same day) | mid-cost, mid-duration run: more than a gate-skip, far less than a full review; see signature table below | prompt hardening + guard step (introduced with this doc) |
 | 6 | Async-wait abandonment — the plugin orchestrator fans out its reviewer subagents, then parks via `ScheduleWakeup` to "wait" for them; in a one-shot headless run the wakeup never fires and the session ends mid-wait. First caught live by the guard 2026-07-24 on PR #416 — transcript artifact showed 26 tool calls, near-zero denials, 4 parallel reviewers spawned, `ScheduleWakeup(180s)` then end at 10 turns/$1.08 with nothing posted. NOT a denial problem: the class-5 prompt note was propagating into every subagent and reads worked fine | mid-cost short run like class 5, but transcript shows `ScheduleWakeup` + spawned agents with unconsumed results | prompt note extended: one-shot/headless, never park, consume subagent results synchronously |
 
+### Failure class 7: findings against the PR body can never be closed (2026-07-29)
+
+The bot files real findings about the PR *description* — a missing
+`## Models / contracts touched` section, a body claim the diff contradicts
+(#494's description repeated a census error that had already been fixed in the
+shipped doc). Fixing one means editing the description, which pushes no commit,
+so no `synchronize` fires, no re-review runs, and nothing ever records the fix.
+Worse than inert: on #493 the next round's summary reported the template
+finding as "already on record and unchanged" — by then it had been fixed.
+
+The workflow now takes `edited` events. Because that also fires on title and
+base-branch edits, the job's `if` admits only body and base changes, and the
+prompt splits them: a body edit gets a cheap description-only re-check that
+re-reads the body, re-checks *only* body-scoped findings, and posts one short
+comment saying which are resolved and which still stand; a base change gets a
+full review, because it silently rewrites the diff.
+
+### Failure class 8: repeat findings restated at constant volume (2026-07-29)
+
+Not a silence — the opposite. The template finding on #493 was raised in three
+consecutive rounds, each time in identical non-inline form at the bottom of a
+summary. The bot tracked the repetition and said so, but a third airing read
+exactly like a first and the check passed either way. The author fixed every
+inline finding across all three rounds and stepped over the repeated one twice.
+
+A finding that survived a round of attention is *stronger* evidence than a
+fresh one, and the prompt now says so: unaddressed findings from prior rounds
+lead the comment on a `**Unaddressed from N prior round(s):**` line, ahead of
+anything new.
+
+A related, smaller correction in the same change: claims about mutable tracker
+state get scoped to when the reviewer looked. The bot correctly reasoned "#490
+is open, so #7 isn't fixed" — #491 merged an hour later and inverted the
+remedy. Such claims are now written "as of this review, …" with a note on what
+would change the conclusion.
+
 Validation history: planted-bug canary #330 (2026-07-21) — first-ever bot
 comment correctly flagged the bug inline with a committable fix; canary
 #368 re-validated after the installer overwrite was restored in #369.
+
+## Merge-time gating (the review is advisory)
+
+**`main` has no branch protection.** `claude-review` is therefore a check
+nobody has to wait for: a PR sitting at `mergeStateStatus=UNSTABLE` with the
+review still running merges cleanly. The guard makes a *finished* run's silence
+loud; it can do nothing about a run that never finished.
+
+That came within one wrong comparison of mattering on 2026-07-29. A session
+polled merge readiness with a hand-rolled loop testing
+`mergeStateStatus != "PENDING"`. GitHub reports a running check as
+`IN_PROGRESS` and the PR as `UNSTABLE`, so the loop exited immediately every
+time and reported "checks done" while an 11-minute review was still going.
+#494 would have merged with zero review coverage and been reported as reviewed.
+
+Two independent mitigations, only one of them applied:
+
+- **Applied** — [`scripts/review-gate.sh`](../scripts/review-gate.sh)
+  `wait <pr>` blocks until the check reaches `status == "COMPLETED"` and exits
+  non-zero on any conclusion that isn't a pass. Use it rather than hand-rolling
+  a poll; the trap is that the obvious-looking sentinel values (`PENDING`,
+  `""`) are not states this API ever reports for a running check, so testing
+  for their absence always succeeds.
+- **Not applied, needs a human call** — `scripts/review-gate.sh require` makes
+  `claude-review` a required status check on `main`. This is the change that
+  actually makes a merge wait. It is deliberately manual: the repo has *no*
+  protection today, so this introduces it, and to bind at all it needs
+  `enforce_admins: true` (with it false, every session using the owner's token
+  bypasses it and the gate is theatre). That form also blocks direct pushes to
+  `main` for everyone, and if the review cannot run at all — rotated secret,
+  action outage — nothing merges until protection is loosened. Real cost, real
+  benefit; `unrequire` reverses it in one command.
 
 ## Forensics playbook
 

--- a/scripts/review-gate.sh
+++ b/scripts/review-gate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# review-gate.sh — wait for the claude-review check correctly, and (optionally)
+# make it a required status check on main.
+#
+# Why this exists: on 2026-07-29 a session polled a PR's merge readiness with a
+# hand-rolled loop testing `mergeStateStatus != "PENDING"`. GitHub reports a
+# *running* check as `IN_PROGRESS`, and a PR whose only outstanding item is a
+# running check as `UNSTABLE` — so the loop exited immediately, every time, and
+# reported "checks done" while an 11-minute review was still going. Nothing in
+# the repo stopped the merge: `main` has no branch protection, so `claude-review`
+# is advisory. #494 came one wrong comparison away from merging with zero review
+# coverage and being reported as reviewed.
+#
+# Rule of thumb: a check is finished when `.status == "COMPLETED"`. Never test
+# for the absence of a value you guessed at.
+#
+# Usage:
+#   scripts/review-gate.sh wait <pr>       # block until claude-review completes
+#   scripts/review-gate.sh status          # report main's protection state
+#   scripts/review-gate.sh require         # make claude-review required on main
+#   scripts/review-gate.sh unrequire       # remove that protection
+set -euo pipefail
+
+REPO="${REPO:-storkme/spaghettio}"
+CHECK="${CHECK:-claude-review}"
+TIMEOUT="${TIMEOUT:-1500}"   # 25 min; a full review runs 8-11.
+
+usage() { sed -n '2,25p' "$0"; exit 2; }
+
+cmd_wait() {
+  local pr="${1:?usage: review-gate.sh wait <pr>}"
+  local deadline=$(( SECONDS + TIMEOUT ))
+  while :; do
+    # `// empty` so a check that has not been *created* yet is distinguishable
+    # from one that is running — the former prints nothing and we keep waiting.
+    local row status conclusion
+    row=$(gh pr view "$pr" -R "$REPO" --json statusCheckRollup \
+          --jq ".statusCheckRollup[] | select((.name // .context) == \"$CHECK\") | \"\(.status)\t\(.conclusion // \"\")\"" \
+          | tail -1)
+    status=${row%%$'\t'*}
+    conclusion=${row#*$'\t'}
+
+    if [ "$status" = "COMPLETED" ]; then
+      echo "$CHECK: COMPLETED / ${conclusion:-unknown}"
+      case "$conclusion" in
+        SUCCESS|NEUTRAL|SKIPPED) return 0 ;;
+        *) echo "  → not a pass; do not merge on this." >&2; return 1 ;;
+      esac
+    fi
+
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "timed out after ${TIMEOUT}s with $CHECK in state '${status:-absent}'" >&2
+      return 1
+    fi
+    echo "  $CHECK: ${status:-not yet reported} — waiting…"
+    sleep 20
+  done
+}
+
+cmd_status() {
+  if out=$(gh api "repos/$REPO/branches/main/protection" 2>/dev/null); then
+    echo "main IS protected. Required checks:"
+    echo "$out" | jq -r '.required_status_checks.contexts[]? | "  - \(.)"'
+    echo "  enforce_admins: $(echo "$out" | jq -r '.enforce_admins.enabled')"
+  else
+    echo "main is NOT protected — every check on it, including $CHECK, is advisory."
+  fi
+}
+
+# The trade-off, stated plainly because it is the whole reason this is a manual
+# command and not something a session runs on its own:
+#
+#   enforce_admins=false — admins (i.e. every session using the owner's token)
+#     bypass the requirement, so `gh pr merge` still merges through a pending
+#     review. Blocks nobody here; effectively cosmetic for this repo.
+#   enforce_admins=true  — the requirement actually binds. It also blocks direct
+#     pushes to main for everyone, and if claude-review cannot run at all
+#     (secret rotated, action outage) nothing merges until protection is
+#     loosened. That is the point, and it is a real operational cost.
+#
+# Defaulting to the binding form: the non-binding one would be theatre.
+cmd_require() {
+  local enforce="${ENFORCE_ADMINS:-true}"
+  echo "Requiring '$CHECK' on $REPO@main (enforce_admins=$enforce)…"
+  gh api -X PUT "repos/$REPO/branches/main/protection" --input - <<JSON
+{
+  "required_status_checks": { "strict": false, "contexts": ["$CHECK"] },
+  "enforce_admins": $enforce,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+  cmd_status
+}
+
+cmd_unrequire() {
+  gh api -X DELETE "repos/$REPO/branches/main/protection"
+  echo "Protection removed from $REPO@main."
+}
+
+case "${1:-}" in
+  wait)      shift; cmd_wait "$@" ;;
+  status)    cmd_status ;;
+  require)   cmd_require ;;
+  unrequire) cmd_unrequire ;;
+  *)         usage ;;
+esac


### PR DESCRIPTION
## Intent

Three gaps in the review integration, all found by using it hard across #489,
#491, #493 and #494 today (11 findings, 11 real, zero false positives). None is
about review *quality* — all three are plumbing that lets a correct finding go
unclosed or a merge go unreviewed.

**1. Body-scoped findings could never be closed.** The workflow fired on
`synchronize` — a push. But the bot files genuine findings against the PR
*description*: it caught #494's body repeating a census error I'd already fixed
in the shipped doc, and flagged a missing template section on both PRs. Fixing
those means editing the body, which pushes nothing, so no re-review fired and
the finding was never confirmed closed. On #493 the next round reported a
template finding "already on record and unchanged" when it had been fixed
minutes earlier.

**2. Nothing stopped a merge while the review was still running.** #494 sat at
`mergeStateStatus=UNSTABLE` with `claude-review` pending, and `gh pr merge` will
take that happily. It came one comparison away from mattering: a poll in this
session tested `!= "PENDING"`, GitHub reports a running check as `IN_PROGRESS`,
so it returned "done" mid-review. Printing the state was the only thing between
that and merging #494 with zero coverage while reporting it reviewed. The #486
guard makes a *finished* run fail loudly on zero activity; it can do nothing
about a run that never finished.

**3. Repeat findings were restated at constant volume.** The same template
finding was raised three consecutive rounds on #493, each time identically, at
the bottom of the summary. That is a large part of why I fixed every inline
finding and stepped over that one twice. A finding that survives a round of
attention is *stronger* evidence than a first sighting and should read that way.

## Scope

- **In — `edited` trigger**, gated by a job `if` to body/base changes only.
  A body edit gets a cheap description-only re-check; a base change gets a full
  review (it silently rewrites the diff); a title edit gets nothing. The #486
  guard carves out `edited` — no new SHA, so no coverage is at stake.
- **In — `scripts/review-gate.sh`**: `wait <pr>` polls `.status == "COMPLETED"`
  rather than guessing at the absence of a value. `status` / `require` /
  `unrequire` manage branch protection.
- **In — prompt**: repeat findings lead with `**Unaddressed from N prior
  round(s):**`; claims about mutable tracker state get scoped to review time
  (a #490-is-open finding inverted within the hour today when #491 merged).
- **In — per-PR `concurrency` + `cancel-in-progress`** for the 8–11 min/push
  cost. Safe *because* the guard enforces coverage on the current head: the
  surviving run reviews the only SHA that can be merged.
- **In — docs**: `docs/review-bot.md` gains failure classes 7 and 8 and a
  merge-time gating section; `CLAUDE.md` gains the operating rule.
- **Out — actually applying branch protection.** See below; it's your call.

## The one decision this PR deliberately does not make

`main` has **no branch protection at all**, so `claude-review` is advisory
today. Making it required is not flipping a flag — it introduces protection.
To bind it needs `enforce_admins: true`, which also blocks direct pushes to
`main` for every session and blocks all merges if the review cannot run
(rotated secret, action outage). `enforce_admins: false` lets every
owner-token session bypass it, i.e. theatre.

`scripts/review-gate.sh require` / `unrequire` does it in one command either
way. Not run here.

## Models / contracts touched

None. CI configuration, one script, and docs.

## Verification

- [x] All three workflow YAMLs parse (`yaml.safe_load`).
- [x] `bash -n scripts/review-gate.sh`.
- [x] All five `workflow-guard` tripwire greps still match — this PR edits the
      very file that guard protects, so this is the load-bearing check.
- [x] `review-gate.sh wait 494` exercised against the live PR; correctly
      reported `COMPLETED / SUCCESS` after blocking through the run.
- [x] `cargo test --manifest-path crates/core/Cargo.toml` — exit 0.
- [x] **Session-side review done**: this PR touches `.github/workflows/`, so
      the action self-skips it (anti-hijack) and the guard carves it out. Per
      CLAUDE.md, workflow-file PRs get session-side review instead — the
      verification above is that pass, not a self-report.

## Deviations from intent

Authored by a subagent in a shared working directory; its commit initially
landed on a sibling branch and was recovered by cherry-pick onto a clean base
(`608f7a3a`). Content is unchanged from `9cef3f14`; only the parent differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ