### PR TITLE
fix(review-bot): the required check must never report skipped

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,14 +27,19 @@ jobs:
     # is indistinguishable at a glance from the silent-failure classes this
     # workflow was hardened against — see docs/review-bot.md.
     #
-    # `edited` fires on title, body, and base-branch changes alike. A title
-    # edit changes nothing reviewable; a body edit gets the cheap
-    # description-only re-check the prompt describes; a base change silently
-    # rewrites the whole diff and gets a full review.
-    if: >-
-      github.event.action != 'edited' ||
-      github.event.changes.body != null ||
-      github.event.changes.base != null
+    # THIS JOB HAS NO `if:` ON PURPOSE — do not add one (#497).
+    #
+    # `claude-review` is a REQUIRED status check on main (enforce_admins:
+    # true, see scripts/review-gate.sh). A job skipped by a job-level `if`
+    # still publishes a check run named `claude-review`, with conclusion
+    # `skipped`, against a head SHA that may already carry a passing one —
+    # and required-check evaluation reads the latest. Whether GitHub counts
+    # `skipped` as a pass is not something to bet a merge queue on.
+    #
+    # So the job always runs and always reports a real conclusion, and the
+    # conditions live on the steps instead. Cost is a runner spin-up
+    # (seconds) for events with nothing to review; the guard below exits
+    # early on those.
     runs-on: ubuntu-latest
     # `pull-requests`/`issues` must be WRITE: the review agent posts its
     # findings as a PR review + inline/summary comments. The stock template
@@ -62,6 +67,22 @@ jobs:
       # made runs abandon mid-review without posting.
       - name: Run Claude Code Review
         id: claude-review
+        # Two gates, both moved here from the job level so a no-op event still
+        # reports a real check conclusion (#497):
+        #
+        # 1. `edited` fires on title, body and base-branch changes alike. A
+        #    title edit changes nothing reviewable; a body edit gets the cheap
+        #    description-only re-check the prompt describes; a base change
+        #    silently rewrites the whole diff and gets a full review.
+        # 2. Fork PRs get no secrets from `pull_request` (by design — not a
+        #    leak), so the action would fail on an empty token. Advisory that
+        #    was noise; required it is an unclearable merge block for an
+        #    outside contributor.
+        if: >-
+          (github.event.action != 'edited' ||
+           github.event.changes.body != null ||
+           github.event.changes.base != null) &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -165,8 +186,19 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EVENT_ACTION: ${{ github.event.action }}
           PUSH_BEFORE: ${{ github.event.before }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -uo pipefail
+          # Fork PR: the review step above is gated off (no secrets reach a
+          # fork's `pull_request` run), so there is nothing for this guard to
+          # find and failing here would be an unclearable block on an outside
+          # contributor. Skipping the guard cannot hide an abandonment — the
+          # review provably never started. Such PRs need session-side review,
+          # same rule as workflow-file PRs (CLAUDE.md "Workflow").
+          if [ -n "${HEAD_REPO:-}" ] && [ "${HEAD_REPO}" != "${REPO}" ]; then
+            echo "Fork PR ($HEAD_REPO != $REPO) — review step gated off, no secrets available. Needs session-side review."
+            exit 0
+          fi
           # Description-edit runs carry no new commit, so head-SHA coverage is
           # owned by whichever push event produced that head — every SHA gets
           # an `opened` or `synchronize` run. Enforcing here would red a PR for

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -144,12 +144,41 @@ Validation history: planted-bug canary #330 (2026-07-21) — first-ever bot
 comment correctly flagged the bug inline with a committable fix; canary
 #368 re-validated after the installer overwrite was restored in #369.
 
-## Merge-time gating (the review is advisory)
+## Merge-time gating (the review is REQUIRED)
 
-**`main` has no branch protection.** `claude-review` is therefore a check
-nobody has to wait for: a PR sitting at `mergeStateStatus=UNSTABLE` with the
-review still running merges cleanly. The guard makes a *finished* run's silence
-loud; it can do nothing about a run that never finished.
+**`claude-review` is a required status check on `main`** — enabled 2026-07-29
+with `enforce_admins: true`, so it binds rather than being bypassable by any
+session holding the owner's token. Verified binding on #473, which went from
+mergeable to `BLOCKED` on a failed review. Direct pushes to `main` are blocked
+for everyone; `scripts/review-gate.sh unrequire` reverses the whole thing.
+
+Before that it was advisory, and the guard could only make a *finished* run's
+silence loud — never a run that never finished. The history below is kept
+because the reasoning is what justifies the cost.
+
+### The never-skip invariant (#497)
+
+Once the check is required, **the `claude-review` job must never be skipped**,
+and must not acquire a job-level `if:`. A job skipped that way still publishes
+a check run named `claude-review` with conclusion `skipped`, against a head SHA
+that may already carry a passing one — and required-check evaluation reads the
+latest. Whether GitHub counts `skipped` as a pass is undocumented enough that it
+is not worth betting a merge on.
+
+So the job always runs and always reports; every condition lives on a *step*:
+
+- the `edited` gate (title edits have nothing to review, body edits get the
+  cheap description-only re-check, base changes get a full review), and
+- the fork gate — `pull_request` withholds secrets from forks by design, so the
+  action would fail on an empty token. Advisory, that was noise. Required, it
+  is an unclearable merge block on an outside contributor.
+
+The guard carves out both cases too: a fork PR's review provably never started,
+so guard silence there cannot be hiding an abandonment. Fork PRs and
+workflow-file PRs both fall back to session-side review (CLAUDE.md "Workflow").
+
+Cost of the invariant is a runner spin-up (seconds) on events with nothing to
+review. That is the price of a check that cannot report `skipped`.
 
 That came within one wrong comparison of mattering on 2026-07-29. A session
 polled merge readiness with a hand-rolled loop testing
@@ -166,15 +195,16 @@ Two independent mitigations, only one of them applied:
   a poll; the trap is that the obvious-looking sentinel values (`PENDING`,
   `""`) are not states this API ever reports for a running check, so testing
   for their absence always succeeds.
-- **Not applied, needs a human call** — `scripts/review-gate.sh require` makes
+- **Applied 2026-07-29** — `scripts/review-gate.sh require` made
   `claude-review` a required status check on `main`. This is the change that
-  actually makes a merge wait. It is deliberately manual: the repo has *no*
-  protection today, so this introduces it, and to bind at all it needs
-  `enforce_admins: true` (with it false, every session using the owner's token
-  bypasses it and the gate is theatre). That form also blocks direct pushes to
-  `main` for everyone, and if the review cannot run at all — rotated secret,
-  action outage — nothing merges until protection is loosened. Real cost, real
-  benefit; `unrequire` reverses it in one command.
+  actually makes a merge wait. It stays a manual command rather than something
+  a session runs: it introduces protection where there was none, and to bind at
+  all it needs `enforce_admins: true` (with it false, every session using the
+  owner's token bypasses it and the gate is theatre). That form also blocks
+  direct pushes to `main` for everyone, and if the review cannot run at all —
+  rotated secret, action outage — nothing merges until protection is loosened.
+  `unrequire` reverses it in one command. See the never-skip invariant above:
+  requiring the check constrains how this workflow may be conditioned.
 
 ## Forensics playbook
 


### PR DESCRIPTION
Closes #497.

## Intent

`claude-review` became a **required** status check on `main` today
(`enforce_admins: true`). Verified binding: #473 went from mergeable to
`BLOCKED` on its failed review. Requiring it also promotes two
previously-harmless cases into merge blockers, and constrains how this workflow
may be conditioned at all.

**The core fix is to delete a question rather than answer it.** #497 asked
whether GitHub counts a `skipped` conclusion as a pass for required checks. I
don't know, and the honest way to find out is a throwaway PR and a 10-minute
review run. The better move is to make it impossible to reach: the
`claude-review` job now has **no `if:` at all**, always runs, and always reports
a real conclusion. Every condition moved to the steps.

That invariant is now written into the workflow as a "do not add one (#497)"
comment, because the natural instinct on reading the file is to re-add a
job-level gate to save a runner minute.

## The two cases

**1. Title-only edits.** #496 added `edited` to the trigger types with a
job-level gate on body/base changes. A title edit satisfies none of them, so the
job skipped and published `claude-review = skipped` over a SHA that already had
a pass. Now the review *step* carries that gate and the job still reports.

**2. Fork PRs.** `pull_request` withholds secrets from forks by design (not a
leak), so the action fails on an empty token. Advisory, that was noise.
Required, it is an **unclearable** merge block on an outside contributor — they
cannot make the check pass by any action available to them. The review step now
requires `head.repo.full_name == github.repository`.

The guard carves forks out too: with the review step gated off, the review
provably never started, so guard silence there cannot be hiding an abandonment
— which is the only thing that guard exists to catch. Fork PRs fall back to
session-side review, the same rule this repo already applies to workflow-file
PRs.

## Scope

- **In:** `.github/workflows/claude-code-review.yml` — job-level `if:` removed;
  `edited` + fork gates on the review step; fork carve-out in the guard.
- **In:** `docs/review-bot.md` — merge-time gating section rewritten from
  "advisory" to "required", plus the never-skip invariant and why it exists.
- **Out:** anything about review content or the prompt.

## Models / contracts touched

None. CI configuration and docs.

## Verification

- [x] All three workflow YAMLs parse (`yaml.safe_load`).
- [x] Parsed structurally, not grepped: the job has **no** top-level `if`, and
      the `claude-review` step **does** — the two facts the fix depends on.
- [x] All five `workflow-guard` tripwires still match. Load-bearing here: this
      PR edits the very file that guard protects.
- [ ] **Cannot be verified pre-merge.** This PR touches
      `.github/workflows/`, so the action self-skips it — its own
      `claude-review` pass means "did not run", not "found nothing". The title-edit
      path also cannot be exercised until the workflow is on `main`. First real
      evidence is the next title edit on a non-workflow PR reporting `success`
      rather than `skipped`.

Session-side review stands in for the bot here, per CLAUDE.md.

## Deviations from intent

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ