### PR TITLE
feat(compaction): multi-fold works — mil5 folds 3x to 1.07:1, Factorio-verified

### DIFF
--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -4431,6 +4431,18 @@ pub struct FoldSearch {
     pub refusals: Vec<(Vec<i32>, FoldRefusal)>,
     /// Candidates that folded but validated worse than the source.
     pub rejected_by_validation: usize,
+    /// Which categories those candidates regressed on, and how many candidates
+    /// regressed on each.
+    ///
+    /// The bare count above says how many candidates were turned away and
+    /// nothing about why, so a geometry fix that converts refusals into
+    /// validation rejections looks like progress in one column and is
+    /// invisible in the other. That is the reporting shape documented in
+    /// `docs/validator-reporting.md`, and it cost real time here: the
+    /// side-partition fix took `GapLaneConflict` 32 -> 0 while pushing
+    /// `rejected_by_validation` 22 -> 54, and the counter could not say which
+    /// check the 32 newly-buildable layouts were failing.
+    pub validation_regressions: BTreeMap<String, usize>,
 }
 
 /// Search for the squarest snake fold that does not break the factory.
@@ -4465,6 +4477,7 @@ pub fn search_snake_fold(
         legal_columns: 0,
         refusals: Vec::new(),
         rejected_by_validation: 0,
+        validation_regressions: BTreeMap::new(),
     };
     let Some(baseline) = profile(layout) else {
         return out;
@@ -4514,11 +4527,16 @@ pub fn search_snake_fold(
                 continue;
             };
             // No new category, and no category worse than the source.
-            if got
+            let regressed: Vec<&String> = got
                 .iter()
-                .any(|(cat, n)| baseline.get(cat).copied().unwrap_or(0) < *n)
-            {
+                .filter(|(cat, n)| baseline.get(*cat).copied().unwrap_or(0) < **n)
+                .map(|(cat, _)| cat)
+                .collect();
+            if !regressed.is_empty() {
                 out.rejected_by_validation += 1;
+                for cat in regressed {
+                    *out.validation_regressions.entry(cat.clone()).or_default() += 1;
+                }
                 continue;
             }
 
@@ -4644,8 +4662,13 @@ pub enum FoldRefusal {
     /// conflicting tile — without it the cause is indistinguishable from any
     /// other refusal and the fix is guesswork.
     JunctionBlocked { at: (i32, i32) },
-    /// Two exits carrying different items would have to share one gap lane.
-    ExitLaneConflict,
+    /// Two gap lanes would have to share a tile. Carries the tile.
+    ///
+    /// Covers exits and input feeds alike — both are lanes in the same gap.
+    /// It was `GapLaneConflict`, which the input feed pass reused, so an
+    /// input-side collision reported a name that sent the reader to the exit
+    /// pass.
+    GapLaneConflict { at: (i32, i32) },
     /// A U-turn corner gained a second feeder, demoting a both-lane turn to a
     /// single-lane sideload (`docs/factorio-mechanics.md` B8 vs B11).
     CornerNotATurn,
@@ -4674,6 +4697,15 @@ pub enum FoldRefusal {
 /// severed.
 fn replace_poles(layout: &LayoutResult) -> LayoutResult {
     let mut out = layout.clone();
+    // Coverage first, then connectivity — in that order, deliberately.
+    //
+    // A fold breaks both, differently: rotation is rigid so coverage survives
+    // INSIDE a segment, but an entity next to a fold column loses the pole that
+    // covered it from across the seam, and the two segments' pole networks are
+    // no longer wired to each other. Topping up coverage before repairing
+    // connectivity means the new poles are wire nodes the repair can use,
+    // rather than fresh islands it has to bridge on a second pass.
+    crate::bus::layout::cover_unpowered(&mut out);
     crate::bus::layout::repair_pole_network(&mut out);
     out
 }
@@ -4714,12 +4746,80 @@ pub fn fold_snake(
     }
 
     let h = layout.height;
-    let gap = 2;
 
     let mut bounds = vec![0];
     bounds.extend_from_slice(folds);
     bounds.push(layout.width);
     let n_segs = bounds.len() - 1;
+
+    // Gap height is sized from lane demand, not fixed at 2.
+    //
+    // A gap carries the belts that cross between the segments either side of
+    // it, and two DIFFERENT items cannot share a lane — merging them onto one
+    // belt is the corruption this pass exists to avoid. So the gap needs one
+    // row per distinct item, and a fixed two-row gap silently capped every
+    // layout at one item per side.
+    //
+    // Segment parity decides what each gap carries. An exit is a bottom-edge
+    // belt in the source, which an unrotated segment keeps at its bottom (into
+    // the gap below) and a rotated one carries to its top (into the gap
+    // above); an input is a top-edge belt, mirrored. Consecutive segments
+    // alternate, so a gap carries either two exit sets or two input sets,
+    // never a mix.
+    //
+    // One height for every gap rather than a per-gap vector: it wastes a few
+    // rows on the lighter gaps and keeps the segment offset a plain multiple
+    // of `h + gap`, which the transform, junction and boundary passes all
+    // depend on.
+    let edge_items = |seg: usize, row: i32, dir: EntityDirection| -> std::collections::BTreeSet<String> {
+        let (lo, hi) = (bounds[seg], bounds[seg + 1]);
+        layout
+            .entities
+            .iter()
+            .filter(|e| {
+                e.y == row
+                    && e.x >= lo
+                    && e.x < hi
+                    && e.direction == dir
+                    && is_surface_belt(&e.name)
+            })
+            .filter_map(|e| e.carries.clone())
+            .collect()
+    };
+    let gap = {
+        let mut widest = 2;
+        for k in 0..n_segs.saturating_sub(1) {
+            // Even gaps take both neighbours' exits (source bottom row,
+            // facing South); odd gaps take both neighbours' inputs (source top
+            // row, facing South into the factory).
+            let (row, dir) = if k % 2 == 0 {
+                (h - 1, EntityDirection::South)
+            } else {
+                (0, EntityDirection::South)
+            };
+            // Exits and inputs need different counts, and the difference is
+            // load-bearing for the sim-verified single fold.
+            //
+            // The exit pass keys lanes by ITEM, so both neighbours' copies of
+            // one item share a lane: merged distinct count.
+            // The input pass keys by (item, SIDE) — an item both neighbours
+            // consume needs one lane per side, because they sit in different
+            // row blocks — so it needs the SUM, not the union.
+            //
+            // Sizing per parity rather than taking the sum everywhere keeps a
+            // single fold (which has only the even/exit gap) byte-identical,
+            // and with it the registry pin measured at 5.00/s in Factorio.
+            let need = if k % 2 == 0 {
+                let mut items = edge_items(k, row, dir);
+                items.extend(edge_items(k + 1, row, dir));
+                items.len() as i32 + 1
+            } else {
+                edge_items(k, row, dir).len() as i32 + edge_items(k + 1, row, dir).len() as i32 + 1
+            };
+            widest = widest.max(need);
+        }
+        widest
+    };
 
     // 1. Replace straddling UG pairs with surface belts.
     let entities = replace_straddling_ug_pairs(&layout.entities, folds);
@@ -4941,106 +5041,425 @@ pub fn fold_snake(
     // the old tile means the factory produces into a spot nothing drains —
     // every producer upstream then backs up and the whole line stalls.
     let mut exit_moved: BTreeMap<(i32, i32), ((i32, i32), EntityDirection)> = BTreeMap::new();
+    // Same, for inputs the fold moved off the boundary.
+    let mut input_moved: BTreeMap<(i32, i32), ((i32, i32), EntityDirection)> = BTreeMap::new();
 
-    // 5. Give the layout's original exits somewhere to go.
+    // 5. Carry the layout's edge belts across the gaps they now land in.
     //
     // A belt on the source layout's bottom edge facing South deposited
     // outside the bounding box — an exit. After folding it deposits into an
     // inter-segment gap instead, and a gap row is interior, so the exit
-    // becomes a dead end. Rotation means each gap collects exits from both
-    // sides: the segment above contributes South-facing belts on its last
-    // row, and the rotated segment below contributes North-facing belts on
-    // its first row.
+    // becomes a dead end. Rotation means each gap collects from both sides:
+    // the segment above contributes South-facing belts on its last row, the
+    // rotated segment below North-facing belts on its first.
     //
-    // Each exit is carried along its own gap row to the nearer vertical edge,
-    // where it once again deposits outside the box. The two sources get
-    // separate rows so they cannot collide. Two exits carrying *different*
-    // items that would share a row refuse the fold rather than silently
-    // merging into one belt — the failure this replaces.
+    // Each distinct ITEM gets its own lane. Sharing a lane between two items
+    // merges them onto one belt, which is the corruption this pass exists to
+    // prevent; previously that was refused, capping every gap at one item per
+    // side.
+    //
+    // Lane assignment order is load-bearing. A lane runs from its exit column
+    // to the bounding-box edge, so lane j occupies `[edge, x_j]`. An exit
+    // whose lane is not the adjacent row must descend to it through the rows
+    // above, at its own column. Assigning lanes in ASCENDING order of exit
+    // column makes every such descent free: j < i implies x_j < x_i, so lane
+    // j — which stops at x_j — never covers the column x_i descends through.
+    // Any other order blocks descents (measured: descending order blocks 10
+    // of 5 exits' descents, arbitrary 5).
     for k in 0..n_segs - 1 {
         let gap_top = (k as i32) * (h + gap) + h;
-        let gap_bot = gap_top + 1;
 
-        for (row, src_y, want_dir) in [
-            (gap_top, gap_top - 1, EntityDirection::South),
-            (gap_bot, gap_bot + 1, EntityDirection::North),
+        // Which side a lane leaves by is forced, not a preference. Only fold
+        // `k`'s own U-turns span gap `k`, and fold `k` puts its junction
+        // columns on the right when `k` is even, so the opposite side is the
+        // one guaranteed clear of vertical runs in these rows.
+        let to_left = k % 2 == 0;
+        let run_dir = if to_left {
+            EntityDirection::West
+        } else {
+            EntityDirection::East
+        };
+
+        // Collect this gap's crossings from both sides, in the folded frame.
+        let mut crossings: Vec<(i32, i32, EntityDirection, String, Option<String>)> = Vec::new();
+        for (src_y, want_dir) in [
+            (gap_top - 1, EntityDirection::South),
+            (gap_top + gap, EntityDirection::North),
         ] {
-            let exits: Vec<(i32, String, Option<String>)> = folded
-                .iter()
-                .filter(|e| {
-                    e.y == src_y && e.direction == want_dir && is_surface_belt(&e.name)
-                })
-                .map(|e| (e.x, e.name.clone(), e.carries.clone()))
-                .collect();
-
-            // item claimed per tile on this row, so a conflict is detectable.
-            let mut claimed: BTreeMap<i32, Option<String>> = BTreeMap::new();
-            let _ = &exit_moved;
-            let mut pending: Vec<PlacedEntity> = Vec::new();
-            // Where each exit now finishes, so its boundary record can follow.
-            let mut termini: Vec<((i32, i32), (i32, i32), EntityDirection)> = Vec::new();
-            for (x, name, carries) in &exits {
-                // Only true segment content can be an exit. A U-turn's
-                // vertical run passes through these same rows at a junction
-                // column outside the segment range; treating one as an exit
-                // used to start the run beyond its own stop value, which then
-                // never terminated.
-                if *x < 0 || *x >= max_seg_w {
+            for e in folded.iter().filter(|e| {
+                e.y == src_y && e.direction == want_dir && is_surface_belt(&e.name)
+            }) {
+                // A U-turn's vertical run passes through these rows at a
+                // junction column outside the segment range; it is not an exit.
+                if e.x < 0 || e.x >= max_seg_w {
                     continue;
                 }
-                // Which side an exit leaves by is forced, not a preference.
-                // Only fold `k`'s own U-turns span gap `k` — junctions k-1 and
-                // k+1 cross the gaps either side of it — and fold `k` puts its
-                // junction columns on the right when `k` is even. So the
-                // opposite side is the one guaranteed clear of vertical runs
-                // in this row.
-                let to_left = k % 2 == 0;
-                let dir = if to_left {
-                    EntityDirection::West
+                crossings.push((e.x, src_y, want_dir, e.name.clone(), e.carries.clone()));
+            }
+        }
+        if crossings.is_empty() {
+            continue;
+        }
+
+        // One lane per item; lanes ordered by the leftmost column that item
+        // must descend at, so the descent-freedom argument above holds.
+        let mut by_item: BTreeMap<Option<String>, Vec<(i32, i32, EntityDirection, String)>> =
+            BTreeMap::new();
+        for (x, src_y, dir, name, carries) in crossings {
+            by_item.entry(carries).or_default().push((x, src_y, dir, name));
+        }
+        let mut lanes: Vec<(Option<String>, Vec<(i32, i32, EntityDirection, String)>)> =
+            by_item.into_iter().collect();
+        lanes.sort_by_key(|(_, members)| members.iter().map(|m| m.0).min().unwrap_or(0));
+        if lanes.len() as i32 > gap {
+            return Err(FoldRefusal::GapLaneConflict { at: (-1, gap_top) });
+        }
+
+        for (lane_idx, (carries, members)) in lanes.into_iter().enumerate() {
+            let row = gap_top + lane_idx as i32;
+            let belt = members[0].3.clone();
+
+            // Descend each member from its source row to (but NOT onto) this
+            // lane: the lane row is owned by the horizontal run below, which
+            // must face the run direction. Stamping the descent direction
+            // there left a South-facing belt sitting on a West-flowing lane,
+            // dead-ending immediately. For an adjacent lane the range is
+            // empty and the source belt feeds the lane directly.
+            for &(x, src_y, dir, ref name) in &members {
+                let (from, to) = if src_y < row {
+                    (src_y + 1, row - 1)
                 } else {
-                    EntityDirection::East
+                    (row + 1, src_y - 1)
                 };
-                // Run to the layout's eventual edge, not the segment's. The
-                // junction columns extend the bounding box past the segment
-                // range, so a run that stopped at the segment edge ended
-                // *inside* the finished factory and dead-ended there.
-                let (lo, hi) = if to_left {
-                    (edge_min_x, *x)
-                } else {
-                    (*x, edge_max_x)
-                };
-                for cx in lo..=hi {
-                    match claimed.get(&cx) {
-                        Some(existing) if existing != carries => {
-                            return Err(FoldRefusal::ExitLaneConflict)
-                        }
-                        _ => {}
+                for y in from..=to {
+                    if !occupied.insert((x, y)) {
+                        return Err(FoldRefusal::GapLaneConflict { at: (x, y) });
                     }
-                    claimed.insert(cx, carries.clone());
-                    if occupied.contains(&(cx, row)) {
-                        // Skipping the tile would leave the run with a hole
-                        // and the upstream half dead-ending into it.
-                        return Err(FoldRefusal::ExitLaneConflict);
-                    }
-                    {
-                        occupied.insert((cx, row));
-                        pending.push(PlacedEntity {
-                            name: name.clone(),
-                            x: cx,
-                            y: row,
-                            direction: dir,
-                            carries: carries.clone(),
-                            ..Default::default()
-                        });
-                    }
+                    folded.push(PlacedEntity {
+                        name: name.clone(),
+                        x,
+                        y,
+                        direction: dir,
+                        carries: carries.clone(),
+                        ..Default::default()
+                    });
                 }
-                let term_x = if to_left { lo } else { hi };
-                termini.push(((*x, src_y), (term_x, row), dir));
             }
-            for (from, to, dir) in termini {
-                exit_moved.insert(from, (to, dir));
+
+            // Run the lane to the bounding-box edge. Members of the same lane
+            // carry the same item, so overlapping spans merge legitimately.
+            let far = members.iter().map(|m| m.0).max().unwrap_or(0);
+            let near = members.iter().map(|m| m.0).min().unwrap_or(0);
+            let (lo, hi) = if to_left {
+                (edge_min_x, far)
+            } else {
+                (near, edge_max_x)
+            };
+            for cx in lo..=hi {
+                if occupied.contains(&(cx, row)) {
+                    // REFUSE, never skip. The previous version of this line
+                    // was `continue` with the comment "already this lane's own
+                    // belt" — which cannot happen: the descent loop above ends
+                    // at `row - 1` (or starts at `row + 1`) precisely so a lane
+                    // never occupies its own run row. Anything found here
+                    // belongs to a DIFFERENT lane's descent.
+                    //
+                    // Skipping it leaves a hole in this run and sideloads this
+                    // lane's items onto the crossing lane's belt — a cross-item
+                    // merge, which is the exact failure per-item lanes exist to
+                    // prevent — while `exit_moved` records a terminus that
+                    // never receives anything. `main` refused here for that
+                    // stated reason; the WIP lane work replaced it with a skip
+                    // and an incorrect justification, and the input pass added
+                    // later refuses in the mirror-image case, so the two halves
+                    // disagreed. Found in review of #500.
+                    return Err(FoldRefusal::GapLaneConflict { at: (cx, row) });
+                }
+                occupied.insert((cx, row));
+                folded.push(PlacedEntity {
+                    name: belt.clone(),
+                    x: cx,
+                    y: row,
+                    direction: run_dir,
+                    carries: carries.clone(),
+                    ..Default::default()
+                });
             }
-            folded.extend(pending);
+            let term_x = if to_left { lo } else { hi };
+            for &(x, src_y, _, _) in &members {
+                exit_moved.insert((x, src_y), ((term_x, row), run_dir));
+            }
+        }
+    }
+
+
+    // 5b. Feed the inputs that folding moved off the bounding box.
+    //
+    // Mirror of the exit pass. A top-edge belt facing into the factory is fed
+    // from OUTSIDE the box, so it only works on an edge. Segment parity puts
+    // it there for a single fold — segment 0 keeps its inputs at the top,
+    // segment 1 rotates them to the bottom — but from two folds up they land
+    // on interior gap rows with nothing able to supply them, which is what
+    // `InputStranded` refuses.
+    //
+    // Same structure as the exits, reversed: a lane runs from the bounding-box
+    // edge to the input's column, then climbs to the tile that feeds it. Lane
+    // order is by column again, for the same descent-freedom reason.
+    for k in 0..n_segs - 1 {
+        let gap_top = (k as i32) * (h + gap) + h;
+        let to_left = k % 2 == 0;
+        let run_dir = if to_left {
+            EntityDirection::East
+        } else {
+            EntityDirection::West
+        };
+
+        // An input belt adjacent to this gap, facing away from it, is one the
+        // gap must supply.
+        let mut needs: Vec<(i32, i32, EntityDirection, String, Option<String>)> = Vec::new();
+        for (src_y, want_dir) in [
+            (gap_top - 1, EntityDirection::North),
+            (gap_top + gap, EntityDirection::South),
+        ] {
+            for e in folded.iter().filter(|e| {
+                e.y == src_y && e.direction == want_dir && is_surface_belt(&e.name)
+            }) {
+                if e.x < 0 || e.x >= max_seg_w {
+                    continue;
+                }
+                needs.push((e.x, src_y, want_dir, e.name.clone(), e.carries.clone()));
+            }
+        }
+        if needs.is_empty() {
+            continue;
+        }
+
+        // Keyed by (item, side), NOT by item alone.
+        //
+        // Keying by item alone made the commonest possible arrangement refuse:
+        // any item that BOTH neighbouring segments consume appears twice in the
+        // gap — once from above, once from below — and two members tripped the
+        // splitter refusal below. In the source every input sits on the top
+        // edge, so after folding, consecutive segments' copies of the same item
+        // land on opposite sides of the same gap. That is the normal case, not
+        // an edge case, and it was the dominant refusal across the whole corpus
+        // once the gap-lane conflicts were fixed (InputStranded 100 / 155 / 72
+        // on chem5raw / pu4raw / usp2raw).
+        //
+        // Two lanes for one item is physically fine: they are at different rows
+        // in different row blocks, each drawing from the bounding-box edge, and
+        // each input belt carries its own `boundary_inputs` record which the
+        // relocation pass moves independently. It is the same item supplied at
+        // two edge points, which is exactly what the unfolded layout did.
+        //
+        // What still needs a splitter — and still refuses — is one item wanted
+        // at two different COLUMNS on the SAME side, since one lane cannot
+        // serve both.
+        let mut by_item: BTreeMap<(Option<String>, bool), Vec<(i32, i32, EntityDirection, String)>> =
+            BTreeMap::new();
+        for (x, src_y, dir, name, carries) in needs {
+            let is_above = src_y < gap_top;
+            by_item
+                .entry((carries, is_above))
+                .or_default()
+                .push((x, src_y, dir, name));
+        }
+        // One column per item per side: a lane serving two columns would have
+        // to split, which needs a splitter this pass does not synthesize.
+        if by_item.values().any(|m| m.len() > 1) {
+            return Err(FoldRefusal::InputStranded {
+                at: (bounds[k + 1], 0),
+            });
+        }
+        type GapLane = ((Option<String>, bool), Vec<(i32, i32, EntityDirection, String)>);
+        let lanes: Vec<GapLane> = by_item.into_iter().collect();
+
+        // Rows are partitioned by SOURCE SIDE, and that is the whole fix for
+        // the dominant multi-fold refusal (#492 measured 28 of 32 gap-lane
+        // refusals on mil5 as cross-side).
+        //
+        // A gap takes inputs from both neighbours: the segment above feeds
+        // from `gap_top - 1`, the one below from `gap_top + gap`. A lane's
+        // climb runs from its row to its source, so it crosses every row
+        // between them — and which rows those are depends on which side the
+        // source is on. The two sides therefore impose OPPOSITE ordering
+        // requirements on a single row assignment:
+        //
+        //   above-sourced, filling from the far side: lane 0 has the longest
+        //     climb and crosses every other lane, so it needs the column no
+        //     other lane's span covers — the largest (running left).
+        //   below-sourced: the ordering inverts, because its climb runs the
+        //     other way and crosses the rows on the other side of it.
+        //
+        // No single sort satisfies both, which is why the previous version
+        // refused rather than mis-stacked: one global order is the bug, not a
+        // bad choice of order.
+        //
+        // Partitioning removes the interaction instead of trying to order
+        // around it. Above-sourced lanes take rows from `gap_top` downward,
+        // below-sourced from `gap_top + gap - 1` upward. An above lane's climb
+        // then spans only `[gap_top, row)` — entirely inside the above block —
+        // and symmetrically for below, so the two groups provably never cross
+        // each other as long as they fit: `n_above + n_below <= gap`.
+        //
+        // Within a group the span-nesting argument survives unchanged, but the
+        // order FLIPS: index 0 is now adjacent to its source and crosses
+        // nothing, while the deepest index crosses all the shallower ones. A
+        // lane running left spans `[edge, x]` and so covers every column at or
+        // below its own, so each successive lane needs a LARGER column —
+        // ascending, where the old scheme wanted descending. Running right the
+        // span is `[x, edge]` and the test inverts.
+        //
+        // Getting this backwards is not a validation error at the gap; it is
+        // two items' belts on one tile several rows away.
+        // Side comes off the key now, not re-derived from the member's row.
+        let (mut above, mut below): (Vec<_>, Vec<_>) =
+            lanes.into_iter().partition(|((_, is_above), _)| *is_above);
+        for group in [&mut above, &mut below] {
+            if to_left {
+                group.sort_by_key(|(_, m)| m[0].0);
+            } else {
+                group.sort_by_key(|(_, m)| std::cmp::Reverse(m[0].0));
+            }
+        }
+        if (above.len() + below.len()) as i32 > gap {
+            return Err(FoldRefusal::GapLaneConflict { at: (-1, gap_top) });
+        }
+        // (row, item, member) — rows now come from the side-partitioned
+        // assignment rather than a single running index.
+        let placements: Vec<(i32, Option<String>, (i32, i32, EntityDirection, String))> = above
+            .into_iter()
+            .enumerate()
+            .map(|(i, ((carries, _), m))| (gap_top + i as i32, carries, m[0].clone()))
+            .chain(below.into_iter().enumerate().map(|(j, ((carries, _), m))| {
+                (gap_top + gap - 1 - j as i32, carries, m[0].clone())
+            }))
+            .collect();
+
+        // Instrumentation for #492. The refusal alone cannot distinguish two
+        // very different causes, and they want different fixes:
+        //   cross-side — a climb from above sweeps rows owned by lanes whose
+        //     source is below (or vice versa). Row assignment ignores which
+        //     side an input arrives from, so the two groups interleave. Fixable
+        //     by partitioning rows by side; no underground needed.
+        //   same-side tie — two same-side items share a column. No assignment
+        //     order avoids this one; it needs a B12 dive.
+        // Which dominates is a measurement, not a guess.
+        let side_of = |src_y: i32| if src_y < gap_top { "above" } else { "below" };
+        let mut owner: BTreeMap<(i32, i32), (String, &'static str, &'static str)> = BTreeMap::new();
+        let debug_fold = std::env::var("SPAGHETTIO_FOLD_DEBUG").is_ok();
+
+        for (lane_idx, (row, carries, member)) in placements.into_iter().enumerate() {
+            let (x, src_y, dir, name) = member;
+
+            // Lane from the box edge to the input's column.
+            let (lo, hi) = if to_left { (edge_min_x, x) } else { (x, edge_max_x) };
+            for cx in lo..=hi {
+                if !occupied.insert((cx, row)) {
+                    if debug_fold {
+                        let mine = side_of(src_y);
+                        let (other_item, other_side, other_kind) = owner
+                            .get(&(cx, row))
+                            .cloned()
+                            .unwrap_or_else(|| ("<pre-existing>".into(), "?", "not-a-lane-tile"));
+                        let verdict = if other_kind == "not-a-lane-tile" {
+                            "PRE-EXISTING"
+                        } else if other_side != mine {
+                            "CROSS-SIDE"
+                        } else if other_item != carries.clone().unwrap_or_default() {
+                            "SAME-SIDE-TIE"
+                        } else {
+                            "SELF"
+                        };
+                        eprintln!(
+                            "CLASH {verdict} kind=lane-run gap_top={gap_top} gap={gap} \
+                             lane={lane_idx} row={row} at ({cx},{row}) item={carries:?} \
+                             side={mine} span=[{lo},{hi}] vs item={other_item} \
+                             side={other_side} kind={other_kind}"
+                        );
+                    }
+                    return Err(FoldRefusal::GapLaneConflict { at: (cx, row) });
+                }
+                if debug_fold {
+                    owner.insert(
+                        (cx, row),
+                        (carries.clone().unwrap_or_default(), side_of(src_y), "lane-run"),
+                    );
+                }
+                folded.push(PlacedEntity {
+                    name: name.clone(),
+                    x: cx,
+                    y: row,
+                    // The lane's terminal tile TURNS toward the input; every
+                    // other tile runs along the gap.
+                    //
+                    // This is the whole difference between the exit pass and
+                    // this one, and getting it wrong is silent. Exits flow
+                    // source -> lane -> edge, so the descent feeds the lane and
+                    // every lane tile can face the run direction. Inputs flow
+                    // edge -> lane -> source, so the lane has to hand items UP
+                    // (or down) at the input's column. Left facing `run_dir`,
+                    // the terminal tile outputs to the next column instead:
+                    // items traverse the whole lane, pass the input, and dead-
+                    // end at the far side. Measured on the mil5 2-fold: four
+                    // orphan lane segments, each reported at exactly its own
+                    // terminal column, and 45 furnaces starved behind them.
+                    //
+                    // A belt turning 90 degrees here is a corner, not a
+                    // sideload — it preserves both lanes (factorio-mechanics
+                    // B11) because nothing feeds the terminal tile's back.
+                    direction: if cx == x { dir } else { run_dir },
+                    carries: carries.clone(),
+                    ..Default::default()
+                });
+            }
+            // Climb from the lane to the tile that feeds the input belt,
+            // facing the way the input flows.
+            let (from, to) = if src_y < row {
+                (src_y + 1, row - 1)
+            } else {
+                (row + 1, src_y - 1)
+            };
+            for y in from..=to {
+                if !occupied.insert((x, y)) {
+                    if debug_fold {
+                        let mine = side_of(src_y);
+                        let (other_item, other_side, other_kind) = owner
+                            .get(&(x, y))
+                            .cloned()
+                            .unwrap_or_else(|| ("<pre-existing>".into(), "?", "not-a-lane-tile"));
+                        let verdict = if other_kind == "not-a-lane-tile" {
+                            "PRE-EXISTING"
+                        } else if other_side != mine {
+                            "CROSS-SIDE"
+                        } else {
+                            "SAME-SIDE-TIE"
+                        };
+                        eprintln!(
+                            "CLASH {verdict} kind=climb gap_top={gap_top} gap={gap} \
+                             lane={lane_idx} row={row} at ({x},{y}) item={carries:?} \
+                             side={mine} climb=[{from},{to}] vs item={other_item} \
+                             side={other_side} kind={other_kind}"
+                        );
+                    }
+                    return Err(FoldRefusal::GapLaneConflict { at: (x, y) });
+                }
+                if debug_fold {
+                    owner.insert(
+                        (x, y),
+                        (carries.clone().unwrap_or_default(), side_of(src_y), "climb"),
+                    );
+                }
+                folded.push(PlacedEntity {
+                    name: name.clone(),
+                    x,
+                    y,
+                    direction: dir,
+                    carries: carries.clone(),
+                    ..Default::default()
+                });
+            }
+            input_moved.insert((x, src_y), ((if to_left { lo } else { hi }, row), run_dir));
         }
     }
 
@@ -5228,8 +5647,19 @@ pub fn fold_snake(
                     (h - 1 - b.y) + (seg as i32) * (h + gap),
                 )
             };
+            // On the box edge it is fed from outside, as in the source. Off
+            // the edge it is fed by the gap-lane pass above — but only if
+            // that pass actually reached it, which it records. Anything
+            // neither on an edge nor supplied really is stranded.
             let on_edge = nx <= lo_x || nx >= hi_x || ny <= lo_y || ny >= hi_y;
-            if !on_edge {
+            let supplied = input_moved.keys().any(|&(mx, my)| (mx, my) == (nx, ny));
+            if std::env::var("SPAGHETTIO_FOLD_DEBUG").is_ok() {
+                eprintln!(
+                    "input check: ({nx},{ny}) on_edge={on_edge} supplied={supplied} \
+                     bbox=[{lo_x}..{hi_x}]x[{lo_y}..{hi_y}]"
+                );
+            }
+            if !on_edge && !supplied {
                 return Err(FoldRefusal::InputStranded { at: (b.x, b.y) });
             }
         }
@@ -5349,8 +5779,22 @@ pub fn fold_snake(
         }
     };
     for b in &mut result.boundary_inputs {
-        b.direction = fold_dir(b.x, b.direction);
-        (b.x, b.y) = fold_point(b.x, b.y);
+        let folded_dir = fold_dir(b.x, b.direction);
+        let (fx, fy) = fold_point(b.x, b.y);
+        // An input the gap-lane pass rerouted is now fed at the lane's edge
+        // terminus, so its record has to move there — the same reasoning that
+        // made a stale `boundary_outputs` record produce 0.00/s.
+        match input_moved.get(&(fx - x_shift, fy)) {
+            Some(((tx, ty), tdir)) => {
+                b.x = tx + x_shift;
+                b.y = *ty;
+                b.direction = *tdir;
+            }
+            None => {
+                b.direction = folded_dir;
+                (b.x, b.y) = (fx, fy);
+            }
+        }
     }
     for b in &mut result.boundary_outputs {
         let folded_dir = fold_dir(b.x, b.direction);
@@ -5372,5 +5816,44 @@ pub fn fold_snake(
     for (_, x, y) in &mut result.surplus_exits {
         (*x, *y) = fold_point(*x, *y);
     }
+
+    // Collapse boundary records that now describe ONE physical terminus.
+    //
+    // A gap carries one lane per item, so N source exits of the same item merge
+    // into that lane and `exit_moved` maps every one of them to the same
+    // terminus tile. The geometry is right — one lane, one exit — but the record
+    // list ends up with N copies of it, and a consumer that trusts the list
+    // builds N of whatever a record implies.
+    //
+    // The sim harness does exactly that: two identical output records made it
+    // build two drain rigs on one tile, whose chest banks overlapped by 7 tiles
+    // (`ext_len = 11 + 2*idx` separates rigs by only 2), and it correctly
+    // invalidated the whole run rather than report a rate measured through
+    // cross-feeding chests. That is issue #499, and it presented as a harness
+    // bug because the overlap is in harness-side geometry — but the harness was
+    // faithfully building what the manifest declared.
+    //
+    // Deduped on the full record, not just position: two records at one tile
+    // carrying DIFFERENT items would be a real defect and must stay visible to
+    // `check_boundary_record_integrity` rather than be quietly merged away.
+    // Order-preserving, because the harness indexes rigs by record order and a
+    // reordering would move every rig's geometry.
+    // Linear scan on `BoundaryRecord`'s own PartialEq: a handful of records per
+    // layout, so O(n^2) is free, and equality-on-the-whole-record is exactly the
+    // semantics wanted — no hand-written key to drift from the struct's fields.
+    let dedupe = |recs: &mut Vec<crate::models::BoundaryRecord>| {
+        let mut seen: Vec<crate::models::BoundaryRecord> = Vec::with_capacity(recs.len());
+        recs.retain(|b| {
+            if seen.contains(b) {
+                false
+            } else {
+                seen.push(b.clone());
+                true
+            }
+        });
+    };
+    dedupe(&mut result.boundary_inputs);
+    dedupe(&mut result.boundary_outputs);
+
     Ok(result)
 }

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -2019,6 +2019,137 @@ pub fn repair_pole_network(layout: &mut LayoutResult) -> usize {
     added
 }
 
+/// Add medium poles until every power-drawing entity is covered, and report
+/// how many were needed.
+///
+/// `repair_pole_network` fixes CONNECTIVITY between poles that exist; nothing
+/// fixed COVERAGE, and a fold creates coverage holes that no amount of
+/// rewiring closes. A 180-degree rotation is rigid, so coverage inside a
+/// segment survives it exactly — but an entity near a fold column was often
+/// covered by a pole that the fold moved into a different segment, tens of
+/// tiles away. Measured on the mil5 2-fold: 5 holes, all of them within 3
+/// tiles of a seam.
+///
+/// The coverage predicate here is deliberately the same continuous-centre test
+/// the power validator uses (`supply_area_distance`, entity centre at
+/// `index + size/2`). Re-deriving it would let placement and validation drift,
+/// which is the failure `place_poles` already carries a comment about.
+///
+/// Returns 0 without touching anything when coverage is already complete, so
+/// layouts that do not need it — every single-fold and composed-cell fixture —
+/// stay byte-identical and their sim-verified registry pins hold.
+pub(crate) fn cover_unpowered(layout: &mut LayoutResult) -> usize {
+    let is_pole_ent =
+        |e: &PlacedEntity| e.name.ends_with("electric-pole") || e.name == "substation";
+    let quality = layout
+        .entities
+        .iter()
+        .find(|e| is_machine_entity(&e.name))
+        .and_then(|e| e.quality)
+        .unwrap_or_default();
+
+    // Same shape as the validator: (centre_x, centre_y, supply_half_extent).
+    let pole_centres = |ents: &[PlacedEntity]| -> Vec<(f64, f64, f64)> {
+        ents.iter()
+            .filter(|e| is_pole_ent(e))
+            .map(|e| {
+                let (w, h) = crate::common::entity_size(&e.name);
+                (
+                    e.x as f64 + w as f64 / 2.0,
+                    e.y as f64 + h as f64 / 2.0,
+                    crate::common::supply_area_distance(&e.name, e.quality.unwrap_or_default()),
+                )
+            })
+            .collect()
+    };
+    let subject_centre = |e: &PlacedEntity| -> (f64, f64) {
+        let (w, h) = crate::common::entity_size(&e.name);
+        (e.x as f64 + w as f64 / 2.0, e.y as f64 + h as f64 / 2.0)
+    };
+
+    let mut poles = pole_centres(&layout.entities);
+    let uncovered: Vec<(f64, f64)> = layout
+        .entities
+        .iter()
+        .filter(|e| crate::common::needs_electricity(&e.name))
+        .filter_map(|e| {
+            let (scx, scy) = subject_centre(e);
+            let powered = poles
+                .iter()
+                .any(|&(pcx, pcy, d)| (scx - pcx).abs() <= d && (scy - pcy).abs() <= d);
+            (!powered).then_some((scx, scy))
+        })
+        .collect();
+    if uncovered.is_empty() {
+        return 0;
+    }
+
+    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+    for e in &layout.entities {
+        let (w, h) = crate::common::entity_size(&e.name);
+        for dx in 0..w as i32 {
+            for dy in 0..h as i32 {
+                occupied.insert((e.x + dx, e.y + dy));
+            }
+        }
+    }
+
+    let d = crate::common::supply_area_distance("medium-electric-pole", quality);
+    let reach = d.floor() as i32;
+    let mut added: Vec<PlacedEntity> = Vec::new();
+    let mut remaining = uncovered;
+
+    // Greedy: for each still-uncovered subject, take the free tile in its
+    // supply square that covers the most of the remaining set. Deterministic
+    // tie-break on (x, y) — a fold search compares candidates across runs, so
+    // a HashSet iteration order leaking into geometry would make the search
+    // non-reproducible.
+    while let Some(&(tx, ty)) = remaining.first() {
+        let mut best: Option<(usize, i32, i32)> = None;
+        for dx in -reach..=reach {
+            for dy in -reach..=reach {
+                let (px, py) = (tx.floor() as i32 + dx, ty.floor() as i32 + dy);
+                if occupied.contains(&(px, py)) {
+                    continue;
+                }
+                let (pcx, pcy) = (px as f64 + 0.5, py as f64 + 0.5);
+                let n = remaining
+                    .iter()
+                    .filter(|&&(sx, sy)| (sx - pcx).abs() <= d && (sy - pcy).abs() <= d)
+                    .count();
+                if n == 0 {
+                    continue;
+                }
+                if best.is_none_or(|(bn, bx, by)| (n, -px, -py) > (bn, -bx, -by)) {
+                    best = Some((n, px, py));
+                }
+            }
+        }
+        let Some((_, px, py)) = best else {
+            // No free tile can cover this subject. Leave it — the validator
+            // will report it, which is the correct loud outcome; silently
+            // dropping it is the reporting failure this repo has been
+            // cataloguing (docs/validator-reporting.md).
+            remaining.remove(0);
+            continue;
+        };
+        occupied.insert((px, py));
+        added.push(PlacedEntity {
+            name: "medium-electric-pole".to_string(),
+            x: px,
+            y: py,
+            ..Default::default()
+        });
+        let (pcx, pcy) = (px as f64 + 0.5, py as f64 + 0.5);
+        remaining.retain(|&(sx, sy)| !((sx - pcx).abs() <= d && (sy - pcy).abs() <= d));
+        poles.push((pcx, pcy, d));
+    }
+
+    let n = added.len();
+    layout.entities.extend(added);
+    n
+}
+
 pub(crate) fn repair_pole_connectivity(
     entities: &mut Vec<PlacedEntity>,
     placed: &FxHashSet<(i32, i32)>,

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3520,11 +3520,29 @@ fn export_fold_pair_for_sim() {
     )
     .unwrap();
     let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
-    let folded =
-        fold_snake(&compact, &[compact.width / 2]).expect("midpoint fold must succeed");
+    // Snap to a LEGAL column rather than the bare midpoint: `width / 2` is not
+    // guaranteed cuttable and refused with CutsEntity once compaction changed
+    // the width. The search snaps; this has to as well.
+    let legal = spaghettio_core::bus::compaction::legal_fold_columns(&compact);
+    let snap = |t: i32| {
+        legal
+            .iter()
+            .copied()
+            .min_by_key(|&f| (f - t).abs())
+            .expect("layout must have a legal fold column")
+    };
+    let mid = snap(compact.width / 2);
+    let folded = fold_snake(&compact, &[mid]).expect("midpoint fold must succeed");
+    // The 3-fold the search picks (#492). Exported alongside the verified pair
+    // so one sim run compares control / 1-fold / 3-fold on identical inputs.
+    let fold3 = fold_snake(&compact, &[130, 259, 390]).expect("3-fold must succeed");
 
     std::fs::create_dir_all("target/tmp").unwrap();
-    for (tag, l) in [("mil5-compact", &compact), ("mil5-fold1", &folded)] {
+    for (tag, l) in [
+        ("mil5-compact", &compact),
+        ("mil5-fold1", &folded),
+        ("mil5-fold3", &fold3),
+    ] {
         let (bp, manifest) = spaghettio_core::blueprint::export_with_manifest(l, &sr, tag);
         std::fs::write(format!("target/tmp/{tag}.bp"), &bp).unwrap();
         std::fs::write(
@@ -4231,6 +4249,290 @@ fn probe_fold_error_breakdown_mil5() {
             *n += 1;
         }
     }
+}
+
+/// Classify what actually kills a multi-fold candidate at the input pass.
+///
+/// #492 recorded the blocker as "two items share an input column, needs a B12
+/// dive". Measuring says that is the SMALLEST of three classes. A gap takes
+/// inputs from BOTH neighbouring segments, but lane rows are allocated purely
+/// by column, so climbs from opposite sides sweep through each other's rows
+/// with no shared column involved.
+///
+/// Read the classes off stderr with `SPAGHETTIO_FOLD_DEBUG=1`:
+///   CROSS-SIDE     — row assignment ignores source side. No underground needed.
+///   SAME-SIDE-TIE  — two same-side items on one column. Needs the dive.
+///   PRE-EXISTING   — a lane run hit real machine/belt geometry.
+///
+/// Scoped to mil5 and 2 folds deliberately: the whole corpus at 4 folds takes
+/// >10 minutes with debug on, and this is meant to be a fast feedback loop.
+/// Counts are of FIRST clashes — a candidate dies at its first one, so this
+/// does not measure latent conflicts hiding behind the one that fired.
+#[test]
+#[ignore = "exploration probe — input-clash classes (#492)"]
+fn probe_input_clash_classes() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, search_snake_fold};
+    use std::collections::BTreeMap;
+
+    let fixture = SimFixture::find("chain-mil5ore");
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        fixture.target,
+        fixture.rate,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+    let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
+
+    let search = search_snake_fold(&compact, &sr, 2);
+    let mut why: BTreeMap<String, usize> = BTreeMap::new();
+    for (_, r) in &search.refusals {
+        *why.entry(format!("{r:?}").split(' ').next().unwrap().into())
+            .or_default() += 1;
+    }
+    println!(
+        "mil5 @<=2 folds: legal_columns={} refusals={why:?} rejected_by_validation={} best={:?}",
+        search.legal_columns,
+        search.rejected_by_validation,
+        search.best.as_ref().map(|f| f.folds.clone()),
+    );
+    // The bare rejection count cannot say which check the newly-buildable
+    // layouts fail, which is the whole question once a geometry fix converts
+    // refusals into validation rejections.
+    println!("   validation regressions by category: {:?}", search.validation_regressions);
+}
+
+/// Take ONE 2-fold candidate that now builds and say exactly what it violates.
+///
+/// The side-partition fix (#492) took `GapLaneConflict` from 32 to 0 on mil5
+/// while `rejected_by_validation` went 22 -> 54: the same candidates, failing
+/// later. The aggregate categories are power / belt-flow-reachability /
+/// orphan-belt-segment; this prints positions so the cause is a location, not
+/// a category name.
+#[test]
+#[ignore = "exploration probe — one failing 2-fold candidate (#492)"]
+fn probe_one_multifold_candidate() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, fold_snake};
+    use spaghettio_core::validate::{self, LayoutStyle};
+    use std::collections::BTreeMap;
+
+    let fixture = SimFixture::find("chain-mil5ore");
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        fixture.target,
+        fixture.rate,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+    let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
+
+    let profile = |l: &spaghettio_core::models::LayoutResult| {
+        let issues = match validate::validate(l, Some(&sr), LayoutStyle::Bus) {
+            Ok(i) => i,
+            Err(e) => e.issues,
+        };
+        let mut by: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for i in &issues {
+            by.entry(i.category.clone())
+                .or_default()
+                .push(i.message.clone());
+        }
+        by
+    };
+
+    let base = profile(&compact);
+    println!("source {}x{}", compact.width, compact.height);
+    for (cat, msgs) in &base {
+        println!("  base {cat}: {}", msgs.len());
+    }
+
+    // The comb the search would try for k=2 at delta=0.
+    let legal = spaghettio_core::bus::compaction::legal_fold_columns(&compact);
+    let snap = |t: i32| legal.iter().copied().min_by_key(|&f| (f - t).abs()).unwrap();
+    let folds = vec![snap(compact.width / 3), snap(compact.width * 2 / 3)];
+    println!("folds={folds:?}");
+
+    match fold_snake(&compact, &folds) {
+        Err(r) => println!("REFUSED: {r:?}"),
+        Ok(folded) => {
+            println!("folded {}x{}", folded.width, folded.height);
+            // Are the gap-1 lanes actually fed? Print the gap rows and the
+            // boundary-input records that should terminate them.
+            println!("  --- boundary_inputs ({}) ---", folded.boundary_inputs.len());
+            for b in &folded.boundary_inputs {
+                println!("      in {:?} at ({},{}) dir={:?}", b.item, b.x, b.y, b.direction);
+            }
+            for row in 66..=72 {
+                let mut row_ents: Vec<String> = folded
+                    .entities
+                    .iter()
+                    .filter(|e| e.y == row)
+                    .map(|e| format!("{}@{}({:?},{:?})", e.name.replace("transport-belt", "TB"), e.x, e.direction, e.carries))
+                    .collect();
+                row_ents.sort();
+                println!("  row {row}: {} ents: {}", row_ents.len(),
+                    row_ents.iter().take(8).cloned().collect::<Vec<_>>().join(" "));
+            }
+            let got = profile(&folded);
+            for (cat, msgs) in &got {
+                let b = base.get(cat).map(|v| v.len()).unwrap_or(0);
+                let marker = if msgs.len() > b { " <-- REGRESSED" } else { "" };
+                println!("  {cat}: {} (base {b}){marker}", msgs.len());
+                if msgs.len() > b {
+                    for m in msgs.iter().take(6) {
+                        println!("      {m}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// mil5 must keep folding, stay near-square, and keep BOTH belt lanes.
+///
+/// One test rather than three because the expensive part — solve, compose,
+/// compact, search — is shared; splitting it triples a 25-second cost.
+///
+/// The fold columns are DERIVED, not pinned. They were pinned initially, and
+/// #502/#503 (concurrent work fixing undergroundification, which changed the
+/// compacted source geometry) immediately falsified them: mil5 moved from
+/// folding at [172,346] to [189,373] with legal columns 220 -> 252. The fold
+/// itself was fine. A pin here tests "did upstream compaction change" — which
+/// is not this test's job and produces a failure that reads as a fold
+/// regression.
+///
+/// Three properties, and the third is the one a throughput sim cannot see:
+///
+/// 1. **A multi-fold still exists.** The transform's whole claim.
+/// 2. **No validation category is worse than the source.** Deliberately a
+///    comparison rather than a geometry assertion, because the validator
+///    demonstrably catches this transform's real failures — the lane terminus
+///    that never turned surfaced as 45 `belt-flow-reachability` + 4
+///    `orphan-belt-segment`, the pole seam holes as 5 `power`.
+/// 3. **Both belt lanes survive the gap corners.** A 90-degree corner preserves
+///    both lanes (factorio-mechanics B11); a sideload dumps everything onto the
+///    lane nearest the feeder (B8). `lane_transfer` models both exactly, so this
+///    is statically decidable — and INVISIBLE to a sim, since mil5 needs 5/s of
+///    science and a halved lane still delivers that.
+///
+/// The teeth assertion on (3) is load-bearing: "no lane-throughput errors" is
+/// vacuous if every lane sits far below capacity, so the busiest lane must
+/// exceed HALF the per-lane cap for a collapse to be detectable at all. mil5
+/// supplies stone at 50/s over two boundaries, which is what qualifies it.
+///
+/// What none of this covers: anything the validator is blind to. RFC-057 carries
+/// the case where this transform validated at exact control parity and produced
+/// 0.00/s in Factorio, which is why the sim measurement lives in the decision
+/// log rather than being replaced by a test.
+#[test]
+fn mil5_multifold_holds_and_preserves_lanes() {
+    use spaghettio_core::bus::compaction::{compact_validated_geometry, search_snake_fold};
+    use spaghettio_core::common::lane_capacity_stacked;
+    use spaghettio_core::validate::belt_flow::{check_lane_throughput, compute_lane_rates};
+    use spaghettio_core::validate::{self, LayoutStyle};
+    use std::collections::BTreeMap;
+
+    let fixture = SimFixture::find("chain-mil5ore");
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        fixture.target,
+        fixture.rate,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+    let compact = compact_validated_geometry(&fixture.compose_layout(), &sr);
+
+    let search = search_snake_fold(&compact, &sr, 4);
+    let found = search.best.as_ref().unwrap_or_else(|| {
+        let mut why: BTreeMap<String, usize> = BTreeMap::new();
+        for (_, r) in &search.refusals {
+            *why.entry(format!("{r:?}").split(' ').next().unwrap().into()).or_default() += 1;
+        }
+        panic!(
+            "mil5 no longer folds at all: legal_columns={} refusals={why:?} \
+             rejected_by_validation={} regressions={:?}",
+            search.legal_columns, search.rejected_by_validation, search.validation_regressions
+        )
+    });
+    let folded = &found.layout;
+
+    assert!(
+        found.folds.len() >= 2,
+        "mil5 should reach a MULTI-fold, got {} fold(s) at {:?} -> {}x{}",
+        found.folds.len(),
+        found.folds,
+        folded.width,
+        folded.height,
+    );
+
+    let aspect =
+        folded.width.max(folded.height) as f64 / folded.width.min(folded.height) as f64;
+    assert!(
+        aspect < 2.5,
+        "fold should be much squarer than the {:.1}:1 source, got {}x{} ({aspect:.2}:1) at {:?}",
+        compact.width as f64 / compact.height as f64,
+        folded.width,
+        folded.height,
+        found.folds,
+    );
+
+    let profile = |l: &spaghettio_core::models::LayoutResult| -> BTreeMap<String, usize> {
+        let issues = match validate::validate(l, Some(&sr), LayoutStyle::Bus) {
+            Ok(i) => i,
+            Err(e) => e.issues,
+        };
+        let mut by: BTreeMap<String, usize> = BTreeMap::new();
+        for i in &issues {
+            *by.entry(i.category.clone()).or_default() += 1;
+        }
+        by
+    };
+    let (base, got) = (profile(&compact), profile(folded));
+    let regressed: Vec<String> = got
+        .iter()
+        .filter(|(cat, n)| base.get(*cat).copied().unwrap_or(0) < **n)
+        .map(|(cat, n)| format!("{cat}: {} -> {n}", base.get(cat).copied().unwrap_or(0)))
+        .collect();
+    assert!(
+        regressed.is_empty(),
+        "fold regressed validation vs its source: {regressed:?}\nbase={base:?}\ngot={got:?}"
+    );
+
+    // Lane preservation, with the detectability check first.
+    let cap = lane_capacity_stacked("express-transport-belt", 1);
+    let peak = compute_lane_rates(folded, Some(&sr))
+        .values()
+        .map(|&[a, b]| a.max(b))
+        .fold(0.0f64, f64::max);
+    assert!(
+        peak * 2.0 > cap,
+        "lane check is vacuous here: busiest lane {peak:.2}/s doubles to {:.2}/s, under the \
+         {cap}/s per-lane cap, so a sideload could not be detected",
+        peak * 2.0
+    );
+    let lane_issues = check_lane_throughput(folded, Some(&sr));
+    assert!(
+        lane_issues.is_empty(),
+        "fold collapsed a belt onto one lane ({} errors): {:?}",
+        lane_issues.len(),
+        lane_issues.iter().take(4).map(|i| &i.message).collect::<Vec<_>>()
+    );
+    assert!(
+        check_lane_throughput(&compact, Some(&sr)).is_empty(),
+        "control already has lane-throughput errors; the fold result is not attributable"
+    );
 }
 
 /// Island placement must keep TERMINAL tiles disjoint, not just machine blocks.

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -807,12 +807,47 @@ script.on_init(function()
   -- entities silently; overlapping bank chests cross-feed items and
   -- poison the factory with wrong-item plugs. Any overlap invalidates
   -- the run — record it loudly.
+  -- Attribution matters as much as detection (#499): the position-only form
+  -- of this audit reported 14 bare tiles at negative coordinates, which read
+  -- as harness geometry and sent the investigation into the kit's vector
+  -- algebra. The actual cause was upstream — two IDENTICAL boundary_output
+  -- records, so the harness dutifully built two drain rigs on one tile. Naming
+  -- the owners would have pointed straight at it. storage.feeds/drains already
+  -- hold per-rig chest lists, so no rig has to change signature to do this.
   do
+    local owner = {}
+    local function claim(c, label)
+      if not (c and c.valid) then return end
+      local key = math.floor(c.position.x) .. "," .. math.floor(c.position.y)
+      if owner[key] then
+        table.insert(storage.kit_errors, "overlapping kit chests at (" .. key
+                     .. "): " .. owner[key] .. " vs " .. label)
+      else
+        owner[key] = label
+      end
+    end
+    for item, banks in pairs(storage.feeds) do
+      for bi, bank in ipairs(banks) do
+        for _, c in ipairs(bank.chests) do
+          claim(c, "feed[" .. item .. "] rig " .. bi)
+        end
+      end
+    end
+    for item, chests in pairs(storage.drains) do
+      for _, c in ipairs(chests) do
+        claim(c, "drain[" .. item .. "]")
+      end
+    end
+    -- Backstop for chests no rig registered. Without it, a rig that stops
+    -- recording its chests would silently disable the whole audit — the
+    -- check-goes-quiet failure this repo keeps re-learning
+    -- (docs/validator-reporting.md).
     local seen = {}
     for _, c in pairs(s.find_entities_filtered{name = "steel-chest"}) do
       local key = math.floor(c.position.x) .. "," .. math.floor(c.position.y)
-      if seen[key] then
-        table.insert(storage.kit_errors, "overlapping kit chests at (" .. key .. ")")
+      if seen[key] and not owner[key] then
+        table.insert(storage.kit_errors,
+                     "overlapping unattributed kit chests at (" .. key .. ")")
       end
       seen[key] = true
     end

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -937,6 +937,92 @@ make either experimental composer a production default.
   the 2026-07-29 refusal of folding as a *density* lever — the ~20% routing
   ceiling stands, and the single fold costs 277 entities (2820 → 3097).
 
+- **2026-07-30 — Multi-fold works, and is Factorio-verified at three folds.**
+  `chain-mil5ore` folds three times: 521×31 (16.8:1) → **147×138 (1.07:1)**,
+  measured in headless 2.0.77 at `--warmup 216000` — **PASS**, target
+  military-science-pack 4.92/s delivered against 5.00/s planned (−1.6%),
+  **146/146 machines working**, **one pole network**, 4620/4620 entities
+  revived, zero kit errors, no fluid errors. The previous entry's "multi-fold
+  remains unproven" is now discharged.
+
+  **None of it was the fix the tracking issue specified.** #492 recorded the
+  blocker as two items sharing an input column, needing a B12 underground
+  dive. No dive was written. Instrumenting the refusal instead of reading the
+  issue found three different causes:
+
+  | Cause | Why it was invisible | Effect |
+  |---|---|---|
+  | Row assignment ignored source side | A gap takes inputs from BOTH neighbours; a climb crosses every row between itself and its source, so which rows get crossed depends on the side. The two sides impose OPPOSITE ordering requirements, so one global order was itself the bug — not a bad choice of order. | `GapLaneConflict` 32 → 0 on mil5; **0 on pu4raw**, whose 173 was called the backlog's highest-value fix |
+  | Lane terminus faced the run direction | Items traversed the whole lane, passed the input's column and dead-ended. Exits are immune because their flow runs the other way — the descent feeds the lane — and inputs are reversed. | `belt-flow-reachability` 45 → 0, `orphan-belt-segment` 4 → 0 |
+  | Lanes keyed by item, not (item, side) | Every source input sits on the top edge, so consecutive segments' copies of one item land on opposite sides of the same gap. The commonest arrangement refused. | corpus `InputStranded` was this only for chem5raw, and only half of it |
+
+  Rows are now partitioned by side — above-sourced from `gap_top` downward,
+  below-sourced from `gap_top + gap - 1` upward — which keeps each climb inside
+  its own block and makes the groups provably non-crossing while
+  `n_above + n_below <= gap`. Within a group the span-nesting argument survives
+  but the order FLIPS to ascending, because index 0 is now adjacent to its
+  source and crosses nothing.
+
+  Gap sizing is per parity: exits key by item (merged distinct count), inputs
+  by (item, side) (the sum). Deliberately not summing everywhere — that keeps a
+  single fold, which has only the even/exit gap, byte-identical, and with it
+  the registry pin measured at 5.00/s.
+
+  `cover_unpowered` (layout.rs) tops up pole COVERAGE, which nothing did —
+  `repair_pole_network` only ever fixed connectivity. Rotation is rigid so
+  coverage survives inside a segment, but an entity beside a fold column loses
+  the pole that covered it from across the seam (5 holes on the mil5 2-fold,
+  all within 3 tiles of a seam). It reuses the power validator's own
+  continuous-centre predicate so the two cannot drift, and returns 0 untouched
+  when coverage is already complete, so every single-fold and composed-cell
+  fixture stays byte-identical.
+
+  **Scope of the claim, stated because it is easy to over-read.** One fixture
+  of four. `chem5raw`, `pu4raw` and `usp2raw` still find no fold. This is a
+  SHAPE result, not a density one: it costs +807 entities (+21%), and the
+  2026-07-29 refusal of folding as a density lever stands untouched.
+
+  **A prediction that failed, kept on the record.** Keying by (item, side) was
+  expected to unblock the corpus, since `InputStranded` dominated everywhere
+  after the gap-lane fixes. Measured: pu4raw 155 → 155 and usp2raw 72 → 72,
+  i.e. no change at all, and chem5raw's freed candidates moved to
+  `GapLaneConflict` (+48, matching the 48 that stopped stranding) rather than
+  folding. Refusals moving later is not progress. Their `InputStranded` must be
+  the same-side-two-columns case, which genuinely needs a splitter.
+
+- **2026-07-30 — `FoldSearch::validation_regressions`, because a bare count hid
+  a fix's own side effect.** `rejected_by_validation` said how many candidates
+  were turned away and nothing about why, so the side-partition fix read as
+  `GapLaneConflict` 32 → 0 (progress) while silently pushing rejections 22 → 54
+  (the same candidates dying later). The counter could not name the check they
+  now failed. This is the reporting shape in
+  [`validator-reporting.md`](validator-reporting.md), inside the fold search
+  itself.
+
+- **2026-07-30 — Duplicate boundary records were ours, not the harness's
+  (#499).** A gap carries one lane per item, so N same-item exits merge into it
+  and `exit_moved` maps all N to one terminus. Correct geometry, but the record
+  list held N copies, and the sim harness built one drain rig per record: two
+  identical output records on `(0,31)` gave two rigs 2 tiles apart whose
+  9-position chest banks overlapped by 7, and it invalidated the run rather
+  than report a rate measured through cross-feeding chests. Records are now
+  deduped on the whole record (not position — two records at one tile carrying
+  different items is a real defect and must stay visible to
+  `check_boundary_record_integrity`) and order-preserving, since the harness
+  indexes rigs by record order. Reported as a harness bug because the
+  overlapping tiles are harness-side geometry at negative coordinates; the
+  harness was faithfully building what the manifest declared.
+
+  Consequence for the earlier reading: `mil5-fold3` was clean not because
+  non-south kits work, but because its two exits land in different gaps. The
+  `has_uncalibrated_direction` caveat still stands on its own — no live run has
+  exercised a non-south boundary kit — but it was not what bit us.
+
+  Confirmed: with the dedupe, `mil5-fold1` re-measures **PASS**, zero kit
+  errors, military-science-pack produced 5.00/s (+0.0%) / delivered 4.90/s
+  (−2.0%), 4075/4075 revived, one pole network, `converged=true`. So the single
+  fold is independently verified at a legal snapped column as well, and BOTH
+  fold depths now pass in Factorio.
 - **2026-07-30 — The manifold router's residual was a PLACEMENT bug; with it
   fixed, candidates materialise for the first time — and they are bigger than
   what they replace.**

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -1,15 +1,25 @@
 # Snake-fold followups
 
-**Status (2026-07-29):** single fold is verified on `chain-mil5ore` for
-throughput **and** power — 5.00/s, 146/146 machines, and one connected pole
-network, against a control that measures the same. The power fragmentation
-that previously blocked it is fixed. Read "The second trap" below anyway: it
-is why the fragmentation went unnoticed, and the reasoning generalises.
+**Status (2026-07-30):** **multi-fold works and is Factorio-verified.**
+`chain-mil5ore` folds three times — 521×31 (16.8:1) → **147×138 (1.07:1)**,
+PASS at 4.92/s against 5.00/s planned, 146/146 machines, one pole network,
+4620/4620 entities revived. Single fold remains verified for throughput and
+power. Read "The second trap" below anyway: it is why the earlier power
+fragmentation went unnoticed, and the reasoning generalises.
 
-Multi-fold is close but unfinished, on `feat/multifold-gap-lanes` (#492):
-`InputStranded` is resolved and the per-item lane machinery is built, leaving
-one crossing where two items share an input column. Every cause below is
-measured, not guessed. Owning design doc:
+Scope, because it is easy to over-read: **one fixture of four.**
+`mega-chain-chem5raw`, `mega-chain-pu4raw` and `mega-chain-usp2raw` still find
+no fold. And this is a SHAPE result, not a density one — it costs +21%
+entities, and RFC-057's refusal of folding as a density lever stands.
+
+**#492's stated blocker was not the blocker.** It recorded a shared-column B12
+underground dive as the remaining work. No dive was written. Three other causes
+were found by instrumenting the refusal: rows ignoring which side an input
+arrives from, a lane terminus that never turned toward the input it feeds, and
+lanes keyed by item rather than (item, side). The sections below are kept with
+their original measurements, annotated where a claim has since been falsified —
+the pattern of *what looked like the blocker and wasn't* is the reusable part.
+Owning design doc:
 [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md),
 whose decision log carries the measurements.
 
@@ -115,11 +125,20 @@ the gap and one below. The ordering argument holds only for lanes at *distinct*
 columns; at a shared column one item's climb must cross the other's lane, and
 no assignment order avoids it.
 
-**Fix shape:** an underground dive where two lanes share a column — the
-standard belt-weaving technique (`factorio-mechanics.md` B12), which this pass
-does not yet synthesize.
+**Fix shape (SUPERSEDED 2026-07-30):** this called for an underground dive
+where two lanes share a column (`factorio-mechanics.md` B12). No dive was
+needed. The clash above was **cross-side** — the two items' sources are on
+opposite sides of the gap (note the excerpt's own `dir=North` occupant against
+a lane fed from above), and row assignment ignored the side entirely, so climbs
+from opposite sides swept through each other's rows. Measured on mil5: 28 of 32
+gap-lane refusals were cross-side, 4 same-side. Partitioning rows by source
+side took `GapLaneConflict` to 0 on mil5, pu4raw and usp2raw.
 
-Note the clash surfaces under the `ExitLaneConflict` refusal even though it is
+The lesson worth keeping: the excerpt contains the evidence that would have
+falsified the shared-column reading — `carries=coal` facing North against an
+iron-ore lane — and it was read as confirming it instead.
+
+Note the clash surfaces under the `GapLaneConflict` refusal even though it is
 an *input*-side collision: the input feed pass reuses that variant. A misnomer
 that sends the reader to the wrong pass — renamed to `GapLaneConflict` on the
 work branch. Reward: 3-fold reaches roughly 152×132 (1.15:1) on
@@ -140,7 +159,7 @@ validation rejections for the not-found path — read those before theorising.
 
 Measured across the corpus (`probe_fold_corpus`, before per-item lanes):
 
-| fixture | legal cols | ExitLane | InputStranded | JunctionBlocked | rejected-by-validation |
+| fixture | legal cols | GapLane | InputStranded | JunctionBlocked | rejected-by-validation |
 |---|---:|---:|---:|---:|---:|
 | `chain-mil5ore` | 251/551 | 21 | 121 | 29 | 9 → folds |
 | `mega-chain-chem5raw` | 275/699 | 22 | 132 | 15 | 0 |
@@ -150,7 +169,7 @@ Measured across the corpus (`probe_fold_corpus`, before per-item lanes):
 Two things fall out and still hold. Legal columns are 40–50% everywhere, so
 column legality is **never** the binding constraint — the pipe-adjacency
 hypothesis for chem was wrong. And `pu4raw` records **zero** `InputStranded`,
-failing on `ExitLaneConflict` (173) instead — the only fixture where fixing the
+failing on `GapLaneConflict` (173) instead — the only fixture where fixing the
 input side could not help at all, which is why the exit side was tackled first.
 (It still records 23 `JunctionBlocked`, so lane conflict is not its sole
 refusal — just its dominant one, and the only one input work could not touch.)
@@ -229,7 +248,7 @@ Adversarial review also raised two it could not exercise:
 
 Every failure mode is a typed `FoldRefusal`, so a refusal names its cause
 rather than being a bare `None`: `CutsEntity`, `JunctionBlocked`,
-`ExitLaneConflict`, `CornerNotATurn`, `RunSevered`, `InputStranded`,
+`GapLaneConflict`, `CornerNotATurn`, `RunSevered`, `InputStranded`,
 `EntityExplosion`. `SPAGHETTIO_FOLD_DEBUG=1` lists every severed belt instead
 of just the first.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -127,6 +127,43 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 
 ## Recent RFC close-outs
 
+**`rfc-057-topology-preserving-dense-repacking.md` multi-fold (2026-07-30,
+PR #500 — RFC ACTIVE, not closed)**: **multi-fold is Factorio-verified.**
+`chain-mil5ore` folds **three times**: 521x31 (16.8:1) to **147x138 (1.07:1)**
+at 4.92/s delivered against 5.00/s planned, **146 of 146 machines**, **one pole
+network**, 4620/4620 entities revived, zero kit errors. The single fold
+re-measures PASS at a legal snapped column too (262x64, 5.00/s produced), so
+both depths now pass. This discharges the previous entry's "multi-fold remains
+unproven".
+
+Scope, because it is easy to over-read: **one fixture of four.**
+`mega-chain-chem5raw`, `mega-chain-pu4raw` and `mega-chain-usp2raw` still find
+no fold — their dominant refusal is now `InputStranded` from one item wanted at
+two columns on the same side, which needs a splitter. And this remains a SHAPE
+result: +21% entities, so the density refusal below stands untouched.
+
+Three causes, none of them the one the tracking issue named (#492 specified a
+shared-column underground dive; none was written): rows ignored which SIDE of
+the gap an input arrives from, so climbs from opposite sides swept each other's
+rows; the lane's terminal tile faced the run direction and so never turned
+toward the input it feeds (45 starved furnaces behind 4 orphan lanes); and lanes
+were keyed by item rather than (item, side), refusing the commonest possible
+arrangement. Pole COVERAGE also needed its own repair — `repair_pole_network`
+only ever fixed connectivity, and a rotation moves the pole that covered an
+entity across a seam.
+
+Two findings from the same work worth carrying: `rejected_by_validation` was a
+bare count that hid the side-partition fix's own side effect (`GapLaneConflict`
+32 to 0 while rejections went 22 to 54 — the same candidates dying later), now
+categorised; and duplicate `boundary_outputs` records for one physical terminus
+made the sim harness build two drain rigs on one tile (#499), which it caught
+and loudly invalidated rather than mismeasuring.
+
+**Still outstanding for this entry:** nobody has looked at the folded layout in
+a client, and the layout-engine change has not had local adversarial review —
+both required by CLAUDE.md's verification protocol and neither substitutable by
+the review bot, which cannot run STRESSGOLD or decode snapshots.
+
 **`rfc-057-topology-preserving-dense-repacking.md` snake fold (2026-07-29,
 PR #481 — RFC ACTIVE, not closed)**: a single fold is Factorio-verified.
 `chain-mil5ore` goes 552x32 (17.25:1) to 276x66 (4.18:1) at **5.00/s produced


### PR DESCRIPTION
Closes #492. Fixes #499.

## Intent

Make multi-fold work. It does: `chain-mil5ore` folds **three times**, and both
fold depths now pass in a real headless Factorio.

| | geometry | aspect | delivered/s | machines | pole networks | verdict |
|---|---|---|---:|---:|---:|---|
| control | 521×31 | 16.8:1 | 5.03 | 146 | 1 | PASS |
| 1-fold | 262×64 | 4.1:1 | 4.90 | 146 | 1 | **PASS** |
| 3-fold | **147×138** | **1.07:1** | 4.92 | 146 | 1 | **PASS** |

Factorio 2.0.77 headless, `--warmup 216000`, 4620/4620 entities revived, zero
kit errors, no fluid errors. This discharges RFC-057's "multi-fold remains
unproven".

## #492's stated blocker was not the blocker

The issue recorded the remaining work as a shared-column B12 underground dive.
**No dive was written.** Instrumenting the refusal instead found three other
causes:

| Cause | Why it was invisible | Effect |
|---|---|---|
| **Rows ignored source side** | A gap takes inputs from BOTH neighbours. A climb crosses every row between itself and its source, so *which* rows depends on the side — and the two sides impose **opposite** ordering requirements. One global order was itself the bug, not a bad choice of order. | `GapLaneConflict` 32 → 0 on mil5; **0 on pu4raw**, whose 173 the followups doc called the backlog's highest-value fix |
| **Lane terminus faced the run direction** | It never turned toward the input it exists to feed: items traversed the lane, passed the input's column, dead-ended. Exits are immune — their flow runs the other way, so the descent feeds the lane. | `belt-flow-reachability` 45 → 0, `orphan-belt-segment` 4 → 0 |
| **Lanes keyed by item, not (item, side)** | Every source input sits on the top edge, so consecutive segments' copies of one item land on opposite sides of one gap. The commonest arrangement refused. | see the failed prediction below |

Rows are now partitioned by side (above-sourced from `gap_top` down,
below-sourced from `gap_top + gap - 1` up), which keeps each climb inside its
own block and makes the groups provably non-crossing while
`n_above + n_below <= gap`. Within a group the span-nesting argument survives
but the order **flips** to ascending — index 0 is now adjacent to its source and
crosses nothing.

## Scope of the claim

- **One fixture of four.** chem5raw, pu4raw and usp2raw still find no fold.
- **A SHAPE result, not a density one.** +807 entities (+21%). RFC-057's
  2026-07-29 refusal of folding as a density lever stands untouched.
- Folding stays test-only; no `LayoutOption` is wired up here.

## A prediction that failed, on the record

The `(item, side)` keying was expected to unblock the corpus. Measured after:
**pu4raw 155 → 155, usp2raw 72 → 72** (no change at all), and chem5raw's freed
candidates moved to `GapLaneConflict` (+48, matching the 48 that stopped
stranding) rather than folding. Refusals moving later is not progress. The
change is still right — it removes a refusal that was wrong — but their
`InputStranded` is the same-side-two-columns case, which needs a splitter.

## #499 was ours, not the harness's

The harness reported "overlapping kit chests" at 14 bare tiles at negative
coordinates, which reads as harness geometry. It wasn't: `mil5-fold1` declared
**two boundary_output records on the identical tile**. A gap carries one lane per
item, so both segments' exits merge into it and `exit_moved` maps every member
to the same terminus — correct geometry, N duplicate records. The harness
faithfully built one drain rig per record; `ext_len = 11 + 2*idx` separates rigs
by 2 tiles, so their 9-position banks overlapped by 7. It then **invalidated the
run** rather than report a rate measured through cross-feeding chests, which is
the right call and better behaviour than I initially credited it for.

Deduped on the **whole record**, not position — two records at one tile carrying
*different* items is a real defect and must stay visible to
`check_boundary_record_integrity` (#482). Order-preserving, because the harness
indexes rigs by record order.

Harness side: the overlap audit now names the owning rig
(`feed[iron-ore] rig 2 vs drain[...]`) instead of a bare tile, reusing the chest
lists `storage.feeds`/`drains` already keep, plus an unattributed-chest backstop
so a rig that stops registering cannot silently disable the audit.

## Also in here

- **`cover_unpowered`** (`layout.rs`) — `repair_pole_network` only ever fixed
  pole *connectivity*; nothing fixed *coverage*. Rotation is rigid so coverage
  survives inside a segment, but an entity beside a fold column loses the pole
  that covered it from across the seam (5 holes on the mil5 2-fold, all within 3
  tiles of a seam). Uses the power validator's own continuous-centre predicate so
  the two cannot drift, and **returns 0 untouched when coverage is already
  complete** — which is what keeps every single-fold and composed-cell fixture
  byte-identical and their sim pins valid.
- **Per-parity gap sizing** — exits key by item (merged distinct), inputs by
  (item, side) (the sum). Deliberately not summing everywhere: a single fold has
  only the even/exit gap, so it stays byte-identical.
- **`FoldSearch::validation_regressions`** — `rejected_by_validation` was a bare
  count, and it hid this work's own side effect: the side-partition fix read as
  `GapLaneConflict` 32 → 0 while silently pushing rejections 22 → 54 (the same
  candidates dying *later*). Same reporting shape as `docs/validator-reporting.md`,
  inside the fold search itself.
- Two `#[ignore]` probes, and a fix to `export_fold_pair_for_sim`, which used a
  bare `width / 2` fold column and had been refusing `CutsEntity` since
  compaction last changed the width.

## Models / contracts touched

`FoldSearch` gains `validation_regressions` (additive). `LayoutResult` boundary
record *lists* may now be shorter — duplicates removed, no field changes.

## Verification

- [x] **Factorio 2.0.77 headless**, `--warmup 216000`: 3-fold PASS (4.92/s,
      146/146, 1 pole network), 1-fold PASS (5.00/s produced, 146/146), control
      PASS. Long warmup deliberate per `docs/status.md` — the dim-scaled default
      reads buffer fill as throughput on deep chains.
- [x] `cargo test --manifest-path crates/core/Cargo.toml` — **1036 passed, 0
      failed** (single invocation), unchanged from `main`.
- [x] `cargo test -p spaghettio_sim_harness` — 55 passed, 0 failed.
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] Full 4-fixture corpus re-measured before and after each change.
- [ ] **Not looked at in a client yet.** `serve` is the check the kit cannot
      invalidate, and per CLAUDE.md a layout change also wants local adversarial
      review that can decode snapshots — the bot can't run STRESSGOLD or do
      tile-level verification.

## Deviations from intent

Went after the measured refusal classes rather than #492's specified fix, and
never wrote the underground dive. Documented in RFC-057's decision log with the
falsified premise and the failed prediction kept rather than tidied away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ