### PR TITLE
fix(review-bot): zero coverage always fails; drop the turn-count carve-out

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -307,14 +307,28 @@ jobs:
             echo "Review coverage exists for the current head — OK."
             exit 0
           fi
-          # Zero coverage. Distinguish a conscious plugin gate-skip (cheap,
-          # few turns: ~2-6 observed) from mid-review abandonment (the
-          # class-5 signature: 16-20 turns, then nothing). Threshold 8 sits
-          # between the observed clusters; see docs/review-bot.md.
+          # Zero coverage on a substantive PR. This now FAILS unconditionally,
+          # and the removal of the turn-count carve-out is the point.
+          #
+          # The old rule passed any run with num_turns <= 8, on the theory that
+          # a cheap run is a conscious plugin gate-skip while abandonment is
+          # expensive (the class-5 signature: 16-20 turns, then nothing).
+          # #500 falsified it: 3 turns, ONE permission denial, nothing posted,
+          # green check — on a 1000-line layout-engine PR. Turn count cannot
+          # distinguish "declined on purpose" from "hit a denial and gave up",
+          # because it only measures cost, not intent.
+          #
+          # And the carve-out was self-defeating even in theory. The prompt
+          # REQUIRES a one-line `gh pr comment` on any conscious skip, and such
+          # a comment is itself coverage — so a compliant skip never reaches
+          # this branch. Everything that gets here is by definition a run that
+          # violated the posting contract. There is nothing left to carve out.
+          #
+          # This is a strictness increase on a check that is REQUIRED on main
+          # (scripts/review-gate.sh), so it can block a merge. That is the
+          # intended trade: an unreviewed merge is worse than a blocked one,
+          # and the escape hatch below is one click.
           turns=$(grep -o '"num_turns"[[:space:]]*:[[:space:]]*[0-9]*' "${RUNNER_TEMP}/claude-execution-output.json" 2>/dev/null | tail -1 | grep -o '[0-9]*$' || true)
-          if [ -n "$turns" ] && [ "$turns" -le 8 ]; then
-            echo "No coverage, but the transcript shows a cheap conscious run (num_turns=$turns <= 8) — plugin gate-skip signature, not abandonment. Passing."
-            exit 0
-          fi
-          echo "::error title=No review for this head commit::claude-review exited green but PR #$PR has no review, inline comment, or bot summary attributable to head $HEAD_SHA (transcript turns: ${turns:-unknown}). Either the run never reviewed (the silent no-op class), or it skipped a substantive follow-up push — the failure #481 merged behind. See docs/review-bot.md. Escape hatch if the skip was legitimate: re-run this job (runs are stochastic), or post a review on the current head and re-run the check."
+          denials=$(grep -o '"permission_denials_count"[[:space:]]*:[[:space:]]*[0-9]*' "${RUNNER_TEMP}/claude-execution-output.json" 2>/dev/null | tail -1 | grep -o '[0-9]*$' || true)
+          echo "::error title=No review for this head commit::claude-review exited green but PR #$PR has no review, inline comment, or bot summary attributable to head $HEAD_SHA (transcript turns: ${turns:-unknown}, permission denials: ${denials:-unknown}). The run did not review, or reviewed and failed to post. A non-zero denial count with a low turn count is the denial-abandonment signature (failure class 5) — check the claude-execution-output artifact for the refused command shape and widen --allowedTools if it was legitimate. See docs/review-bot.md. Escape hatch: re-run this job (runs are stochastic), or post a review on the current head and re-run the check."
           exit 1

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -206,6 +206,37 @@ Two independent mitigations, only one of them applied:
   `unrequire` reverses it in one command. See the never-skip invariant above:
   requiring the check constrains how this workflow may be conditioned.
 
+### Failure class 9: cheap denial-abandonment passed as a gate-skip (2026-07-30)
+
+The guard used to pass any zero-coverage run with `num_turns <= 8`, reasoning
+that a conscious plugin gate-skip is cheap while abandonment is expensive (the
+class-5 signature: 16-20 turns, then nothing).
+
+#500 falsified it. A 1000-line layout-engine PR got a **3-turn** run with **one
+permission denial**, posted nothing, and green-checked:
+
+```
+coverage on 48e7ee6b...: reviews=0 inline=0 bot_summaries=0
+num_turns=3   permission_denials_count=1
+```
+
+Turn count measures cost, not intent, so it cannot separate "declined on
+purpose" from "hit a denial and gave up". Worse, the carve-out was
+self-defeating in theory too: the prompt REQUIRES a one-line `gh pr comment` on
+any conscious skip, and that comment is itself coverage — so a compliant skip
+never reaches the carve-out. Everything that got there had already violated the
+posting contract.
+
+Zero coverage on a substantive PR now fails unconditionally. The error reports
+both turn count and denial count, since a low turn count with a non-zero denial
+count is the denial-abandonment fingerprint and points at a refused command
+shape in the transcript artifact.
+
+Note what made this one visible: the check was green and every other signal
+agreed, so the only clue was the review taking **1m8s** where real reviews on
+this repo take 3-11 minutes. A green check plus an implausibly fast run is worth
+opening even when nothing else complains.
+
 ## Forensics playbook
 
 **Run signatures** (from the action's result JSON in the job log — grep the


### PR DESCRIPTION
## Intent

**#500 got no review at all, behind a green required check.** 1000 lines of
layout-engine change:

```
coverage on 48e7ee6b...: reviews=0 inline=0 bot_summaries=0
num_turns=3   permission_denials_count=1
```

The guard passed it via the `num_turns <= 8` carve-out, which assumed a cheap
zero-coverage run is a conscious plugin gate-skip while abandonment is expensive
(the class-5 signature: 16–20 turns, then nothing). **Turn count measures cost,
not intent.** Three turns with a permission denial and nothing posted is
denial-abandonment, not a considered skip.

And the carve-out was self-defeating in theory as well as in practice: the
prompt **requires** a one-line `gh pr comment` on any conscious skip, and that
comment *is* coverage — so a compliant skip never reaches this branch.
Everything that got there had already violated the posting contract. There was
nothing legitimate left to carve out.

## What changes

Zero coverage on a substantive PR fails unconditionally. The error now reports
**turn count and denial count together**, because a low turn count with non-zero
denials points at a refused command shape in the transcript artifact rather than
at a triviality gate — that's the difference between "widen `--allowedTools`" and
"the diff was trivial".

The earlier carve-outs are untouched and still fail *open*: draft PRs,
workflow-file PRs, fork PRs, sub-20-line diffs, sub-20-line follow-up pushes, and
every API error. Only confirmed zero-coverage abandonment fails closed.

## This will block a merge, on purpose

`claude-review` is a **required** check on `main` (`scripts/review-gate.sh`), so
this is a strictness increase that can stop merges — starting with **#500's own**,
which is correct: #500 has not been reviewed. An unreviewed merge is worse than a
blocked one, and the escape hatch is a one-click job re-run.

## How this was caught, which is the reusable part

Every signal agreed: check green, guard green, all other jobs green. The *only*
clue was `claude-review` finishing in **1m8s** where real reviews on this repo
take 3–11 minutes. A green check plus an implausibly fast run is worth opening
even when nothing complains. Recorded in `docs/review-bot.md` as failure class 9,
that heuristic included.

## Models / contracts touched

None. CI configuration and docs.

## Verification

- [x] YAML parses (`yaml.safe_load`).
- [x] All five `workflow-guard` tripwires still match — load-bearing, since this
      edits the file that guard protects.
- [x] The job still has **no** job-level `if`, preserving #497's never-skip
      invariant (verified structurally by parsing, not grepping).
- [ ] **Cannot be verified pre-merge.** This PR touches `.github/workflows/`, so
      the action self-skips it and the guard carves it out — its own
      `claude-review` pass means "did not run". The behaviour change only
      demonstrates on the next zero-coverage run against a non-workflow PR.
      Session-side review stands in, per CLAUDE.md.

## Deviations from intent

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ