### PR TITLE
fix(compaction): recompute the wire graph after undergroundification

### DIFF
--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -937,6 +937,18 @@ pub fn undergroundify_straight_belts(layout: &LayoutResult) -> LayoutResult {
         .collect();
     result.regions.clear();
     result.trace = None;
+    // `power_wires` are index pairs into `entities`, and the rebuild above
+    // deletes the interior of every undergrounded run — so every stored pair
+    // now names a different entity. Left stale, `wires_for` hands the
+    // connectivity check a garbage graph and it reports a fragmented pole
+    // network that does not exist. Both coordinate-cut passes already
+    // recompute here; this one did not, and because the transport stage runs
+    // FIRST and is gated on total error count, the phantom errors rejected the
+    // whole stage on every bus layout measured.
+    result.power_wires = Some(crate::power_wires::compute_pole_wires(
+        &result.entities,
+        result.wire_mode,
+    ));
     result
 }
 


### PR DESCRIPTION
## Intent

`undergroundify_straight_belts` rebuilds the `entities` vector, but `power_wires` is a list of index pairs **into that vector** and was carried over unchanged — so after the rebuild every wire named a different pair of entities. The connectivity check walked that garbage graph and reported a fragmented pole network that does not exist.

The consequence is bigger than a bad warning. `compact_transport_geometry` runs **first** in `compact_validated_geometry` and is gated by `accept_if_no_worse` on total error count, so the phantom power errors rejected the entire transport stage on every bus layout measured. The underground resynthesis behind RFC-057's headline belt reductions was silently dead on the bus path — the only path `LayoutOptions::compact_layout` is wired to.

Both coordinate-cut passes already recompute the wire graph at exactly this point (`compaction.rs:687`, `:766`); this pass did not.

Found while reviewing the RFC-057 arc. Owning doc: [`rfc-057-topology-preserving-dense-repacking.md`](../blob/main/docs/rfc-057-topology-preserving-dense-repacking.md).

## Scope

- **In:** recompute `power_wires` from the rebuilt entity vector, using the layout's own `wire_mode`.
- **Out:** the per-cut gate in `compact_validated_{columns,rows}` is *absolute* (`any Error` → reject) while the transport gate is *relative*. That inconsistency is real, but I implemented the relative version and measured it as an exact **no-op** on this corpus, so it is not in this PR. Not worth changing without evidence.
- **Out:** the bbox regression noted below — that wants a scored fixed point, which is its own change.

## Verification

Measured over ten bus layouts spanning the shapes the web app produces (gears, EC, belts, inserters, science, PU, LDS):

| corpus-wide | before | after |
|---|---:|---:|
| belt tiles | 4,920 | 3,770 (**−23.4%**) |
| entities | 7,039 | 6,269 (−10.9%) |
| occupied tiles | 10,263 | 9,493 (−7.5%) |

`pu1-plate` is the clearest case: 2,431 → 1,873 entities (−23%), and its **21 `lane-throughput` ERRORS disappear** — the transport candidate was strictly better and was being discarded on phantom power errors.

Direct confirmation that the errors were phantom, before → after on the transport stage:

```
sci1-ore   source     39x36 ent=281 ERRORS=0  {}
           transport  38x36 ent=267 ERRORS=20 {"power": 20}   <- before
           transport  38x36 ent=267 ERRORS=0  {}              <- after
```

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 915 lib + 121 across other targets, **0 failures**
- [x] `cargo clippy --all-targets` — no findings in `compaction.rs`
- [ ] WASM rebuild + browser eyeball — **N/A and stated deliberately**: `crates/wasm-bindings/src/lib.rs:113` hard-codes `compact_layout: false`, so this code is not reachable from the web app. Nothing to eyeball; no user-visible change.
- [ ] Snapshot — not used. The equivalent evidence is the per-stage error census above, which names the specific invariant (`power_wires` index validity) rather than a count going quiet.

Reproduce with `crates/core/examples/density_audit.rs` and `pu1_probe.rs` (gitignored, local-only).

## Deviations from intent

The fix improves occupied tiles and entity counts but **raises total bbox 2.6%** on this corpus — some heights grow 1–3 tiles, because the alternating cut fixed point now converges from a different state. Both directions are reported rather than quoting only the favourable one. Making the fixed point scored (occupied + bbox) instead of blind is follow-up work, not this PR.

## Models / contracts touched

None. This restores an invariant `power_wires` already documents in `models.rs:424` ("index pairs into `entities`") — the field was simply not maintained across an entity-vector rebuild.