### PR TITLE
fix(compaction): pack islands on terminal-inclusive extents

### DIFF
--- a/crates/core/src/bus/compaction.rs
+++ b/crates/core/src/bus/compaction.rs
@@ -1142,24 +1142,64 @@ pub fn build_manifold_nets(
         }
     }
 
-    // Boundary terminals have no island-relative representation.
+    // Boundary terminals have no island-relative representation, so island
+    // placement cannot carry them. Keeping their SOURCE coordinates is only
+    // safe while placement preserves those coordinates; once islands are
+    // repacked in 2D the stale tile is arbitrary, and it can land exactly on
+    // a relocated machine terminal. After terminal-aware packing removed the
+    // island-vs-island collisions, this was the entire remaining residual on
+    // three of six bus fixtures.
+    //
+    // Relocate them onto the perimeter of the placed extent instead: inputs
+    // on the row above, outputs on the row below, which also agrees with the
+    // south-flowing orientation the balancer library is stamped for. Order is
+    // deterministic and the stride is 2, so no two boundary belts ever touch.
+    let mut min_x = i32::MAX;
+    let mut min_y = i32::MAX;
+    let mut max_y = i32::MIN;
+    for island in placed_islands {
+        let (offset_dx, offset_dy, _, height) = terminal_inclusive_extent(island);
+        min_x = min_x.min(island.block.x + offset_dx);
+        min_y = min_y.min(island.block.y + offset_dy);
+        max_y = max_y.max(island.block.y + offset_dy + height - 1);
+    }
+    if min_x == i32::MAX {
+        min_x = 0;
+        min_y = 0;
+        max_y = 0;
+    }
+
+    let mut boundaries: Vec<(RouteTerminalKind, &str, i32, i32)> = Vec::new();
     for net in &ir.route_nets {
-        let terminals = by_item.get_mut(&net.item).unwrap();
         for terminal in &net.terminals {
-            if !matches!(
+            if matches!(
                 terminal.kind,
                 RouteTerminalKind::BoundaryInput | RouteTerminalKind::BoundaryOutput
             ) {
-                continue;
+                boundaries.push((terminal.kind, net.item.as_str(), terminal.x, terminal.y));
             }
-            terminals.push(ManifoldTerminal {
-                kind: terminal.kind,
-                x: terminal.x,
-                y: terminal.y,
-                island_id: None,
-                inserter_entity_index: None,
-            });
         }
+    }
+    boundaries.sort();
+    boundaries.dedup();
+    let (mut next_input, mut next_output) = (0i32, 0i32);
+    for (kind, item, _, _) in boundaries {
+        let (x, y) = if matches!(kind, RouteTerminalKind::BoundaryInput) {
+            let x = min_x + next_input * 2;
+            next_input += 1;
+            (x, min_y - 1)
+        } else {
+            let x = min_x + next_output * 2;
+            next_output += 1;
+            (x, max_y + 1)
+        };
+        by_item.get_mut(item).unwrap().push(ManifoldTerminal {
+            kind,
+            x,
+            y,
+            island_id: None,
+            inserter_entity_index: None,
+        });
     }
 
     let mut result = Vec::with_capacity(by_item.len());
@@ -1188,6 +1228,37 @@ pub struct RecipeClusterPlacement {
     pub block: CompactBlock,
 }
 
+/// Island footprint grown to contain every terminal tile, as
+/// `(offset_dx, offset_dy, width, height)` where `offset_*` (always `<= 0`)
+/// says where `block` sits inside the padded extent.
+///
+/// A terminal is the belt tile an inserter reaches to, so it lies OUTSIDE
+/// `block`. Packing on `block` alone guarantees only that machines do not
+/// overlap — it freely lets one island's input terminal land exactly on
+/// another island's output terminal. That is a physically impossible belt
+/// tile (one tile cannot be the delivery point for two commodities), and no
+/// router can repair it, because the conflict is created at placement time,
+/// before routing starts.
+///
+/// Measured across six bus fixtures, cross-item shared terminal tiles exactly
+/// equalled the manifold router's unresolved-route count — 2, 2, 44, 4, 8, 7
+/// — i.e. this was the entire residual keeping candidates non-exportable.
+/// Negotiated-congestion rerouting could not touch it: contested tile counts
+/// fell over 24 rounds but the contested ROUTE count never moved.
+fn terminal_inclusive_extent(island: &RigidIsland) -> (i32, i32, i32, i32) {
+    let mut min_dx = 0;
+    let mut min_dy = 0;
+    let mut max_dx = island.block.width - 1;
+    let mut max_dy = island.block.height - 1;
+    for terminal in &island.terminals {
+        min_dx = min_dx.min(terminal.dx);
+        min_dy = min_dy.min(terminal.dy);
+        max_dx = max_dx.max(terminal.dx);
+        max_dy = max_dy.max(terminal.dy);
+    }
+    (min_dx, min_dy, max_dx - min_dx + 1, max_dy - min_dy + 1)
+}
+
 /// Repack rigid islands into recipe banks, then place those banks in 2D by
 /// solver-rate-weighted production adjacency. This is the first RFC-057
 /// placement that does not preserve incumbent row/corridor coordinates.
@@ -1211,11 +1282,15 @@ pub fn place_recipe_clusters(
             let block = &ir.islands[id].block;
             std::cmp::Reverse((block.height, block.width, id))
         });
+        // Pack on the terminal-inclusive extent, not the bare machine block —
+        // see `terminal_inclusive_extent`. The shelf coordinates below address
+        // that extent; `block` is then offset back inside it, so the emitted
+        // machine geometry keeps its shape and only its origin moves.
         let area: i64 = island_ids
             .iter()
             .map(|&id| {
-                let block = &ir.islands[id].block;
-                i64::from(block.width + clearance) * i64::from(block.height + clearance)
+                let (_, _, width, height) = terminal_inclusive_extent(&ir.islands[id]);
+                i64::from(width + clearance) * i64::from(height + clearance)
             })
             .sum();
         let target_width = (area as f64).sqrt().ceil() as i32;
@@ -1223,25 +1298,21 @@ pub fn place_recipe_clusters(
         let mut y = 0;
         let mut row_height = 0;
         let mut max_x = 0;
+        let mut max_y = 0;
         for &id in &island_ids {
-            let width = islands[id].block.width;
-            let height = islands[id].block.height;
+            let (offset_dx, offset_dy, width, height) = terminal_inclusive_extent(&islands[id]);
             if x > 0 && x + width > target_width {
                 x = 0;
                 y += row_height + clearance;
                 row_height = 0;
             }
-            islands[id].block.x = x;
-            islands[id].block.y = y;
+            islands[id].block.x = x - offset_dx;
+            islands[id].block.y = y - offset_dy;
             x += width + clearance;
             row_height = row_height.max(height);
             max_x = max_x.max(x - clearance);
+            max_y = max_y.max(y + height);
         }
-        let max_y = island_ids
-            .iter()
-            .map(|&id| islands[id].block.y + islands[id].block.height)
-            .max()
-            .unwrap_or(0);
         let id = clusters.len();
         clusters.push(RecipeClusterPlacement {
             recipes,

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -4232,3 +4232,122 @@ fn probe_fold_error_breakdown_mil5() {
         }
     }
 }
+
+/// Island placement must keep TERMINAL tiles disjoint, not just machine blocks.
+///
+/// A terminal is the belt tile an inserter reaches to, so it sits OUTSIDE the
+/// island's block. Packing on blocks alone let one island's input terminal
+/// land exactly on another island's output terminal — one tile asked to be the
+/// delivery point for two different commodities, which is physically
+/// impossible and which no router can repair, because the conflict is created
+/// before routing starts.
+///
+/// This asserts the invariant by COUNT and reports every offending tile, not a
+/// sample: the failure it guards was previously visible only as an aggregate
+/// "N routes still contain surface conflicts", which said nothing about cause.
+/// Cross-item shared terminals exactly equalled that unresolved-route count on
+/// all six bus fixtures measured (2, 2, 44, 4, 8, 7).
+#[test]
+fn rfc057_island_placement_keeps_terminals_disjoint() {
+    use spaghettio_core::bus::compaction::{
+        build_manifold_nets, materialize_legalized_manifold_routes, place_recipe_clusters,
+        CompactIr,
+    };
+    use std::collections::BTreeMap;
+
+    let cases: &[(&str, &str, f64, &[&str], &str)] = &[
+        ("gear5-plate", "iron-gear-wheel", 5.0, &["iron-plate"], "assembling-machine-1"),
+        ("sci1-ore", "automation-science-pack", 1.0, &["iron-ore", "copper-ore"], "assembling-machine-1"),
+        ("ec15-plate", "electronic-circuit", 15.0, &["iron-plate", "copper-plate"], "assembling-machine-2"),
+        ("belt5-ore", "transport-belt", 5.0, &["iron-ore"], "assembling-machine-2"),
+    ];
+
+    let mut materialized = 0usize;
+    for (label, item, rate, inputs, machine) in cases {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item,
+            *rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            machine,
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap_or_else(|e| panic!("{label}: solver refused: {e}"));
+        let bus = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
+            .unwrap_or_else(|e| panic!("{label}: layout refused: {e}"));
+        let src = spaghettio_core::bus::compaction::compact_validated_geometry(&bus, &sr);
+
+        let ir = CompactIr::from_source(&src, &sr);
+        let (clustered, _) = place_recipe_clusters(&ir, 1);
+        let manifolds = build_manifold_nets(&ir, &clustered)
+            .unwrap_or_else(|e| panic!("{label}: manifold nets refused: {e}"));
+
+        // One entry per tile, so a failure names every collision.
+        let mut by_tile: BTreeMap<(i32, i32), Vec<&str>> = BTreeMap::new();
+        for net in &manifolds {
+            for terminal in &net.terminals {
+                by_tile
+                    .entry((terminal.x, terminal.y))
+                    .or_default()
+                    .push(net.item.as_str());
+            }
+        }
+        let cross_item: Vec<_> = by_tile
+            .iter()
+            .filter(|(_, items)| items.iter().any(|i| *i != items[0]))
+            .collect();
+        assert!(
+            cross_item.is_empty(),
+            "{label}: {} tile(s) host terminals for more than one commodity: {cross_item:?}",
+            cross_item.len(),
+        );
+
+        let inside: Vec<_> = manifolds
+            .iter()
+            .flat_map(|net| net.terminals.iter().map(move |t| (net.item.as_str(), t)))
+            .filter(|(_, t)| {
+                clustered.iter().enumerate().any(|(idx, island)| {
+                    Some(idx) != t.island_id
+                        && t.x >= island.block.x
+                        && t.x < island.block.x + island.block.width
+                        && t.y >= island.block.y
+                        && t.y < island.block.y + island.block.height
+                })
+            })
+            .map(|(item, t)| (item, t.x, t.y))
+            .collect();
+        assert!(
+            inside.is_empty(),
+            "{label}: {} terminal(s) land inside another island's footprint: {inside:?}",
+            inside.len(),
+        );
+
+        // The point of the invariant: routing can now actually complete.
+        let plans = spaghettio_core::bus::compaction::plan_local_manifolds(&clustered, &manifolds, 1);
+        let graphs: Vec<_> = plans
+            .iter()
+            .map(spaghettio_core::bus::compaction::build_local_manifold_graph)
+            .collect();
+        let hubs = spaghettio_core::bus::compaction::place_distributed_local_manifold_nodes(
+            &clustered, &graphs, 3,
+        )
+        .unwrap_or_else(|e| panic!("{label}: hub placement refused: {e}"));
+        let routed =
+            spaghettio_core::bus::compaction::route_local_manifold_edges(&clustered, &graphs, &hubs)
+                .unwrap_or_else(|e| panic!("{label}: routing refused: {e}"));
+        let legalized =
+            spaghettio_core::bus::compaction::legalize_manifold_routes(&routed.routes);
+        assert_eq!(
+            legalized.unresolved_routes, 0,
+            "{label}: {} routes still conflict after terminal-disjoint placement \
+             ({} tiles) — the placement invariant holds, so this is a genuine \
+             routing failure and wants its own diagnosis",
+            legalized.unresolved_routes, legalized.unresolved_tiles,
+        );
+        assert!(materialize_legalized_manifold_routes(&legalized.routes).is_ok());
+        materialized += 1;
+    }
+    assert_eq!(materialized, cases.len());
+}

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -4337,6 +4337,32 @@ fn rfc057_island_placement_keeps_terminals_disjoint() {
         let routed =
             spaghettio_core::bus::compaction::route_local_manifold_edges(&clustered, &graphs, &hubs)
                 .unwrap_or_else(|e| panic!("{label}: routing refused: {e}"));
+        // An edge that fails all three routing passes lands in `unroutable`
+        // and NEVER enters `routes` — so the legalization and materialization
+        // gates below cannot see it. Without these two assertions they hold
+        // trivially for every dropped edge, and vacuously in the limit where
+        // nothing routes at all. Exactly the "a check going quiet is not
+        // evidence" failure in CLAUDE.md's verification protocol.
+        let edge_count: usize = graphs.iter().map(|graph| graph.edges.len()).sum();
+        // …and `routes.len() == edge_count` is itself vacuous at zero, so the
+        // corpus has to actually pose the problem.
+        assert!(
+            edge_count > 0,
+            "{label}: no manifold edges to route — this fixture proves nothing",
+        );
+        assert!(
+            routed.unroutable.is_empty(),
+            "{label}: {} of {edge_count} manifold edge(s) could not be routed at all: {:?}",
+            routed.unroutable.len(),
+            routed.unroutable,
+        );
+        assert_eq!(
+            routed.routes.len(),
+            edge_count,
+            "{label}: {} routes emitted for {edge_count} graph edges — every edge \
+             must be accounted for before the gates below mean anything",
+            routed.routes.len(),
+        );
         let legalized =
             spaghettio_core::bus::compaction::legalize_manifold_routes(&routed.routes);
         assert_eq!(

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -936,3 +936,94 @@ make either experimental composer a production default.
   Factorio adjudication the single fold just received. This does not change
   the 2026-07-29 refusal of folding as a *density* lever — the ~20% routing
   ceiling stands, and the single fold costs 277 entities (2820 → 3097).
+
+- **2026-07-30 — The manifold router's residual was a PLACEMENT bug; with it
+  fixed, candidates materialise for the first time — and they are bigger than
+  what they replace.**
+
+  The 2026-07-26 routing entry left ~1,200 residual conflicting tiles and a
+  strict materializer that correctly refused. That residual was diagnosed as
+  needing "negotiated rip-up/reroute". It did not.
+
+  Measured on six **bus** layouts — the path `LayoutOptions::compact_layout`
+  actually wires, whereas every previous RFC-057 number is `compose_chain_*`
+  output — the unresolved-route count exactly equalled the number of tiles
+  hosting terminals for two different commodities:
+
+  | fixture | cross-item shared terminal tiles | unresolved routes |
+  |---|---:|---:|
+  | `gear5-plate` | 2 | 2 |
+  | `sci1-ore` | 2 | 2 |
+  | `gear15-ore` | 44 | 44 |
+  | `ec15-plate` | 4 | 4 |
+  | `belt5-ore` | 8 | 8 |
+  | `sci1b-ore` | 7 | 7 |
+
+  An exact match on all six. The cause: `place_recipe_clusters` shelf-packs on
+  `RigidIsland::block`, which covers machines and inserters. A **terminal is
+  the belt tile an inserter reaches to, and lies outside that block**, so
+  block-disjointness says nothing about terminals. Packed tightly, one
+  island's input terminal lands exactly on another's output terminal — one
+  tile asked to deliver two commodities. No router can repair that; the
+  conflict exists before routing starts. Packing on a terminal-inclusive
+  extent fixes it. A second, smaller instance: boundary terminals kept their
+  *source* coordinates while every island moved, so they too could land on a
+  relocated terminal; they are now placed on the packed perimeter.
+
+  With both fixed, **five of six fixtures materialise** — the first RFC-057
+  candidates ever to clear the strict materializer — with zero terminal
+  collisions and zero terminals inside a foreign island. `gear15-ore` retains
+  one genuinely conflicting route out of 157.
+
+  **Negotiated congestion was implemented and measured as a no-op.** A
+  PathFinder loop (history cost per contested tile, all edges rerouted each
+  round, cost plumbed through both the dense A* and the ghost fallback) drove
+  contested *tiles* down hard (35→9, 27→8, 19→4) but left the contested
+  *route* count invariant at 2, 2, 44, 4, 8, 7 across 24 rounds — the tell
+  that the obstruction was structural, not congestion. After the placement fix
+  it changed nothing at all (rounds=0 and rounds=24 byte-identical), so it was
+  reverted rather than landed as unexercised complexity. Reserving terminals
+  in the pass-2/pass-3 hard sets was also tried and made `gear15-ore` worse
+  (1 → 6 residual tiles); also reverted.
+
+  **The decisive result is the assembled candidate, and it fails the density
+  gate outright.** Islands + stamped hubs + routed belts, normalised, zero
+  entity overlaps except one on `belt5-ore`:
+
+  | fixture | source bbox | candidate bbox | Δ | island ents | hub ents | route ents |
+  |---|---:|---:|---:|---:|---:|---:|
+  | `gear5-plate` | 128 | 448 | **+250%** | 15 | 28 | 60 |
+  | `sci1-ore` | 1,184 | 2,142 | **+81%** | 61 | 125 | 250 |
+  | `ec15-plate` | 731 | 2,091 | **+186%** | 57 | 173 | 284 |
+  | `belt5-ore` | 1,120 | 1,722 | **+54%** | 47 | 109 | 192 |
+  | `sci1b-ore` | 2,960 | 4,087 | **+38%** | 87 | 206 | 379 |
+
+  Logistics outweighs machinery 6–8×. On `sci1-ore` the manifold spends 375
+  logistics entities where the bus it replaces spends 201 — **86% more** — for
+  the same production. This is the RFC's own "density may never buy a slower
+  factory and call itself a win", inverted: the placement is genuinely tighter
+  (rigid bbox 35×23 against a 37×32 source) and the *transport* to serve it
+  costs more than the space it saves.
+
+  **Diagnosis: `(n,1)`/`(1,m)` balancer trees are the wrong primitive for the
+  commodities this corpus actually has.** `plan_local_manifolds` gives every
+  commodity a merger tree over all producer terminals and a distributor tree
+  over all consumer terminals, regardless of rate. But this RFC already
+  measured that almost every commodity needs ONE lane (USP: 28 lanes total
+  across all items, max 3 for any one; military science 14, max 2). For a
+  one-lane commodity a balanced tree is pure overhead — the bus answers the
+  same problem with a single trunk belt and inserter taps and no balancer at
+  all. §"Logistics synthesis" already ranks "shared item trunk with balanced
+  taps" above private manifolds; the implementation never built that tier and
+  goes straight to trees.
+
+  **Recommendation: do not pursue tree-based local manifolds further.** Build
+  the single-lane shared-trunk tier first and re-measure; reserve `(n,m)`
+  trees for the genuinely multi-lane commodities that measurement says are
+  rare. The 2D placement itself is vindicated and worth keeping — it is the
+  transport layer that is uneconomic.
+
+  Guard: `rfc057_island_placement_keeps_terminals_disjoint` asserts the
+  invariant by count and names every offending tile. Verified to fail without
+  the fix (`gear5-plate: 2 tile(s) host terminals for more than one
+  commodity`), not merely to pass with it.


### PR DESCRIPTION
## Intent

The RFC-057 manifold router has never produced an exportable candidate — the 2026-07-26 decision log left ~1,200 residual conflicting tiles and diagnosed the gap as needing "negotiated rip-up/reroute". **That diagnosis was wrong.** The residual was a placement bug.

`place_recipe_clusters` shelf-packs on `RigidIsland::block`, which covers machines and inserters. A **terminal is the belt tile an inserter reaches to, and lies outside that block** — so block-disjointness guarantees nothing about terminals. Packed tightly, one island's input terminal lands exactly on another island's output terminal: one tile asked to be the delivery point for two commodities. No router can repair that, because the conflict exists before routing starts.

A second instance of the same class: boundary terminals kept their *source* coordinates while every island moved.

Owning doc: [`rfc-057-topology-preserving-dense-repacking.md`](../blob/main/docs/rfc-057-topology-preserving-dense-repacking.md), whose decision log carries the full measurement.

## Scope

- **In:** pack on a terminal-inclusive extent; relocate boundary terminals to the packed perimeter; a regression test asserting the invariant.
- **Out — negotiated congestion.** Implemented in full (PathFinder history cost, all edges rerouted per round, cost plumbed through both the dense A\* and the ghost fallback) and **measured as a no-op**, so reverted rather than landed as unexercised complexity. It drove contested *tiles* down (35→9, 27→8, 19→4) but left the contested *route* count invariant at 2, 2, 44, 4, 8, 7 across 24 rounds — which is the tell that the obstruction was structural. After this fix, rounds=0 and rounds=24 are identical.
- **Out — reserving terminals in the pass-2/3 hard sets.** Tried; made `gear15-ore` worse (1 → 6 residual tiles). Reverted.
- **Out — density.** See below. This makes candidates *routable*, not *smaller*.

## Verification

Measured on six **bus** layouts — the path `LayoutOptions::compact_layout` actually wires. Every previous RFC-057 number is `compose_chain_*` (cell) output.

Cross-item shared terminal tiles exactly equalled the router's unresolved-route count:

| fixture | shared terminal tiles | unresolved routes |
|---|---:|---:|
| `gear5-plate` | 2 | 2 |
| `sci1-ore` | 2 | 2 |
| `gear15-ore` | 44 | **44** |
| `ec15-plate` | 4 | 4 |
| `belt5-ore` | 8 | 8 |
| `sci1b-ore` | 7 | 7 |

An exact match on all six — the entire residual, fully explained. With it fixed, **five of six materialise**, the first RFC-057 candidates to clear the strict materializer gate. `gear15-ore` retains one genuinely conflicting route out of 157.

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — 915 lib + 122 across targets, **0 failures**
- [x] `cargo clippy --all-targets` — no findings in `compaction.rs`
- [x] **Guard verified to discriminate**, not merely to pass: with `terminal_inclusive_extent` neutered the new test fails with `gear5-plate: 2 tile(s) host terminals for more than one commodity: [((1,5), ["iron-gear-wheel","iron-plate"]), ((5,5), …)]`. It asserts by count and names every offending tile, per `docs/validator-reporting.md`.
- [ ] WASM rebuild + browser eyeball — **N/A, stated deliberately**: `compact_layout` is hard-`false` at the wasm boundary and `place_recipe_clusters` is not on that path at all. No user-visible change.

## Deviations from intent

**The candidates materialise but are not denser — they are 38–250% larger.** Assembled (islands + stamped hubs + routed belts, zero entity overlaps except one on `belt5-ore`):

| fixture | source bbox | candidate bbox | Δ | island ents | hub ents | route ents |
|---|---:|---:|---:|---:|---:|---:|
| `gear5-plate` | 128 | 448 | +250% | 15 | 28 | 60 |
| `sci1-ore` | 1,184 | 2,142 | +81% | 61 | 125 | 250 |
| `ec15-plate` | 731 | 2,091 | +186% | 57 | 173 | 284 |
| `belt5-ore` | 1,120 | 1,722 | +54% | 47 | 109 | 192 |
| `sci1b-ore` | 2,960 | 4,087 | +38% | 87 | 206 | 379 |

Logistics outweighs machinery 6–8×. The *placement* is genuinely tighter (`sci1-ore` rigid bbox 35×23 against a 37×32 source); the transport built to serve it costs more than the space it saves.

Diagnosis in the decision log: `(n,1)`/`(1,m)` balancer trees are the wrong primitive here. `plan_local_manifolds` builds a tree per commodity regardless of rate, but this RFC already measured that nearly every commodity needs **one** lane (USP: 28 lanes total, max 3 for any item). For a one-lane commodity a balanced tree is pure overhead — the bus answers it with a trunk belt and inserter taps and no balancer at all. §"Logistics synthesis" already ranks shared trunks above private manifolds; the implementation skipped that tier.

**Recommendation recorded: build the single-lane shared-trunk tier before any further tree work.** This PR is worth landing regardless — the placement bug is a real physical-impossibility defect, and without it fixed nothing downstream can be measured end-to-end at all.

## Models / contracts touched

None. This restores an invariant the geometry already required; `RigidIsland`'s public shape is unchanged.