### PR TITLE
docs(rfc-057, status): re-measure the fold on post-#502 geometry

### DIFF
--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -3585,7 +3585,7 @@ fn export_fold_pair_for_sim() {
     let folded = fold_snake(&compact, &[mid]).expect("midpoint fold must succeed");
     // The 3-fold the search picks (#492). Exported alongside the verified pair
     // so one sim run compares control / 1-fold / 3-fold on identical inputs.
-    let fold3 = fold_snake(&compact, &[130, 259, 390]).expect("3-fold must succeed");
+    let fold3 = fold_snake(&compact, &[138, 276, 414]).expect("3-fold must succeed");
 
     std::fs::create_dir_all("target/tmp").unwrap();
     for (tag, l) in [

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -988,7 +988,7 @@ make either experimental composer a production default.
 
   **Scope of the claim, stated because it is easy to over-read.** One fixture
   of four. `chem5raw`, `pu4raw` and `usp2raw` still find no fold. This is a
-  SHAPE result, not a density one: it costs +807 entities (+21%), and the
+  SHAPE result, not a density one: it costs +736 entities (+26%), and the
   2026-07-29 refusal of folding as a density lever stands untouched.
 
   **A prediction that failed, kept on the record.** Keying by (item, side) was
@@ -1028,10 +1028,11 @@ make either experimental composer a production default.
   exercised a non-south boundary kit — but it was not what bit us.
 
   Confirmed: with the dedupe, `mil5-fold1` re-measures **PASS**, zero kit
-  errors, military-science-pack produced 5.00/s (+0.0%) / delivered 4.90/s
-  (−2.0%), 4075/4075 revived, one pole network, `converged=true`. So the single
-  fold is independently verified at a legal snapped column as well, and BOTH
-  fold depths now pass in Factorio.
+  errors, one pole network. On post-#502 geometry that is **277×66**, 3110/3110
+  revived, 5.02/s delivered against 5.00/s planned (+0.3%), 146/146 machines.
+  (The pre-#502 run measured 262×64 at 5.00/s produced / 4.90/s delivered with
+  4075 entities.) So the single fold is independently verified as well, and BOTH
+  fold depths pass in Factorio on the geometry current code produces.
 - **2026-07-30 — The manifold router's residual was a PLACEMENT bug; with it
   fixed, candidates materialise for the first time — and they are bigger than
   what they replace.**

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -938,11 +938,20 @@ make either experimental composer a production default.
   ceiling stands, and the single fold costs 277 entities (2820 → 3097).
 
 - **2026-07-30 — Multi-fold works, and is Factorio-verified at three folds.**
-  `chain-mil5ore` folds three times: 521×31 (16.8:1) → **147×138 (1.07:1)**,
+  `chain-mil5ore` folds three times: 553×32 (17.3:1) → **153×141 (1.09:1)**,
   measured in headless 2.0.77 at `--warmup 216000` — **PASS**, target
-  military-science-pack 4.92/s delivered against 5.00/s planned (−1.6%),
-  **146/146 machines working**, **one pole network**, 4620/4620 entities
-  revived, zero kit errors, no fluid errors. The previous entry's "multi-fold
+  military-science-pack 5.02/s delivered against 5.00/s planned (+0.3%),
+  **146/146 machines working**, **one pole network**, 3567/3567 entities
+  revived, zero kit errors, no fluid errors.
+
+  Re-measured 2026-07-30 on post-#502 geometry. The first measurement was
+  147×138 (1.07:1) at 4.92/s from a 521×31 / 3813-entity source; #502's
+  undergroundification cut the source to 553×32 / 2831 entities, which moved the
+  fold columns to [138, 276, 414] and the result to the figures above. Both
+  measurements PASS; the numbers here are the ones current code produces, and
+  the folded layout is now 3567 entities rather than 4620. Recording the shift
+  rather than overwriting it, because a claim measured against a base that no
+  longer exists is the trap #489's green checks fell into. The previous entry's "multi-fold
   remains unproven" is now discharged.
 
   **None of it was the fix the tracking issue specified.** #492 recorded the

--- a/docs/rfc-057-topology-preserving-dense-repacking.md
+++ b/docs/rfc-057-topology-preserving-dense-repacking.md
@@ -940,7 +940,7 @@ make either experimental composer a production default.
 - **2026-07-30 — Multi-fold works, and is Factorio-verified at three folds.**
   `chain-mil5ore` folds three times: 553×32 (17.3:1) → **153×141 (1.09:1)**,
   measured in headless 2.0.77 at `--warmup 216000` — **PASS**, target
-  military-science-pack 5.02/s delivered against 5.00/s planned (+0.3%),
+  military-science-pack 5.016/s delivered against 5.00/s planned (+0.3%),
   **146/146 machines working**, **one pole network**, 3567/3567 entities
   revived, zero kit errors, no fluid errors.
 
@@ -1029,7 +1029,7 @@ make either experimental composer a production default.
 
   Confirmed: with the dedupe, `mil5-fold1` re-measures **PASS**, zero kit
   errors, one pole network. On post-#502 geometry that is **277×66**, 3110/3110
-  revived, 5.02/s delivered against 5.00/s planned (+0.3%), 146/146 machines.
+  revived, 5.016/s delivered against 5.00/s planned (+0.3%), 146/146 machines.
   (The pre-#502 run measured 262×64 at 5.00/s produced / 4.90/s delivered with
   4075 entities.) So the single fold is independently verified as well, and BOTH
   fold depths pass in Factorio on the geometry current code produces.

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -2,7 +2,7 @@
 
 **Status (2026-07-30):** **multi-fold works and is Factorio-verified.**
 `chain-mil5ore` folds three times — 553×32 (17.3:1) → **153×141 (1.09:1)**,
-PASS at 5.02/s against 5.00/s planned, 146/146 machines, one pole network,
+PASS at 5.016/s against 5.00/s planned (+0.3%), 146/146 machines, one pole network,
 3567/3567 entities revived. Single fold remains verified for throughput and
 power. Read "The second trap" below anyway: it is why the earlier power
 fragmentation went unnoticed, and the reasoning generalises.

--- a/docs/snake-fold-followups.md
+++ b/docs/snake-fold-followups.md
@@ -1,16 +1,21 @@
 # Snake-fold followups
 
 **Status (2026-07-30):** **multi-fold works and is Factorio-verified.**
-`chain-mil5ore` folds three times — 521×31 (16.8:1) → **147×138 (1.07:1)**,
-PASS at 4.92/s against 5.00/s planned, 146/146 machines, one pole network,
-4620/4620 entities revived. Single fold remains verified for throughput and
+`chain-mil5ore` folds three times — 553×32 (17.3:1) → **153×141 (1.09:1)**,
+PASS at 5.02/s against 5.00/s planned, 146/146 machines, one pole network,
+3567/3567 entities revived. Single fold remains verified for throughput and
 power. Read "The second trap" below anyway: it is why the earlier power
 fragmentation went unnoticed, and the reasoning generalises.
 
+*(Re-measured on post-#502 geometry. The first run recorded 521×31 → 147×138
+at 4.92/s with 4620 entities; #502's undergroundification cut the compacted
+source from 3813 to 2831 entities, moving the fold columns to
+`[138, 276, 414]` and every figure with them.)*
+
 Scope, because it is easy to over-read: **one fixture of four.**
 `mega-chain-chem5raw`, `mega-chain-pu4raw` and `mega-chain-usp2raw` still find
-no fold. And this is a SHAPE result, not a density one — it costs +21%
-entities, and RFC-057's refusal of folding as a density lever stands.
+no fold. And this is a SHAPE result, not a density one — it costs +736
+entities (+26%), and RFC-057's refusal of folding as a density lever stands.
 
 **#492's stated blocker was not the blocker.** It recorded a shared-column B12
 underground dive as the remaining work. No dive was written. Three other causes

--- a/docs/status.md
+++ b/docs/status.md
@@ -134,7 +134,8 @@ at 5.02/s delivered against 5.00/s planned, **146 of 146 machines**, **one pole
 network**, 3567/3567 entities revived, zero kit errors. (Re-measured on
 post-#502 geometry; the first run measured 147x138 at 4.92/s from a
 521x31/3813-entity source, and #502's undergroundification moved both.) The single fold
-re-measures PASS at a legal snapped column too (262x64, 5.00/s produced), so
+re-measures PASS on the same geometry too — 277x66, 5.02/s delivered against
+5.00/s planned, 146 of 146 machines, one pole network, 3110/3110 revived — so
 both depths now pass. This discharges the previous entry's "multi-fold remains
 unproven".
 
@@ -142,7 +143,8 @@ Scope, because it is easy to over-read: **one fixture of four.**
 `mega-chain-chem5raw`, `mega-chain-pu4raw` and `mega-chain-usp2raw` still find
 no fold — their dominant refusal is now `InputStranded` from one item wanted at
 two columns on the same side, which needs a splitter. And this remains a SHAPE
-result: +21% entities, so the density refusal below stands untouched.
+result: +26% entities (2831 -> 3567), so the density refusal below stands
+untouched.
 
 Three causes, none of them the one the tracking issue named (#492 specified a
 shared-column underground dive; none was written): rows ignored which SIDE of

--- a/docs/status.md
+++ b/docs/status.md
@@ -130,11 +130,11 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 **`rfc-057-topology-preserving-dense-repacking.md` multi-fold (2026-07-30,
 PR #500 — RFC ACTIVE, not closed)**: **multi-fold is Factorio-verified.**
 `chain-mil5ore` folds **three times**: 553x32 (17.3:1) to **153x141 (1.09:1)**
-at 5.02/s delivered against 5.00/s planned, **146 of 146 machines**, **one pole
+at 5.016/s delivered against 5.00/s planned (+0.3%), **146 of 146 machines**, **one pole
 network**, 3567/3567 entities revived, zero kit errors. (Re-measured on
 post-#502 geometry; the first run measured 147x138 at 4.92/s from a
 521x31/3813-entity source, and #502's undergroundification moved both.) The single fold
-re-measures PASS on the same geometry too — 277x66, 5.02/s delivered against
+re-measures PASS on the same geometry too — 277x66, 5.016/s delivered against
 5.00/s planned, 146 of 146 machines, one pole network, 3110/3110 revived — so
 both depths now pass. This discharges the previous entry's "multi-fold remains
 unproven".

--- a/docs/status.md
+++ b/docs/status.md
@@ -129,9 +129,11 @@ budgets — utility@2/s FAIL×2 is the most reachable new fix target.
 
 **`rfc-057-topology-preserving-dense-repacking.md` multi-fold (2026-07-30,
 PR #500 — RFC ACTIVE, not closed)**: **multi-fold is Factorio-verified.**
-`chain-mil5ore` folds **three times**: 521x31 (16.8:1) to **147x138 (1.07:1)**
-at 4.92/s delivered against 5.00/s planned, **146 of 146 machines**, **one pole
-network**, 4620/4620 entities revived, zero kit errors. The single fold
+`chain-mil5ore` folds **three times**: 553x32 (17.3:1) to **153x141 (1.09:1)**
+at 5.02/s delivered against 5.00/s planned, **146 of 146 machines**, **one pole
+network**, 3567/3567 entities revived, zero kit errors. (Re-measured on
+post-#502 geometry; the first run measured 147x138 at 4.92/s from a
+521x31/3813-entity source, and #502's undergroundification moved both.) The single fold
 re-measures PASS at a legal snapped column too (262x64, 5.00/s produced), so
 both depths now pass. This discharges the previous entry's "multi-fold remains
 unproven".


### PR DESCRIPTION
## Intent

#500's Factorio figures were measured on the **pre-#502** source. #502's
undergroundification then cut mil5's compacted source from 521×31 / 3813 entities
to 553×32 / 2831, which moved the fold columns and the result. Re-measured rather
than adjusted on paper:

| | geometry | aspect | delivered | entities |
|---|---|---|---|---|
| documented in #500 | 147×138 | 1.07:1 | 4.92/s | 4620 |
| **measured now** | **153×141** | **1.09:1** | **5.016/s (+0.3%)** | **3567** |

Both runs PASS. Control 5.00/s (+0.0%), 3-fold 5.016/s (+0.3%), 146/146 machines
and one pole network each, 3567/3567 entities revived, zero kit errors. So the
result survives the new baseline and the folded layout is **1053 entities cheaper
than documented**, because the source it folds shrank 26%.

## Scope

- **In:** the corrected figures in RFC-057's decision log and the status ledger,
  with the shift recorded rather than silently overwritten — this file is where
  someone reads *current* capability, and a claim measured against a base that no
  longer exists is what made #489's green checks meaningless at merge time.
- **In:** `export_fold_pair_for_sim`'s pinned 3-fold columns `[130, 259, 390]`,
  which are no longer in the legal set. The export produced the old geometry
  silently until it would have stopped folding at all.
- **Out:** no code behaviour change; the fold itself is untouched.

## Models / contracts touched

None. Docs plus one test fixture constant.

## Verification

- [x] Two headless 2.0.77 runs at `--warmup 216000` on the current geometry —
      figures above.
- [x] Post-merge corpus: mil5 still folds three times at `[138, 276, 414]`;
      `GapLaneConflict` is **0 across all four fixtures**, so the exit-lane
      refusal restored in #500 is unreachable on the new geometry too.
- [x] `cargo test` green on main before branching.

## Deviations from intent

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ


---

*Rate quoted as 5.016/s rather than 5.02/s wherever a delta accompanies it: the
harness computes the delta from full precision (`measured_delivered_rate =
5.016393442622951`, `delta_pct_delivered = 0.3279`), so pairing the 2dp display
with it gives arithmetic a reader cannot reproduce. Corrected in the docs by
`b7c00313` and here in the body — review caught the docs fix landing without the
description, the same drift as #494.*
