### PR TITLE
docs(rfc-058): DI coupling assignment is a matching problem, not a walk order

### DIFF
--- a/docs/rfc-058-di-coupling-assignment.md
+++ b/docs/rfc-058-di-coupling-assignment.md
@@ -48,6 +48,29 @@ Three entities is not a mandate to change a corpus-wide tie-break. The reason to
 do this work is that **nobody knows what the right rule is**, not that the
 current one is demonstrably costly.
 
+### The winning rate is not recoverable from the record
+
+Review of this RFC asked which rate produces 261-vs-264, since `rail@5` is
+explicitly the no-difference case. The answer is that **RFC-053 contradicts
+itself**, so no rate can be quoted honestly:
+
+- [`rfc-053`](rfc-053-direct-insertion-cells.md) line ~2249 puts the win at
+  `rail@1`, and says that at `rail@5` "the straddle does not balance and reverse
+  order builds the same stacked cell as forward".
+- The same document's coupling table (line ~1943) says `plan_row_straddle`
+  "balances at only 2 of 12 sampled rates (**5/s, 10/s**)", and that at 1/s
+  `snap()`'s rounding leaves supply and demand unequal — `P1:C1, 3.0 vs 1.5`.
+
+Those disagree about which rates balance, and therefore about where the win is.
+The measurement came from a scratch env flag that was never committed, so it
+cannot be re-run from the repository as it stands.
+
+**This raises the value of phase 1 rather than lowering it.** The first
+deliverable is not a policy — it is a reproducible measurement of *where the two
+orders differ at all*, sweeping rates rather than trusting either recorded
+figure. Until that exists, "the win is 3 entities at one rate" is a claim with no
+executable form, and kill criterion 1 cannot be evaluated.
+
 ### What changed since #473, and why the question is now answerable
 
 #473 noted that "a green suite is weak evidence here — nearly every test runs
@@ -116,10 +139,17 @@ static.
    assignment to greedy-by-gain on every corpus target, drop P3 and keep P2.
    Do not ship matching machinery for a tie.
 5. **The win stays at three entities.** If, after implementing the best policy
-   the above allows, the total measured improvement across the corpus is under
-   **1% of entities** on every target and resolves no validator issue anywhere,
-   revert it. A tie-break with no measurable consequence should stay an
-   arbitrary tie-break with a comment, not become a subsystem.
+   the above allows, the total measured improvement is **5 entities or fewer on
+   every target** and resolves no validator issue anywhere, revert it. A
+   tie-break with no measurable consequence should stay an arbitrary tie-break
+   with a comment, not become a subsystem.
+
+   Stated in absolute entities, not a percentage, because a percentage cannot
+   fire on the case this criterion is named for: 3 of 264 entities is 1.14%, so
+   an "under 1%" threshold would leave the three-entity win *passing* the test
+   meant to kill it. Caught in review of this RFC — a kill criterion that cannot
+   trip on its own titular scenario is worse than none, because it reads as
+   protection.
 
 ## Verification plan
 
@@ -137,8 +167,12 @@ able to distinguish "policy had no effect" from "policy was not applied."
   sweep reports the missed improvement. Without this, "0 regressed" is
   unfalsifiable — the same defect
   [`validator-reporting.md`](validator-reporting.md) catalogues.
-- **`rail@5` and the rate where the straddle balances**: assert the row cell is
-  built under the chosen policy, at tile level (belt positions and the
+- **A rate sweep over `iron-stick → rail`, not a named rate.** The verification
+  cannot plug in "the rate where the straddle balances" because the record
+  disagrees with itself about which rate that is (see Motivation). So phase 1
+  sweeps rates under both orders and reports every rate where the chosen layout
+  differs — that output IS the missing measurement. Once a differing rate exists,
+  assert the row cell at tile level there (belt positions and the
   `input_belt_ys` ↔ fused-spec positional contract), not "it returned `Some`".
 - **Sim** any newly-built cell that the corpus starts producing. #473 ran no sim
   because nothing reached the path; if a policy makes it reachable, that
@@ -147,9 +181,11 @@ able to distinguish "policy had no effect" from "policy was not applied."
 
 ## Phasing
 
-1. **Measure P0 vs P1 across the corpus.** Cheap, and it may trip kill
-   criterion 1 immediately — in which case the RFC closes having cost a day and
-   answered the question.
+1. **Measure P0 vs P1 across the corpus, sweeping rates on `rail`.** Cheap, and
+   it may trip kill criterion 1 immediately — in which case the RFC closes having
+   cost a day and answered the question. This phase also has to *establish* the
+   motivating measurement, since the recorded rate is contradictory and the
+   scratch flag that produced it was never committed.
 2. **P2 gain estimate**, only if (1) shows contention beyond `rail`.
 3. **P3 matching**, only if (2) shows greedy is measurably sub-optimal.
 
@@ -166,3 +202,16 @@ tie-break with evidence, not necessarily a new algorithm.
   file exists. Note the question only became measurable once #474 defaulted DI
   to `Candidate`, so the ordering of the two PRs matters: this RFC's phase 1
   cannot be run meaningfully before #474 lands.
+
+- *2026-07-30 — two review findings, both fixed, and the second changed the
+  RFC's shape.* Kill criterion 5 was stated as "under 1% of entities", which
+  cannot fire on the 3-of-264-entity win it is named for (1.14%); restated in
+  absolute entities. And the rate producing 261-vs-264 was asked for and turned
+  out to be **unrecoverable**: RFC-053 says `rail@1` in one place and, in its own
+  coupling table, that the straddle balances only at 5/s and 10/s — with 1/s
+  explicitly unbalanced. The measurement came from an uncommitted scratch flag.
+  So phase 1's first deliverable is now a reproducible rate sweep rather than a
+  policy, and kill criterion 1 cannot be evaluated until that exists. Worth
+  noting the failure mode: the original RFC quoted a measurement it could not
+  reproduce, and only a reviewer asking "at what rate?" surfaced that the source
+  disagreed with itself.

--- a/docs/rfc-058-di-coupling-assignment.md
+++ b/docs/rfc-058-di-coupling-assignment.md
@@ -1,0 +1,168 @@
+# RFC-058: Direct-insertion coupling assignment
+
+## Summary
+
+A DI spec may be fused into at most one cell. When a spec is an eligible
+member of two different couplings, the dispatcher currently resolves the
+contention by **iteration order** — consumers are walked in topological order,
+so the upstream coupling claims the spec and the downstream one is never
+evaluated. That is not a decision anyone made; it is a loop direction.
+
+This RFC proposes replacing it with an explicit, measured assignment policy,
+and — equally in scope — proposes the possibility that the answer is "keep
+upstream-first, pin it with a test, and write down why." The point is to stop
+having an unexamined tie-break in a code path that now runs by default.
+
+## Motivation
+
+Concrete and reproducible, from #473 (`iron-plate → iron-stick → rail`):
+
+```text
+COUPLING iron-plate -> iron-stick on iron-plate    <- claimed first
+COUPLING iron-stick -> rail       on iron-stick    <- never tried
+```
+
+`iron-stick` is eligible in both couplings. The greedy upstream-first walk
+claims it for a stacked cell, and `iron-stick → rail` is skipped **before its
+eligibility is evaluated at all**. Confirmed by instrumenting the dispatch, not
+inferred.
+
+Forcing the downstream coupling to claim first (scratch env flag, never
+committed) builds `di-row:iron-stick:rail` with **0 validation issues** and
+**261 entities against the forward order's 264**.
+
+So the geometry #473 built is reachable, and it is reached only by a policy this
+project has never agreed. That is the whole motivation: the blocker for `rail`
+turned out not to be geometric.
+
+**The honest counter-evidence, stated up front**, because it is why #473
+declined to flip the order in passing:
+
+- `electronic-circuit@10`, `steel-plate@5` and `iron-gear-wheel@10` are
+  **byte-identical** under both orders.
+- The full suite is green under both.
+- The measured win is **3 entities at one rate**. At `rail@5` the straddle
+  doesn't balance and both orders build the same stacked cell.
+
+Three entities is not a mandate to change a corpus-wide tie-break. The reason to
+do this work is that **nobody knows what the right rule is**, not that the
+current one is demonstrably costly.
+
+### What changed since #473, and why the question is now answerable
+
+#473 noted that "a green suite is weak evidence here — nearly every test runs
+with `direct_insertion: false`." **#474 changes that**: DI defaults to
+`Candidate`, so the corpus now exercises DI on every layout, and the never-worse
+decision means a *wrong* claim choice shows up as a **missed improvement**
+rather than a regression. Before #474 this RFC could not be measured without
+building a bespoke harness. After it, the existing change-surface sweep answers
+it directly.
+
+## Design
+
+The contention is a **matching problem**, not an ordering problem: given a set
+of candidate couplings over a shared pool of specs, choose a subset that is
+pairwise spec-disjoint and best by some objective. Framing it as "which
+direction do we walk" is what hid it.
+
+Four policies, in increasing cost:
+
+| Policy | Rule | Cost |
+|---|---|---|
+| **P0 — upstream-first** | status quo; topological order claims | zero |
+| **P1 — downstream-first** | reverse the walk | zero |
+| **P2 — greedy by gain** | score each candidate coupling in isolation, claim in descending order of predicted gain | one extra pass per coupling |
+| **P3 — optimal matching** | max-weight matching over the coupling/spec bipartite graph | small; contention sets are tiny |
+
+**Predicted shape of the diff.** The dispatcher's claim loop
+(`bus/di_cell.rs`, the walk that produces fused specs) gains a policy parameter
+rather than an inverted loop. P0/P1 are orderings of the same loop. P2 needs a
+per-coupling gain estimate that does **not** require building the layout —
+otherwise the cost is a full layout per candidate. P3 needs the contention graph
+materialised, which is only worth it if P2's greedy proves to be measurably
+sub-optimal.
+
+**Load-bearing constraint.** Whatever the policy, it must interact correctly
+with #474's `di_choice`: DI competes against a DI-free native layout and may
+only displace it on a strict improvement across both issue channels. So a claim
+policy cannot make anything *worse* — the worst a bad policy does is leave a
+better cell unbuilt. That bounds the risk of this work to "missed upside", and
+it is why the RFC is worth doing at all rather than being dangerous.
+
+**Rejected alternative: score-driven claiming that builds each variant.**
+Building a full layout per candidate coupling to score it is the obvious
+approach and is refused on cost — the decomposition search already builds
+several candidates per layout, and DI multiplies that. P2's estimate must be
+static.
+
+## Kill criteria
+
+**Required.** Any of these ends the work.
+
+1. **The question is empirically empty.** If sweeping the corpus under P0 and P1
+   with `DI=Candidate` shows the final chosen layout differing on **only** the
+   known `rail` case, then no policy machinery is justified: pin P0 with a test
+   naming `rail` as the known sacrifice, add the reasoning to RFC-053's decision
+   log, and close this RFC as *rejected — not a real contention in practice*.
+2. **P2 cannot be estimated statically.** If a per-coupling gain estimate that
+   does not build a layout cannot be made to correlate with measured outcome on
+   the `rail` case plus at least two others, drop P2 and P3 — the matching
+   objective is unknowable at claim time, and the honest answer is a pinned
+   static order.
+3. **Cost.** If any policy adds more than **1.25×** to end-to-end layout time on
+   the existing corpus, it is refused regardless of quality gain. #474 already
+   spent 1.23× of K-DS1-3's 1.5× budget; there is not another 1.5× available.
+4. **P3 buys nothing over P2.** If optimal matching produces an identical
+   assignment to greedy-by-gain on every corpus target, drop P3 and keep P2.
+   Do not ship matching machinery for a tie.
+5. **The win stays at three entities.** If, after implementing the best policy
+   the above allows, the total measured improvement across the corpus is under
+   **1% of entities** on every target and resolves no validator issue anywhere,
+   revert it. A tie-break with no measurable consequence should stay an
+   arbitrary tie-break with a comment, not become a subsystem.
+
+## Verification plan
+
+Per CLAUDE.md's layout-engine protocol, plus one thing specific to this RFC:
+**the same-outcome case is the expected case**, so the verification has to be
+able to distinguish "policy had no effect" from "policy was not applied."
+
+- **`di_change_surface_sweep`** (added for #474) run under each policy, reporting
+  identical / better / regressed per target. This is the primary instrument, and
+  it must be extended to print which policy produced each result — otherwise a
+  no-op reads the same as a win.
+- **`di_candidate_never_degrades_a_succeeding_bus_layout`** must stay green under
+  every policy. It is the structural pin, and no claim policy may weaken it.
+- **A teeth test**: force a policy that deliberately claims badly, and assert the
+  sweep reports the missed improvement. Without this, "0 regressed" is
+  unfalsifiable — the same defect
+  [`validator-reporting.md`](validator-reporting.md) catalogues.
+- **`rail@5` and the rate where the straddle balances**: assert the row cell is
+  built under the chosen policy, at tile level (belt positions and the
+  `input_belt_ys` ↔ fused-spec positional contract), not "it returned `Some`".
+- **Sim** any newly-built cell that the corpus starts producing. #473 ran no sim
+  because nothing reached the path; if a policy makes it reachable, that
+  exemption expires.
+- Full suite, clippy `-D warnings` on core and wasm, `tsc`, web tests.
+
+## Phasing
+
+1. **Measure P0 vs P1 across the corpus.** Cheap, and it may trip kill
+   criterion 1 immediately — in which case the RFC closes having cost a day and
+   answered the question.
+2. **P2 gain estimate**, only if (1) shows contention beyond `rail`.
+3. **P3 matching**, only if (2) shows greedy is measurably sub-optimal.
+
+Landing (1) alone is a legitimate outcome: the deliverable is a *decided*
+tie-break with evidence, not necessarily a new algorithm.
+
+## Decision log
+
+- *2026-07-30 — opened.* Split out of #473, which built the three-input row-cell
+  geometry and discovered that the face count was never `rail`'s blocker: the
+  dispatcher's claim order was. #473 deliberately did not flip the order, on the
+  grounds that a corpus-wide tie-break should not change on 3 entities of
+  evidence at one rate. That judgement is endorsed here and is the reason this
+  file exists. Note the question only became measurable once #474 defaulted DI
+  to `Candidate`, so the ordering of the two PRs matters: this RFC's phase 1
+  cannot be run meaningfully before #474 lands.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,5 +69,6 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
+| RFC-058 | 2026-07-30 | [`rfc-058-di-coupling-assignment.md`](rfc-058-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; phase 1 blocked on #474 landing |
 
-Next number: **RFC-058**.
+Next number: **RFC-059**.


### PR DESCRIPTION
## Intent

Turn an unexamined tie-break into a decided one. A DI spec may be fused into at
most one cell; when a spec is eligible in two couplings the dispatcher resolves
it by **iteration order** — topological walk, so upstream claims and downstream
is never evaluated. Nobody chose that.

Found by #473, which built the three-input row-cell geometry and discovered the
face count was never `rail`'s blocker:

```
COUPLING iron-plate -> iron-stick on iron-plate    <- claimed first
COUPLING iron-stick -> rail       on iron-stick    <- never tried
```

Forcing downstream-first builds `di-row:iron-stick:rail` at **0 validation
issues, 261 entities vs 264**.

## Scope

- **In:** the RFC and its registry row. Design, four candidate policies
  (upstream-first / downstream-first / greedy-by-gain / optimal matching), five
  kill criteria, a verification plan, phasing, decision log.
- **Out:** any code. Phase 1 is a measurement and cannot run meaningfully until
  #474 lands.

## Two things worth review attention

**This RFC may well conclude "change nothing."** Kill criterion 1 closes it as
*rejected* if sweeping upstream-first vs downstream-first shows the chosen layout
differing on the `rail` case alone. The measured win today is **3 entities at one
rate**, and `electronic-circuit@10` / `steel-plate@5` / `iron-gear-wheel@10` are
byte-identical under both orders. That is deliberately stated in Motivation
rather than buried — the reason to do the work is that nobody knows the right
rule, not that the current one is costly. #473's refusal to flip it in passing is
endorsed, not overridden.

**The verification plan has to distinguish "no effect" from "not applied",**
because same-outcome is the *expected* case. So it requires a teeth test that
claims deliberately badly and asserts the sweep reports the missed improvement —
without it, "0 regressed" is unfalsifiable, which is the exact defect
`docs/validator-reporting.md` catalogues.

## Dependency on #474

Explicit in the decision log: #473 observed that a green suite was weak evidence
because nearly every test ran DI-off. Once #474 defaults DI to `Candidate` the
corpus exercises it, and a wrong claim shows up as a *missed improvement* rather
than a regression. That also bounds this RFC's risk to missed upside, since
`di_choice` may only displace native on a strict improvement — a bad policy
cannot make a layout worse, only leave a better cell unbuilt.

## Models / contracts touched

None. Documentation only.

## Verification

- [x] RFC-058 confirmed **unclaimed on `origin/main`** before writing — parallel
      sessions collide on numbers, and first-to-main wins.
- [x] Registry row added in the same commit, per CLAUDE.md.
- [x] Template sections present, including kill criteria (five, each phrased to
      be unambiguous after the experiment) and a decision log.
- [ ] No code, so no test/clippy/sim gates apply.

## Deviations from intent

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVeZCwSKE4Yde51gDo6eDJ