### PR TITLE
feat(web): expose RFC-057 layout compaction as `?compact=1`

### DIFF
--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -41,6 +41,12 @@ fn layout_options(
     // "off" | "on" | anything else (incl. absent) -> Candidate, the
     // engine default. Same shape as `cell_composition` below.
     direct_insertion: Option<String>,
+    // RFC-057 post-layout compaction. "1" enables; absent/anything else is
+    // off, so every existing URL keeps byte-identical geometry. Opt-in
+    // rather than default because it rewrites geometry the user may have
+    // bookmarked, and because it can trade a slightly taller box for a
+    // large entity saving — a call the user should make, not the engine.
+    compact_layout: Option<String>,
 ) -> LayoutOptions {
     let strategy = match strategy.as_deref() {
         // `partitioned-per-consumer` is the deprecated P1 string; the
@@ -115,11 +121,11 @@ fn layout_options(
             Some("off") => spaghettio_core::bus::cells::CellComposition::Off,
             _ => spaghettio_core::bus::cells::CellComposition::Candidate,
         },
-        // RFC-057 post-layout compaction: experimental, and deliberately not
-        // reachable from the web surface yet. It is an opt-in post-pass over
-        // an already-validated layout, so exposing it is a UI decision, not a
-        // fallback-semantics one — hard-false until that decision is made.
-        compact_layout: false,
+        // RFC-057 post-layout compaction, now reachable from the web surface.
+        // Transactional: `compact_validated_geometry` commits a transform only
+        // when validation is no worse than its input, so the worst case is
+        // "no change", never a broken factory.
+        compact_layout: compact_layout.as_deref() == Some("1"),
         // No `..Default::default()`: adding `direct_insertion` completed
         // the field list, and a no-op struct update is a clippy error
         // under the workspace's `-D warnings`. A field added to
@@ -305,10 +311,11 @@ pub fn layout(
     inserter_capacity: Option<u8>,
     cell_composition: Option<String>,
     direct_insertion: Option<String>,
+    compact_layout: Option<String>,
 ) -> Result<LayoutResult, JsError> {
     build_bus_layout(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion, compact_layout),
     )
     .map_err(|e| JsError::new(&e))
 }
@@ -331,10 +338,11 @@ pub fn layout_traced(
     inserter_capacity: Option<u8>,
     cell_composition: Option<String>,
     direct_insertion: Option<String>,
+    compact_layout: Option<String>,
 ) -> Result<LayoutResult, JsError> {
     spaghettio_core::bus::layout::build_bus_layout_traced(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion, compact_layout),
     )
     .map_err(|e| JsError::new(&e))
 }
@@ -401,6 +409,7 @@ pub fn layout_streaming(
     inserter_capacity: Option<u8>,
     cell_composition: Option<String>,
     direct_insertion: Option<String>,
+    compact_layout: Option<String>,
     emit: &js_sys::Function,
 ) -> Result<LayoutResult, JsError> {
     let emit = emit.clone();
@@ -414,7 +423,7 @@ pub fn layout_streaming(
     });
     spaghettio_core::bus::layout::build_bus_layout_streaming(
         &solver_result,
-        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion),
+        layout_options(max_belt_tier, strategy, row_layout, max_inserter_tier, quality, wire_mode, stacking, inserter_capacity, cell_composition, direct_insertion, compact_layout),
         on_event,
     )
     .map_err(|e| JsError::new(&e))

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -102,7 +102,7 @@ or don't land.
 | 3 | No harness `--allowedTools` — every posting/diff call denied | 11 denials on the #330 canary | #331 |
 | 4 | Re-running `/install-github-app` overwrote both workflow files with the stock template — wiped fixes 1–3 at once (plus `claude.yml`'s owner-only sender gate) | all of the above, after a period of working fine | #369 (canary #368) |
 | 5 | Shape-sensitive denial starvation — the allowlist admits plain `gh pr/issue` commands but denies improvised *shapes* (env prefixes `GH_PAGER= gh …`, command substitution `$(…)`, `cd … &&` chains, `gh api`); enough denials and the orchestrator abandons mid-review without posting. Stochastic per run, worse on large PRs (more context wanted → more improvised commands). Diagnosed 2026-07-24 on PR #389 (two consecutive silent no-ops; PR #405 succeeded through 31 denials the same day) | mid-cost, mid-duration run: more than a gate-skip, far less than a full review; see signature table below | prompt hardening + guard step (introduced with this doc) |
-| 6 | Async-wait abandonment — the plugin orchestrator fans out its reviewer subagents, then parks via `ScheduleWakeup` to "wait" for them; in a one-shot headless run the wakeup never fires and the session ends mid-wait. First caught live by the guard 2026-07-24 on PR #416 — transcript artifact showed 26 tool calls, near-zero denials, 4 parallel reviewers spawned, `ScheduleWakeup(180s)` then end at 10 turns/$1.08 with nothing posted. NOT a denial problem: the class-5 prompt note was propagating into every subagent and reads worked fine | mid-cost short run like class 5, but transcript shows `ScheduleWakeup` + spawned agents with unconsumed results | prompt note extended: one-shot/headless, never park, consume subagent results synchronously |
+| 6 | Async-wait abandonment — the plugin orchestrator fans out its reviewer subagents, then parks via `ScheduleWakeup` to "wait" for them; in a one-shot headless run the wakeup never fires and the session ends mid-wait. First caught live by the guard 2026-07-24 on PR #416 — transcript artifact showed 26 tool calls, near-zero denials, 4 parallel reviewers spawned, `ScheduleWakeup(180s)` then end at 10 turns/$1.08 with nothing posted. NOT a denial problem: the class-5 prompt note was propagating into every subagent and reads worked fine | mid-cost short run like class 5, but transcript shows `ScheduleWakeup` + spawned agents with unconsumed results | prompt note extended: one-shot/headless, never park, consume subagent results synchronously — **insufficient; recurred 2026-07-30 on #511, see below** |
 
 ### Failure class 7: findings against the PR body can never be closed (2026-07-29)
 
@@ -236,6 +236,47 @@ Note what made this one visible: the check was green and every other signal
 agreed, so the only clue was the review taking **1m8s** where real reviews on
 this repo take 3-11 minutes. A green check plus an implausibly fast run is worth
 opening even when nothing else complains.
+
+### Failure class 6 recurred with a new parking mechanism (2026-07-30)
+
+Class 6's mitigation was a prompt note telling the orchestrator never to park
+and to consume subagent results synchronously. On PR #511 it parked anyway,
+**without using `ScheduleWakeup`** — it simply ended its turn with a statement
+of intent:
+
+> Two background agents are now checking PR eligibility and gathering
+> CLAUDE.md file paths. I'll wait for their results before proceeding — no
+> further action needed from me until they complete.
+
+`num_turns: 6`, `subtype: success`, `$0.23`, `reviews=0 inline=0
+bot_summaries=0`. The guard caught it; the check failed correctly.
+
+Two details make this worth its own entry rather than a tally mark on the row
+above.
+
+**The results it was waiting for had already arrived.** The transcript
+artifact contains both subagents' outputs — one answering `SHOULD_STOP: no`
+with a correct eligibility rationale, the other listing the two relevant
+`CLAUDE.md` paths. Nothing was pending. The orchestrator ended a turn holding
+the answers it claimed to be waiting for, so a fix that only makes waiting
+work would not have helped here.
+
+**The mitigation is keyed to the wrong thing.** "Never park" was written
+against `ScheduleWakeup`, a specific tool call the guard can look for. Ending
+a turn is not a tool call, so no amount of tightening the note about parking
+tools covers it. Any prompt-level fix has to be phrased as an obligation to
+*post before ending* rather than a prohibition on a parking mechanism —
+mechanisms are open-ended, the posting contract is not.
+
+Also in the same transcript, before the park: the orchestrator called `Agent`
+with `subagent_type: "claude-haiku-4-5-20251001"` — a model ID in the agent-type
+slot — then self-corrected to `subagent_type: "claude", model: "haiku"`. Costs
+turns, not fatal, but it is the same run.
+
+The first attempt on this PR burned **28 turns** and also posted nothing;
+a plain re-run produced the 6-turn park above. So this is not stochastic in
+the way class 5 is — re-running is not the remedy, and two consecutive silent
+no-ops on one head is the signal to stop re-running and pull the artifact.
 
 ## Forensics playbook
 

--- a/web/src/engine.ts
+++ b/web/src/engine.ts
@@ -274,7 +274,7 @@ function allProducerMachines(): string[] {
   return machinesCache;
 }
 
-function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string, directInsertion?: boolean): Promise<LayoutResult> {
+function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string, directInsertion?: boolean, compactLayout?: boolean): Promise<LayoutResult> {
   return call<LayoutResult>({
     method: "layout",
     result,
@@ -291,10 +291,13 @@ function buildLayout(result: SolverResult, maxBeltTier?: string, strategy?: stri
     // unchecked. Checked means FORCE DI into the native pass — the
     // A/B-comparison mode, and what `di=1` has always meant.
     directInsertion: directInsertion ? "on" : undefined,
+    // RFC-057 post-layout compaction. Off unless asked for: it rewrites
+    // geometry, so a bookmarked URL must keep rendering what it did.
+    compactLayout: compactLayout ?? false,
   });
 }
 
-function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string, directInsertion?: boolean): Promise<LayoutResult> {
+function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?: string, rowLayout?: string, maxInserterTier?: string, quality?: string, wireMode?: string, stacking?: string, inserterCapacity?: string, directInsertion?: boolean, compactLayout?: boolean): Promise<LayoutResult> {
   return call<LayoutResult>({
     method: "layoutTraced",
     result,
@@ -311,6 +314,9 @@ function buildLayoutTraced(result: SolverResult, maxBeltTier?: string, strategy?
     // unchecked. Checked means FORCE DI into the native pass — the
     // A/B-comparison mode, and what `di=1` has always meant.
     directInsertion: directInsertion ? "on" : undefined,
+    // RFC-057 post-layout compaction. Off unless asked for: it rewrites
+    // geometry, so a bookmarked URL must keep rendering what it did.
+    compactLayout: compactLayout ?? false,
   });
 }
 
@@ -341,6 +347,7 @@ async function buildLayoutStreaming(
   stacking: string | undefined,
   inserterCapacity: string | undefined,
   directInsertion: boolean | undefined,
+  compactLayout: boolean | undefined,
   onEvent: (evt: TraceEvent) => void,
 ): Promise<LayoutResult> {
   if (activeStreamingId !== null) {
@@ -382,6 +389,7 @@ async function buildLayoutStreaming(
     // unchecked. Checked means FORCE DI into the native pass — the
     // A/B-comparison mode, and what `di=1` has always meant.
     directInsertion: directInsertion ? "on" : undefined,
+    compactLayout: compactLayout ?? false,
       traceLogs,
     });
   });

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -28,6 +28,7 @@ function makeState(overrides: Partial<FormState>): FormState {
     machines: {},
     inputs: DEFAULT_CHECKED_INPUTS,
     belt: null,
+    compactLayout: false,
     strategy: null,
     rowLayout: null,
     inserterTier: null,
@@ -47,6 +48,7 @@ describe("readUrlState — defaults", () => {
     expect(readUrlState()).toEqual({
       item: DEFAULT_ITEM,
       rate: DEFAULT_RATE,
+      compactLayout: false,
       machines: {},
       inputs: DEFAULT_CHECKED_INPUTS,
       belt: null,
@@ -121,6 +123,7 @@ describe("readUrlState — hash form", () => {
     expect(readUrlState()).toEqual({
       item: DEFAULT_ITEM,
       rate: DEFAULT_RATE,
+      compactLayout: false,
       machines: {},
       inputs: DEFAULT_CHECKED_INPUTS,
       belt: null,

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -52,6 +52,9 @@ export interface FormState {
    * bus, so enabling this never makes a layout worse — it is opt-in only
    * because coverage is still narrow (fluids and modules refuse). */
   directInsertion: boolean;
+  /** RFC-057 post-layout compaction (`?compact=1`). Off by default: it
+   * rewrites geometry, so a bookmarked URL must keep rendering what it did. */
+  compactLayout: boolean;
   /** Global module policy, compact form `<kind><tier><quality?>` —
    * `s`peed / `p`roductivity, tier 1–3, optional module-quality initial
    * (`u`/`r`/`e`/`l`), e.g. "s2", "p3l". null = no modules (today's
@@ -153,6 +156,7 @@ export const URL_KEY_BY_CATEGORY: Record<string, string> = {
 /** Back-compat alias: the legacy single-machine URL parameter used to
  * configure the assembler tier. Read into `machines.crafting`. */
 const LEGACY_MACHINE_KEY = "machine";
+const COMPACT_EXTRAS_KEY = "compact";
 
 // Hash-form (Bucket B) URL scheme:
 //
@@ -335,6 +339,7 @@ function readHashState(): FormState | null {
   const inserterCapacity =
     irShort && (KNOWN_INSERTER_CAPACITY as readonly string[]).includes(irShort) ? irShort : null;
   const directInsertion = extras.get(DIRECT_INSERTION_EXTRAS_KEY) === "1";
+  const compactLayout = extras.get(COMPACT_EXTRAS_KEY) === "1";
   const mShort = extras.get("m");
   const modules = mShort && MODULES_RE.test(mShort) ? mShort : null;
   const ciRaw = extras.get("ci");
@@ -360,7 +365,7 @@ function readHashState(): FormState | null {
     machines[category] = slug;
   }
 
-  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, modules, customInputs };
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, compactLayout, modules, customInputs };
 }
 
 function readQueryState(): FormState {
@@ -418,12 +423,13 @@ function readQueryState(): FormState {
       ? rawInserterCapacity
       : null;
   const directInsertion = params.get("direct_insertion") === "1";
+  const compactLayout = params.get("compact") === "1";
   const rawModules = params.get("modules");
   const modules = rawModules && MODULES_RE.test(rawModules) ? rawModules : null;
   const ciParam = params.get("ci");
   const customInputs = ciParam ? ciParam.split(",").filter((s) => s.length > 0) : [];
 
-  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, modules, customInputs };
+  return { item, rate, machines, inputs, belt, strategy, rowLayout, inserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, compactLayout, modules, customInputs };
 }
 
 export function readUrlState(): FormState {
@@ -505,6 +511,9 @@ function formatHashState(state: FormState): string {
     (KNOWN_INSERTER_CAPACITY as readonly string[]).includes(state.inserterCapacity)
   ) {
     extras.set(INSERTER_CAPACITY_EXTRAS_KEY, state.inserterCapacity);
+  }
+  if (state.compactLayout) {
+    extras.set(COMPACT_EXTRAS_KEY, "1");
   }
   if (state.directInsertion) {
     extras.set(DIRECT_INSERTION_EXTRAS_KEY, "1");

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -858,6 +858,7 @@ export function renderSidebar(
   if (urlState.stacking) stackingSelect.value = urlState.stacking;
   if (urlState.inserterCapacity) inserterCapacitySelect.value = urlState.inserterCapacity;
   directInsertionCb.checked = urlState.directInsertion === true;
+  compactCb.checked = urlState.compactLayout === true;
   // Restore custom inputs from URL
   for (const item of urlState.customInputs) {
     if (itemSet.has(item) && !defaultInputSet.has(item) && !customInputs.includes(item)) {

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -1051,6 +1051,7 @@ export function renderSidebar(
   inserterTierSelect.addEventListener("change", scheduleAutoSolve);
   qualitySelect.addEventListener("change", scheduleAutoSolve);
   directInsertionCb.addEventListener("change", scheduleAutoSolve);
+  compactCb.addEventListener("change", scheduleAutoSolve);
   modulesSelect.addEventListener("change", scheduleAutoSolve);
   moduleQualitySelect.addEventListener("change", scheduleAutoSolve);
   wireModeSelect.addEventListener("change", scheduleAutoSolve);

--- a/web/src/ui/sidebar.ts
+++ b/web/src/ui/sidebar.ts
@@ -605,6 +605,21 @@ export function renderSidebar(
     "debugging.";
   targetBody.appendChild(makeField("Direct insertion", directInsertionCb));
 
+  // RFC-057 post-layout compaction. Off by default because it rewrites
+  // geometry — a bookmarked URL must keep rendering what it did — but it is
+  // safe to enable: the pass commits a transform only where validation is no
+  // worse than its input, so the worst case is no change.
+  const compactCb = document.createElement("input");
+  compactCb.type = "checkbox";
+  compactCb.className = "sb-checkbox";
+  compactCb.title =
+    "Compact the finished layout (RFC-057): replace long surface belt runs " +
+    "with underground pairs, then delete redundant rows and columns. Each " +
+    "step is kept only if the layout still validates no worse, so the worst " +
+    "case is no change. On the largest corpus layout this is -26% bounding " +
+    "box and -45% entities.";
+  targetBody.appendChild(makeField("Compact layout", compactCb));
+
   // Layout strategy. Phase 0b of `rfc-modular-production` shipped the
   // dropdown; the surviving `partitioned-decomposed` variant produces
   // strictly ≤ Pooled errors on every case in the corpus. The deprecated
@@ -908,6 +923,7 @@ export function renderSidebar(
     writeUrlState({
       item: targetItem,
       rate: targetRate,
+      compactLayout: compactCb.checked,
       machines: palette,
       inputs: checkedDefaults,
       belt: beltSelect.value || null,
@@ -994,8 +1010,9 @@ export function renderSidebar(
       const stacking = stackingSelect.value || undefined;
       const inserterCapacity = inserterCapacitySelect.value || undefined;
       const directInsertion = directInsertionCb.checked;
+      const compactLayout = compactCb.checked;
       const onEvent = callbacks.startStreaming();
-      layout = await engine.buildLayoutStreaming(result, maxTier, strategy, rowLayout, maxInserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, onEvent);
+      layout = await engine.buildLayoutStreaming(result, maxTier, strategy, rowLayout, maxInserterTier, quality, wireMode, stacking, inserterCapacity, directInsertion, compactLayout, onEvent);
     } catch (err) {
       if (gen !== solveGeneration) return;
       const errDiv = document.createElement("div");

--- a/web/src/workers/engine.worker.ts
+++ b/web/src/workers/engine.worker.ts
@@ -38,9 +38,9 @@ type Request =
       quality: string | null;
       modules: string | null;
     }
-  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: string }
-  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: string }
-  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: string }
+  | { id: number; method: "layout"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: string; compactLayout?: boolean }
+  | { id: number; method: "layoutTraced"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: string; compactLayout?: boolean }
+  | { id: number; method: "layoutStreaming"; result: SolverResult; maxBeltTier: string | null; strategy: string | null; rowLayout: string | null; maxInserterTier: string | null; quality: string | null; wireMode: string | null; stacking: string | null; inserterCapacity: string | null; directInsertion?: string; compactLayout?: boolean }
   | { id: number; method: "exportBlueprint"; layout: LayoutResult; label: string }
   | {
       id: number;
@@ -124,10 +124,10 @@ self.onmessage = async (e: MessageEvent<Request>) => {
         );
         break;
       case "layout":
-        result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? undefined);
+        result = layout(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? undefined, req.compactLayout ? "1" : undefined);
         break;
       case "layoutTraced":
-        result = layout_traced(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? undefined);
+        result = layout_traced(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? undefined, req.compactLayout ? "1" : undefined);
         break;
       case "layoutStreaming": {
         const id = req.id;
@@ -170,7 +170,7 @@ self.onmessage = async (e: MessageEvent<Request>) => {
           if (batch.length >= BATCH_SIZE) flushBatch();
         };
         try {
-          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? undefined, emit);
+          result = layout_streaming(req.result, req.maxBeltTier ?? undefined, req.strategy ?? undefined, req.rowLayout ?? undefined, req.maxInserterTier ?? undefined, req.quality ?? undefined, req.wireMode ?? undefined, req.stacking ? Number(req.stacking) : undefined, req.inserterCapacity ? Number(req.inserterCapacity) : undefined, undefined, req.directInsertion ?? undefined, req.compactLayout ? "1" : undefined, emit);
         } finally {
           flushBatch();
           if (TRACE_LOGS) {


### PR DESCRIPTION
## Intent

`LayoutOptions::compact_layout` has existed and validated for weeks, hard-coded `false` at the wasm boundary with a comment saying exposing it was *"a UI decision, not a fallback-semantics one — hard-false until that decision is made"*. This makes that decision.

Measured on the largest layout in the corpus, `processing-unit @3/s from plates`:

| | geometry | tiles | entities |
|---|---|---:|---:|
| as shipped | 942×84 | 79,128 | 11,069 |
| `?compact=1` | 727×81 | **58,887** | **6,089** |
| | | **−25.6%** | **−45.0%** |

Part of that entity drop is #502 landing earlier today — undergroundification now actually commits, where a stale copper-wire graph had been making the whole transport stage reject itself.

## Scope

- **In:** `?compact=1` URL param (+ hash-state extras key), a "Compact layout" sidebar checkbox, and the parameter threaded through all three wasm entry points.
- **Out — default-on.** Deliberate. The pass is *safe* (`compact_validated_geometry` commits a transform only where validation is no worse than its input, so the worst case is no change), but it rewrites geometry and a bookmarked URL must keep rendering what it did. It also sometimes trades a slightly taller box for a large entity saving, which is a call for the person building the factory, not the engine.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — **916 lib + 125 across targets, 0 failures**
- [x] `cargo clippy` (core + wasm-bindings) — clean
- [x] `npx vitest run` — **36/36**. Three state assertions needed the new `FormState` field.
- [x] `wasm-pack build` — succeeds, and `tsc --noEmit` is clean **against the generated types**, which is what confirms all three entry points (`layout`, `layout_traced`, `layout_streaming`) actually carry the parameter rather than just compiling on the Rust side.
- [ ] Browser eyeball — **not done, and worth doing before merge.** Load any layout with and without `?compact=1` and confirm the geometry change looks sane. Per `CLAUDE.md`'s protocol a zero-warning layout with visibly disconnected belts is a validator bug, not a success, and this pass moves belts.

## Deviations from intent

One thing that reads as a regression but isn't: on some layouts `fill%` *drops* after compaction (13.4% here, down from 16.3%). That's because occupied tiles fall faster than the bounding box does — fewer entities for the same production. It's a good outcome, and a reminder that fill% is a poor headline metric; bbox and entity count are the ones to watch.

Unrelated: `cargo test` hit a stale-artifact link failure (`undefined hidden symbol` in core's sort shim) after pulling main. `cargo clean -p spaghettio_core` cleared it. Not caused by this change.

## Models / contracts touched

The wasm surface gains one optional parameter on three functions, default-absent. Every existing URL and every existing caller keeps byte-identical behaviour.