### PR TITLE
RFC-058 Phase 0: e2e-corpus band census — KC2 clears at 37.5%

### DIFF
--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -5258,9 +5258,17 @@ fn rfc058_band_packing_premise_holds() {
 /// recorded so the denominator is arguable rather than mysterious:
 /// strategy/row-layout variants are normalised to the default bus path,
 /// duplicate tuples are listed once (`source` names one owning test), and
-/// `#[ignore]`d tests are out — which excludes `measure_utility_10s_am3`
-/// and, notably, `pipe_belt_processing_unit_1s_routes` (pu1-plate): the
-/// KC1 gate fixture is NOT part of KC2's denominator.
+/// `#[ignore]`d tests are out — which excludes `measure_utility_10s_am3`,
+/// `fixture_source_ec_15s_am1_yellow_from_ore`, the ignored stress trio
+/// (`ac_partitioned_7s`, `ac_45s`, `pu_20s` — pu20 was an 85-band packable
+/// winner, so this rule costs the numerator too) and, notably,
+/// `pipe_belt_processing_unit_1s_routes` (pu1-plate): the KC1 gate fixture
+/// is NOT part of KC2's denominator. Two non-ignored requests are also out
+/// because this harness cannot express them —
+/// `fulgora_scrap_sorter_mechanism_present` needs the recycling-aware
+/// `solve_fulgora` path, and `cable13u_bridged_row_lane_throughput_clean`
+/// solves at `QualityTier::Uncommon` — so "every distinct request" is
+/// exact only over default-quality, non-recycling solves.
 ///
 /// KC2 asks what fraction of this corpus has >=3 bands and no
 /// width-dominant band. The aspect cap is consequential (it alone refuses
@@ -5308,7 +5316,6 @@ fn probe_band_census_e2e_corpus() {
         Case { label: "ec10-plate", source: "tier2_electronic_circuit", item: "electronic-circuit", rate: 10.0, machine: A2, belt: None, inputs: &["iron-plate", "copper-plate"], excluded: &[] },
         Case { label: "ec10-plate-am1-red", source: "tier2_electronic_circuit_splitter_stamp_regression", item: "electronic-circuit", rate: 10.0, machine: A1, belt: RED, inputs: &["iron-plate", "copper-plate"], excluded: &[] },
         Case { label: "ec10-ore-yellow", source: "tier2_electronic_circuit_from_ore", item: "electronic-circuit", rate: 10.0, machine: A1, belt: YELLOW, inputs: ORES, excluded: &[] },
-        Case { label: "ec15-ore-yellow", source: "fixture_source_ec_15s_am1_yellow_from_ore", item: "electronic-circuit", rate: 15.0, machine: A1, belt: YELLOW, inputs: ORES, excluded: &[] },
         Case { label: "ec20-ore", source: "tier2_electronic_circuit_20s_from_ore", item: "electronic-circuit", rate: 20.0, machine: A2, belt: None, inputs: ORES, excluded: &[] },
         Case { label: "plastic10-gas", source: "tier3_plastic_bar", item: "plastic-bar", rate: 10.0, machine: CHEM, belt: None, inputs: &["petroleum-gas", "coal"], excluded: &[] },
         Case { label: "plastic10-crude", source: "tier3_plastic_bar_from_crude", item: "plastic-bar", rate: 10.0, machine: CHEM, belt: None, inputs: &["crude-oil", "coal"], excluded: &[] },
@@ -5319,14 +5326,12 @@ fn probe_band_census_e2e_corpus() {
         Case { label: "ac1-nauvis", source: "tier4_advanced_circuit_from_plates", item: "advanced-circuit", rate: 1.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
         Case { label: "ac4-nauvis", source: "stress_advanced_circuit_partitioned_4s_from_plates", item: "advanced-circuit", rate: 4.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
         Case { label: "ac5-nauvis", source: "stress_advanced_circuit_partitioned_5s_from_plates", item: "advanced-circuit", rate: 5.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
-        Case { label: "ac7-nauvis", source: "stress_advanced_circuit_partitioned_7s_from_plates", item: "advanced-circuit", rate: 7.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
+        Case { label: "ac7-nauvis-yellow", source: "tier4_advanced_circuit_7s_horizontal_stack_belt_pipe_crossing", item: "advanced-circuit", rate: 7.0, machine: A2, belt: YELLOW, inputs: NAUVIS5, excluded: &[] },
         Case { label: "ac5-ore-yellow", source: "tier4_advanced_circuit_from_ore_am2", item: "advanced-circuit", rate: 5.0, machine: A2, belt: YELLOW, inputs: ORES5, excluded: &[] },
-        Case { label: "ac45-plates", source: "stress_advanced_circuit_45s_from_plates", item: "advanced-circuit", rate: 45.0, machine: A2, belt: None, inputs: &["iron-plate", "copper-plate", "plastic-bar"], excluded: &[] },
         Case { label: "pu2-ore-red", source: "tier5_processing_unit_from_ore_am3", item: "processing-unit", rate: 2.0, machine: A3, belt: RED, inputs: ORES5, excluded: &[] },
         Case { label: "pu2-ore-hs", source: "tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass", item: "processing-unit", rate: 2.0, machine: A3, belt: None, inputs: &["iron-ore", "copper-ore", "stone", "coal", "water", "crude-oil"], excluded: &[] },
         Case { label: "pu2.5-plates-hs", source: "tier5_processing_unit_25s_horizontal_stack_pole_coverage", item: "processing-unit", rate: 2.5, machine: A3, belt: None, inputs: PU9, excluded: &[] },
         Case { label: "pu2-am2-red", source: "processing_unit_2s_am2_fast_belts_validation_baseline", item: "processing-unit", rate: 2.0, machine: A2, belt: RED, inputs: PU9, excluded: &[] },
-        Case { label: "pu20-plates", source: "stress_processing_unit_20s_from_plates", item: "processing-unit", rate: 20.0, machine: A3, belt: None, inputs: &["iron-plate", "copper-plate", "plastic-bar", "sulfuric-acid"], excluded: &[] },
         Case { label: "u235-kovarex", source: "tier_kovarex_self_loop", item: "uranium-235", rate: 0.1, machine: A3, belt: None, inputs: &["uranium-238"], excluded: &["uranium-processing"] },
         Case { label: "u235-up", source: "tier_uranium_processing_surplus_export", item: "uranium-235", rate: 0.05, machine: A3, belt: None, inputs: &["uranium-ore"], excluded: &["kovarex-enrichment-process"] },
         Case { label: "pentapod0.2", source: "tier_pentapod_egg_self_loop", item: "pentapod-egg", rate: 0.2, machine: A3, belt: None, inputs: &["nutrients", "water"], excluded: &[] },
@@ -5411,7 +5416,7 @@ fn probe_band_census_e2e_corpus() {
     println!("  >=3 bands: {ge3}/{n} ({:.0}%)", pct(ge3));
     for (i, cap) in caps.iter().enumerate() {
         println!(
-            "  >=3 bands AND packable at {cap}:1: {}/{n} ({:.0}%) — KC2 bar is 30%",
+            "  >=3 bands AND packable at {cap}:1: {}/{n} ({:.1}%) — KC2 bar is 30%",
             packable[i],
             pct(packable[i]),
         );

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -4730,6 +4730,163 @@ fn rfc057_island_placement_keeps_terminals_disjoint() {
     assert_eq!(materialized, cases.len());
 }
 
+// ---------------------------------------------------------------------------
+// RFC-058 band helpers, shared by the phase-0 probes below.
+//
+// A band is a maximal run of rows containing machines or inserters. Trunk
+// belts span all rows and are deliberately NOT band-forming — they are the
+// transport being priced, not the structure being packed.
+//
+// `rfc058_band_packing_premise_holds` (the CI guard) intentionally does NOT
+// use these helpers: it keeps its own self-contained copy so a defect
+// introduced here cannot blind the guard that exists to catch drift.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct Rfc058Band {
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    recipes: Vec<String>,
+}
+
+impl Rfc058Band {
+    fn cx(&self) -> f64 {
+        self.x as f64 + self.w as f64 / 2.0
+    }
+    fn cy(&self) -> f64 {
+        self.y as f64 + self.h as f64 / 2.0
+    }
+}
+
+fn rfc058_extract_bands(l: &spaghettio_core::models::LayoutResult) -> Vec<Rfc058Band> {
+    use spaghettio_core::common::{entity_size, is_machine_entity};
+    let h = l.height.max(0) as usize;
+    let mut structural = vec![false; h];
+    for e in &l.entities {
+        if is_machine_entity(&e.name) || e.name.contains("inserter") {
+            let (_, eh) = entity_size(&e.name);
+            for dy in 0..eh as i32 {
+                let y = e.y + dy;
+                if y >= 0 && (y as usize) < h {
+                    structural[y as usize] = true;
+                }
+            }
+        }
+    }
+    let mut bands = Vec::new();
+    let mut y = 0usize;
+    while y < h {
+        if !structural[y] {
+            y += 1;
+            continue;
+        }
+        let start = y;
+        while y < h && structural[y] {
+            y += 1;
+        }
+        let end = y - 1;
+        let (mut xmin, mut xmax) = (i32::MAX, i32::MIN);
+        let mut recipes: FxHashSet<String> = FxHashSet::default();
+        for e in &l.entities {
+            if !(is_machine_entity(&e.name) || e.name.contains("inserter")) {
+                continue;
+            }
+            if e.y < start as i32 || e.y > end as i32 {
+                continue;
+            }
+            let (ew, _) = entity_size(&e.name);
+            xmin = xmin.min(e.x);
+            xmax = xmax.max(e.x + ew as i32 - 1);
+            if let Some(r) = &e.recipe {
+                recipes.insert(r.clone());
+            }
+        }
+        if xmin > xmax {
+            continue;
+        }
+        let mut recipes: Vec<String> = recipes.into_iter().collect();
+        recipes.sort();
+        bands.push(Rfc058Band {
+            x: xmin,
+            y: start as i32,
+            w: xmax - xmin + 1,
+            h: (end - start + 1) as i32,
+            recipes,
+        });
+    }
+    bands
+}
+
+fn rfc058_bbox(bands: &[Rfc058Band]) -> (i32, i32) {
+    let w = bands.iter().map(|b| b.x + b.w).max().unwrap_or(0)
+        - bands.iter().map(|b| b.x).min().unwrap_or(0);
+    let h = bands.iter().map(|b| b.y + b.h).max().unwrap_or(0)
+        - bands.iter().map(|b| b.y).min().unwrap_or(0);
+    (w, h)
+}
+
+fn rfc058_shelf_pack(
+    bands: &[Rfc058Band],
+    target_w: i32,
+    gap: i32,
+    sort_desc: bool,
+) -> Vec<Rfc058Band> {
+    let mut idx: Vec<usize> = (0..bands.len()).collect();
+    if sort_desc {
+        idx.sort_by_key(|&i| std::cmp::Reverse((bands[i].h, bands[i].w, i)));
+    }
+    let mut out = bands.to_vec();
+    let (mut x, mut y, mut shelf_h) = (0, 0, 0);
+    for &i in &idx {
+        let (w, h) = (bands[i].w, bands[i].h);
+        if x > 0 && x + w > target_w {
+            x = 0;
+            y += shelf_h + gap;
+            shelf_h = 0;
+        }
+        out[i].x = x;
+        out[i].y = y;
+        x += w + gap;
+        shelf_h = shelf_h.max(h);
+    }
+    out
+}
+
+/// Best aspect-capped shelf packing: target width swept from the widest band
+/// to twice the control width, both source and height-descending order, and
+/// the minimum bounding-box area under `max_aspect` wins. Returns
+/// `(area, w, h, packed)`, or None when no packing fits the cap — a
+/// width-dominant band. Selection is by area alone with strict `<`, so the
+/// first candidate at the minimum wins; iteration order is part of the
+/// contract (the probe's published numbers depend on it).
+fn rfc058_best_pack(
+    bands: &[Rfc058Band],
+    gap: i32,
+    max_aspect: f64,
+) -> Option<(i64, i32, i32, Vec<Rfc058Band>)> {
+    let (cw, _) = rfc058_bbox(bands);
+    let widest = bands.iter().map(|b| b.w).max().unwrap_or(1);
+    let mut best: Option<(i64, i32, i32, Vec<Rfc058Band>)> = None;
+    for sort_desc in [false, true] {
+        let mut t = widest;
+        while t <= cw.max(widest) * 2 {
+            let packed = rfc058_shelf_pack(bands, t, gap, sort_desc);
+            let (w, h) = rfc058_bbox(&packed);
+            let aspect = w.max(h) as f64 / w.min(h).max(1) as f64;
+            if aspect <= max_aspect {
+                let area = (w as i64) * (h as i64);
+                if best.as_ref().is_none_or(|(ba, _, _, _)| area < *ba) {
+                    best = Some((area, w, h, packed));
+                }
+            }
+            t += 2;
+        }
+    }
+    best
+}
+
 /// RFC-058 Phase 0 instrument: band census + packing headroom.
 ///
 /// This reproduces every number the RFC cites, so its premise is checkable by
@@ -4751,86 +4908,7 @@ fn rfc057_island_placement_keeps_terminals_disjoint() {
 #[test]
 #[ignore = "RFC-058 Phase 0 probe — run with --ignored --nocapture"]
 fn probe_band_packing_headroom() {
-    use spaghettio_core::common::{entity_size, is_machine_entity};
-    use spaghettio_core::models::{LayoutResult, SolverResult};
-
-    #[derive(Clone, Debug)]
-    struct Band {
-        x: i32,
-        y: i32,
-        w: i32,
-        h: i32,
-        recipes: Vec<String>,
-    }
-    impl Band {
-        fn cx(&self) -> f64 {
-            self.x as f64 + self.w as f64 / 2.0
-        }
-        fn cy(&self) -> f64 {
-            self.y as f64 + self.h as f64 / 2.0
-        }
-    }
-
-    // A band is a maximal run of rows containing machines or inserters. Trunk
-    // belts span all rows and are deliberately NOT band-forming — they are the
-    // transport being priced, not the structure being packed.
-    fn extract_bands(l: &LayoutResult) -> Vec<Band> {
-        let h = l.height.max(0) as usize;
-        let mut structural = vec![false; h];
-        for e in &l.entities {
-            if is_machine_entity(&e.name) || e.name.contains("inserter") {
-                let (_, eh) = entity_size(&e.name);
-                for dy in 0..eh as i32 {
-                    let y = e.y + dy;
-                    if y >= 0 && (y as usize) < h {
-                        structural[y as usize] = true;
-                    }
-                }
-            }
-        }
-        let mut bands = Vec::new();
-        let mut y = 0usize;
-        while y < h {
-            if !structural[y] {
-                y += 1;
-                continue;
-            }
-            let start = y;
-            while y < h && structural[y] {
-                y += 1;
-            }
-            let end = y - 1;
-            let (mut xmin, mut xmax) = (i32::MAX, i32::MIN);
-            let mut recipes: FxHashSet<String> = FxHashSet::default();
-            for e in &l.entities {
-                if !(is_machine_entity(&e.name) || e.name.contains("inserter")) {
-                    continue;
-                }
-                if e.y < start as i32 || e.y > end as i32 {
-                    continue;
-                }
-                let (ew, _) = entity_size(&e.name);
-                xmin = xmin.min(e.x);
-                xmax = xmax.max(e.x + ew as i32 - 1);
-                if let Some(r) = &e.recipe {
-                    recipes.insert(r.clone());
-                }
-            }
-            if xmin > xmax {
-                continue;
-            }
-            let mut recipes: Vec<String> = recipes.into_iter().collect();
-            recipes.sort();
-            bands.push(Band {
-                x: xmin,
-                y: start as i32,
-                w: xmax - xmin + 1,
-                h: (end - start + 1) as i32,
-                recipes,
-            });
-        }
-        bands
-    }
+    use spaghettio_core::models::SolverResult;
 
     // Rate-weighted transport: for every (band, consumed item) pair, Manhattan
     // distance to the nearest band producing it, times planned rate. External
@@ -4841,7 +4919,7 @@ fn probe_band_packing_headroom() {
     // close to Manhattan for the stacked control but not necessarily for a
     // packed layout whose bands are no longer in one column. It may therefore
     // flatter packing. The area result does not depend on it.
-    fn transport_cost(bands: &[Band], sr: &SolverResult) -> f64 {
+    fn transport_cost(bands: &[Rfc058Band], sr: &SolverResult) -> f64 {
         let mut produced_by: FxHashMap<&str, Vec<usize>> = FxHashMap::default();
         for spec in &sr.machines {
             for out in &spec.outputs {
@@ -4882,36 +4960,6 @@ fn probe_band_packing_headroom() {
             }
         }
         total
-    }
-
-    fn bbox(bands: &[Band]) -> (i32, i32) {
-        let w = bands.iter().map(|b| b.x + b.w).max().unwrap_or(0)
-            - bands.iter().map(|b| b.x).min().unwrap_or(0);
-        let h = bands.iter().map(|b| b.y + b.h).max().unwrap_or(0)
-            - bands.iter().map(|b| b.y).min().unwrap_or(0);
-        (w, h)
-    }
-
-    fn shelf_pack(bands: &[Band], target_w: i32, gap: i32, sort_desc: bool) -> Vec<Band> {
-        let mut idx: Vec<usize> = (0..bands.len()).collect();
-        if sort_desc {
-            idx.sort_by_key(|&i| std::cmp::Reverse((bands[i].h, bands[i].w, i)));
-        }
-        let mut out = bands.to_vec();
-        let (mut x, mut y, mut shelf_h) = (0, 0, 0);
-        for &i in &idx {
-            let (w, h) = (bands[i].w, bands[i].h);
-            if x > 0 && x + w > target_w {
-                x = 0;
-                y += shelf_h + gap;
-                shelf_h = 0;
-            }
-            out[i].x = x;
-            out[i].y = y;
-            x += w + gap;
-            shelf_h = shelf_h.max(h);
-        }
-        out
     }
 
     // Minimising bbox AREA alone drives every packing to a one-shelf ribbon
@@ -4963,7 +5011,7 @@ fn probe_band_packing_headroom() {
             println!("{label:<13} layout refused");
             continue;
         };
-        let bands = extract_bands(&l);
+        let bands = rfc058_extract_bands(&l);
         let dims: Vec<(i32, i32)> = bands.iter().map(|b| (b.w, b.h)).collect();
         // Two gates, deliberately distinct.
         //
@@ -4982,27 +5030,12 @@ fn probe_band_packing_headroom() {
         }
         let kc2_candidate = bands.len() >= 3;
         multi_band += 1;
-        let (cw, ch) = bbox(&bands);
+        let (cw, ch) = rfc058_bbox(&bands);
         let ctrl_area = (cw as i64) * (ch as i64);
         let ctrl_tx = transport_cost(&bands, &sr);
 
-        let widest = bands.iter().map(|b| b.w).max().unwrap_or(1);
-        let mut best: Option<(i64, f64, i32, i32)> = None;
-        for sort_desc in [false, true] {
-            let mut t = widest;
-            while t <= cw.max(widest) * 2 {
-                let packed = shelf_pack(&bands, t, GAP, sort_desc);
-                let (w, h) = bbox(&packed);
-                let aspect = w.max(h) as f64 / w.min(h).max(1) as f64;
-                if aspect <= MAX_ASPECT {
-                    let area = (w as i64) * (h as i64);
-                    if best.as_ref().is_none_or(|(ba, _, _, _)| area < *ba) {
-                        best = Some((area, transport_cost(&packed, &sr), w, h));
-                    }
-                }
-                t += 2;
-            }
-        }
+        let best = rfc058_best_pack(&bands, GAP, MAX_ASPECT)
+            .map(|(area, w, h, packed)| (area, transport_cost(&packed, &sr), w, h));
 
         corpus_ctrl += ctrl_area;
         match best {
@@ -5214,4 +5247,173 @@ fn rfc058_band_packing_premise_holds() {
          different number makes the gate wrong — update the RFC before relying on it.",
         66.1,
     );
+}
+
+/// RFC-058 Phase 0: band census over the e2e corpus — the reach measurement
+/// kill criterion 2 turns on.
+///
+/// The corpus is every distinct production request (item, rate, machine,
+/// belt, inputs, exclusions) exercised by a non-ignored test in
+/// `crates/core/tests/e2e.rs`, transcribed 2026-07-31. Inclusion rule,
+/// recorded so the denominator is arguable rather than mysterious:
+/// strategy/row-layout variants are normalised to the default bus path,
+/// duplicate tuples are listed once (`source` names one owning test), and
+/// `#[ignore]`d tests are out — which excludes `measure_utility_10s_am3`
+/// and, notably, `pipe_belt_processing_unit_1s_routes` (pu1-plate): the
+/// KC1 gate fixture is NOT part of KC2's denominator.
+///
+/// KC2 asks what fraction of this corpus has >=3 bands and no
+/// width-dominant band. The aspect cap is consequential (it alone refuses
+/// insert3-ore at 3.16:1 in the probe corpus), so applicability is
+/// reported as a function of the cap instead of inheriting 3:1.
+///
+/// Band structure is host-geometry-relative (RFC-058 decision log,
+/// 2026-07-31: ec10-ore extracts 1 or 3 bands depending on the machine's
+/// SAT-cache state). Treat these numbers like stress goldens — comparable
+/// on one machine, not portable constants — and re-run on a second machine
+/// before calling KC2 if the result lands within a few points of the 30%
+/// bar.
+#[test]
+#[ignore = "RFC-058 Phase 0 census — run with --ignored --nocapture"]
+fn probe_band_census_e2e_corpus() {
+    struct Case {
+        label: &'static str,
+        source: &'static str,
+        item: &'static str,
+        rate: f64,
+        machine: &'static str,
+        belt: Option<&'static str>,
+        inputs: &'static [&'static str],
+        excluded: &'static [&'static str],
+    }
+    const A1: &str = "assembling-machine-1";
+    const A2: &str = "assembling-machine-2";
+    const A3: &str = "assembling-machine-3";
+    const CHEM: &str = "chemical-plant";
+    const REFINERY: &str = "oil-refinery";
+    const YELLOW: Option<&'static str> = Some("transport-belt");
+    const RED: Option<&'static str> = Some("fast-transport-belt");
+    const ORES: &[&str] = &["iron-ore", "copper-ore"];
+    const NAUVIS5: &[&str] = &["iron-plate", "copper-plate", "coal", "crude-oil", "water"];
+    const ORES5: &[&str] = &["iron-ore", "copper-ore", "coal", "water", "crude-oil"];
+    const PU9: &[&str] = &[
+        "iron-plate", "copper-plate", "steel-plate", "stone", "coal",
+        "water", "crude-oil", "iron-ore", "copper-ore",
+    ];
+
+    let cases: &[Case] = &[
+        Case { label: "gear10-plate", source: "tier1_iron_gear_wheel", item: "iron-gear-wheel", rate: 10.0, machine: A1, belt: None, inputs: &["iron-plate"], excluded: &[] },
+        Case { label: "gear10-ore", source: "tier1_iron_gear_wheel_from_ore", item: "iron-gear-wheel", rate: 10.0, machine: A2, belt: None, inputs: &["iron-ore"], excluded: &[] },
+        Case { label: "gear20-plate", source: "tier1_iron_gear_wheel_20s", item: "iron-gear-wheel", rate: 20.0, machine: A2, belt: None, inputs: &["iron-plate"], excluded: &[] },
+        Case { label: "ec10-plate", source: "tier2_electronic_circuit", item: "electronic-circuit", rate: 10.0, machine: A2, belt: None, inputs: &["iron-plate", "copper-plate"], excluded: &[] },
+        Case { label: "ec10-plate-am1-red", source: "tier2_electronic_circuit_splitter_stamp_regression", item: "electronic-circuit", rate: 10.0, machine: A1, belt: RED, inputs: &["iron-plate", "copper-plate"], excluded: &[] },
+        Case { label: "ec10-ore-yellow", source: "tier2_electronic_circuit_from_ore", item: "electronic-circuit", rate: 10.0, machine: A1, belt: YELLOW, inputs: ORES, excluded: &[] },
+        Case { label: "ec15-ore-yellow", source: "fixture_source_ec_15s_am1_yellow_from_ore", item: "electronic-circuit", rate: 15.0, machine: A1, belt: YELLOW, inputs: ORES, excluded: &[] },
+        Case { label: "ec20-ore", source: "tier2_electronic_circuit_20s_from_ore", item: "electronic-circuit", rate: 20.0, machine: A2, belt: None, inputs: ORES, excluded: &[] },
+        Case { label: "plastic10-gas", source: "tier3_plastic_bar", item: "plastic-bar", rate: 10.0, machine: CHEM, belt: None, inputs: &["petroleum-gas", "coal"], excluded: &[] },
+        Case { label: "plastic10-crude", source: "tier3_plastic_bar_from_crude", item: "plastic-bar", rate: 10.0, machine: CHEM, belt: None, inputs: &["crude-oil", "coal"], excluded: &[] },
+        Case { label: "sulfuric5", source: "tier3_sulfuric_acid", item: "sulfuric-acid", rate: 5.0, machine: CHEM, belt: None, inputs: &["iron-plate", "sulfur", "water"], excluded: &[] },
+        Case { label: "lightoil5-hoc", source: "tier3_heavy_oil_cracking", item: "light-oil", rate: 5.0, machine: CHEM, belt: None, inputs: &["water", "heavy-oil"], excluded: &["advanced-oil-processing", "coal-liquefaction"] },
+        Case { label: "gas12-aop", source: "tier3_advanced_oil_processing_multi_machine", item: "petroleum-gas", rate: 12.0, machine: REFINERY, belt: None, inputs: &["water", "crude-oil"], excluded: &[] },
+        Case { label: "gas24-aop", source: "tier3_advanced_oil_processing_forced_multi_machine_pipe_isolation", item: "petroleum-gas", rate: 24.0, machine: REFINERY, belt: None, inputs: &["water", "crude-oil"], excluded: &["basic-oil-processing", "coal-liquefaction"] },
+        Case { label: "ac1-nauvis", source: "tier4_advanced_circuit_from_plates", item: "advanced-circuit", rate: 1.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
+        Case { label: "ac4-nauvis", source: "stress_advanced_circuit_partitioned_4s_from_plates", item: "advanced-circuit", rate: 4.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
+        Case { label: "ac5-nauvis", source: "stress_advanced_circuit_partitioned_5s_from_plates", item: "advanced-circuit", rate: 5.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
+        Case { label: "ac7-nauvis", source: "stress_advanced_circuit_partitioned_7s_from_plates", item: "advanced-circuit", rate: 7.0, machine: A2, belt: None, inputs: NAUVIS5, excluded: &[] },
+        Case { label: "ac5-ore-yellow", source: "tier4_advanced_circuit_from_ore_am2", item: "advanced-circuit", rate: 5.0, machine: A2, belt: YELLOW, inputs: ORES5, excluded: &[] },
+        Case { label: "ac45-plates", source: "stress_advanced_circuit_45s_from_plates", item: "advanced-circuit", rate: 45.0, machine: A2, belt: None, inputs: &["iron-plate", "copper-plate", "plastic-bar"], excluded: &[] },
+        Case { label: "pu2-ore-red", source: "tier5_processing_unit_from_ore_am3", item: "processing-unit", rate: 2.0, machine: A3, belt: RED, inputs: ORES5, excluded: &[] },
+        Case { label: "pu2-ore-hs", source: "tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass", item: "processing-unit", rate: 2.0, machine: A3, belt: None, inputs: &["iron-ore", "copper-ore", "stone", "coal", "water", "crude-oil"], excluded: &[] },
+        Case { label: "pu2.5-plates-hs", source: "tier5_processing_unit_25s_horizontal_stack_pole_coverage", item: "processing-unit", rate: 2.5, machine: A3, belt: None, inputs: PU9, excluded: &[] },
+        Case { label: "pu2-am2-red", source: "processing_unit_2s_am2_fast_belts_validation_baseline", item: "processing-unit", rate: 2.0, machine: A2, belt: RED, inputs: PU9, excluded: &[] },
+        Case { label: "pu20-plates", source: "stress_processing_unit_20s_from_plates", item: "processing-unit", rate: 20.0, machine: A3, belt: None, inputs: &["iron-plate", "copper-plate", "plastic-bar", "sulfuric-acid"], excluded: &[] },
+        Case { label: "u235-kovarex", source: "tier_kovarex_self_loop", item: "uranium-235", rate: 0.1, machine: A3, belt: None, inputs: &["uranium-238"], excluded: &["uranium-processing"] },
+        Case { label: "u235-up", source: "tier_uranium_processing_surplus_export", item: "uranium-235", rate: 0.05, machine: A3, belt: None, inputs: &["uranium-ore"], excluded: &["kovarex-enrichment-process"] },
+        Case { label: "pentapod0.2", source: "tier_pentapod_egg_self_loop", item: "pentapod-egg", rate: 0.2, machine: A3, belt: None, inputs: &["nutrients", "water"], excluded: &[] },
+        Case { label: "fish0.15", source: "tier_fish_breeding_self_loop", item: "raw-fish", rate: 0.15, machine: A3, belt: RED, inputs: &["nutrients", "water"], excluded: &[] },
+        Case { label: "bacteria1", source: "tier_bacteria_self_loop_regression", item: "iron-bacteria", rate: 1.0, machine: A3, belt: None, inputs: &["bioflux"], excluded: &["iron-bacteria"] },
+        Case { label: "superconductor1", source: "phase0e1_superconductor_electromagnetic_plant", item: "superconductor", rate: 1.0, machine: A3, belt: None, inputs: &["holmium-plate", "copper-plate", "plastic-bar", "light-oil"], excluded: &[] },
+        Case { label: "fusioncell1", source: "phase0e1_fusion_power_cell_cryogenic_plant", item: "fusion-power-cell", rate: 1.0, machine: A3, belt: None, inputs: &["lithium-plate", "holmium-plate", "ammonia"], excluded: &[] },
+        Case { label: "molteniron5", source: "phase0e1_molten_iron_foundry", item: "molten-iron", rate: 5.0, machine: A3, belt: None, inputs: &["iron-ore", "calcite"], excluded: &[] },
+        Case { label: "biolube5", source: "phase0e1_biolubricant_biochamber", item: "lubricant", rate: 5.0, machine: A3, belt: None, inputs: &["jelly"], excluded: &[] },
+        Case { label: "ec22-ore-yellow", source: "stress_electronic_circuit_22s_from_ore", item: "electronic-circuit", rate: 22.0, machine: A2, belt: YELLOW, inputs: ORES, excluded: &[] },
+        Case { label: "ec23-ore-yellow", source: "stress_electronic_circuit_23s_from_ore", item: "electronic-circuit", rate: 23.0, machine: A2, belt: YELLOW, inputs: ORES, excluded: &[] },
+        Case { label: "ec30-ore-yellow", source: "stress_electronic_circuit_30s_from_ore", item: "electronic-circuit", rate: 30.0, machine: A2, belt: YELLOW, inputs: ORES, excluded: &[] },
+        Case { label: "ec35-ore-yellow", source: "stress_electronic_circuit_35s_from_ore", item: "electronic-circuit", rate: 35.0, machine: A2, belt: YELLOW, inputs: ORES, excluded: &[] },
+        Case { label: "ec40-ore-yellow", source: "stress_electronic_circuit_40s_from_ore", item: "electronic-circuit", rate: 40.0, machine: A2, belt: YELLOW, inputs: ORES, excluded: &[] },
+        Case { label: "ec60-ore-red", source: "stress_electronic_circuit_60s_red_from_ore", item: "electronic-circuit", rate: 60.0, machine: A2, belt: RED, inputs: ORES, excluded: &[] },
+    ];
+
+    const GAP: i32 = 2;
+    let caps = [3.0f64, 3.5, 4.0];
+
+    let mut built = 0usize;
+    let mut ge3 = 0usize;
+    let mut packable = [0usize; 3];
+
+    for c in cases {
+        let inputs: FxHashSet<String> = c.inputs.iter().map(|s| s.to_string()).collect();
+        let excluded: FxHashSet<String> = c.excluded.iter().map(|s| s.to_string()).collect();
+        let sr = match solver::solve_with_exclusions(c.item, c.rate, &inputs, c.machine, &excluded) {
+            Ok(sr) => sr,
+            Err(e) => {
+                println!("{:<20} SOLVER REFUSED ({}) — counted in the denominator: {e}", c.label, c.source);
+                continue;
+            }
+        };
+        let l = match layout::build_bus_layout(
+            &sr,
+            layout::LayoutOptions {
+                max_belt_tier: c.belt.map(|s| s.to_string()),
+                ..Default::default()
+            },
+        ) {
+            Ok(l) => l,
+            Err(e) => {
+                println!("{:<20} LAYOUT REFUSED ({}) — counted in the denominator: {e}", c.label, c.source);
+                continue;
+            }
+        };
+        built += 1;
+        let bands = rfc058_extract_bands(&l);
+        let dims: Vec<(i32, i32)> = bands.iter().map(|b| (b.w, b.h)).collect();
+        let (cw, ch) = rfc058_bbox(&bands);
+        if bands.len() < 3 {
+            println!(
+                "{:<20} bands={:<2} ctrl {cw}x{ch} — below the 3-band floor  {dims:?}",
+                c.label,
+                bands.len(),
+            );
+            continue;
+        }
+        ge3 += 1;
+        let ctrl_area = (cw as i64) * (ch as i64);
+        let mut cells = String::new();
+        for (i, &cap) in caps.iter().enumerate() {
+            match rfc058_best_pack(&bands, GAP, cap) {
+                Some((area, w, h, _)) => {
+                    packable[i] += 1;
+                    cells.push_str(&format!(
+                        "  {cap}:1 {w}x{h} ({:+.0}%)",
+                        (area - ctrl_area) as f64 / ctrl_area as f64 * 100.0,
+                    ));
+                }
+                None => cells.push_str(&format!("  {cap}:1 —")),
+            }
+        }
+        println!("{:<20} bands={:<2} ctrl {cw}x{ch}{cells}  {dims:?}", c.label, bands.len());
+    }
+
+    let n = cases.len();
+    let pct = |k: usize| k as f64 / n as f64 * 100.0;
+    println!("\n=== RFC-058 KC2: reach over the e2e corpus ===");
+    println!("  corpus rows: {n} ({built} built; refusals stay in the denominator)");
+    println!("  >=3 bands: {ge3}/{n} ({:.0}%)", pct(ge3));
+    for (i, cap) in caps.iter().enumerate() {
+        println!(
+            "  >=3 bands AND packable at {cap}:1: {}/{n} ({:.0}%) — KC2 bar is 30%",
+            packable[i],
+            pct(packable[i]),
+        );
+    }
 }

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -5268,7 +5268,9 @@ fn rfc058_band_packing_premise_holds() {
 /// `fulgora_scrap_sorter_mechanism_present` needs the recycling-aware
 /// `solve_fulgora` path, and `cable13u_bridged_row_lane_throughput_clean`
 /// solves at `QualityTier::Uncommon` — so "every distinct request" is
-/// exact only over default-quality, non-recycling solves.
+/// exact only over default-quality, non-recycling solves. (The Legendary
+/// leg of `quality_differential_ec_normal_vs_legendary` is excluded the
+/// same way; its Normal leg is the `ec4-plate-am3-red` row.)
 ///
 /// KC2 asks what fraction of this corpus has >=3 bands and no
 /// width-dominant band. The aspect cap is consequential (it alone refuses
@@ -5315,6 +5317,7 @@ fn probe_band_census_e2e_corpus() {
         Case { label: "gear20-plate", source: "tier1_iron_gear_wheel_20s", item: "iron-gear-wheel", rate: 20.0, machine: A2, belt: None, inputs: &["iron-plate"], excluded: &[] },
         Case { label: "ec10-plate", source: "tier2_electronic_circuit", item: "electronic-circuit", rate: 10.0, machine: A2, belt: None, inputs: &["iron-plate", "copper-plate"], excluded: &[] },
         Case { label: "ec10-plate-am1-red", source: "tier2_electronic_circuit_splitter_stamp_regression", item: "electronic-circuit", rate: 10.0, machine: A1, belt: RED, inputs: &["iron-plate", "copper-plate"], excluded: &[] },
+        Case { label: "ec4-plate-am3-red", source: "quality_differential_ec_normal_vs_legendary (Normal leg)", item: "electronic-circuit", rate: 4.0, machine: A3, belt: RED, inputs: &["iron-plate", "copper-plate"], excluded: &[] },
         Case { label: "ec10-ore-yellow", source: "tier2_electronic_circuit_from_ore", item: "electronic-circuit", rate: 10.0, machine: A1, belt: YELLOW, inputs: ORES, excluded: &[] },
         Case { label: "ec20-ore", source: "tier2_electronic_circuit_20s_from_ore", item: "electronic-circuit", rate: 20.0, machine: A2, belt: None, inputs: ORES, excluded: &[] },
         Case { label: "plastic10-gas", source: "tier3_plastic_bar", item: "plastic-bar", rate: 10.0, machine: CHEM, belt: None, inputs: &["petroleum-gas", "coal"], excluded: &[] },

--- a/docs/rfc-058-band-packing.md
+++ b/docs/rfc-058-band-packing.md
@@ -1,6 +1,7 @@
 # RFC-058: Band packing — 2D placement at row granularity
 
-Registry: [`rfcs.md`](rfcs.md). Status: **Active (Phase 0)**.
+Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phase 0 complete (KC2
+cleared 2026-07-31 at 37.5% against the 30% bar); Phase 3 trunk spike next.**
 Tracking: [#507](https://github.com/storkme/spaghettio/issues/507).
 
 ## Summary
@@ -203,7 +204,8 @@ its gates — same discipline as `compact_layout`.
 2. **Reach is too narrow.** If fewer than **30%** of the e2e corpus has ≥3
    bands and no width-dominant band, the technique cannot pay for its
    complexity regardless of how well it works where it applies. Measure this
-   in Phase 0, before writing the packer.
+   in Phase 0, before writing the packer. *(Evaluated 2026-07-31: cleared at
+   37.5%, cap-insensitive across 3:1–4:1 — see decision log.)*
 3. **Correctness regression that isn't mechanical.** If packed candidates
    validate worse than their controls (new categories, or higher counts in any
    category) and the cause is not a mechanical record-relocation fix, stop.
@@ -431,3 +433,37 @@ clears. Rationale in the decision log.
   measurement, not a packer tuning knob. Nothing about the gates changes —
   KC2 is still evaluated at phase 0, KC1 still at the spike, and all three
   gate fixtures are still required before phase 4 starts.
+
+- **2026-07-31 — Phase 0 complete: KC2 clears at 37.5%, and the aspect cap
+  turns out not to matter on the real corpus.** The census
+  (`probe_band_census_e2e_corpus` in `crates/core/tests/cell_composition.rs`)
+  transcribes every distinct production request exercised by a non-ignored
+  test in `e2e.rs` — 40 rows; the inclusion rule lives in the test's doc
+  comment. One consequence worth naming: `pu1-plate`, a KC1 gate fixture, is
+  **not** in KC2's denominator, because its owning e2e test
+  (`pipe_belt_processing_unit_1s_routes`) is `#[ignore]`d.
+
+  All 40 rows built. 22/40 (55%) have ≥3 bands; **15/40 (37.5%) also pack,
+  against the 30% bar**. The sweep (3.0 / 3.5 / 4.0) changes nothing — 15/40
+  at every cap. The probe-corpus concern (`insert3-ore` refused at 3.16:1)
+  does not generalise: on the e2e corpus every ≥3-band fixture either packs
+  inside 3:1 or is width-dominant beyond 4:1. The 3:1 default stands and the
+  sweep obligation from the reorder entry is discharged.
+
+  Two honesty notes on the margin. First, one packable row (`ec10-plate`, 3
+  bands, 30×15 control) packs at exactly ±0%; KC2's wording counts it, but
+  excluding zero-gain rows gives 14/40 (35%) — the verdict does not hinge on
+  it. Second, this is one machine's geometry (see the sensitivity entry
+  above); the margin is 3 fixtures, and the packable set is dominated by
+  deep multi-band fixtures (8–85 bands) whose candidacy small band-count
+  jitter cannot flip, so the second-machine re-run is not being demanded.
+
+  Findings that shape later phases: width-dominance is the *entire* failure
+  mode among candidates (7/22 — `ec20-ore`, `ac4/5/7-nauvis`, `ac45-plates`,
+  `pu2-ore-hs`, `pu2.5-plates-hs`; widest bands 97–692 tiles, all smelter or
+  assembler mega-rows), which sharpens the case for a separate wide-band RFC.
+  The winners are deep and save −63% to −81% (`pu20-plates`: 85 bands,
+  145×735 → 166×124), consistent with the probe corpus. And band extraction
+  has a benign artifact — `ec10-plate` yields a 1-tall inserter-only band
+  [(30,5), (20,1), (21,5)] — to keep in mind when phase 1 makes `RowSpan`
+  the source of truth.

--- a/docs/rfc-058-band-packing.md
+++ b/docs/rfc-058-band-packing.md
@@ -1,7 +1,7 @@
 # RFC-058: Band packing — 2D placement at row granularity
 
 Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phase 0 complete (KC2
-cleared 2026-07-31 at 37.8% against the 30% bar); Phase 3 trunk spike next.**
+cleared 2026-07-31 at 36.8% against the 30% bar); Phase 3 trunk spike next.**
 Tracking: [#507](https://github.com/storkme/spaghettio/issues/507).
 
 ## Summary
@@ -205,7 +205,7 @@ its gates — same discipline as `compact_layout`.
    bands and no width-dominant band, the technique cannot pay for its
    complexity regardless of how well it works where it applies. Measure this
    in Phase 0, before writing the packer. *(Evaluated 2026-07-31: cleared at
-   37.8%, cap-insensitive across 3:1–4:1 — see decision log.)*
+   36.8%, cap-insensitive across 3:1–4:1 — see decision log.)*
 3. **Correctness regression that isn't mechanical.** If packed candidates
    validate worse than their controls (new categories, or higher counts in any
    category) and the cause is not a mechanical record-relocation fix, stop.
@@ -434,25 +434,26 @@ clears. Rationale in the decision log.
   KC2 is still evaluated at phase 0, KC1 still at the spike, and all three
   gate fixtures are still required before phase 4 starts.
 
-- **2026-07-31 — Phase 0 complete: KC2 clears at 37.8%, and the aspect cap
+- **2026-07-31 — Phase 0 complete: KC2 clears at 36.8%, and the aspect cap
   turns out not to matter on the real corpus.** The census
   (`probe_band_census_e2e_corpus` in `crates/core/tests/cell_composition.rs`)
   transcribes every distinct production request exercised by a non-ignored
-  test in `e2e.rs` — 37 rows; the inclusion rule lives in the test's doc
+  test in `e2e.rs` — 38 rows; the inclusion rule lives in the test's doc
   comment. Two consequences worth naming. `pu1-plate`, a KC1 gate fixture,
   is **not** in KC2's denominator, because its owning e2e test
   (`pipe_belt_processing_unit_1s_routes`) is `#[ignore]`d. And the rule cuts
   the numerator too: `pu20-plates` — measured during the census as an
   85-band packable winner at −81% (145×735 → 166×124) — is excluded the
   same way, so it stands as evidence that reach extends beyond the counted
-  corpus, not as part of the 37.8%. (The first transcription violated its
+  corpus, not as part of the 36.8%. (The first transcription violated its
   own rule on 4 rows — three ignored stress tests and one ignored fixture
-  source — and claimed completeness while missing three expressible or
-  named-inexpressible requests; the #516 review caught both, and the
-  numbers here are from the corrected 37-row corpus.)
+  source — and claimed completeness while missing expressible requests; two
+  rounds of #516 review caught all of it, the second round by auditing
+  every remaining non-ignored test. The numbers here are from the corrected
+  38-row corpus.)
 
-  All 37 rows built. 19/37 (51%) have ≥3 bands; **14/37 (37.8%) also pack,
-  against the 30% bar**. The sweep (3.0 / 3.5 / 4.0) changes nothing — 14/37
+  All 38 rows built. 19/38 (50%) have ≥3 bands; **14/38 (36.8%) also pack,
+  against the 30% bar**. The sweep (3.0 / 3.5 / 4.0) changes nothing — 14/38
   at every cap. The probe-corpus concern (`insert3-ore` refused at 3.16:1)
   does not generalise: on the e2e corpus every ≥3-band fixture either packs
   inside 3:1 or is width-dominant beyond 4:1. The 3:1 default stands and the
@@ -460,17 +461,17 @@ clears. Rationale in the decision log.
 
   Two honesty notes on the margin. First, one packable row (`ec10-plate`, 3
   bands, 30×15 control) packs at exactly ±0%; KC2's wording counts it, but
-  excluding zero-gain rows gives 13/37 (35.1%) — the verdict does not hinge
+  excluding zero-gain rows gives 13/38 (34.2%) — the verdict does not hinge
   on it. Second, this is one machine's geometry (see the sensitivity entry
-  above); the margin is ~3 fixtures, and the packable set is dominated by
+  above); the margin is ~2.6 fixtures, and the packable set is dominated by
   deep multi-band fixtures (8–23 bands) whose candidacy small band-count
   jitter cannot flip, so the second-machine re-run is not being demanded.
 
   Findings that shape later phases: width-dominance is the *entire* failure
-  mode among candidates (5/19 — `ec20-ore`, `ac4-nauvis`, `ac5-nauvis`,
-  `pu2-ore-hs`, `pu2.5-plates-hs`; widest bands 96–692 tiles, all smelter or
-  assembler mega-rows), which sharpens the case for a separate wide-band
-  RFC. Belt tier shapes candidacy more than rate does: `ac7-nauvis-yellow`
+  mode among ≥3-band candidates (5/19 — `ec20-ore`, `ac4-nauvis`,
+  `ac5-nauvis`, `pu2-ore-hs`, `pu2.5-plates-hs`; widest bands 96–692 tiles,
+  all smelter or assembler mega-rows), which sharpens the case for a
+  separate wide-band RFC. Belt tier shapes candidacy more than rate does: `ac7-nauvis-yellow`
   (the yellow-capped AC@7) splits into 16 narrow bands and packs at −78%,
   while the uncapped ignored variant of the same request is a 169-wide
   monolith. In-corpus winners save −63% to −78% (`ac7-nauvis-yellow` 16

--- a/docs/rfc-058-band-packing.md
+++ b/docs/rfc-058-band-packing.md
@@ -1,7 +1,7 @@
 # RFC-058: Band packing — 2D placement at row granularity
 
 Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phase 0 complete (KC2
-cleared 2026-07-31 at 37.5% against the 30% bar); Phase 3 trunk spike next.**
+cleared 2026-07-31 at 37.8% against the 30% bar); Phase 3 trunk spike next.**
 Tracking: [#507](https://github.com/storkme/spaghettio/issues/507).
 
 ## Summary
@@ -205,7 +205,7 @@ its gates — same discipline as `compact_layout`.
    bands and no width-dominant band, the technique cannot pay for its
    complexity regardless of how well it works where it applies. Measure this
    in Phase 0, before writing the packer. *(Evaluated 2026-07-31: cleared at
-   37.5%, cap-insensitive across 3:1–4:1 — see decision log.)*
+   37.8%, cap-insensitive across 3:1–4:1 — see decision log.)*
 3. **Correctness regression that isn't mechanical.** If packed candidates
    validate worse than their controls (new categories, or higher counts in any
    category) and the cause is not a mechanical record-relocation fix, stop.
@@ -434,17 +434,25 @@ clears. Rationale in the decision log.
   KC2 is still evaluated at phase 0, KC1 still at the spike, and all three
   gate fixtures are still required before phase 4 starts.
 
-- **2026-07-31 — Phase 0 complete: KC2 clears at 37.5%, and the aspect cap
+- **2026-07-31 — Phase 0 complete: KC2 clears at 37.8%, and the aspect cap
   turns out not to matter on the real corpus.** The census
   (`probe_band_census_e2e_corpus` in `crates/core/tests/cell_composition.rs`)
   transcribes every distinct production request exercised by a non-ignored
-  test in `e2e.rs` — 40 rows; the inclusion rule lives in the test's doc
-  comment. One consequence worth naming: `pu1-plate`, a KC1 gate fixture, is
-  **not** in KC2's denominator, because its owning e2e test
-  (`pipe_belt_processing_unit_1s_routes`) is `#[ignore]`d.
+  test in `e2e.rs` — 37 rows; the inclusion rule lives in the test's doc
+  comment. Two consequences worth naming. `pu1-plate`, a KC1 gate fixture,
+  is **not** in KC2's denominator, because its owning e2e test
+  (`pipe_belt_processing_unit_1s_routes`) is `#[ignore]`d. And the rule cuts
+  the numerator too: `pu20-plates` — measured during the census as an
+  85-band packable winner at −81% (145×735 → 166×124) — is excluded the
+  same way, so it stands as evidence that reach extends beyond the counted
+  corpus, not as part of the 37.8%. (The first transcription violated its
+  own rule on 4 rows — three ignored stress tests and one ignored fixture
+  source — and claimed completeness while missing three expressible or
+  named-inexpressible requests; the #516 review caught both, and the
+  numbers here are from the corrected 37-row corpus.)
 
-  All 40 rows built. 22/40 (55%) have ≥3 bands; **15/40 (37.5%) also pack,
-  against the 30% bar**. The sweep (3.0 / 3.5 / 4.0) changes nothing — 15/40
+  All 37 rows built. 19/37 (51%) have ≥3 bands; **14/37 (37.8%) also pack,
+  against the 30% bar**. The sweep (3.0 / 3.5 / 4.0) changes nothing — 14/37
   at every cap. The probe-corpus concern (`insert3-ore` refused at 3.16:1)
   does not generalise: on the e2e corpus every ≥3-band fixture either packs
   inside 3:1 or is width-dominant beyond 4:1. The 3:1 default stands and the
@@ -452,18 +460,21 @@ clears. Rationale in the decision log.
 
   Two honesty notes on the margin. First, one packable row (`ec10-plate`, 3
   bands, 30×15 control) packs at exactly ±0%; KC2's wording counts it, but
-  excluding zero-gain rows gives 14/40 (35%) — the verdict does not hinge on
-  it. Second, this is one machine's geometry (see the sensitivity entry
-  above); the margin is 3 fixtures, and the packable set is dominated by
-  deep multi-band fixtures (8–85 bands) whose candidacy small band-count
+  excluding zero-gain rows gives 13/37 (35.1%) — the verdict does not hinge
+  on it. Second, this is one machine's geometry (see the sensitivity entry
+  above); the margin is ~3 fixtures, and the packable set is dominated by
+  deep multi-band fixtures (8–23 bands) whose candidacy small band-count
   jitter cannot flip, so the second-machine re-run is not being demanded.
 
   Findings that shape later phases: width-dominance is the *entire* failure
-  mode among candidates (7/22 — `ec20-ore`, `ac4/5/7-nauvis`, `ac45-plates`,
-  `pu2-ore-hs`, `pu2.5-plates-hs`; widest bands 97–692 tiles, all smelter or
-  assembler mega-rows), which sharpens the case for a separate wide-band RFC.
-  The winners are deep and save −63% to −81% (`pu20-plates`: 85 bands,
-  145×735 → 166×124), consistent with the probe corpus. And band extraction
-  has a benign artifact — `ec10-plate` yields a 1-tall inserter-only band
-  [(30,5), (20,1), (21,5)] — to keep in mind when phase 1 makes `RowSpan`
-  the source of truth.
+  mode among candidates (5/19 — `ec20-ore`, `ac4-nauvis`, `ac5-nauvis`,
+  `pu2-ore-hs`, `pu2.5-plates-hs`; widest bands 96–692 tiles, all smelter or
+  assembler mega-rows), which sharpens the case for a separate wide-band
+  RFC. Belt tier shapes candidacy more than rate does: `ac7-nauvis-yellow`
+  (the yellow-capped AC@7) splits into 16 narrow bands and packs at −78%,
+  while the uncapped ignored variant of the same request is a 169-wide
+  monolith. In-corpus winners save −63% to −78% (`ac7-nauvis-yellow` 16
+  bands, `pu2-ore-red` 23 bands at −77%), consistent with the probe corpus.
+  And band extraction has a benign artifact — `ec10-plate` yields a 1-tall
+  inserter-only band [(30,5), (20,1), (21,5)] — to keep in mind when phase 1
+  makes `RowSpan` the source of truth.

--- a/docs/rfc-058-band-packing.md
+++ b/docs/rfc-058-band-packing.md
@@ -1,6 +1,6 @@
 # RFC-058: Band packing — 2D placement at row granularity
 
-Registry: [`rfcs.md`](rfcs.md). Status: **Design (circulated for review)**.
+Registry: [`rfcs.md`](rfcs.md). Status: **Active (Phase 0)**.
 Tracking: [#507](https://github.com/storkme/spaghettio/issues/507).
 
 ## Summary
@@ -246,11 +246,18 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
 ## Phasing
 
 0. **Reach measurement** — band census across the e2e corpus. Answers kill
-   criterion 2 before any packer exists.
+   criterion 2 before any packer exists. Carries the aspect-cap sweep
+   originally assigned to phase 2: the cap changes KC2's applicable-fixture
+   count, so it belongs with KC2's measurement (reordered 2026-07-31, see
+   decision log).
 1. **Band extraction from `RowSpan`** — placer-native, replacing the probe's
-   y-projection. No behaviour change.
+   y-projection. No behaviour change. **Deferred until the phase-3 gate
+   clears** (2026-07-31 reorder).
 2. **Packer** — shelf packing with aspect cap and swept target width, behind a
    default-off flag. Emits positions only; nothing consumes them yet.
+   **Deferred until the phase-3 gate clears** (2026-07-31 reorder): the spike
+   consumes the probe's own packed positions, so the production packer is
+   scaffolding that only pays off if the premise survives.
 3. **Trunk spike — throwaway code, all three gate fixtures.** Route trunks for
    the packed layouts with whatever is quickest and measure real bounding-box
    area and real transport against each control. Start with `sci1-ore` (4
@@ -280,6 +287,11 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
 Phases 0–2 are cheap, land independently, and are not evidence. Phase 3 is the
 gate: it is deliberately throwaway so that a negative result costs a day rather
 than the lane-planner rewrite.
+
+**Execution order (2026-07-31): 0 → 3 → 1 → 2 → 4 → 5 → 6.** The spike runs
+on the probe's packed positions, so phases 1 and 2 are not prerequisites for
+it — they are production scaffolding for phase 4, built only if the gate
+clears. Rationale in the decision log.
 
 ## Relationship to earlier RFCs
 
@@ -389,3 +401,33 @@ than the lane-planner rewrite.
 
   The 3:1 aspect cap is acknowledged as arbitrary and consequential — it alone
   refuses `insert3-ore` at 3.16:1 — with a sweep assigned to phase 2.
+
+- **2026-07-31 — band structure is host-geometry-relative; corpus aggregates
+  must be read like stress goldens.** Re-running the committed phase-0
+  instrument on a second machine, at the same commit with no core changes in
+  between, reproduced the three gate fixtures and the winners aggregate
+  exactly (−66.1% KC1 baseline, −64.5% winners, −38.1% transport) but
+  extracted **3 bands from `ec10-ore` where the #510 run saw 1**, moving the
+  corpus headline from −39.6% (7 multi-band) to −35.4% (8 multi-band).
+  Layout geometry is already known to vary with host SAT-cache state — the
+  reason stress goldens are never enforced in CI without pinning the cache —
+  and band extraction inherits that. Consequences: the premise-drift guard's
+  loose ≥50% bounds on the gate fixtures are the right shape (exact corpus
+  pins would flap across machines); phase 0's census reports KC2 as measured
+  on one named machine, not as a portable constant; and any KC2 result within
+  a few points of the 30% bar must be re-run on a second machine before the
+  criterion is called.
+
+- **2026-07-31 — execution order changed to 0 → 3 → 1 → 2 (phases 1–2
+  deferred behind the spike).** As circulated, the plan built the placer-native
+  band extractor and the flagged packer before the trunk spike. Both are
+  production scaffolding for phase 4, and the spike does not need them — it
+  consumes packed positions the phase-0 probe already computes. Building them
+  first would repeat, in miniature, the shape this RFC's own phasing section
+  criticises: cheap green work stacked ahead of the phase that can kill the
+  premise (RFC-057 died in its expensive phase after exactly that pattern).
+  The aspect-cap sweep moves from phase 2 into phase 0 for the same reason:
+  the cap changes KC2's applicable-fixture count, so it is part of KC2's
+  measurement, not a packer tuning knob. Nothing about the gates changes —
+  KC2 is still evaluated at phase 0, KC1 still at the spike, and all three
+  gate fixtures are still required before phase 4 starts.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,7 +69,7 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
-| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active (Phase 0) — 2D placement at ROW-BAND granularity; premise measured before writing: −39.6% band-bbox corpus-wide over 7 multi-band fixtures (−64.5% on the 4 where it applies), transport −38.1%, all obstacle-free. Execution reordered 2026-07-31: census → trunk spike (KC1 gate) → scaffolding. Tracking #507 |
+| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phase 0 complete 2026-07-31: **KC2 cleared at 37.5%** (15/40 e2e-corpus rows ≥3 bands and packable, bar 30%, cap-insensitive 3:1–4:1); packable winners save −63% to −81% band-bbox. Next: Phase 3 trunk spike (KC1). Tracking #507 |
 | RFC-059 | 2026-07-30 | [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; DI spec→cell contention is a matching problem, not a walk order; phase 1 must first establish a reproducible rate |
 
 Next number: **RFC-060**.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,7 +69,7 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
-| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Design (circulated for review) — 2D placement at ROW-BAND granularity; premise measured before writing: −39.6% band-bbox corpus-wide over 7 multi-band fixtures (−64.5% on the 4 where it applies), transport −38.1%, all obstacle-free. Tracking #507 |
+| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active (Phase 0) — 2D placement at ROW-BAND granularity; premise measured before writing: −39.6% band-bbox corpus-wide over 7 multi-band fixtures (−64.5% on the 4 where it applies), transport −38.1%, all obstacle-free. Execution reordered 2026-07-31: census → trunk spike (KC1 gate) → scaffolding. Tracking #507 |
 | RFC-059 | 2026-07-30 | [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; DI spec→cell contention is a matching problem, not a walk order; phase 1 must first establish a reproducible rate |
 
 Next number: **RFC-060**.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,7 +69,7 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
-| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phase 0 complete 2026-07-31: **KC2 cleared at 37.5%** (15/40 e2e-corpus rows ≥3 bands and packable, bar 30%, cap-insensitive 3:1–4:1); packable winners save −63% to −81% band-bbox. Next: Phase 3 trunk spike (KC1). Tracking #507 |
+| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phase 0 complete 2026-07-31: **KC2 cleared at 37.8%** (14/37 e2e-corpus rows ≥3 bands and packable, bar 30%, cap-insensitive 3:1–4:1); in-corpus winners save −63% to −78% band-bbox. Next: Phase 3 trunk spike (KC1). Tracking #507 |
 | RFC-059 | 2026-07-30 | [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; DI spec→cell contention is a matching problem, not a walk order; phase 1 must first establish a reproducible rate |
 
 Next number: **RFC-060**.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,7 +69,7 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
-| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phase 0 complete 2026-07-31: **KC2 cleared at 37.8%** (14/37 e2e-corpus rows ≥3 bands and packable, bar 30%, cap-insensitive 3:1–4:1); in-corpus winners save −63% to −78% band-bbox. Next: Phase 3 trunk spike (KC1). Tracking #507 |
+| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phase 0 complete 2026-07-31: **KC2 cleared at 36.8%** (14/38 e2e-corpus rows ≥3 bands and packable, bar 30%, cap-insensitive 3:1–4:1); in-corpus winners save −63% to −78% band-bbox. Next: Phase 3 trunk spike (KC1). Tracking #507 |
 | RFC-059 | 2026-07-30 | [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; DI spec→cell contention is a matching problem, not a walk order; phase 1 must first establish a reproducible rate |
 
 Next number: **RFC-060**.


### PR DESCRIPTION
## Intent

RFC-058's kill criterion 2 required a band census over the real e2e corpus before any packer exists — the RFC's 40–50% reach figure was measured on ten hand-picked fixtures and explicitly not treated as settled. This PR runs Phase 0 and records the verdict: **KC2 clears at 36.8%** (14/38 rows with ≥3 bands and a packing inside the aspect cap, bar 30%), identical at caps 3.0/3.5/4.0. It also adopts the evidence-first execution reorder (0 → 3 → 1 → 2) in the decision log: the phase-3 trunk spike consumes the probe's packed positions, so the placer-native extractor and flagged packer are deferred until the KC1 gate clears.

## Scope

- **In:**
  - `probe_band_census_e2e_corpus` (#[ignore], ~7 min release): 38 distinct production requests transcribed from non-ignored `e2e.rs` tests, built on the default bus path with each source test's belt tier and recipe exclusions; per-fixture band dims + packability as a function of aspect cap; refusals stay in the KC2 denominator.
  - Band helpers lifted to module level (`Rfc058Band`, `rfc058_extract_bands/_bbox/_shelf_pack/_best_pack`), shared by both probes.
  - RFC-058 decision-log entries: phase reorder, host-geometry sensitivity (ec10-ore extracts 1 vs 3 bands across machines; corpus headline −39.6% vs −35.4%), and the Phase 0 verdict with its margins and the zero-gain `ec10-plate` caveat. Registry row updated.
- **Out:** the trunk spike (next unit, carries KC1), phases 1–2 (deferred behind the spike per the reorder), any engine behaviour change — this PR is test + docs only.

## Verification

- `probe_band_packing_headroom` output verified **line-for-line identical** before/after the helper lift (same fixtures, same aggregates: −35.4% corpus / −64.5% winners / −66.1% KC1 baseline on this machine).
- `rfc058_band_packing_premise_holds` (CI guard) passes; it deliberately keeps its own self-contained helper copy so a defect in the shared helpers cannot blind it.
- Census run in release: 38/38 rows built, results transcribed verbatim into the decision log.
- `cargo clippy -p spaghettio_core -- -D warnings` clean (the pre-commit hook's invocation).
- Full e2e suite not re-run: no `crates/core/src` change; the only Rust touched is an `#[ignore]`d probe + helper lift inside `tests/cell_composition.rs`, and the two affected tests were run directly (above).

## Deviations from intent

Phase 0 was specified as "band census across the e2e corpus"; the aspect-cap sweep originally assigned to phase 2 was folded in, because the cap changes KC2's denominator. That reorder and the census inclusion rule (non-ignored tests only — which excludes gate fixture `pu1-plate` from KC2's denominator) are recorded as decision-log entries rather than silent choices.

## Models / contracts touched

None in code. `docs/rfc-058-band-packing.md` decision log + status, `docs/rfcs.md` registry row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mbi9vxoH7RMPfkGaMY8SaG

