### PR TITLE
RFC-058 Phase 3: trunk spike — KC1 clears at −35.9%, narrowly

### DIFF
--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -5425,3 +5425,396 @@ fn probe_band_census_e2e_corpus() {
         );
     }
 }
+
+/// RFC-058 Phase 3: the trunk spike — kill criterion 1's gate, on all three
+/// gate fixtures.
+///
+/// Phases 0–2 are cheap and prove nothing about whether trunks fit; this is
+/// the deliberately-throwaway measurement that does. Bands are packed with
+/// `rfc058_best_pack` (the phase-0 packer, 3:1 cap), then every band-to-band
+/// item flow is routed as a real 1-tile corridor with A*:
+///
+/// - band rectangles are opaque obstacles;
+/// - corridors may cross each other only PERPENDICULARLY (the underground
+///   dive every real bus crossing uses); same-axis overlap is forbidden, and
+///   corner tiles are hard-blocked for everyone (a UG cannot dive through a
+///   turn);
+/// - every band gets REAL full-width belt rows reserved before any routing:
+///   `ceil(distinct inputs / 2)` feed rows above it (a belt carries two
+///   lanes, so two items per feed row — the dual-input row template's
+///   capability; fluids count as inputs too, a pipe row being no thinner)
+///   and one output row below. This is the row's shared-belt structure the
+///   RFC's premise rests on, and it is what a single-tile-termination model
+///   would silently omit. Reserved rows count as transport tiles;
+/// - a flow STARTS on its producer's output row and terminates on any tile
+///   of its consumer's feed rows (a sideload/merge point). Inserter-column
+///   specificity, splitters and poles are out of scope, and every flow gets
+///   exactly ONE lane (all gate-fixture flows are far below one belt's
+///   capacity);
+/// - external inputs enter from the arrangement's west edge, the target item
+///   exits east — matching the control bus's edge-fed shape;
+/// - if any flow fails to route, or a band's reserved rows collide with a
+///   neighbouring band, the whole arrangement is re-packed with a wider gap
+///   (2 → 8) and every flow re-routed from scratch.
+///
+/// The score is the REAL bounding box — band rects plus every corridor tile —
+/// against the control's as-placed band-bbox, the same quantity kill
+/// criterion 1's 10,729-tile baseline is measured in. KC1: the three-fixture
+/// aggregate saving must beat −33.0% (half the obstacle-free −66.1%).
+///
+/// Like every RFC-058 number, host-geometry-relative; the KC1 verdict is
+/// recorded in the RFC decision log with the machine it was measured on.
+#[test]
+#[ignore = "RFC-058 Phase 3 trunk spike — run with --ignored --nocapture"]
+fn probe_trunk_spike_gate_fixtures() {
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+
+    // One aggregated item flow between two bands (or an edge, when None).
+    #[derive(Clone, Debug)]
+    struct Flow {
+        item: String,
+        src: Option<usize>,
+        dst: Option<usize>,
+        rate: f64,
+    }
+
+    // Occupancy bits per tile.
+    const BAND: u8 = 1;
+    const HCOR: u8 = 2;
+    const VCOR: u8 = 4;
+    const TURN: u8 = 8;
+
+    struct Grid {
+        occ: FxHashMap<(i32, i32), u8>,
+        min: (i32, i32),
+        max: (i32, i32),
+    }
+
+    impl Grid {
+        fn passable(&self, t: (i32, i32), horizontal: bool) -> bool {
+            if t.0 < self.min.0 || t.0 > self.max.0 || t.1 < self.min.1 || t.1 > self.max.1 {
+                return false;
+            }
+            let bits = self.occ.get(&t).copied().unwrap_or(0);
+            if bits & (BAND | TURN) != 0 {
+                return false;
+            }
+            let axis = if horizontal { HCOR } else { VCOR };
+            bits & axis == 0
+        }
+    }
+
+    // Multi-source, multi-target A* returning the path, or None. Visited
+    // state is (tile, entry axis) because crossing legality depends on the
+    // axis a corridor occupies a tile with.
+    fn route(
+        grid: &Grid,
+        starts: &[(i32, i32)],
+        targets: &FxHashSet<(i32, i32)>,
+        goal_hint: (i32, i32),
+    ) -> Option<Vec<(i32, i32)>> {
+        let h = |t: (i32, i32)| (t.0 - goal_hint.0).abs() + (t.1 - goal_hint.1).abs();
+        let mut open: BinaryHeap<Reverse<(i32, i32, (i32, i32), bool)>> = BinaryHeap::new();
+        let mut best: FxHashMap<((i32, i32), bool), i32> = FxHashMap::default();
+        let mut parent: FxHashMap<((i32, i32), bool), ((i32, i32), bool)> = FxHashMap::default();
+        for &s in starts {
+            for horizontal in [true, false] {
+                if !grid.passable(s, horizontal) {
+                    continue;
+                }
+                if best.get(&(s, horizontal)).is_none_or(|&c| c > 0) {
+                    best.insert((s, horizontal), 0);
+                    open.push(Reverse((h(s), 0, s, horizontal)));
+                }
+            }
+        }
+        while let Some(Reverse((_, cost, tile, horizontal))) = open.pop() {
+            if best.get(&(tile, horizontal)).copied().unwrap_or(i32::MAX) < cost {
+                continue;
+            }
+            if targets.contains(&tile) {
+                let mut path = vec![tile];
+                let mut cur = (tile, horizontal);
+                while let Some(&p) = parent.get(&cur) {
+                    path.push(p.0);
+                    cur = p;
+                }
+                path.reverse();
+                return Some(path);
+            }
+            for (dx, dy) in [(1, 0), (-1, 0), (0, 1), (0, -1)] {
+                let next = (tile.0 + dx, tile.1 + dy);
+                let next_h = dy == 0;
+                if !grid.passable(next, next_h) {
+                    continue;
+                }
+                let ncost = cost + 1;
+                if best.get(&(next, next_h)).copied().unwrap_or(i32::MAX) <= ncost {
+                    continue;
+                }
+                best.insert((next, next_h), ncost);
+                parent.insert((next, next_h), (tile, horizontal));
+                open.push(Reverse((ncost + h(next), ncost, next, next_h)));
+            }
+        }
+        None
+    }
+
+    // Stamp a routed path: each tile takes the axis it is traversed on;
+    // a tile where the axis changes is a corner and blocks everything.
+    fn stamp(grid: &mut Grid, path: &[(i32, i32)]) {
+        for (i, &t) in path.iter().enumerate() {
+            let axis_in = if i > 0 { Some(path[i - 1].1 == t.1) } else { None };
+            let axis_out = if i + 1 < path.len() { Some(path[i + 1].1 == t.1) } else { None };
+            let bits = grid.occ.entry(t).or_insert(0);
+            match (axis_in, axis_out) {
+                (Some(a), Some(b)) if a != b => *bits |= TURN,
+                (Some(a), _) | (_, Some(a)) => *bits |= if a { HCOR } else { VCOR },
+                (None, None) => {}
+            }
+        }
+    }
+
+    let gate: &[(&str, &str, f64, &[&str], &str)] = &[
+        ("sci1-ore", "automation-science-pack", 1.0, &["iron-ore", "copper-ore"], "assembling-machine-1"),
+        ("sci2-ore", "logistic-science-pack", 2.0, &["iron-ore", "copper-ore"], "assembling-machine-2"),
+        ("pu1-plate", "processing-unit", 1.0, &["iron-plate", "copper-plate", "sulfuric-acid"], "assembling-machine-2"),
+    ];
+
+    let (mut agg_ctrl, mut agg_real) = (0i64, 0i64);
+
+    for (label, item, rate, inputs, machine) in gate {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item,
+            *rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            machine,
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap_or_else(|e| panic!("{label}: solver refused: {e}"));
+        let l = layout::build_bus_layout(&sr, layout::LayoutOptions::default())
+            .unwrap_or_else(|e| panic!("{label}: layout refused: {e}"));
+        let bands = rfc058_extract_bands(&l);
+        let (cw, ch) = rfc058_bbox(&bands);
+        let ctrl_area = (cw as i64) * (ch as i64);
+
+        // Aggregate flows at (src band, dst band, item) granularity from the
+        // solver's machine specs, splitting a recipe's demand evenly across
+        // the bands that carry it — the same convention as the probe's
+        // transport proxy. Producer selection (nearest by centre) happens
+        // per packing attempt, because "nearest" changes when bands move.
+        let mut item_producers: FxHashMap<&str, Vec<usize>> = FxHashMap::default();
+        for spec in &sr.machines {
+            for out in &spec.outputs {
+                for (i, b) in bands.iter().enumerate() {
+                    if b.recipes.iter().any(|r| r == &spec.recipe) {
+                        item_producers.entry(out.item.as_str()).or_default().push(i);
+                    }
+                }
+            }
+        }
+        let target_producers: Vec<usize> = sr
+            .external_outputs
+            .iter()
+            .flat_map(|out| item_producers.get(out.item.as_str()).cloned().unwrap_or_default())
+            .collect();
+
+        let mut demand: Vec<(usize, String, f64)> = Vec::new();
+        for spec in &sr.machines {
+            let consumers: Vec<usize> = bands
+                .iter()
+                .enumerate()
+                .filter(|(_, b)| b.recipes.iter().any(|r| r == &spec.recipe))
+                .map(|(i, _)| i)
+                .collect();
+            if consumers.is_empty() {
+                continue;
+            }
+            for inp in &spec.inputs {
+                let per = inp.rate * spec.count / consumers.len() as f64;
+                for &ci in &consumers {
+                    demand.push((ci, inp.item.clone(), per));
+                }
+            }
+        }
+
+        // Widen the packing gap until every flow routes. GAP starts at the
+        // probe's 2; each retry re-packs and re-routes everything.
+        let mut solved: Option<(i32, i64, i64, usize, usize, usize)> = None;
+        'gaps: for gap in 2..=8 {
+            let Some((_, _, _, packed)) = rfc058_best_pack(&bands, gap, 3.0) else {
+                continue;
+            };
+
+            let bmin_x = packed.iter().map(|b| b.x).min().unwrap();
+            let bmin_y = packed.iter().map(|b| b.y).min().unwrap();
+            let bmax_x = packed.iter().map(|b| b.x + b.w - 1).max().unwrap();
+            let bmax_y = packed.iter().map(|b| b.y + b.h - 1).max().unwrap();
+            let mut grid = Grid {
+                occ: FxHashMap::default(),
+                min: (bmin_x - 6, bmin_y - 6),
+                max: (bmax_x + 6, bmax_y + 6),
+            };
+            for b in &packed {
+                for x in b.x..b.x + b.w {
+                    for y in b.y..b.y + b.h {
+                        *grid.occ.entry((x, y)).or_insert(0) |= BAND;
+                    }
+                }
+            }
+
+            // Reserve each band's real belt rows BEFORE any through-routing:
+            // ceil(distinct inputs / 2) full-width feed rows above (two lanes
+            // per belt), one output row below. A reservation landing on a
+            // band tile, or on another band's reservation, means this gap
+            // cannot physically hold the rows the bands need — widen.
+            let mut band_inputs: Vec<FxHashSet<&str>> = vec![FxHashSet::default(); packed.len()];
+            for (ci, item, _) in &demand {
+                band_inputs[*ci].insert(item.as_str());
+            }
+            let feed_row_count = |i: usize| band_inputs[i].len().div_ceil(2) as i32;
+            let mut reserved_tiles = 0usize;
+            let mut reserve_ok = true;
+            'bands: for (i, b) in packed.iter().enumerate() {
+                let mut rows: Vec<i32> = (1..=feed_row_count(i)).map(|k| b.y - k).collect();
+                rows.push(b.y + b.h); // output row
+                for row in rows {
+                    for x in b.x..b.x + b.w {
+                        let bits = grid.occ.entry((x, row)).or_insert(0);
+                        if *bits & (BAND | HCOR) != 0 {
+                            reserve_ok = false;
+                            break 'bands;
+                        }
+                        *bits |= HCOR;
+                        reserved_tiles += 1;
+                    }
+                }
+            }
+            if !reserve_ok {
+                println!("{label}: gap {gap}: reserved belt rows collide — widening");
+                continue 'gaps;
+            }
+
+            // A producer's flows leave from its output row (or a 2-tile
+            // extension past either end — a belt extends); a consumer's
+            // flows arrive by sideloading anywhere onto its feed rows.
+            let out_row = |b: &Rfc058Band| -> Vec<(i32, i32)> {
+                (b.x - 2..b.x + b.w + 2).map(|x| (x, b.y + b.h)).collect()
+            };
+            let feed_tiles = |i: usize, b: &Rfc058Band| -> Vec<(i32, i32)> {
+                let mut v = Vec::new();
+                for k in 1..=feed_row_count(i) {
+                    for x in b.x..b.x + b.w {
+                        v.push((x, b.y - k));
+                    }
+                }
+                v
+            };
+            let centre = |b: &Rfc058Band| (b.x + b.w / 2, b.y + b.h / 2);
+
+            // Nearest-producer selection on the PACKED geometry, then one
+            // aggregated flow per (src, dst, item).
+            let mut flows: FxHashMap<(Option<usize>, Option<usize>, String), f64> =
+                FxHashMap::default();
+            for (ci, item, per) in &demand {
+                let src = item_producers.get(item.as_str()).and_then(|ps| {
+                    ps.iter()
+                        .filter(|&&pi| pi != *ci)
+                        .min_by_key(|&&pi| {
+                            let (px, py) = centre(&packed[pi]);
+                            let (cx, cy) = centre(&packed[*ci]);
+                            (px - cx).abs() + (py - cy).abs()
+                        })
+                        .copied()
+                });
+                if item_producers.contains_key(item.as_str()) && src.is_none() {
+                    continue; // self-supplied within the band
+                }
+                *flows.entry((src, Some(*ci), item.clone())).or_default() += per;
+            }
+            for &pi in &target_producers {
+                *flows
+                    .entry((Some(pi), None, format!("OUT:{item}")))
+                    .or_default() += *rate / target_producers.len().max(1) as f64;
+            }
+            let mut flows: Vec<Flow> = flows
+                .into_iter()
+                .map(|((src, dst, item), rate)| Flow { item, src, dst, rate })
+                .collect();
+            flows.sort_by(|a, b| {
+                b.rate
+                    .total_cmp(&a.rate)
+                    .then_with(|| a.item.cmp(&b.item))
+                    .then_with(|| a.dst.cmp(&b.dst))
+                    .then_with(|| a.src.cmp(&b.src))
+            });
+
+            let west: Vec<(i32, i32)> = (grid.min.1..=grid.max.1).map(|y| (grid.min.0, y)).collect();
+            let east: FxHashSet<(i32, i32)> =
+                (grid.min.1..=grid.max.1).map(|y| (grid.max.0, y)).collect();
+
+            let mut corridor_tiles = 0usize;
+            let n_flows = flows.len();
+            for f in &flows {
+                let starts: Vec<(i32, i32)> = match f.src {
+                    Some(pi) => out_row(&packed[pi]),
+                    None => west.clone(),
+                };
+                let (targets, hint): (FxHashSet<(i32, i32)>, (i32, i32)) = match f.dst {
+                    Some(ci) => (
+                        feed_tiles(ci, &packed[ci]).into_iter().collect(),
+                        centre(&packed[ci]),
+                    ),
+                    None => (east.clone(), (grid.max.0, (grid.min.1 + grid.max.1) / 2)),
+                };
+                let Some(path) = route(&grid, &starts, &targets, hint) else {
+                    println!(
+                        "{label}: gap {gap}: flow {} {:?}->{:?} failed to route — widening",
+                        f.item, f.src, f.dst,
+                    );
+                    continue 'gaps;
+                };
+                corridor_tiles += path.len();
+                stamp(&mut grid, &path);
+            }
+
+            // Real bbox: band rects plus every corridor tile.
+            let (mut lo_x, mut lo_y, mut hi_x, mut hi_y) = (bmin_x, bmin_y, bmax_x, bmax_y);
+            for (&(x, y), &bits) in &grid.occ {
+                if bits & (HCOR | VCOR | TURN) != 0 {
+                    lo_x = lo_x.min(x);
+                    lo_y = lo_y.min(y);
+                    hi_x = hi_x.max(x);
+                    hi_y = hi_y.max(y);
+                }
+            }
+            let real = ((hi_x - lo_x + 1) as i64) * ((hi_y - lo_y + 1) as i64);
+            solved = Some((gap, real, ctrl_area, n_flows, corridor_tiles, reserved_tiles));
+            break;
+        }
+
+        let Some((gap, real, ctrl, n_flows, corridor_tiles, reserved_tiles)) = solved else {
+            panic!("{label}: no gap in 2..=8 routes all flows — KC1 cannot be evaluated");
+        };
+        agg_ctrl += ctrl;
+        agg_real += real;
+        println!(
+            "{label:<10} ctrl {cw}x{ch}={ctrl}  packed+trunks {real} ({:+.1}%)  gap={gap} flows={n_flows} belt_rows={reserved_tiles} corridors={corridor_tiles}",
+            (real - ctrl) as f64 / ctrl as f64 * 100.0,
+        );
+    }
+
+    let saving = (agg_ctrl - agg_real) as f64 / agg_ctrl as f64 * 100.0;
+    println!("\n=== RFC-058 KC1 (trunk spike, three-fixture aggregate) ===");
+    println!(
+        "  control {agg_ctrl} -> packed+trunks {agg_real}  saving {saving:.1}%  (bar: 33.0%, obstacle-free estimate: 66.1%)"
+    );
+    println!(
+        "  KC1 {}",
+        if saving >= 33.0 { "CLEARS" } else { "FAILS — stop; do not re-tune the packer" }
+    );
+}

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -5512,9 +5512,19 @@ fn probe_trunk_spike_gate_fixtures() {
         grid: &Grid,
         starts: &[(i32, i32)],
         targets: &FxHashSet<(i32, i32)>,
-        goal_hint: (i32, i32),
     ) -> Option<Vec<(i32, i32)>> {
-        let h = |t: (i32, i32)| (t.0 - goal_hint.0).abs() + (t.1 - goal_hint.1).abs();
+        // Admissible heuristic: Manhattan distance to the targets' bounding
+        // rectangle. Every target lies inside the rect, so this never
+        // exceeds the true remaining cost and is 0 on every target tile —
+        // a hint-point heuristic here was inadmissible (h > 0 on targets)
+        // and could return non-shortest corridors.
+        let tx0 = targets.iter().map(|t| t.0).min().unwrap_or(0);
+        let tx1 = targets.iter().map(|t| t.0).max().unwrap_or(0);
+        let ty0 = targets.iter().map(|t| t.1).min().unwrap_or(0);
+        let ty1 = targets.iter().map(|t| t.1).max().unwrap_or(0);
+        let h = move |t: (i32, i32)| {
+            (tx0 - t.0).max(t.0 - tx1).max(0) + (ty0 - t.1).max(t.1 - ty1).max(0)
+        };
         let mut open: BinaryHeap<Reverse<(i32, i32, (i32, i32), bool)>> = BinaryHeap::new();
         let mut best: FxHashMap<((i32, i32), bool), i32> = FxHashMap::default();
         let mut parent: FxHashMap<((i32, i32), bool), ((i32, i32), bool)> = FxHashMap::default();
@@ -5547,6 +5557,14 @@ fn probe_trunk_spike_gate_fixtures() {
                 let next = (tile.0 + dx, tile.1 + dy);
                 let next_h = dy == 0;
                 if !grid.passable(next, next_h) {
+                    continue;
+                }
+                // Changing axis makes `tile` a corner, which occupies BOTH
+                // axes there — so the current tile must be free on the new
+                // axis too. Without this, a corridor could turn on top of a
+                // reserved belt row or another corridor's straight run it
+                // was only ever allowed to CROSS.
+                if next_h != horizontal && !grid.passable(tile, next_h) {
                     continue;
                 }
                 let ncost = cost + 1;
@@ -5764,14 +5782,11 @@ fn probe_trunk_spike_gate_fixtures() {
                     Some(pi) => out_row(&packed[pi]),
                     None => west.clone(),
                 };
-                let (targets, hint): (FxHashSet<(i32, i32)>, (i32, i32)) = match f.dst {
-                    Some(ci) => (
-                        feed_tiles(ci, &packed[ci]).into_iter().collect(),
-                        centre(&packed[ci]),
-                    ),
-                    None => (east.clone(), (grid.max.0, (grid.min.1 + grid.max.1) / 2)),
+                let targets: FxHashSet<(i32, i32)> = match f.dst {
+                    Some(ci) => feed_tiles(ci, &packed[ci]).into_iter().collect(),
+                    None => east.clone(),
                 };
-                let Some(path) = route(&grid, &starts, &targets, hint) else {
+                let Some(path) = route(&grid, &starts, &targets) else {
                     println!(
                         "{label}: gap {gap}: flow {} {:?}->{:?} failed to route — widening",
                         f.item, f.src, f.dst,

--- a/docs/rfc-058-band-packing.md
+++ b/docs/rfc-058-band-packing.md
@@ -1,7 +1,7 @@
 # RFC-058: Band packing — 2D placement at row granularity
 
 Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phases 0 and 3 complete
-(KC2 cleared at 36.8% vs 30%; KC1 cleared at −35.2% vs −33.0%, narrowly —
+(KC2 cleared at 36.8% vs 30%; KC1 cleared at −35.9% vs −33.0%, narrowly —
 both 2026-07-31). Next: phases 1–2 scaffolding, then phase 4 (2D lane
 planning), with kill criterion 1 staying armed through phase 4.**
 Tracking: [#507](https://github.com/storkme/spaghettio/issues/507).
@@ -222,7 +222,7 @@ its gates — same discipline as `compact_layout`.
 Criterion 1 is the one this RFC exists to test. The probe deliberately could
 not measure it: it prices band-to-band distance, not trunk corridors, so the
 −66.1% excludes the space trunks will consume. *(Evaluated 2026-07-31 by the
-phase-3 spike: cleared at −35.2%, a 2.2-point margin — see decision log. The
+phase-3 spike: cleared at −35.9%, a 2.9-point margin — see decision log. The
 criterion stays armed through phase 4; the spike's model is throwaway and
 the real lane planner must re-clear it.)*
 
@@ -485,7 +485,7 @@ clears. Rationale in the decision log.
   inserter-only band [(30,5), (20,1), (21,5)] — to keep in mind when phase 1
   makes `RowSpan` the source of truth.
 
-- **2026-07-31 — Phase 3 trunk spike: KC1 clears at −35.2% against the
+- **2026-07-31 — Phase 3 trunk spike: KC1 clears at −35.9% against the
   −33.0% bar. Narrowly — and the margin's history is the real content of
   this entry.** The spike (`probe_trunk_spike_gate_fixtures`) packs the gate
   fixtures with the phase-0 packer, then routes every band-to-band item flow
@@ -507,9 +507,9 @@ clears. Rationale in the decision log.
   | fixture | control | packed+trunks | saving | gap | flows | belt-row tiles | corridor tiles |
   |---|---:|---:|---:|---:|---:|---:|---:|
   | `sci1-ore` | 990 | 672 | −32.1% | 2 | 6 | 102 | 55 |
-  | `sci2-ore` | 4,104 | 2,695 | −34.3% | 6 | 14 | 301 | 454 |
-  | `pu1-plate` | 5,635 | 3,584 | −36.4% | 4 | 20 | 603 | 379 |
-  | **aggregate** | **10,729** | **6,951** | **−35.2%** | | | | |
+  | `sci2-ore` | 4,104 | 2,618 | −36.2% | 6 | 14 | 301 | 428 |
+  | `pu1-plate` | 5,635 | 3,584 | −36.4% | 4 | 20 | 603 | 368 |
+  | **aggregate** | **10,729** | **6,874** | **−35.9%** | | | | |
 
   KC1 is defined on the aggregate; `sci1-ore` individually sits at −32.1%.
   Trunk cost consumed roughly half the obstacle-free −66.1% — the exact
@@ -524,6 +524,16 @@ clears. Rationale in the decision log.
   feed row is not checked (capacity is sized at two items per row but
   which-item-which-lane is unmodelled); fluids are priced as belt lanes;
   external inputs are assumed available anywhere on the west edge. Net
-  lean is conservative, but the 2.2-point margin is thin enough that phase
+  lean is conservative, but the 2.9-point margin is thin enough that phase
   4's real lane planner must treat −33.0% as a live bar, not a cleared
   formality — kill criterion 1 stays armed through phase 4.
+
+  Two router defects found by #517's review were fixed and re-measured
+  before this entry's numbers were frozen: a corridor could TURN on a tile
+  it was only entitled to cross (the corner check ignored pre-existing
+  perpendicular occupancy — generous), and the A\* heuristic aimed at a
+  hint point instead of the target set, making it inadmissible and the
+  corridors non-minimal (conservative). The fixes move the aggregate
+  −35.2% → −35.9% (`sci2-ore` 2,695 → 2,618; corridor tiles 454 → 428 and
+  379 → 368): the shorter true-minimal corridors outweigh the stricter
+  turn rule, so the verdict stands with a slightly wider margin.

--- a/docs/rfc-058-band-packing.md
+++ b/docs/rfc-058-band-packing.md
@@ -1,7 +1,9 @@
 # RFC-058: Band packing — 2D placement at row granularity
 
-Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phase 0 complete (KC2
-cleared 2026-07-31 at 36.8% against the 30% bar); Phase 3 trunk spike next.**
+Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phases 0 and 3 complete
+(KC2 cleared at 36.8% vs 30%; KC1 cleared at −35.2% vs −33.0%, narrowly —
+both 2026-07-31). Next: phases 1–2 scaffolding, then phase 4 (2D lane
+planning), with kill criterion 1 staying armed through phase 4.**
 Tracking: [#507](https://github.com/storkme/spaghettio/issues/507).
 
 ## Summary
@@ -219,7 +221,10 @@ its gates — same discipline as `compact_layout`.
 
 Criterion 1 is the one this RFC exists to test. The probe deliberately could
 not measure it: it prices band-to-band distance, not trunk corridors, so the
-−66.1% excludes the space trunks will consume.
+−66.1% excludes the space trunks will consume. *(Evaluated 2026-07-31 by the
+phase-3 spike: cleared at −35.2%, a 2.2-point margin — see decision log. The
+criterion stays armed through phase 4; the spike's model is throwaway and
+the real lane planner must re-clear it.)*
 
 ## Verification plan
 
@@ -479,3 +484,46 @@ clears. Rationale in the decision log.
   And band extraction has a benign artifact — `ec10-plate` yields a 1-tall
   inserter-only band [(30,5), (20,1), (21,5)] — to keep in mind when phase 1
   makes `RowSpan` the source of truth.
+
+- **2026-07-31 — Phase 3 trunk spike: KC1 clears at −35.2% against the
+  −33.0% bar. Narrowly — and the margin's history is the real content of
+  this entry.** The spike (`probe_trunk_spike_gate_fixtures`) packs the gate
+  fixtures with the phase-0 packer, then routes every band-to-band item flow
+  as a 1-tile A\* corridor: band rects opaque, perpendicular crossings
+  allowed (the UG dive), same-axis overlap forbidden, corners opaque, global
+  gap widening (2→8) on any failure. Score = real bounding box of bands +
+  belt rows + corridors, against the control band-bbox — the same quantity
+  as KC1's 10,729-tile baseline, which this machine reproduces exactly.
+
+  The first model let a flow terminate on any tile touching its destination
+  band, and it reported **−54.3%** with every fixture routing at gap 2. That
+  number was discarded as too generous, not recorded as a pass: a band's
+  machines are fed by full-width belt rows — the shared-belt structure the
+  whole RFC is premised on — and a single-tile termination silently omits
+  them. With `ceil(distinct inputs / 2)` feed rows above each band and one
+  output row below reserved *before* any through-routing, sci2 needs gap 6,
+  pu1 gap 4, and the result is:
+
+  | fixture | control | packed+trunks | saving | gap | flows | belt-row tiles | corridor tiles |
+  |---|---:|---:|---:|---:|---:|---:|---:|
+  | `sci1-ore` | 990 | 672 | −32.1% | 2 | 6 | 102 | 55 |
+  | `sci2-ore` | 4,104 | 2,695 | −34.3% | 6 | 14 | 301 | 454 |
+  | `pu1-plate` | 5,635 | 3,584 | −36.4% | 4 | 20 | 603 | 379 |
+  | **aggregate** | **10,729** | **6,951** | **−35.2%** | | | | |
+
+  KC1 is defined on the aggregate; `sci1-ore` individually sits at −32.1%.
+  Trunk cost consumed roughly half the obstacle-free −66.1% — the exact
+  tolerance the criterion was written around.
+
+  Model honesty, both directions. Conservative choices: same-axis corridor
+  overlap is forbidden even for the same item (reality merges and splits);
+  gap widening is global (one congested seam widens every shelf boundary);
+  feed rows are sized per band with no sharing between vertically adjacent
+  bands (reality could direct-sideload a neighbour's output row). Generous
+  choices: poles and balancers are absent; lane-to-item assignment within a
+  feed row is not checked (capacity is sized at two items per row but
+  which-item-which-lane is unmodelled); fluids are priced as belt lanes;
+  external inputs are assumed available anywhere on the west edge. Net
+  lean is conservative, but the 2.2-point margin is thin enough that phase
+  4's real lane planner must treat −33.0% as a live bar, not a cleared
+  formality — kill criterion 1 stays armed through phase 4.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,7 +69,7 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
-| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phase 0 complete 2026-07-31: **KC2 cleared at 36.8%** (14/38 e2e-corpus rows ≥3 bands and packable, bar 30%, cap-insensitive 3:1–4:1); in-corpus winners save −63% to −78% band-bbox. Next: Phase 3 trunk spike (KC1). Tracking #507 |
+| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phases 0 + 3 complete 2026-07-31: **KC2 cleared at 36.8%** (14/38 e2e-corpus rows, bar 30%, cap-insensitive 3:1–4:1); **KC1 cleared at −35.2%** vs the −33.0% bar (trunk spike, three-fixture aggregate, narrowly — criterion stays armed through phase 4). Next: phases 1–2 scaffolding, then phase 4 2D lane planning. Tracking #507 |
 | RFC-059 | 2026-07-30 | [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; DI spec→cell contention is a matching problem, not a walk order; phase 1 must first establish a reproducible rate |
 
 Next number: **RFC-060**.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,7 +69,7 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
-| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phases 0 + 3 complete 2026-07-31: **KC2 cleared at 36.8%** (14/38 e2e-corpus rows, bar 30%, cap-insensitive 3:1–4:1); **KC1 cleared at −35.2%** vs the −33.0% bar (trunk spike, three-fixture aggregate, narrowly — criterion stays armed through phase 4). Next: phases 1–2 scaffolding, then phase 4 2D lane planning. Tracking #507 |
+| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phases 0 + 3 complete 2026-07-31: **KC2 cleared at 36.8%** (14/38 e2e-corpus rows, bar 30%, cap-insensitive 3:1–4:1); **KC1 cleared at −35.9%** vs the −33.0% bar (trunk spike, three-fixture aggregate, narrowly — criterion stays armed through phase 4). Next: phases 1–2 scaffolding, then phase 4 2D lane planning. Tracking #507 |
 | RFC-059 | 2026-07-30 | [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; DI spec→cell contention is a matching problem, not a walk order; phase 1 must first establish a reproducible rate |
 
 Next number: **RFC-060**.


### PR DESCRIPTION
## Intent

RFC-058's kill criterion 1 — does real trunk routing eat the packing gain? — required a throwaway spike on all three gate fixtures before any lane-planner work. This PR runs it per the reordered phasing (#516): **KC1 clears at −35.9% aggregate against the −33.0% bar** (sci1-ore −32.1%, sci2-ore −36.2%, pu1-plate −36.4%; the criterion is defined on the aggregate). The margin is 2.9 points, so the decision log keeps KC1 armed through phase 4 rather than treating the gate as cleared formality.

## Scope

- **In:** `probe_trunk_spike_gate_fixtures` (#[ignore], <1s warm): packs the gate fixtures with the phase-0 packer, reserves every band's real belt rows first (`ceil(distinct inputs / 2)` full-width feed rows + one output row), then routes every band-to-band item flow as a 1-tile A* corridor under real crossing rules (perpendicular UG-style crossings allowed, same-axis overlap forbidden, corners opaque), with global gap widening 2→8 on any failure or reservation collision. Score = real bounding box (bands + belt rows + corridors) vs the control band-bbox — the same quantity as KC1's 10,729-tile baseline. Decision-log entry + status header + registry row record the verdict.
- **Out:** phases 1–2 (placer-native extraction, flagged packer) and phase 4 (real 2D lane planning) — the spike is deliberately throwaway evidence, not integration. No engine behaviour change; test + docs only.

## Verification

- The spike's naive first model (single-tile termination, no belt rows) reported −54.3% with everything routing at gap 2; it was **discarded as too generous, not recorded as a pass** — the delta against the hardened model (−35.9%) is the measured cost of per-band belt rows and gap congestion, and both numbers are in the decision log.
- KC1 baseline reconciles: control aggregate 10,729 matches the probe corpus and the RFC exactly on this machine.
- `rfc058_band_packing_premise_holds` (CI guard) passes on the rebased branch; spike re-run post-rebase, same verdict.
- Full core suite green on the pre-rebase branch (18/18 test binaries, exit 0); the rebase brought in only #516's census-row edits, which the two re-run tests cover.
- Model assumptions (conservative and generous) are enumerated in the decision-log entry rather than left implicit.

## Deviations from intent

The RFC's phase 3 said "whatever is quickest"; the naive quickest model was built, measured, and then rejected in favour of a belt-row-reserving one because the naive number could not survive adversarial scrutiny. That judgement call and both measurements are recorded in the decision log.

## Models / contracts touched

None in code. `docs/rfc-058-band-packing.md` (decision log, status, KC1 note), `docs/rfcs.md` registry row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mbi9vxoH7RMPfkGaMY8SaG
