### PR TITLE
RFC-058 phases 1–2: placer-native bands + flag-gated packer, inert by construction

### DIFF
--- a/crates/core/src/bus/bands.rs
+++ b/crates/core/src/bus/bands.rs
@@ -1,0 +1,264 @@
+//! RFC-058 band extraction and packing (phases 1–2).
+//!
+//! A band is a maximal run of rows containing machines or inserters — one
+//! recipe's machine row plus the inserter rows serving it. Belt rows are
+//! deliberately not band structure: they are the transport RFC-058 re-plans.
+//!
+//! Extraction is placer-native (phase 1): the placer's `RowSpan`s are the
+//! grouping authority — each band records which spans contribute to it,
+//! the linkage phase 4's lane planner needs — while geometry is measured
+//! from the spans' own machine and inserter entities, footprint-aware.
+//! `probe_band_packing_headroom` (tests/cell_composition.rs) keeps its
+//! deliberately decoupled y-projection copy as the oracle; the parity test
+//! `rfc058_placer_bands_match_y_projection` pins the two against each
+//! other, and the CI premise guard keeps a third self-contained copy so a
+//! defect here cannot blind it. The duplication is intentional.
+//!
+//! Packing (phase 2) is the phase-0 probe's shelf packer, ported verbatim:
+//! target width swept from the widest band to twice the control width,
+//! source and height-descending order, minimum bounding-box area under an
+//! aspect cap, strict `<` so the first minimum wins. It emits positions
+//! only — `layout_pass` records them in a `BandPackingPlanned` trace event
+//! and NOTHING consumes them yet. Kill criterion 1 cleared its spike on
+//! 2026-07-31 at −35.9% against a −33.0% bar and stays armed through
+//! phase 4; this module deliberately cannot move an entity.
+
+use crate::bus::placer::RowSpan;
+use crate::common::{entity_size, is_machine_entity};
+use crate::models::PlacedEntity;
+use rustc_hash::FxHashSet;
+
+/// The probe's aspect cap. Phase 0 swept 3.0–4.0 and the applicable-fixture
+/// count did not move, so 3:1 stands (RFC-058 decision log, 2026-07-31).
+pub const MAX_ASPECT: f64 = 3.0;
+/// Inter-band gap in tiles, both axes — the phase-0 probe's value. The
+/// phase-3 spike measured real fixtures needing up to 6 once per-band belt
+/// rows are reserved; the gap becomes a planner concern in phase 4.
+pub const GAP: i32 = 2;
+
+/// One band: a maximal machine+inserter row run, with its placer linkage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Band {
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+    /// Indices into the placer's `RowSpan` list that contribute structural
+    /// rows to this band. Usually one; more when rows fuse with no belt
+    /// row between them (direct-insertion bridges).
+    pub row_indices: Vec<usize>,
+    /// Sorted, deduplicated recipes of the contributing spans.
+    pub recipes: Vec<String>,
+}
+
+fn is_structural(e: &PlacedEntity) -> bool {
+    is_machine_entity(&e.name) || e.name.contains("inserter")
+}
+
+/// Placer-native band extraction (RFC-058 phase 1).
+///
+/// Structural rows are computed footprint-aware from machine and inserter
+/// entities; contiguous structural runs are collected *within each span's
+/// y-range* and runs that touch across span boundaries merge into one
+/// band. Restricting runs to span ranges is what makes the spans the
+/// grouping authority; the merge step preserves the y-projection's maximal
+/// runs where DI has fused adjacent rows.
+pub fn extract_bands(rows: &[RowSpan], entities: &[PlacedEntity]) -> Vec<Band> {
+    let mut structural_ys: FxHashSet<i32> = FxHashSet::default();
+    for e in entities {
+        if is_structural(e) {
+            let (_, eh) = entity_size(&e.name);
+            for dy in 0..eh as i32 {
+                structural_ys.insert(e.y + dy);
+            }
+        }
+    }
+
+    // Contiguous structural runs, per span.
+    struct Run {
+        y0: i32,
+        y1: i32, // inclusive
+        span: usize,
+    }
+    let mut runs: Vec<Run> = Vec::new();
+    for (i, rs) in rows.iter().enumerate() {
+        let mut y = rs.y_start;
+        while y < rs.y_end {
+            if !structural_ys.contains(&y) {
+                y += 1;
+                continue;
+            }
+            let y0 = y;
+            while y < rs.y_end && structural_ys.contains(&y) {
+                y += 1;
+            }
+            runs.push(Run { y0, y1: y - 1, span: i });
+        }
+    }
+    runs.sort_by_key(|r| r.y0);
+
+    // Merge runs that touch or overlap across span boundaries.
+    let mut merged: Vec<(i32, i32, Vec<usize>)> = Vec::new();
+    for r in runs {
+        if let Some(last) = merged.last_mut() {
+            if r.y0 <= last.1 + 1 {
+                last.1 = last.1.max(r.y1);
+                last.2.push(r.span);
+                continue;
+            }
+        }
+        merged.push((r.y0, r.y1, vec![r.span]));
+    }
+
+    // Geometry per merged run: x-extent of the structural entities whose
+    // anchor row falls inside it (same predicate as the probe, so the
+    // parity test compares like with like).
+    let mut bands = Vec::new();
+    for (y0, y1, spans) in merged {
+        let (mut xmin, mut xmax) = (i32::MAX, i32::MIN);
+        for e in entities {
+            if !is_structural(e) || e.y < y0 || e.y > y1 {
+                continue;
+            }
+            let (ew, _) = entity_size(&e.name);
+            xmin = xmin.min(e.x);
+            xmax = xmax.max(e.x + ew as i32 - 1);
+        }
+        if xmin > xmax {
+            continue;
+        }
+        let mut recipes: Vec<String> =
+            spans.iter().map(|&i| rows[i].spec.recipe.clone()).collect();
+        recipes.sort();
+        recipes.dedup();
+        bands.push(Band {
+            x: xmin,
+            y: y0,
+            w: xmax - xmin + 1,
+            h: y1 - y0 + 1,
+            row_indices: spans,
+            recipes,
+        });
+    }
+    bands
+}
+
+/// Bounding box (w, h) over band rectangles.
+pub fn bbox(bands: &[Band]) -> (i32, i32) {
+    let w = bands.iter().map(|b| b.x + b.w).max().unwrap_or(0)
+        - bands.iter().map(|b| b.x).min().unwrap_or(0);
+    let h = bands.iter().map(|b| b.y + b.h).max().unwrap_or(0)
+        - bands.iter().map(|b| b.y).min().unwrap_or(0);
+    (w, h)
+}
+
+/// One shelf-packing pass at a fixed target width. Identical construction
+/// to the phase-0 probe's — see the module docs for why the probe keeps
+/// its own copy.
+fn shelf_pack(bands: &[Band], target_w: i32, gap: i32, sort_desc: bool) -> Vec<Band> {
+    let mut idx: Vec<usize> = (0..bands.len()).collect();
+    if sort_desc {
+        idx.sort_by_key(|&i| std::cmp::Reverse((bands[i].h, bands[i].w, i)));
+    }
+    let mut out = bands.to_vec();
+    let (mut x, mut y, mut shelf_h) = (0, 0, 0);
+    for &i in &idx {
+        let (w, h) = (bands[i].w, bands[i].h);
+        if x > 0 && x + w > target_w {
+            x = 0;
+            y += shelf_h + gap;
+            shelf_h = 0;
+        }
+        out[i].x = x;
+        out[i].y = y;
+        x += w + gap;
+        shelf_h = shelf_h.max(h);
+    }
+    out
+}
+
+/// A packing the aspect cap admits.
+#[derive(Debug, Clone)]
+pub struct PackedPlan {
+    pub w: i32,
+    pub h: i32,
+    /// Planned (x, y) origin per band, index-aligned with the extraction
+    /// order of the `Band` slice the plan was computed from.
+    pub positions: Vec<(i32, i32)>,
+}
+
+/// Best aspect-capped shelf packing: minimum bounding-box area under
+/// `max_aspect`, target width swept from the widest band to twice the
+/// control width, both orders, strict `<` so the first minimum wins
+/// (iteration order is part of the published-numbers contract). `None`
+/// when nothing fits the cap — a width-dominant band.
+pub fn best_pack(bands: &[Band], gap: i32, max_aspect: f64) -> Option<PackedPlan> {
+    let (cw, _) = bbox(bands);
+    let widest = bands.iter().map(|b| b.w).max().unwrap_or(1);
+    let mut best: Option<(i64, PackedPlan)> = None;
+    for sort_desc in [false, true] {
+        let mut t = widest;
+        while t <= cw.max(widest) * 2 {
+            let packed = shelf_pack(bands, t, gap, sort_desc);
+            let (w, h) = bbox(&packed);
+            let aspect = w.max(h) as f64 / w.min(h).max(1) as f64;
+            if aspect <= max_aspect {
+                let area = (w as i64) * (h as i64);
+                if best.as_ref().is_none_or(|(ba, _)| area < *ba) {
+                    best = Some((
+                        area,
+                        PackedPlan {
+                            w,
+                            h,
+                            positions: packed.iter().map(|b| (b.x, b.y)).collect(),
+                        },
+                    ));
+                }
+            }
+            t += 2;
+        }
+    }
+    best.map(|(_, plan)| plan)
+}
+
+/// RFC-058 phase 2 entry point, called from `layout_pass` when
+/// `LayoutOptions.band_packing` is on: extract, pack, and record the plan
+/// as a trace event. Deliberately returns nothing — positions live in the
+/// trace and nowhere else until phase 4 exists.
+pub fn plan_band_packing(rows: &[RowSpan], entities: &[PlacedEntity]) {
+    let bands = extract_bands(rows, entities);
+    let widest = bands.iter().map(|b| b.w).max().unwrap_or(0);
+    if bands.len() < 3 {
+        crate::trace::emit(crate::trace::TraceEvent::BandPackingRefused {
+            bands: bands.len(),
+            widest_band: widest,
+            reason: "fewer than 3 bands — nothing to pack".into(),
+        });
+        return;
+    }
+    let (control_w, control_h) = bbox(&bands);
+    match best_pack(&bands, GAP, MAX_ASPECT) {
+        Some(plan) => {
+            let aspect10 =
+                (plan.w.max(plan.h) as i64 * 10) / (plan.w.min(plan.h).max(1) as i64);
+            crate::trace::emit(crate::trace::TraceEvent::BandPackingPlanned {
+                band_rects: bands.iter().map(|b| (b.x, b.y, b.w, b.h)).collect(),
+                control_w,
+                control_h,
+                packed_w: plan.w,
+                packed_h: plan.h,
+                aspect10,
+                positions: plan.positions,
+            });
+        }
+        None => {
+            crate::trace::emit(crate::trace::TraceEvent::BandPackingRefused {
+                bands: bands.len(),
+                widest_band: widest,
+                reason: format!(
+                    "no target width packs within {MAX_ASPECT}:1 — width-dominant band"
+                ),
+            });
+        }
+    }
+}

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -371,6 +371,10 @@ impl DecompositionCandidate for ModuleSizeSplit {
             splitter_tap_spacers: opts.splitter_tap_spacers,
             direct_insertion: opts.direct_insertion,
             compact_layout: false,
+            // Same discipline as compact_layout: the flag-gated RFC-058
+            // plan is emitted by the native pass, not re-emitted by every
+            // candidate variant's inner run.
+            band_packing: false,
         };
         run_layout_with_retry(&transformed, &inner_opts)
     }

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -139,6 +139,12 @@ pub struct LayoutOptions {
     /// RFC-057 topology-preserving post-layout compaction. Experimental and
     /// default off, so the normal pipeline remains byte-identical.
     pub compact_layout: bool,
+    /// RFC-058 phase 2: plan band packing and record the plan as a
+    /// `BandPackingPlanned` trace event. Positions only — nothing consumes
+    /// them yet, so the layout geometry is identical with the flag on or
+    /// off (a focused test pins this). Default off; stays off until kill
+    /// criterion 1 clears again on the real phase-4 lane planner.
+    pub band_packing: bool,
 }
 
 impl Default for LayoutOptions {
@@ -174,6 +180,7 @@ impl Default for LayoutOptions {
             // strictly improve stays bit-identical.
             direct_insertion: crate::bus::di_cell::DirectInsertion::Candidate,
             compact_layout: false,
+            band_packing: false,
         }
     }
 }
@@ -1343,6 +1350,13 @@ fn layout_pass(
             })
         })
         .collect();
+
+    // RFC-058 phase 2: flag-gated band packing plan. Emits trace events
+    // only — positions are recorded, nothing consumes them, and the
+    // entity list is untouched by construction (the call takes `&`).
+    if opts.band_packing {
+        crate::bus::bands::plan_band_packing(&row_spans, &all_entities);
+    }
 
     Ok((
         LayoutResult {
@@ -3128,6 +3142,81 @@ mod tests {
     /// `inserter-direction` (which would otherwise flag them as touching no
     /// machine) nor `belt-flow-reachability` (which would otherwise call the
     /// producer's bridge-consumed output belt a dead-end) fires on them.
+    /// RFC-058 phase 2 inertness gate: `band_packing` may add trace events
+    /// and NOTHING else. The packer emits positions only — nothing
+    /// consumes them — so the entity list must be identical with the flag
+    /// on or off, and a flag-on build must record either a plan or a
+    /// typed refusal (a silent flag would be indistinguishable from a
+    /// broken one).
+    #[test]
+    fn band_packing_option_is_inert_and_traced() {
+        use crate::trace::{self, TraceEvent};
+        let inputs: FxHashSet<String> =
+            ["iron-ore", "copper-ore"].iter().map(|s| s.to_string()).collect();
+        let sr = crate::solver::solve_with_exclusions(
+            "automation-science-pack",
+            1.0,
+            &inputs,
+            "assembling-machine-1",
+            &FxHashSet::default(),
+        )
+        .expect("solve sci1");
+        let control = build_bus_layout(&sr, LayoutOptions::default()).expect("control layout");
+        let _guard = trace::start_trace();
+        let packed = build_bus_layout(
+            &sr,
+            LayoutOptions {
+                band_packing: true,
+                ..Default::default()
+            },
+        )
+        .expect("flag-on layout");
+        let events = trace::drain_events();
+
+        assert_eq!(
+            format!("{:?}", control.entities),
+            format!("{:?}", packed.entities),
+            "band_packing must not move a single entity",
+        );
+        let last_plan = events.iter().rev().find(|e| {
+            matches!(
+                e,
+                TraceEvent::BandPackingPlanned { .. } | TraceEvent::BandPackingRefused { .. }
+            )
+        });
+        match last_plan {
+            None => panic!("flag-on build recorded neither a plan nor a refusal"),
+            Some(TraceEvent::BandPackingPlanned {
+                band_rects,
+                positions,
+                control_w,
+                control_h,
+                packed_w,
+                packed_h,
+                ..
+            }) => {
+                assert_eq!(
+                    band_rects.len(),
+                    positions.len(),
+                    "one planned position per extracted band",
+                );
+                assert!(
+                    (*packed_w as i64) * (*packed_h as i64)
+                        <= (*control_w as i64) * (*control_h as i64),
+                    "a packing the cap admits never exceeds the control area \
+                     (worst case is the control arrangement itself)",
+                );
+            }
+            Some(TraceEvent::BandPackingRefused { bands, .. }) => {
+                // Band structure is host-geometry-relative (RFC-058
+                // decision log 2026-07-31), so a refusal here is legal —
+                // but only the typed kinds the packer can actually emit.
+                assert!(*bands >= 1, "refusal must still report extracted bands");
+            }
+            Some(_) => unreachable!(),
+        }
+    }
+
     #[test]
     fn compact_layout_option_is_explicit_and_validated() {
         let inputs: FxHashSet<String> =

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -26,6 +26,7 @@
 //! - [`junction`] — `Junction` snapshot type consumed by strategies
 
 pub mod balancer;
+pub mod bands;
 pub mod cells;
 pub mod compaction;
 pub mod balancer_classify;

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -616,6 +616,33 @@ pub enum TraceEvent {
         recipes: Vec<String>,
     },
 
+    /// RFC-058 phase 2 (flag-gated, default off): the band packer planned
+    /// a 2D arrangement for the placer's row bands. Positions land HERE
+    /// and nowhere else — nothing consumes them yet, so this event is the
+    /// phase-2 deliverable and the diagnosable record of what the packer
+    /// would do. `band_rects` is the placer-native extraction (phase 1);
+    /// `positions` is index-aligned with it.
+    BandPackingPlanned {
+        /// As-placed (x, y, w, h) per band, extraction order.
+        band_rects: Vec<(i32, i32, i32, i32)>,
+        control_w: i32,
+        control_h: i32,
+        packed_w: i32,
+        packed_h: i32,
+        /// Achieved aspect in tenths — integral, like the fold search score.
+        aspect10: i64,
+        /// Planned packed origin per band, index-aligned with `band_rects`.
+        positions: Vec<(i32, i32)>,
+    },
+
+    /// RFC-058 phase 2: the packer ran and refused — too few bands, or a
+    /// width-dominant band no swept target width fits under the aspect cap.
+    BandPackingRefused {
+        bands: usize,
+        widest_band: i32,
+        reason: String,
+    },
+
     /// The reactive power-repair pass (RFC `docs/rfc-power-reservation.md`
     /// Phase 3a-ii / 3b) re-ran the full pipeline with widened substation bands,
     /// but `place_poles` STILL reported uncovered electric inserters afterward —

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -5833,3 +5833,110 @@ fn probe_trunk_spike_gate_fixtures() {
         if saving >= 33.0 { "CLEARS" } else { "FAILS — stop; do not re-tune the packer" }
     );
 }
+
+/// RFC-058 phase 1 parity: the engine's placer-native band extraction
+/// (`bus::bands::extract_bands`, grouped by `RowSpan`) must agree with the
+/// phase-0 probe's deliberately decoupled y-projection on the layouts both
+/// can see. The probe stays the oracle — its published numbers are the
+/// RFC's evidence — so a disagreement here means the placer-native path is
+/// wrong, not the probe.
+///
+/// Also pins phase-2 packing parity: the positions the engine records in
+/// `BandPackingPlanned` must reproduce `rfc058_best_pack` on the same
+/// bands (same sweep, same tie-break).
+///
+/// Runs with cell composition and DI forced OFF so the native pass — the
+/// one that emits the trace event — is also the layout that wins, keeping
+/// the comparison apples-to-apples.
+#[test]
+fn rfc058_placer_bands_match_y_projection() {
+    use spaghettio_core::trace::{self, TraceEvent};
+
+    let cases: &[(&str, &str, f64, &[&str], &str)] = &[
+        ("sci1-ore", "automation-science-pack", 1.0, &["iron-ore", "copper-ore"], "assembling-machine-1"),
+        ("sci2-ore", "logistic-science-pack", 2.0, &["iron-ore", "copper-ore"], "assembling-machine-2"),
+        ("pu1-plate", "processing-unit", 1.0, &["iron-plate", "copper-plate", "sulfuric-acid"], "assembling-machine-2"),
+        ("gear15-ore", "iron-gear-wheel", 15.0, &["iron-ore"], "assembling-machine-2"),
+    ];
+
+    for (label, item, rate, inputs, machine) in cases {
+        let inputs_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve_with_palette_exclusions_and_quality(
+            item,
+            *rate,
+            &inputs_set,
+            &MachinePalette::default(),
+            machine,
+            &FxHashSet::default(),
+            QualityTier::Normal,
+        )
+        .unwrap_or_else(|e| panic!("{label}: solver refused: {e}"));
+
+        let opts = layout::LayoutOptions {
+            band_packing: true,
+            cell_composition: spaghettio_core::bus::cells::CellComposition::Off,
+            direct_insertion: spaghettio_core::bus::di_cell::DirectInsertion::Off,
+            ..Default::default()
+        };
+        let _guard = trace::start_trace();
+        let l = layout::build_bus_layout(&sr, opts)
+            .unwrap_or_else(|e| panic!("{label}: layout refused: {e}"));
+        let events = trace::drain_events();
+        drop(_guard);
+
+        // Oracle: the probe's y-projection over the final layout.
+        let oracle = rfc058_extract_bands(&l);
+        let oracle_rects: Vec<(i32, i32, i32, i32)> =
+            oracle.iter().map(|b| (b.x, b.y, b.w, b.h)).collect();
+
+        let last_plan = events
+            .iter()
+            .rev()
+            .find(|e| {
+                matches!(
+                    e,
+                    TraceEvent::BandPackingPlanned { .. } | TraceEvent::BandPackingRefused { .. }
+                )
+            })
+            .unwrap_or_else(|| panic!("{label}: no band-packing event emitted"));
+
+        match last_plan {
+            TraceEvent::BandPackingPlanned {
+                band_rects,
+                packed_w,
+                packed_h,
+                positions,
+                ..
+            } => {
+                assert_eq!(
+                    band_rects, &oracle_rects,
+                    "{label}: placer-native band rects diverge from the y-projection oracle",
+                );
+                let oracle_pack = rfc058_best_pack(&oracle, 2, 3.0)
+                    .unwrap_or_else(|| panic!("{label}: oracle packs but engine claims a plan?"));
+                assert_eq!(
+                    (*packed_w, *packed_h),
+                    (oracle_pack.1, oracle_pack.2),
+                    "{label}: packed dimensions diverge from the probe packer",
+                );
+                let oracle_positions: Vec<(i32, i32)> =
+                    oracle_pack.3.iter().map(|b| (b.x, b.y)).collect();
+                assert_eq!(
+                    positions, &oracle_positions,
+                    "{label}: planned positions diverge from the probe packer",
+                );
+            }
+            TraceEvent::BandPackingRefused { bands, .. } => {
+                // The oracle must agree there is nothing to pack here:
+                // either too few bands, or no packing under the cap.
+                assert_eq!(*bands, oracle.len(), "{label}: refusal band count diverges");
+                assert!(
+                    oracle.len() < 3 || rfc058_best_pack(&oracle, 2, 3.0).is_none(),
+                    "{label}: engine refused but the oracle packs {} bands",
+                    oracle.len(),
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -126,6 +126,10 @@ fn layout_options(
         // when validation is no worse than its input, so the worst case is
         // "no change", never a broken factory.
         compact_layout: compact_layout.as_deref() == Some("1"),
+        // RFC-058 phase 2 is engine-only: the packer emits a trace plan and
+        // moves nothing, so there is no web surface to expose yet. Wire a
+        // URL param here only when phase 4 gives the flag visible effect.
+        band_packing: false,
         // No `..Default::default()`: adding `direct_insertion` completed
         // the field list, and a no-op struct update is a clippy error
         // under the workspace's `-D warnings`. A field added to

--- a/docs/rfc-058-band-packing.md
+++ b/docs/rfc-058-band-packing.md
@@ -1,9 +1,10 @@
 # RFC-058: Band packing — 2D placement at row granularity
 
-Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phases 0 and 3 complete
-(KC2 cleared at 36.8% vs 30%; KC1 cleared at −35.9% vs −33.0%, narrowly —
-both 2026-07-31). Next: phases 1–2 scaffolding, then phase 4 (2D lane
-planning), with kill criterion 1 staying armed through phase 4.**
+Registry: [`rfcs.md`](rfcs.md). Status: **Active — phases 0–3 complete
+(KC2 cleared at 36.8% vs 30%; KC1 cleared at −35.9% vs −33.0%, narrowly;
+placer-native extraction + flag-gated packer landed inert — all
+2026-07-31). Next: phase 4 (2D lane planning), where kill criterion 1 is
+re-evaluated on the real planner.**
 Tracking: [#507](https://github.com/storkme/spaghettio/issues/507).
 
 ## Summary
@@ -258,13 +259,15 @@ Per the layout-engine protocol in [`CLAUDE.md`](../CLAUDE.md#verification-protoc
    count, so it belongs with KC2's measurement (reordered 2026-07-31, see
    decision log).
 1. **Band extraction from `RowSpan`** — placer-native, replacing the probe's
-   y-projection. No behaviour change. **Deferred until the phase-3 gate
-   clears** (2026-07-31 reorder).
+   y-projection. No behaviour change. **Landed 2026-07-31** (`bus::bands`,
+   after the phase-3 gate cleared per the reorder): spans are the grouping
+   authority, geometry is measured from their own entities, and a parity
+   test pins the result against the probe's y-projection oracle.
 2. **Packer** — shelf packing with aspect cap and swept target width, behind a
    default-off flag. Emits positions only; nothing consumes them yet.
-   **Deferred until the phase-3 gate clears** (2026-07-31 reorder): the spike
-   consumes the probe's own packed positions, so the production packer is
-   scaffolding that only pays off if the premise survives.
+   **Landed 2026-07-31**: `LayoutOptions.band_packing` records the plan as
+   a `BandPackingPlanned` trace event (or a typed refusal); an inertness
+   test asserts entity-identical output with the flag on or off.
 3. **Trunk spike — throwaway code, all three gate fixtures.** Route trunks for
    the packed layouts with whatever is quickest and measure real bounding-box
    area and real transport against each control. Start with `sci1-ore` (4
@@ -537,3 +540,34 @@ clears. Rationale in the decision log.
   −35.2% → −35.9% (`sci2-ore` 2,695 → 2,618; corridor tiles 454 → 428 and
   379 → 368): the shorter true-minimal corridors outweigh the stricter
   turn rule, so the verdict stands with a slightly wider margin.
+
+- **2026-07-31 — phases 1–2 landed: placer-native bands and the flag-gated
+  packer, both inert by construction.** New module `bus::bands`. Extraction
+  takes the placer's `RowSpan`s as the grouping authority — each band
+  records the row indices that contribute to it, which is the linkage
+  phase 4's lane planner needs — while geometry is measured
+  footprint-aware from those spans' own machine and inserter entities.
+  Structural runs are collected within each span's y-range and merged
+  across spans when they touch (direct-insertion fusions), which
+  reproduces the probe's maximal-run semantics exactly. The probe keeps
+  its deliberately decoupled y-projection as the oracle;
+  `rfc058_placer_bands_match_y_projection` pins band rects, packed
+  dimensions, AND planned positions against it on the three gate fixtures
+  plus `gear15-ore` (a refusal case) — exact agreement. The packer is the
+  probe's shelf packer ported verbatim; the strict-`<` first-minimum
+  tie-break is documented as part of the published-numbers contract.
+
+  `LayoutOptions.band_packing` (default off) gates one call at the end of
+  `layout_pass`: extract, pack, and emit `BandPackingPlanned` (band rects,
+  control/packed dims, aspect, positions) or a typed `BandPackingRefused`.
+  Positions live in the trace and nowhere else — phase 2's "emits
+  positions only" is structural (the seam borrows everything immutably),
+  and `band_packing_option_is_inert_and_traced` asserts entity-identical
+  output flag-on vs flag-off. Candidate variants' inner runs do not
+  re-emit (same discipline as `compact_layout`'s inner-opts handling), and
+  the wasm surface pins the flag off until phase 4 gives it a visible
+  effect. Three intentional copies of the band/packing logic now exist —
+  engine (`bus::bands`), probe (frozen instrument), CI premise guard
+  (self-contained by design) — with the parity test and the guard holding
+  them together; consolidation would couple the oracle to the thing it
+  checks.

--- a/docs/rfcs.md
+++ b/docs/rfcs.md
@@ -69,7 +69,7 @@ backfill the status next time the doc is touched.
 | RFC-055 | 2026-07-26 | [`rfc-055-compact-cell-chain.md`](rfc-055-compact-cell-chain.md) | Design — competes with RFC-056; #456 |
 | RFC-056 | 2026-07-26 | [`rfc-056-folded-cell-chain.md`](rfc-056-folded-cell-chain.md) | Design — competes with RFC-055; #456 |
 | RFC-057 | 2026-07-26 | [`rfc-057-topology-preserving-dense-repacking.md`](rfc-057-topology-preserving-dense-repacking.md) | Active |
-| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phases 0 + 3 complete 2026-07-31: **KC2 cleared at 36.8%** (14/38 e2e-corpus rows, bar 30%, cap-insensitive 3:1–4:1); **KC1 cleared at −35.9%** vs the −33.0% bar (trunk spike, three-fixture aggregate, narrowly — criterion stays armed through phase 4). Next: phases 1–2 scaffolding, then phase 4 2D lane planning. Tracking #507 |
+| RFC-058 | 2026-07-30 | [`rfc-058-band-packing.md`](rfc-058-band-packing.md) | Active — 2D placement at ROW-BAND granularity. Phases 0–3 complete 2026-07-31: **KC2 cleared at 36.8%** (14/38 e2e-corpus rows, bar 30%, cap-insensitive 3:1–4:1); **KC1 cleared at −35.9%** vs the −33.0% bar (trunk spike, narrowly — stays armed); placer-native extraction + flag-gated packer landed inert (`bus::bands`, `LayoutOptions.band_packing`, positions-in-trace only). Next: phase 4 2D lane planning. Tracking #507 |
 | RFC-059 | 2026-07-30 | [`rfc-059-di-coupling-assignment.md`](rfc-059-di-coupling-assignment.md) | Design (circulated for review) — split out of #473; DI spec→cell contention is a matching problem, not a walk order; phase 1 must first establish a reproducible rate |
 
 Next number: **RFC-060**.


### PR DESCRIPTION
## Intent

With both kill gates cleared (#516 KC2 at 36.8%, #517 KC1 at −35.9%), this lands RFC-058's production scaffolding: phase 1 (band extraction from the placer's `RowSpan`s, replacing the probe's y-projection as the engine-side source of truth) and phase 2 (the shelf packer behind a default-off `LayoutOptions.band_packing` flag, emitting positions only). Nothing consumes the positions — that is phase 4's job, where kill criterion 1 gets re-evaluated on the real lane planner.

## Scope

- **In:**
  - `bus::bands` (new): `extract_bands` — spans are the grouping authority (each band records contributing row indices, the phase-4 linkage), geometry measured footprint-aware from the spans' own machine/inserter entities, cross-span merge where DI fuses rows; `best_pack` — the probe's packer ported verbatim, strict-`<` first-minimum tie-break documented as part of the published-numbers contract.
  - `LayoutOptions.band_packing` (default off) → one call at the end of `layout_pass` → `BandPackingPlanned` / `BandPackingRefused` trace events. Candidate variants' inner runs don't re-emit (same discipline as `compact_layout`); the wasm-bindings literal pins the flag off with a comment saying when to expose it.
  - Tests: `band_packing_option_is_inert_and_traced` (entity-identical flag-on vs flag-off, and a flag-on build must record a plan or typed refusal); `rfc058_placer_bands_match_y_projection` (band rects, packed dims, and positions pinned against the frozen probe helpers on the three gate fixtures + `gear15-ore` refusal case — exact agreement).
- **Out:** anything that moves an entity; phase 4 lane planning; web/URL surface for the flag (engine-only until the flag has visible effect). The probe and CI premise guard keep their own copies deliberately — consolidating would couple the oracle to the thing it checks; the parity test and guard hold the three copies together.

## Verification

- Full core suite green in release: 18/18 test binaries, real exit code checked (not a piped tail).
- `cargo clippy -p spaghettio_core -- -D warnings` (the pre-commit hook's invocation) clean; `cargo check` on `crates/wasm-bindings` passes with the new field wired.
- Parity test passes exactly — including planned positions, not just counts — and the inertness test compares full entity lists.
- No snapshot/e2e goldens touched: the default path emits nothing new (trace variants are additive; `RowsPlaced` precedent).

## Deviations from intent

None — this is the RFC's phases 1–2 as specified, landed after the gate per the 2026-07-31 reorder. The one judgement call (spans-as-grouping-authority with measured geometry, rather than reconstructing structural rows from span metadata alone) is recorded in the decision log with its rationale.

## Models / contracts touched

`LayoutOptions` gains `band_packing` (default off; wasm literal updated — the deliberate compile-break-here pattern). `TraceEvent` gains two additive variants. Decision log, phasing section, status header, and registry row updated in `docs/rfc-058-band-packing.md` / `docs/rfcs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mbi9vxoH7RMPfkGaMY8SaG