### PR TITLE
fix(ci): a description-edit run cancelled the code review and passed the guard

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,8 +16,18 @@ on:
 # several runs racing over superseded heads. Cancelling is safe *because* the
 # guard enforces coverage on the CURRENT head: the surviving run reviews the
 # only SHA that can be merged. Keyed by PR so PRs never cancel each other.
+#
+# Keyed by EVENT CLASS as well, and that half is load-bearing. The reasoning
+# above holds only while the survivor actually reviews the diff. A `edited`
+# (description) run deliberately does NOT — it re-checks body-scoped findings
+# and nothing else — so when a body edit cancelled a code run, the survivor
+# reviewed nothing and its guard branch skipped too. Net: green check, zero
+# review. Observed 2026-07-31 on #521: run 30624281369 (code, 38s in) was
+# cancelled by run 30624312907 (`edited`), which passed on the
+# "coverage is enforced by the push events" carve-out — the push event whose
+# coverage it deferred to being the one it had just killed.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ github.event.pull_request.number }}-${{ github.event.action == 'edited' && 'body' || 'code' }}
   cancel-in-progress: true
 
 jobs:
@@ -114,10 +124,11 @@ jobs:
             end is indistinguishable from a crash and fails the check.
             — Re-review rule: "I already reviewed this PR" is NOT a valid
             skip when new commits have landed since. This job fires on
-            every push, and the guard below only checks that the PR has
-            SOME review in its lifetime, so a skip here means the new
-            commits get no review at all — which is exactly how a PR that
-            was reviewed at its third commit merged at its ninth (#481,
+            every push, and the guard below enforces coverage on the
+            CURRENT HEAD SHA, so a skip here means the new commits get no
+            review at all AND the check goes red — which is exactly how a
+            PR that was reviewed at its third commit merged at its ninth
+            (#481,
             2026-07-29: four real bugs found, then six further commits
             including the fixes for those bugs went unreviewed). When
             ${{ github.event.action }} is `synchronize`, review the
@@ -201,12 +212,36 @@ jobs:
           fi
           # Description-edit runs carry no new commit, so head-SHA coverage is
           # owned by whichever push event produced that head — every SHA gets
-          # an `opened` or `synchronize` run. Enforcing here would red a PR for
-          # a body edit whose cheap re-check legitimately had nothing to post.
-          # Carving this out cannot lose coverage on any SHA.
+          # an `opened` or `synchronize` run. Enforcing head-SHA coverage here
+          # would red a PR for a body edit whose cheap re-check legitimately
+          # had nothing to post.
+          #
+          # But the carve-out used to read "this cannot lose coverage on any
+          # SHA", and that was false: the concurrency group let an `edited` run
+          # CANCEL the push run whose coverage it defers to (#521, 2026-07-31).
+          # The group is now keyed by event class so that cannot recur — and
+          # this branch no longer takes it on trust either. Deferring to
+          # another run is only honest if that run left something behind, so a
+          # body edit on a PR with NO review anywhere in its lifetime fails
+          # instead of passing. Lifetime, not head-SHA: the point is to catch
+          # "never reviewed at all", not to demand a body edit re-review code.
           if [ "${EVENT_ACTION:-}" = "edited" ]; then
-            echo "Description-edit run — no new head SHA; coverage is enforced by the push events."
-            exit 0
+            if ! any=$( { gh api "repos/$REPO/pulls/$PR/reviews" --paginate --jq 'length'
+                          gh api "repos/$REPO/pulls/$PR/comments" --paginate --jq 'length'
+                          gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                            --jq '[.[] | select(.user.login == "claude[bot]")] | length'
+                        } | awk '{s+=$1} END {print s+0}'); then
+              echo "::warning::guard: lifetime-coverage query failed — failing open."; exit 0
+            fi
+            if [ "${any:-0}" -gt 0 ]; then
+              echo "Description-edit run — no new head SHA, and the PR has $any review artifact(s); head coverage is enforced by the push events."
+              exit 0
+            fi
+            echo "::error::Description-edit run on a PR with ZERO review activity in its lifetime."
+            echo "This carve-out defers head-SHA coverage to the push events, which is only"
+            echo "honest if a push run actually reviewed something. None did — most likely the"
+            echo "code run was cancelled (check for a cancelled claude-review run at this SHA)."
+            exit 1
           fi
           # Fail-open on API errors: the guard is a safety net, and its own
           # flakiness must never block a merge. It fails ONLY on confirmed

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -225,58 +225,12 @@ jobs:
             echo "Fork PR ($HEAD_REPO != $REPO) — review step gated off, no secrets available. Needs session-side review."
             exit 0
           fi
-          # Description-edit runs carry no new commit, so head-SHA coverage is
-          # owned by whichever push event produced that head — every SHA gets
-          # an `opened` or `synchronize` run. Enforcing head-SHA coverage here
-          # would red a PR for a body edit whose cheap re-check legitimately
-          # had nothing to post.
-          #
-          # But the carve-out used to read "this cannot lose coverage on any
-          # SHA", and that was false: the concurrency group let an `edited` run
-          # CANCEL the push run whose coverage it defers to (#521, 2026-07-31).
-          # The group is now keyed by event class so that cannot recur — and
-          # this branch no longer takes it on trust either. Deferring to
-          # another run is only honest if that run left something behind, so a
-          # body edit on a PR with NO review anywhere in its lifetime fails
-          # instead of passing. Lifetime, not head-SHA: the point is to catch
-          # "never reviewed at all", not to demand a body edit re-review code.
-          if [ "${EVENT_ACTION:-}" = "edited" ]; then
-            # Three queries, each checked SEPARATELY and summed in the shell.
-            # Not one brace group piped to awk: a group's exit status is its
-            # LAST command's, so a transient failure in either of the first two
-            # would go undetected, contribute 0, and let this branch red a PR
-            # that does have reviews. A false red is the one direction this
-            # guard must never fail in — every other query here fails open.
-            any=0
-            for q in "pulls/$PR/reviews|length" \
-                     "pulls/$PR/comments|length" \
-                     "issues/$PR/comments|[.[] | select(.user.login == \"claude[bot]\")] | length"; do
-              path="${q%%|*}"; expr="${q#*|}"
-              # awk validates each line rather than summing blindly. A plain
-              # `{s+=$1}` coerces any non-numeric output to 0 and prints a
-              # perfectly numeric total, so garbage or an error body that still
-              # exits 0 would read as "no reviews" and red the PR. Exiting
-              # non-zero here trips `pipefail` and the fail-open below. `!seen`
-              # covers empty output for the same reason: absent data is not
-              # evidence of zero coverage.
-              if ! n=$(gh api "repos/$REPO/$path" --paginate --jq "$expr" | awk '
-                        /^[0-9]+$/ { s += $1; seen = 1; next }
-                        { bad = 1; exit 3 }
-                        END { if (bad || !seen) exit 3; print s + 0 }'); then
-                echo "::warning::guard: lifetime-coverage query ($path) failed or returned non-numeric output — failing open."; exit 0
-              fi
-              any=$((any + n))
-            done
-            if [ "${any:-0}" -gt 0 ]; then
-              echo "Description-edit run — no new head SHA, and the PR has $any review artifact(s); head coverage is enforced by the push events."
-              exit 0
-            fi
-            echo "::error::Description-edit run on a PR with ZERO review activity in its lifetime."
-            echo "This carve-out defers head-SHA coverage to the push events, which is only"
-            echo "honest if a push run actually reviewed something. None did — most likely the"
-            echo "code run was cancelled (check for a cancelled claude-review run at this SHA)."
-            exit 1
-          fi
+          # `edited` runs are handled AFTER the not-applicable carve-outs
+          # below, not here. Ordering is semantics in this step: putting the
+          # description-edit branch first meant a workflow-file PR — which the
+          # action never reviews, by anti-hijack design — hit the coverage
+          # requirement before reaching its own carve-out, producing an
+          # UNCLEARABLE red. Observed on #522, the PR that added the branch.
           # Fail-open on API errors: the guard is a safety net, and its own
           # flakiness must never block a merge. It fails ONLY on confirmed
           # zero-coverage abandonment.
@@ -320,6 +274,61 @@ jobs:
             else
               echo "::warning::guard: compare query failed — treating push as substantive."
             fi
+          fi
+          # Description-edit runs carry no new commit, so head-SHA coverage is
+          # owned by whichever push event produced that head — every SHA gets
+          # an `opened` or `synchronize` run. Enforcing head-SHA coverage here
+          # would red a PR for a body edit whose cheap re-check legitimately
+          # had nothing to post.
+          #
+          # But the carve-out used to read "this cannot lose coverage on any
+          # SHA", and that was false: the concurrency group let an `edited` run
+          # CANCEL the push run whose coverage it defers to (#521, 2026-07-31).
+          # The group is now keyed by event class so that cannot recur — and
+          # this branch no longer takes it on trust either. Deferring to
+          # another run is only honest if that run left something behind, so a
+          # body edit on a PR with NO review anywhere in its lifetime fails
+          # instead of passing. Lifetime, not head-SHA: the point is to catch
+          # "never reviewed at all", not to demand a body edit re-review code.
+          #
+          # Placed HERE, after every not-applicable carve-out, so it can only
+          # fire on a PR the action was actually supposed to review.
+          if [ "${EVENT_ACTION:-}" = "edited" ]; then
+            # Three queries, each checked SEPARATELY and summed in the shell.
+            # Not one brace group piped to awk: a group's exit status is its
+            # LAST command's, so a transient failure in either of the first two
+            # would go undetected, contribute 0, and let this branch red a PR
+            # that does have reviews. A false red is the one direction this
+            # guard must never fail in — every other query here fails open.
+            any=0
+            for q in "pulls/$PR/reviews|length" \
+                     "pulls/$PR/comments|length" \
+                     "issues/$PR/comments|[.[] | select(.user.login == \"claude[bot]\")] | length"; do
+              path="${q%%|*}"; expr="${q#*|}"
+              # awk validates each line rather than summing blindly. A plain
+              # `{s+=$1}` coerces any non-numeric output to 0 and prints a
+              # perfectly numeric total, so garbage or an error body that still
+              # exits 0 would read as "no reviews" and red the PR. Exiting
+              # non-zero here trips `pipefail` and the fail-open below. `!seen`
+              # covers empty output for the same reason: absent data is not
+              # evidence of zero coverage.
+              if ! n=$(gh api "repos/$REPO/$path" --paginate --jq "$expr" | awk '
+                        /^[0-9]+$/ { s += $1; seen = 1; next }
+                        { bad = 1; exit 3 }
+                        END { if (bad || !seen) exit 3; print s + 0 }'); then
+                echo "::warning::guard: lifetime-coverage query ($path) failed or returned non-numeric output — failing open."; exit 0
+              fi
+              any=$((any + n))
+            done
+            if [ "${any:-0}" -gt 0 ]; then
+              echo "Description-edit run — no new head SHA, and the PR has $any review artifact(s); head coverage is enforced by the push events."
+              exit 0
+            fi
+            echo "::error::Description-edit run on a PR with ZERO review activity in its lifetime."
+            echo "This carve-out defers head-SHA coverage to the push events, which is only"
+            echo "honest if a push run actually reviewed something. None did — most likely the"
+            echo "code run was cancelled (check for a cancelled claude-review run at this SHA)."
+            exit 1
           fi
           # Coverage must be on the CURRENT HEAD, not merely somewhere in the
           # PR's lifetime.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -226,13 +226,32 @@ jobs:
           # instead of passing. Lifetime, not head-SHA: the point is to catch
           # "never reviewed at all", not to demand a body edit re-review code.
           if [ "${EVENT_ACTION:-}" = "edited" ]; then
-            if ! any=$( { gh api "repos/$REPO/pulls/$PR/reviews" --paginate --jq 'length'
-                          gh api "repos/$REPO/pulls/$PR/comments" --paginate --jq 'length'
-                          gh api "repos/$REPO/issues/$PR/comments" --paginate \
-                            --jq '[.[] | select(.user.login == "claude[bot]")] | length'
-                        } | awk '{s+=$1} END {print s+0}'); then
-              echo "::warning::guard: lifetime-coverage query failed — failing open."; exit 0
-            fi
+            # Three queries, each checked SEPARATELY and summed in the shell.
+            # Not one brace group piped to awk: a group's exit status is its
+            # LAST command's, so a transient failure in either of the first two
+            # would go undetected, contribute 0, and let this branch red a PR
+            # that does have reviews. A false red is the one direction this
+            # guard must never fail in — every other query here fails open.
+            any=0
+            for q in "pulls/$PR/reviews|length" \
+                     "pulls/$PR/comments|length" \
+                     "issues/$PR/comments|[.[] | select(.user.login == \"claude[bot]\")] | length"; do
+              path="${q%%|*}"; expr="${q#*|}"
+              # awk validates each line rather than summing blindly. A plain
+              # `{s+=$1}` coerces any non-numeric output to 0 and prints a
+              # perfectly numeric total, so garbage or an error body that still
+              # exits 0 would read as "no reviews" and red the PR. Exiting
+              # non-zero here trips `pipefail` and the fail-open below. `!seen`
+              # covers empty output for the same reason: absent data is not
+              # evidence of zero coverage.
+              if ! n=$(gh api "repos/$REPO/$path" --paginate --jq "$expr" | awk '
+                        /^[0-9]+$/ { s += $1; seen = 1; next }
+                        { bad = 1; exit 3 }
+                        END { if (bad || !seen) exit 3; print s + 0 }'); then
+                echo "::warning::guard: lifetime-coverage query ($path) failed or returned non-numeric output — failing open."; exit 0
+              fi
+              any=$((any + n))
+            done
             if [ "${any:-0}" -gt 0 ]; then
               echo "Description-edit run — no new head SHA, and the PR has $any review artifact(s); head coverage is enforced by the push events."
               exit 0

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -111,17 +111,32 @@ jobs:
             command in plain allowed form and continue the review. Never
             abandon the review because of denials; if you have findings
             or a no-issues verdict, exhaust plain `gh pr comment` before
-            giving up on posting. You are running ONE-SHOT and headless:
-            never use ScheduleWakeup, background tasks, or any
-            wait-for-later mechanism — a parked session simply ends and
-            the review is lost (observed 2026-07-24, PR #416: the
-            orchestrator scheduled a wakeup to wait for its subagents
-            and ended mid-wait). Launch subagents and consume their
-            results synchronously within this run. If you consciously
-            decide NOT to review (triviality gate, out-of-scope diff,
-            already reviewed), do not end silently — post a one-line
-            `gh pr comment` stating the skip and the reason. A silent
-            end is indistinguishable from a crash and fails the check.
+            giving up on posting. — THE POSTING CONTRACT, and it is
+            UNCONDITIONAL: you MUST call `gh pr comment` before your
+            final turn ends. Every run, every outcome. Findings, a
+            no-issues verdict, a conscious skip, a partial review you ran
+            out of room for, or "I could not complete this and here is
+            how far I got" — all of those are acceptable comments. Ending
+            a turn without having posted is the ONE failure mode this job
+            cannot tolerate, because a silent end is indistinguishable
+            from a crash and reds the check. If you are ever unsure
+            whether to post, post. — This obligation is deliberately not
+            phrased as a ban on parking mechanisms, because three
+            different ones have now defeated that phrasing: a
+            ScheduleWakeup wait (#416, 2026-07-24), a bare statement of
+            intent to wait (#511, 2026-07-30), and an ASYNC `Agent`
+            launch followed by "I'll continue once it reports back"
+            (#521, 2026-07-31). Mechanisms are open-ended; the posting
+            contract is not. — Concretely on subagents: the `Agent` tool
+            here may return IMMEDIATELY with "agent launched
+            successfully… working in the background". That is not a
+            result, and this run has no way to wait for one — nothing
+            will wake you, and the notification lands after the job is
+            gone. So do the work INLINE with plain `gh pr view` / `gh pr
+            diff` and your own reading. If you do launch a subagent and
+            its result has not arrived, that is not a reason to wait: it
+            is a reason to finish the review yourself and post. You are
+            running ONE-SHOT and headless.
             — Re-review rule: "I already reviewed this PR" is NOT a valid
             skip when new commits have landed since. This job fires on
             every push, and the guard below enforces coverage on the

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -339,6 +339,57 @@ stopped being true on 2026-07-29 when the guard moved to head-SHA coverage
 (class 6's fix). That understated the consequence of a skip to the one reader
 whose behaviour it was trying to change. Corrected in the same PR.
 
+### Failure class 6 recurred a THIRD time: an async subagent launch (2026-07-31)
+
+Same head as class 10, one run later. PR #521, run `30624630414`:
+`num_turns: 4`, `subtype: success`, `permission_denials_count: 0`, $0.19, 23.7s,
+`reviews=0 inline=0 bot_summaries=0`. The guard caught it; the check failed
+correctly.
+
+The transcript, in order:
+
+```
+[4]  Agent(...)   -> "Async agent launched successfully… working in the background"
+[9]  "I'll wait for the eligibility check to complete before proceeding further."
+[10] ToolSearch(select:SendMessage)
+[14] gh pr view 521 --json state,isDraft,title,body,comments
+[19] ScheduleWakeup({stop: true})
+[26] "I've kicked off the eligibility check… I'll continue once it reports back."  -> ends
+```
+
+**The root cause is that `Agent` returned asynchronously.** The prompt told the
+orchestrator to "launch subagents and consume their results synchronously within
+this run", but the tool handed back a launch acknowledgement rather than a
+result, and there is no wake-up path in a one-shot headless job — the completion
+notification arrives after the runner is gone. Having no way to wait and no
+instruction covering that case, it ended the turn.
+
+Note it *did* call `ScheduleWakeup`, which the prompt banned outright — with
+`stop: true`, so the ban was technically honoured while the behaviour it exists
+to prevent happened anyway.
+
+**This is the third distinct parking mechanism**, and the previous entry
+predicted it in as many words: *"Any prompt-level fix has to be phrased as an
+obligation to post before ending rather than a prohibition on a parking
+mechanism — mechanisms are open-ended, the posting contract is not."* That advice
+was recorded and then not acted on; the prompt kept the ban and left the posting
+obligation **conditional** on "if you consciously decide NOT to review". This run
+never decided not to review — it believed it was mid-review — so the obligation
+did not bind. A conditional obligation is not a contract.
+
+**Fixes:**
+
+1. The posting contract is now **unconditional**: post a `gh pr comment` before
+   the final turn ends, in every run and every outcome, including a partial
+   review or an "I could not finish, here is how far I got". "If unsure, post."
+2. The async-`Agent` trap is named explicitly, with the instruction to do the
+   work inline via plain `gh pr view` / `gh pr diff`, and that an unarrived
+   subagent result is a reason to finish and post rather than to wait.
+
+The tally is what matters here: a prohibition on parking has now been defeated
+three times, by a wakeup call, by prose, and by a tool's async return. Each fix
+addressed the mechanism in front of it. Only the obligation generalises.
+
 ## Forensics playbook
 
 **Run signatures** (from the action's result JSON in the job log — grep the

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -278,6 +278,67 @@ a plain re-run produced the 6-turn park above. So this is not stochastic in
 the way class 5 is — re-running is not the remedy, and two consecutive silent
 no-ops on one head is the signal to stop re-running and pull the artifact.
 
+### Failure class 10: a description-edit run cancelled the code run (2026-07-31)
+
+The first genuinely *structural* green-with-no-review: nothing crashed, nothing
+was denied, no agent gave up. Two runs raced and the wrong one survived.
+
+On PR #521, at head `269dc3e3`:
+
+| run | event | outcome |
+|---|---|---|
+| `30624281369` | code review | **cancelled** 38s in |
+| `30624312907` | `edited` (body) | **success**, 1m4s, `reviews=0 inline=0 bot_summaries=0` |
+
+`claude-review` went green with zero review activity, and the guard agreed it
+should.
+
+**Both halves were behaving as designed.** The concurrency group
+(`claude-review-<pr>`, `cancel-in-progress: true`) exists so a burst of pushes
+does not leave several runs reviewing superseded heads — its comment justified
+cancelling on the grounds that "the surviving run reviews the only SHA that can
+be merged." The `edited` handler exists so body-scoped findings can be confirmed
+closed without an 11-minute re-review, and its guard branch skips head-SHA
+enforcement because "coverage is enforced by the push events."
+
+Composed, they contradict: an `edited` run deliberately does **not** review the
+diff, so when it wins the cancellation race the survivor reviews nothing — and
+then defers coverage to the push event it just killed. Each comment was true in
+isolation and the pair was false.
+
+**Sequence that triggers it**, and it is an ordinary one: push a branch, open a
+PR, then edit the PR body within the review's 8-11 minute window. Anyone who
+opens a PR and immediately corrects a number in the description hits it.
+
+**Two fixes, deliberately redundant:**
+
+1. The concurrency group is keyed by event class —
+   `claude-review-<pr>-<body|code>` — so body edits and code runs are in
+   separate groups and cannot cancel each other.
+2. The guard's `edited` branch no longer takes the deferral on trust. Deferring
+   is only honest if a push run left something behind, so a body edit on a PR
+   with **zero** review artifacts anywhere in its lifetime now fails. Lifetime,
+   not head-SHA: the point is to catch "never reviewed at all" without demanding
+   that a body edit re-review code.
+
+Fix 1 prevents this specific race; fix 2 catches any future route to the same
+end state, since the failure is "the guard passed a PR nothing ever reviewed"
+rather than "these two events raced".
+
+**The generalisable lesson is about the comments, not the code.** Both carve-outs
+carried a written justification, and each justification quantified over the other
+mechanism's behaviour without naming it — "the surviving run reviews" assumed
+every survivor reviews; "coverage is enforced by the push events" assumed the
+push events still exist. When a carve-out's rationale depends on another
+mechanism's behaviour, name that mechanism in the comment, because that is what
+makes the dependency visible when the other one changes.
+
+Also caught in the same log: the review prompt still told the agent that "the
+guard below only checks that the PR has SOME review in its lifetime", which
+stopped being true on 2026-07-29 when the guard moved to head-SHA coverage
+(class 6's fix). That understated the consequence of a skip to the one reader
+whose behaviour it was trying to change. Corrected in the same PR.
+
 ## Forensics playbook
 
 **Run signatures** (from the action's result JSON in the job log — grep the

--- a/scripts/review-guard-edited-branch-test.sh
+++ b/scripts/review-guard-edited-branch-test.sh
@@ -4,6 +4,25 @@ REPO=o/r; PR=521
 CTR=$(mktemp)   # file-based counter: the previous stub incremented inside a
                 # command substitution, so the parent never saw it and case 4
                 # silently tested case 3 again.
+
+# The loop below is a COPY of the one in the workflow, because the workflow
+# cannot be dry-run and the block cannot be sourced out of a YAML `run:`.
+# A copy that drifts is worse than no test, so assert the shipped text still
+# contains the load-bearing lines before trusting any result below.
+WF=".github/workflows/claude-code-review.yml"
+if [ -f "$WF" ]; then
+  for needle in 'for q in "pulls/$PR/reviews|length"' \
+                '/^[0-9]+$/ { s += $1; seen = 1; next }' \
+                '{ bad = 1; exit 3 }' \
+                'END { if (bad || !seen) exit 3; print s + 0 }'; do
+    if ! grep -qF -- "$needle" "$WF"; then
+      echo "DRIFT: the workflow no longer contains: $needle" >&2
+      echo "This test is asserting behaviour the shipped guard may not have." >&2
+      exit 2
+    fi
+  done
+  echo "(drift check: workflow still contains the guard lines under test)"
+fi
 run_loop() {
   any=0
   for q in "pulls/$PR/reviews|length" \

--- a/scripts/review-guard-edited-branch-test.sh
+++ b/scripts/review-guard-edited-branch-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -uo pipefail
+REPO=o/r; PR=521
+CTR=$(mktemp)   # file-based counter: the previous stub incremented inside a
+                # command substitution, so the parent never saw it and case 4
+                # silently tested case 3 again.
+run_loop() {
+  any=0
+  for q in "pulls/$PR/reviews|length" \
+           "pulls/$PR/comments|length" \
+           "issues/$PR/comments|[.[] | select(.user.login == \"claude[bot]\")] | length"; do
+    path="${q%%|*}"; expr="${q#*|}"
+    if ! n=$(gh api "repos/$REPO/$path" --paginate --jq "$expr" | awk '
+              /^[0-9]+$/ { s += $1; seen = 1; next }
+              { bad = 1; exit 3 }
+              END { if (bad || !seen) exit 3; print s + 0 }'); then
+      echo "  -> FAIL-OPEN ($path)"; return 9
+    fi
+    any=$((any + n))
+  done
+  echo "  -> any=$any"
+  [ "$any" -gt 0 ] && return 0 || return 1
+}
+bump() { c=$(( $(cat "$CTR") + 1 )); echo "$c" > "$CTR"; echo "$c"; }
+
+echo "1. all three return paginated counts   (expect rc=0, pass)"
+gh() { printf '2\n1\n'; }; run_loop; echo "   rc=$?"
+
+echo "2. all three return zero               (expect rc=1, FAIL the check)"
+gh() { echo 0; }; run_loop; echo "   rc=$?"
+
+echo "3. FIRST query exits non-zero          (expect rc=9, fail open)"
+echo 0 > "$CTR"; gh() { [ "$(bump)" = 1 ] && return 1; echo 5; }; run_loop; echo "   rc=$?"
+
+echo "4. SECOND query exits non-zero         (expect rc=9, fail open)"
+echo 0 > "$CTR"; gh() { if [ "$(bump)" = 2 ]; then return 1; fi; echo 5; }; run_loop; echo "   rc=$?"
+
+echo "5. THIRD query exits non-zero          (expect rc=9, fail open)"
+echo 0 > "$CTR"; gh() { if [ "$(bump)" = 3 ]; then return 1; fi; echo 5; }; run_loop; echo "   rc=$?"
+
+echo "6. non-numeric body, exit 0            (expect rc=9, fail open)"
+gh() { echo "not json"; }; run_loop; echo "   rc=$?"
+
+echo "7. empty output, exit 0                (expect rc=9, fail open)"
+gh() { true; }; run_loop; echo "   rc=$?"
+
+echo "8. mixed: a number then garbage        (expect rc=9, fail open)"
+gh() { printf '3\noops\n'; }; run_loop; echo "   rc=$?"


### PR DESCRIPTION
## Intent

`claude-review` went green on #521 with **zero review activity** — no inline comments, no verdict, no crash, no denial. Two runs raced at head `269dc3e3` and the wrong one survived:

| run | event | outcome |
|---|---|---|
| [`30624281369`](https://github.com/storkme/spaghettio/actions/runs/30624281369) | code review | **cancelled** 38s in |
| [`30624312907`](https://github.com/storkme/spaghettio/actions/runs/30624312907) | `edited` (body) | **success**, 1m4s, `reviews=0 inline=0 bot_summaries=0` |

**Both halves were behaving as designed**, which is what makes this structural rather than another flake:

- the concurrency group cancels superseded runs, justified in its own comment because *"the surviving run reviews the only SHA that can be merged"*;
- the `edited` handler skips head-SHA enforcement, justified because *"coverage is enforced by the push events"*.

Composed, they contradict. An `edited` run deliberately does **not** review the diff, so when it wins the race the survivor reviews nothing — and then defers coverage to the push event it had just killed. Each comment was true in isolation; the pair was false.

The triggering sequence is ordinary: open a PR, then fix a number in the description inside the review's 8–11 minute window.

## Scope

- **In:** two redundant fixes, plus one stale prompt claim and the failure-class writeup.
  1. Concurrency group keyed by **event class** — `claude-review-<pr>-<body|code>` — so body edits and code runs are in separate groups and cannot cancel each other.
  2. The guard's `edited` branch no longer takes the deferral on trust: a body edit on a PR with **zero** review artifacts anywhere in its lifetime now fails. *Lifetime*, not head-SHA — the point is to catch "never reviewed at all" without demanding that a body edit re-review code.
  3. The prompt told the agent *"the guard below only checks that the PR has SOME review in its lifetime."* That stopped being true on 2026-07-29 when the guard moved to head-SHA coverage (class 6's fix), so it was understating the consequence of a skip to the one reader whose behaviour it exists to change.
  4. `docs/review-bot.md` — failure class 10.
- **Out:** anything that would change when a review is *skipped*. The triviality gate, workflow-file carve-out, draft carve-out and fork carve-out are untouched.

The two fixes are deliberately redundant. Fix 1 prevents this race; fix 2 catches any other route to the same end state, because the failure is "the guard passed a PR that nothing ever reviewed", not "these two events raced".

## Two more findings, both from this PR's own session-side review

Because the bot cannot review this file, I reviewed the diff myself — and it produced two further commits.

**1. My guard change could red a PR that HAS reviews** (`6c46f299`). Two holes, both failing in the one direction this guard must never fail in:

- The three coverage queries ran as `{ gh; gh; gh; } | awk`, and a brace group's exit status is its **last** command's. A transient failure in either of the first two went undetected, contributed 0, and could take the total to zero.
- `awk '{s+=$1} END {print s+0}'` coerces any non-numeric line to `0` and prints a perfectly numeric total, so the `case "$n" in *[!0-9]*` validation downstream could never see it. An error body that still exits 0 — or empty output — read as "no reviews".

Fixed: three separately-checked queries, and awk now validates each line and exits non-zero on garbage or on no lines at all, tripping `pipefail` into the fail-open. **Absent data is not evidence of zero coverage.** `scripts/review-guard-edited-branch-test.sh` covers 8 cases against a stubbed `gh`; only genuine-zero fails the check, all seven error paths fail open.

That bug is why "the YAML parses" is not verification: it parsed, it was valid shell, and it inverted the guard's failure direction on input that occurs in practice. The *test* had the same class of bug on its first pass — a counter incremented inside a command substitution, so the "second query fails" case silently re-tested the first and reported a pass.

**2. Failure class 6 has recurred a third time** (`f18b6314`). Re-triggering #521's review produced a silent no-op — `num_turns: 4`, `subtype: success`, **0 denials**, nothing posted:

```
[4]  Agent(...)  -> "Async agent launched successfully… working in the background"
[9]  "I'll wait for the eligibility check to complete before proceeding further."
[19] ScheduleWakeup({stop: true})
[26] "I've kicked off the eligibility check… I'll continue once it reports back."  -> ends
```

The `Agent` tool returned **asynchronously**. The prompt said "consume their results synchronously", but the tool handed back a launch acknowledgement, and a one-shot headless job has no wake-up path. With no way to wait and no instruction covering that case, it ended.

`docs/review-bot.md` predicted this exactly — *"any prompt-level fix has to be phrased as an obligation to post before ending rather than a prohibition on a parking mechanism"* — and the prediction was recorded but not acted on: the prompt kept the ban and left the posting obligation **conditional** on "if you consciously decide NOT to review". This run never decided not to review; it believed it was mid-review, so the obligation did not bind. **A conditional obligation is not a contract.**

Fixed: the posting contract is now unconditional (post before the final turn ends, every run, every outcome, "if unsure, post"), and the async-`Agent` trap is named with the instruction to work inline instead.

## Restacked onto main — it was silently carrying all of RFC-059

Caught on the final pre-merge diff read. I branched this from `feat/rfc-059-phase1` rather than `main`, so `gh pr diff 522 --name-only` listed **thirteen** files: the whole RFC-059 change — engine, tests, RFC, status ledger — plus these three.

Its base is `main`. **Merging it would have landed all of RFC-059 unreviewed**, through precisely the hole this PR exists to close: a green `claude-review` on a PR nothing reviewed. #521's own review would then have been reviewing code already on `main`.

Rebased with `git rebase --onto origin/main feat/rfc-059-phase1`, so the diff is now the three intended files only:

```
.github/workflows/claude-code-review.yml
docs/review-bot.md
scripts/review-guard-edited-branch-test.sh
```

Worth stating plainly because the near-miss is the same shape as the bugs above and it was found the same way — by reading the artifact rather than trusting that the intent matched the output. A file list is cheap to check and I checked it last.

## Verification

- [x] YAML parses (`yaml.safe_load`).
- [x] **Guard logic executed, not just inspected** — `bash scripts/review-guard-edited-branch-test.sh` runs the shipped loop against a stubbed `gh` across 8 cases: paginated counts, genuine zero, each of the three queries failing in turn, non-numeric body, empty output, and a number followed by garbage. Only genuine-zero fails the check; every error path fails open.
- [x] `bash -n` on the guard step extracted from the YAML (the workflow itself cannot be dry-run).
- [x] **Gate order verified** by extracting the step and listing its conditions in sequence: fork → draft → workflow-files → diff-size → push-delta → **edited floor** → head-SHA coverage. The floor was originally placed first, which reddened this very PR unclearably in 15s (run [`30624947669`](https://github.com/storkme/spaghettio/actions/runs/30624947669)) — a workflow-file PR hit "you have zero reviews" before reaching the carve-out that exists because the action never reviews workflow-file PRs.
- [x] **The ordering fix is confirmed end-to-end on this PR**: `claude-review` now passes in 10s via `PR touches workflow files — action self-skips these (anti-hijack); guard not applicable.` — and this body edit is itself the `edited`-on-a-zero-review-workflow-PR case that used to fail.
- [x] `git diff --name-only origin/main..HEAD` — three files, checked after the restack.
- [x] Reproduction is on the record: run IDs above, with `EVENT_ACTION: edited` and the guard printing `Description-edit run — no new head SHA; coverage is enforced by the push events.` while the code run for the same SHA shows `outcome=cancelled`.
- [x] `cargo test` / `clippy` — **N/A**, no Rust touched.
- [ ] The bot reviewing this PR — **it cannot.** This touches `.github/workflows/`, so the action self-skips by anti-hijack design and the guard's matching carve-out passes it. **Needs session-side review** per CLAUDE.md's Workflow section. Flagging explicitly because that carve-out is exactly the shape of hole this PR is fixing.

## Deviations from intent

Scope grew from one fix to three. The concurrency key was the whole of the original diagnosis; the guard's fail-open holes and the posting contract came out of reviewing my own work and out of watching #521's re-triggered review fail. All three are the same defect class — `claude-review` green, or red for the wrong reason, without a review having happened — so they belong together in the file they all live in.

Fix 2 was not in the original diagnosis — the concurrency key alone explains and prevents the observed failure. Added it because the guard's comment made a claim about the world (*"carving this out cannot lose coverage on any SHA"*) that was falsified, and restoring the claim's truth is worth more than the minimal fix. A carve-out whose rationale has been shown wrong should stop relying on that rationale, not just have the one known counterexample blocked.

## Models / contracts touched

- `docs/review-bot.md` — new failure class 10, and its lesson is about the **comments** rather than the code: both carve-outs quantified over the other mechanism's behaviour without naming it, which is what hid the dependency when the other changed. Worth applying when writing any future carve-out here.
- No engine contract touched.

