### PR TITLE
fix(validate): belt-flow reachability asked per machine, and shipped a half-rate factory

### DIFF
--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -1304,10 +1304,25 @@ pub fn check_belt_flow_reachability(
         }
     }
     let mut reported: FxHashSet<(i32, i32)> = FxHashSet::default();
+    // A tile that is BOTH a drop and a pickup is fed by the drop, even though
+    // the one-step-in seeding cannot see it: the seeding exists to stop a tile
+    // supplying itself, and a drop AT the tile is a different thing from the
+    // tile being its own upstream. Caught in review of this change — it is the
+    // common shape, since `stamp_di_bridge`'s pickup column and a producer's own
+    // output-drop column both land at `mx+1` under the default row geometry.
+    //
+    // Deliberately NOT `!source_tiles.contains(&t)`: `source_tiles` also holds
+    // every boundary tile, and letting a pickup satisfy itself by sitting on the
+    // boundary is the laxity the seeding was added to remove. Only an actual
+    // drop at the tile counts.
     let mut unfed: Vec<(i32, i32)> = machines_by_input
         .keys()
         .chain(lift_pickup_tiles.iter())
-        .filter(|&&t| !fed.contains(&t))
+        .filter(|&&t| {
+            !fed.contains(&t)
+                && !output_belt_tiles.contains(&t)
+                && !lift_drop_tiles.contains(&t)
+        })
         .copied()
         .collect();
     unfed.sort();
@@ -1363,9 +1378,21 @@ pub fn check_belt_flow_reachability(
             }
         }
     }
+    // Mirror of the input-side allowance: items leave a tile that something
+    // picks FROM, even when that tile is the machine's own drop tile. The old
+    // code encoded this only for DI bridges, by testing the INCLUSIVE
+    // `downstream` set against `di_bridge_pickup_tiles` while using the strict
+    // `downstream_beyond` for every other arm. That asymmetry was load-bearing
+    // and undocumented; it is stated here and extended to the other pickup
+    // kinds, which have the same physics.
     let mut stuck: Vec<(i32, i32)> = machines_by_output
         .keys()
-        .filter(|&&t| !drains.contains(&t))
+        .filter(|&&t| {
+            !drains.contains(&t)
+                && !input_belt_tiles.contains(&t)
+                && !di_bridge_pickup_tiles.contains(&t)
+                && !lift_pickup_tiles.contains(&t)
+        })
         .copied()
         .collect();
     stuck.sort();
@@ -4224,6 +4251,109 @@ mod tests {
             .filter(|i| i.message.contains("cannot leave"))
             .collect();
         assert_eq!(errors.len(), 1);
+    }
+
+    /// Regression for the same-tile false positive on the OUTPUT side (#524
+    /// review): a DI bridge picks straight off the producer's own drop tile.
+    ///
+    /// The tile is in `sink_tiles` but never in the strictly-one-step-upstream
+    /// `drains` closure, so a membership test alone reported "items cannot
+    /// leave" on a working layout. This is the COMMON shape rather than a corner
+    /// case — `stamp_di_bridge`'s pickup column and the producer's own
+    /// output-drop column both land at `mx + 1` under the default row geometry —
+    /// and because `di_choice` gates on being better on every channel, the
+    /// spurious warning would have suppressed correct DI layouts.
+    #[test]
+    fn flow_reachability_di_bridge_on_own_drop_tile_is_not_stuck() {
+        let sr = simple_solver(5.0, 2.5);
+        let mut entities = vec![
+            PlacedEntity {
+                name: "assembling-machine-3".to_string(),
+                x: 3,
+                y: 0,
+                direction: EntityDirection::North,
+                recipe: Some("iron-gear-wheel".to_string()),
+                ..Default::default()
+            },
+            inserter(4, -1, EntityDirection::South), // input: picks (4,-2)
+        ];
+        for x in 0..5 {
+            entities.push(belt(x, -2, EntityDirection::East));
+        }
+        // Output inserter drops on (4,4); that belt flows nowhere...
+        entities.push(inserter(4, 3, EntityDirection::South));
+        entities.push(belt(4, 4, EntityDirection::North));
+        // ...because a DI bridge lifts straight off it. South-facing at (4,5)
+        // picks from (4,4) and carries to the consumer.
+        let mut bridge = inserter(4, 5, EntityDirection::South);
+        bridge.segment_id = Some("di-bridge:iron-gear-wheel".to_string());
+        entities.push(bridge);
+        let lr = LayoutResult {
+            entities,
+            width: 20,
+            height: 20,
+            ..Default::default()
+        };
+        let issues = check_belt_flow_reachability(&lr, Some(&sr), LayoutStyle::Spaghetti);
+        let stuck: Vec<_> = issues
+            .iter()
+            .filter(|i| i.message.contains("cannot leave"))
+            .collect();
+        assert!(
+            stuck.is_empty(),
+            "a DI bridge picking off the producer's own drop tile is a valid \
+             exit: {stuck:?}"
+        );
+    }
+
+    /// Mirror of the above on the INPUT side: a belt-to-belt lift drops onto the
+    /// exact tile another inserter picks from. That tile is a genuine, active
+    /// source, but the one-step-in seeding excluded it from `fed`.
+    ///
+    /// The geometry mirrors `flow_reachability_output_dead_end_fails`
+    /// deliberately. A first draft put the machine where its input inserter's
+    /// drop tile missed the machine footprint, so the pickup was never
+    /// classified as a machine input and never checked — the test passed with
+    /// the fix AND with it sabotaged, i.e. it asserted nothing.
+    #[test]
+    fn flow_reachability_lift_drop_on_pickup_tile_is_fed() {
+        let sr = simple_solver(5.0, 2.5);
+        let mut entities = vec![
+            PlacedEntity {
+                name: "assembling-machine-3".to_string(),
+                x: 3,
+                y: 0,
+                direction: EntityDirection::North,
+                recipe: Some("iron-gear-wheel".to_string()),
+                ..Default::default()
+            },
+            // Machine input: picks from (4,-2).
+            inserter(4, -1, EntityDirection::South),
+        ];
+        // (4,-2) is isolated: nothing FLOWS into it. Its only supply is the lift.
+        entities.push(belt(4, -2, EntityDirection::South));
+        // A fed run along y = -4, reaching the boundary at x = 0.
+        for x in 0..5 {
+            entities.push(belt(x, -4, EntityDirection::East));
+        }
+        // Lift at (4,-3) facing South: picks (4,-4) off the fed run, drops (4,-2)
+        // — the machine's pickup tile.
+        entities.push(inserter(4, -3, EntityDirection::South));
+        let lr = LayoutResult {
+            entities,
+            width: 20,
+            height: 20,
+            ..Default::default()
+        };
+        let issues = check_belt_flow_reachability(&lr, Some(&sr), LayoutStyle::Spaghetti);
+        let unfed: Vec<_> = issues
+            .iter()
+            .filter(|i| i.message.contains("nothing feeds its pickup belt at (4,-2)"))
+            .collect();
+        assert!(
+            unfed.is_empty(),
+            "a lift dropping onto the pickup tile feeds it: {unfed:?}"
+        );
     }
 
     // --- check_belt_dead_ends: UG output ---

--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -224,6 +224,67 @@ fn bfs_belt_downstream(
     visited
 }
 
+/// One step of belt flow, mirroring `bfs_belt_downstream`'s three rules
+/// (direction, underground tunnel, splitter sibling). Used to seed a
+/// STRICTLY-DOWNSTREAM closure: `bfs_belt_downstream` includes its own starts,
+/// so seeding it with the sources would let a tile count as its own supply.
+fn belt_step_successors(
+    t: (i32, i32),
+    belt_dir_map: &FxHashMap<(i32, i32), EntityDirection>,
+    ug_pairs: &FxHashMap<(i32, i32), (i32, i32)>,
+    splitter_siblings: &FxHashMap<(i32, i32), (i32, i32)>,
+) -> Vec<(i32, i32)> {
+    let mut out = Vec::new();
+    if let Some(&d) = belt_dir_map.get(&t) {
+        let (dx, dy) = dir_to_vec(d);
+        let nb = (t.0 + dx, t.1 + dy);
+        if belt_dir_map.contains_key(&nb) {
+            out.push(nb);
+        }
+    }
+    if let Some(&p) = ug_pairs.get(&t) {
+        if belt_dir_map.contains_key(&p) {
+            out.push(p);
+        }
+    }
+    if let Some(&sib) = splitter_siblings.get(&t) {
+        if belt_dir_map.contains_key(&sib) {
+            out.push(sib);
+        }
+    }
+    out
+}
+
+/// Mirror of [`belt_step_successors`] for the upstream direction.
+fn belt_step_predecessors(
+    t: (i32, i32),
+    belt_dir_map: &FxHashMap<(i32, i32), EntityDirection>,
+    ug_pairs: &FxHashMap<(i32, i32), (i32, i32)>,
+    splitter_siblings: &FxHashMap<(i32, i32), (i32, i32)>,
+) -> Vec<(i32, i32)> {
+    let mut out = Vec::new();
+    for (ddx, ddy) in [(1, 0i32), (-1, 0), (0, 1), (0, -1)] {
+        let n = (t.0 + ddx, t.1 + ddy);
+        if let Some(&nd) = belt_dir_map.get(&n) {
+            let (ndx, ndy) = dir_to_vec(nd);
+            if (n.0 + ndx, n.1 + ndy) == t {
+                out.push(n);
+            }
+        }
+    }
+    if let Some(&p) = ug_pairs.get(&t) {
+        if belt_dir_map.contains_key(&p) {
+            out.push(p);
+        }
+    }
+    if let Some(&sib) = splitter_siblings.get(&t) {
+        if belt_dir_map.contains_key(&sib) {
+            out.push(sib);
+        }
+    }
+    out
+}
+
 fn bfs_belt_upstream(
     starts: &FxHashSet<(i32, i32)>,
     belt_dir_map: &FxHashMap<(i32, i32), EntityDirection>,
@@ -1109,46 +1170,35 @@ pub fn check_belt_flow_reachability(
         Severity::Warning
     };
 
-    // Input check
-    let mut checked: FxHashSet<(i32, i32)> = FxHashSet::default();
-    for e in &layout.entities {
-        if !is_machine_entity(&e.name) {
+    // BELT-TO-BELT LIFT inserters: pick off one belt and drop onto another.
+    // Invisible to the classification above, which only recognises
+    // machine<->belt, and that blind spot is half of #520 — a lift's drop was
+    // not counted as a source of its belt, and its own pickup was never
+    // verified, so a lift feeding off permanently empty belt looked fine.
+    //
+    // Modelled as BOTH: its drop tile is a source (items do arrive there) and
+    // its pickup tile is a sink that must itself be fed. That is what makes the
+    // check transitive, and it localises the fault at the lift's pickup rather
+    // than at the machine three rows downstream that starves because of it.
+    let mut lift_drop_tiles: FxHashSet<(i32, i32)> = FxHashSet::default();
+    let mut lift_pickup_tiles: FxHashSet<(i32, i32)> = FxHashSet::default();
+    let mut lift_by_pickup: FxHashMap<(i32, i32), (String, i32, i32, Option<String>)> =
+        FxHashMap::default();
+    for ins in &layout.entities {
+        if !is_inserter(&ins.name) {
             continue;
         }
-        let mpos = (e.x, e.y);
-        if !checked.insert(mpos) {
-            continue;
-        }
-        if e.recipe.as_deref().is_some_and(|r| fluid_only.contains(r)) {
-            continue;
-        }
-        let belts = match machine_input_belts.get(&mpos) {
-            Some(b) => b,
-            None => continue,
-        };
-        let belt_set: FxHashSet<(i32, i32)> = belts.iter().copied().collect();
-        let upstream = bfs_belt_upstream(
-            &belt_set,
-            &belt_dir_map,
-            Some(&ug_pairs),
-            Some(&splitter_siblings),
-        );
-        let upstream_beyond: FxHashSet<(i32, i32)> =
-            upstream.difference(&belt_set).copied().collect();
-        let reaches_source = upstream_beyond.iter().any(|&t| on_boundary(t))
-            || upstream_beyond.intersection(&output_belt_tiles).next().is_some();
-        if !reaches_source {
-            issues.push(ValidationIssue::with_pos(
-                severity,
-                "belt-flow-reachability",
-                format!(
-                    "{} at ({},{}): items can't reach input \
-                     (no upstream path from boundary or another machine's output)",
-                    e.name, e.x, e.y
-                ),
-                e.x,
-                e.y,
-            ));
+        let (dx, dy) = dir_to_vec(ins.direction);
+        let reach = inserter_reach(&ins.name);
+        let drop_pos = (ins.x + dx * reach, ins.y + dy * reach);
+        let pickup_pos = (ins.x - dx * reach, ins.y - dy * reach);
+        if belt_dir_map.contains_key(&drop_pos) && belt_dir_map.contains_key(&pickup_pos) {
+            lift_drop_tiles.insert(drop_pos);
+            lift_pickup_tiles.insert(pickup_pos);
+            lift_by_pickup.insert(
+                pickup_pos,
+                (ins.name.clone(), ins.x, ins.y, ins.carries.clone()),
+            );
         }
     }
 
@@ -1167,54 +1217,171 @@ pub fn check_belt_flow_reachability(
         })
         .collect();
 
-    // Output check
-    checked.clear();
+    // ONE forward sweep from every source, and one backward sweep from every
+    // sink, instead of a BFS per machine.
+    //
+    // This is the other half of #520, and it is a reporting defect rather than a
+    // missing rule. The check used to seed the BFS with ALL of a machine's input
+    // belts at once and ask whether the UNION reached a source, so on
+    // display-panel (iron-plate + electronic-circuit) the iron-plate belt's path
+    // back to the furnaces satisfied the test and the electronic-circuit belt —
+    // which no source fed — was never examined. A per-machine question cannot
+    // distinguish "every input is fed" from "some input is fed"; the same shape
+    // `validator-reporting.md` catalogues for counts that cannot tell 2 from
+    // 218. Per-TILE membership answers it exactly, and costs one sweep instead
+    // of one per machine.
+    let mut source_tiles: FxHashSet<(i32, i32)> = belt_dir_map
+        .keys()
+        .copied()
+        .filter(|&t| on_boundary(t))
+        .collect();
+    source_tiles.extend(output_belt_tiles.iter().copied());
+    source_tiles.extend(lift_drop_tiles.iter().copied());
+    // Seeded one step IN from each source, not with the sources themselves:
+    // the old per-machine form asked about `upstream \ own_belts`, so a tile was
+    // never its own supply. Seeding `bfs_belt_downstream` directly would have
+    // made a boundary output tile drain into itself — caught by this check's own
+    // `flow_reachability_output_dead_end_fails` unit test, which is the only
+    // reason the regression did not ship.
+    let mut fed_seed: FxHashSet<(i32, i32)> = FxHashSet::default();
+    for &t in &source_tiles {
+        fed_seed.extend(belt_step_successors(
+            t,
+            &belt_dir_map,
+            &ug_pairs,
+            &splitter_siblings,
+        ));
+    }
+    let fed = bfs_belt_downstream(
+        &fed_seed,
+        &belt_dir_map,
+        Some(&ug_pairs),
+        Some(&splitter_siblings),
+    );
+
+    let mut sink_tiles: FxHashSet<(i32, i32)> = belt_dir_map
+        .keys()
+        .copied()
+        .filter(|&t| on_boundary(t))
+        .collect();
+    sink_tiles.extend(input_belt_tiles.iter().copied());
+    sink_tiles.extend(di_bridge_pickup_tiles.iter().copied());
+    sink_tiles.extend(lift_pickup_tiles.iter().copied());
+    let mut drain_seed: FxHashSet<(i32, i32)> = FxHashSet::default();
+    for &t in &sink_tiles {
+        drain_seed.extend(belt_step_predecessors(
+            t,
+            &belt_dir_map,
+            &ug_pairs,
+            &splitter_siblings,
+        ));
+    }
+    let drains = bfs_belt_upstream(
+        &drain_seed,
+        &belt_dir_map,
+        Some(&ug_pairs),
+        Some(&splitter_siblings),
+    );
+
+    // Input check — one issue per unfed pickup TILE, positioned at the
+    // consumer, so two starved inputs on one machine report as two.
+    let mut machines_by_input: FxHashMap<(i32, i32), Vec<(String, i32, i32)>> =
+        FxHashMap::default();
     for e in &layout.entities {
         if !is_machine_entity(&e.name) {
-            continue;
-        }
-        let mpos = (e.x, e.y);
-        if !checked.insert(mpos) {
             continue;
         }
         if e.recipe.as_deref().is_some_and(|r| fluid_only.contains(r)) {
             continue;
         }
-        let belts = match machine_output_belts.get(&mpos) {
-            Some(b) => b,
-            None => continue,
-        };
-        let belt_set: FxHashSet<(i32, i32)> = belts.iter().copied().collect();
-        let downstream = bfs_belt_downstream(
-            &belt_set,
-            &belt_dir_map,
-            Some(&ug_pairs),
-            Some(&splitter_siblings),
-        );
-        let downstream_beyond: FxHashSet<(i32, i32)> =
-            downstream.difference(&belt_set).copied().collect();
-        let reaches_sink = downstream_beyond.iter().any(|&t| on_boundary(t))
-            || downstream_beyond
-                .intersection(&input_belt_tiles)
-                .next()
-                .is_some()
-            // DI: the output belt (or a tile downstream of it) is picked
-            // from by a direct-insertion bridge inserter — the items leave
-            // via the bridge, not by flowing onward.
-            || !downstream.is_disjoint(&di_bridge_pickup_tiles);
-        if !reaches_sink {
-            issues.push(ValidationIssue::with_pos(
-                severity,
-                "belt-flow-reachability",
-                format!(
-                    "{} at ({},{}): items can't leave output \
-                     (no downstream path to boundary or another machine's input)",
-                    e.name, e.x, e.y
-                ),
-                e.x,
-                e.y,
-            ));
+        if let Some(belts) = machine_input_belts.get(&(e.x, e.y)) {
+            for &b in belts {
+                machines_by_input
+                    .entry(b)
+                    .or_default()
+                    .push((e.name.clone(), e.x, e.y));
+            }
         }
+    }
+    let mut reported: FxHashSet<(i32, i32)> = FxHashSet::default();
+    let mut unfed: Vec<(i32, i32)> = machines_by_input
+        .keys()
+        .chain(lift_pickup_tiles.iter())
+        .filter(|&&t| !fed.contains(&t))
+        .copied()
+        .collect();
+    unfed.sort();
+    for t in unfed {
+        if !reported.insert(t) {
+            continue;
+        }
+        let who = if let Some(ms) = machines_by_input.get(&t) {
+            let (n, mx, my) = &ms[0];
+            format!("{n} at ({mx},{my})")
+        } else if let Some((n, ix, iy, carry)) = lift_by_pickup.get(&t) {
+            format!(
+                "belt-to-belt {n} at ({ix},{iy}){}",
+                carry
+                    .as_deref()
+                    .map(|c| format!(" carrying {c}"))
+                    .unwrap_or_default()
+            )
+        } else {
+            "consumer".to_string()
+        };
+        issues.push(ValidationIssue::with_pos(
+            severity,
+            "belt-flow-reachability",
+            format!(
+                "{who}: nothing feeds its pickup belt at ({},{}) — no upstream path \
+                 from the boundary, a machine's output, or another belt",
+                t.0, t.1
+            ),
+            t.0,
+            t.1,
+        ));
+    }
+
+    // Output check — one issue per output TILE whose items cannot leave. Also
+    // per-tile for the same reason: a machine with two output belts, one of
+    // which dead-ends, used to pass on the other.
+    let mut machines_by_output: FxHashMap<(i32, i32), Vec<(String, i32, i32)>> =
+        FxHashMap::default();
+    for e in &layout.entities {
+        if !is_machine_entity(&e.name) {
+            continue;
+        }
+        if e.recipe.as_deref().is_some_and(|r| fluid_only.contains(r)) {
+            continue;
+        }
+        if let Some(belts) = machine_output_belts.get(&(e.x, e.y)) {
+            for &b in belts {
+                machines_by_output
+                    .entry(b)
+                    .or_default()
+                    .push((e.name.clone(), e.x, e.y));
+            }
+        }
+    }
+    let mut stuck: Vec<(i32, i32)> = machines_by_output
+        .keys()
+        .filter(|&&t| !drains.contains(&t))
+        .copied()
+        .collect();
+    stuck.sort();
+    for t in stuck {
+        let (n, mx, my) = &machines_by_output[&t][0];
+        issues.push(ValidationIssue::with_pos(
+            severity,
+            "belt-flow-reachability",
+            format!(
+                "{n} at ({mx},{my}): items dropped on ({},{}) cannot leave \
+                 (no downstream path to the boundary, a machine's input, or another belt)",
+                t.0, t.1
+            ),
+            t.0,
+            t.1,
+        ));
     }
 
     issues
@@ -3989,7 +4156,7 @@ mod tests {
         let issues = check_belt_flow_reachability(&lr, Some(&sr), LayoutStyle::Spaghetti);
         let errors: Vec<_> = issues
             .iter()
-            .filter(|i| i.message.contains("can't reach input"))
+            .filter(|i| i.message.contains("nothing feeds its pickup belt"))
             .collect();
         assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
     }
@@ -4020,7 +4187,7 @@ mod tests {
         let issues = check_belt_flow_reachability(&lr, Some(&sr), LayoutStyle::Spaghetti);
         let errors: Vec<_> = issues
             .iter()
-            .filter(|i| i.message.contains("can't reach input"))
+            .filter(|i| i.message.contains("nothing feeds its pickup belt"))
             .collect();
         assert_eq!(errors.len(), 1);
     }
@@ -4054,7 +4221,7 @@ mod tests {
         let issues = check_belt_flow_reachability(&lr, Some(&sr), LayoutStyle::Spaghetti);
         let errors: Vec<_> = issues
             .iter()
-            .filter(|i| i.message.contains("can't leave output"))
+            .filter(|i| i.message.contains("cannot leave"))
             .collect();
         assert_eq!(errors.len(), 1);
     }

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -9216,41 +9216,38 @@ fn probe_di_contention_corpus_sweep() {
     }
 }
 
-/// RFC-059's DECISION, pinned: the status quo (`Upstream`) stays live, and the
-/// measured-better `Search` policy stays reachable but off.
+/// #520 / RFC-059: the engine can now SEE the jammed DI cell, so its own
+/// never-worse gate rejects it.
 ///
-/// Both halves need pinning, and for different reasons.
+/// The defect this pins was invisible on every signal the engine had.
+/// `di-row:copper-cable:electronic-circuit` on am1 drops its output partway
+/// along an east-flowing merger belt and the consumer picks up UPSTREAM of that
+/// drop, so the pickup sits on permanently empty belt — the consumer starves
+/// while everything behind the drop backs up. It validated with zero errors and
+/// zero warnings and produced 0/s in a headless Factorio run, against native's
+/// measured 1.00/s.
 ///
-/// **The default must stay `Upstream`** because a headless-Factorio run
-/// falsified the premise that made `Search` safe. On `display-panel@1` / am1 the
-/// arm `Search` prefers ships a `di-row:copper-cable:electronic-circuit` cell
-/// that the validator passes with zero errors and zero warnings and that
-/// produces **0/s in game** (jammed: `full_output: 10`), against native's
-/// measured 1.00/s under `Upstream`. Nothing in the test suite can see that, so
-/// this test names the fixture and asserts the working layout ships.
+/// `check_belt_flow_reachability` missed it for two compounding reasons, both
+/// now fixed: it asked its question PER MACHINE over the union of a machine's
+/// input belts (so `display-panel`'s healthy iron-plate belt satisfied the test
+/// and its starved electronic-circuit belt was never examined), and it did not
+/// model belt-to-belt lift inserters at all (so the lift's drop was not a source
+/// and its own pickup was never checked).
 ///
-/// **`Search` must keep working** because it is the measured-correct policy
-/// modulo that one defect, and re-deriving the measurement means a corpus sweep
-/// across three machine tiers. Asserting it still picks the better arm is what
-/// stops it rotting into unreachable code while it waits for the cell fix.
+/// Three assertions, because "the layout is no longer selected" is weaker than
+/// "the engine knows why":
+///   1. the validator FLAGS the jammed variant, at the pickup tile;
+///   2. consequently the shipped layout under `Search` is the sim-verified one;
+///   3. `Search` still functions where nothing is broken.
 #[test]
-fn di_claim_order_status_quo_ships_and_search_stays_reachable() {
+fn di_jammed_cell_is_visible_and_therefore_refused() {
     use spaghettio_core::bus::di_cell::{DiClaimOrder, DirectInsertion};
-
-    assert_eq!(
-        DiClaimOrder::default(),
-        DiClaimOrder::Upstream,
-        "RFC-059 measured `Search` as better on every validator channel and kept \
-         `Upstream` anyway, because the sim showed the validator is blind to the \
-         cell `Search` selects on display-panel@1/am1. Flipping this default \
-         needs that cell fixed and re-simmed, not a one-line edit"
-    );
 
     let raw: FxHashSet<String> = ["iron-ore", "copper-ore", "coal", "stone", "water", "crude-oil"]
         .iter()
         .map(|s| s.to_string())
         .collect();
-    let ship = |item: &str, rate: f64, tier: &str, di: DirectInsertion, order: DiClaimOrder| {
+    let build = |item: &str, rate: f64, tier: &str, di: DirectInsertion, order: DiClaimOrder| {
         let sr = solver::solve(item, rate, &raw, tier)
             .unwrap_or_else(|e| panic!("{item}@{rate} on {tier} solves: {e}"));
         let opts = layout::LayoutOptions {
@@ -9266,66 +9263,83 @@ fn di_claim_order_status_quo_ships_and_search_stays_reachable() {
             spaghettio_core::validate::LayoutStyle::Bus,
         )
         .unwrap_or_else(|e| e.issues);
-        (
-            issues.iter().filter(|i| i.severity == Severity::Error).count(),
-            issues.iter().filter(|i| i.severity == Severity::Warning).count(),
-            l.warnings.len(),
-            l.entities.len(),
-        )
+        (l.entities.len(), issues)
     };
 
-    // THE SIM-VERIFIED LAYOUT. 221 entities is native: under `Upstream` the DI
-    // candidate's own arm carries 3 validation errors and is refused, so native
-    // ships — and native is what measured 1.00/s against plan.
-    let dflt = ship(
+    // 1. The jammed variant is now visible, and the issue is positioned at the
+    //    starved pickup rather than at the machine that starves because of it.
+    let (jammed_ents, jammed_issues) = build(
         "display-panel",
         1.0,
         "assembling-machine-1",
-        DirectInsertion::Candidate,
-        DiClaimOrder::default(),
+        DirectInsertion::Forced,
+        DiClaimOrder::Downstream,
     );
-    let searched = ship(
-        "display-panel",
-        1.0,
-        "assembling-machine-1",
-        DirectInsertion::Candidate,
-        DiClaimOrder::Search,
-    );
-    assert_eq!(
-        dflt.3, 221,
-        "display-panel@1 on am1 must ship the sim-verified native layout (221 \
-         entities); got {dflt:?}. 202 is the DI variant that sims at 0/s"
-    );
-    // The trap this guards, stated as an assertion rather than a comment: the
-    // rejected layout is DENSER and validator-clean. Any future scoring change
-    // that ranks on density or issue counts alone will pick it again.
+    assert_eq!(jammed_ents, 202, "the jammed variant is the 202-entity one");
+    let reach: Vec<_> = jammed_issues
+        .iter()
+        .filter(|i| i.category == "belt-flow-reachability")
+        .collect();
     assert!(
-        searched.3 < dflt.3 && (searched.0, searched.1, searched.2) == (0, 0, 0),
-        "the broken variant is supposed to look BETTER on every signal the engine \
-         has — if it no longer does, either the cell was fixed (re-sim and flip \
-         the default) or the corpus moved: default={dflt:?} search={searched:?}"
+        !reach.is_empty(),
+        "the jammed DI cell must be visible to the validator — it sims at 0/s. \
+         Issues seen: {:?}",
+        jammed_issues.iter().map(|i| &i.category).collect::<Vec<_>>()
+    );
+    assert!(
+        reach.iter().any(|i| i.message.contains("(8,26)")),
+        "the issue must point at the starved pickup tile (8,26), not at the \
+         machine three rows downstream: {:?}",
+        reach.iter().map(|i| &i.message).collect::<Vec<_>>()
     );
 
-    // `Search` still functions where it is not blocked: on am1
-    // `small-electric-pole@5` wants the upstream arm and on am3 `land-mine@1`
-    // wants the downstream one, so a search that had silently collapsed to one
-    // arm would fail one of these.
-    let sep = ship(
-        "small-electric-pole",
-        5.0,
-        "assembling-machine-1",
-        DirectInsertion::Candidate,
-        DiClaimOrder::Search,
+    // 2. So DI's own never-worse gate now declines it and the sim-verified
+    //    native layout ships — under BOTH the default and the search policy.
+    for order in [DiClaimOrder::default(), DiClaimOrder::Search] {
+        let (ents, issues) = build(
+            "display-panel",
+            1.0,
+            "assembling-machine-1",
+            DirectInsertion::Candidate,
+            order.clone(),
+        );
+        assert_eq!(
+            ents, 221,
+            "display-panel@1 am1 must ship the sim-verified 221-entity layout \
+             under {order:?}; 202 is the variant that sims at 0/s"
+        );
+        assert!(
+            issues.is_empty(),
+            "the shipped layout must stay clean under {order:?}: {:?}",
+            issues.iter().map(|i| &i.message).collect::<Vec<_>>()
+        );
+    }
+
+    // 3. THE OTHER CONFIRMED HALF-RATE LAYOUT, and the reason this assertion
+    //    reads backwards from its first draft. `small-electric-pole@5` on am1
+    //    used to ship a 126-entity DI layout: denser than native's 163, clean
+    //    on every validator channel, and measured in a headless run at
+    //    **2.52/s against a planned 5.00/s** — converged, so a steady state
+    //    rather than a warmup artifact. Native measures 5.08/s. Same starved-lift
+    //    defect as display-panel, in a different coupling
+    //    (`copper-plate -> copper-cable`), which is why sweeping for the cell
+    //    rather than for the defect class missed it.
+    //
+    //    So 163 is the correct answer here and 126 must never ship again.
+    assert_eq!(
+        build("small-electric-pole", 5.0, "assembling-machine-1",
+              DirectInsertion::Candidate, DiClaimOrder::Search).0,
+        163,
+        "small-electric-pole@5 am1 must ship native (163); 126 is the DI layout \
+         that sims at 2.52/s against a planned 5.00/s"
     );
-    assert_eq!(sep.3, 126, "Search keeps the upstream arm here; got {sep:?}");
-    let lm = ship(
-        "land-mine",
-        1.0,
-        "assembling-machine-3",
-        DirectInsertion::Candidate,
-        DiClaimOrder::Search,
+    // 4. `Search` still selects a DI cell where the cell is sound.
+    assert_eq!(
+        build("land-mine", 1.0, "assembling-machine-3",
+              DirectInsertion::Candidate, DiClaimOrder::Search).0,
+        282,
+        "Search keeps the downstream arm on land-mine@1 am3"
     );
-    assert_eq!(lm.3, 282, "Search keeps the downstream arm here; got {lm:?}");
 }
 
 /// RFC-059's corpus verdict — the measurement that decided the policy.
@@ -9552,14 +9566,32 @@ fn probe_di_claim_order_shipped_corpus_verdict() {
         worse_than_up.join("\n"),
         worse_than_down.join("\n")
     );
+    // The probe must find SOMETHING, or it proves nothing about claim order.
     assert!(
-        !beats_up.is_empty() && !beats_down.is_empty(),
-        "the search must beat BOTH fixed arms somewhere. If it only beats one, \
-         that arm is dominated and RFC-059's answer is to pick the other one \
-         rather than to search: beats_up={} beats_down={}",
-        beats_up.len(),
-        beats_down.len()
+        !beats_up.is_empty() || !beats_down.is_empty(),
+        "the search beats neither fixed arm anywhere — either the corpus moved \
+         or this probe has stopped discriminating"
     );
+    // WHICH arm dominates is reported, not asserted, because the answer moved
+    // once the validator could see a starved pickup (#520). It used to be
+    // "neither": downstream looked strictly worse on the two
+    // `small-electric-pole@5` targets. Those were exactly the layouts where
+    // UPSTREAM shipped a validator-clean factory running at half its planned
+    // rate, so downstream was never worse there — it was better, and the
+    // measurement could not tell. With the defect visible, downstream is
+    // never worse and better on several targets, which makes the two-arm
+    // search equivalent to simply flipping the default.
+    if beats_down.is_empty() {
+        println!("\n  DOWNSTREAM DOMINATES: the search never beats it, so a fixed");
+        println!("  `Downstream` default would ship the same layouts for one build");
+        println!("  instead of two. RFC-059's KC4 logic applies — do not ship search");
+        println!("  machinery for a tie. Flipping needs sim verification of the");
+        println!("  targets it improves first; validator-clean is not enough (#520).");
+    } else if beats_up.is_empty() {
+        println!("\n  UPSTREAM DOMINATES: keep the status quo and drop the search.");
+    } else {
+        println!("\n  NEITHER ARM DOMINATES: the two-arm search earns its extra build.");
+    }
     assert!(
         pin_beats_search.is_empty(),
         "a per-target assignment now beats the search — RFC-059 dropped P2/P3 \

--- a/docs/rfc-059-di-coupling-assignment.md
+++ b/docs/rfc-059-di-coupling-assignment.md
@@ -110,6 +110,42 @@ the better arm where nothing blocks it.
   three trace events, and `probe_di_claim_order_shipped_corpus_verdict`, which
   re-derives every number above in ~10 minutes.
 
+### Re-measured after #520 (2026-07-31) — the answer moved
+
+The blocking defect was in the **validator**, not the cell geometry, and fixing
+it changed this RFC's measurement.
+
+`check_belt_flow_reachability` asked its question per MACHINE over the union of a
+machine's input belts, so one fed input masked a starved one, and it did not
+model belt-to-belt lift inserters at all. With both fixed, DI's never-worse gate
+sees the jammed cell and declines it on its own — `display-panel@1` am1 ships the
+sim-verified native layout under **both** the default and `Search`.
+
+The corpus re-measurement is the consequential part:
+
+| | before #520's fix | after |
+|---|---:|---:|
+| search beats fixed **upstream** | 6 | **6** |
+| search beats fixed **downstream** | 2 | **0** |
+| search worse than either arm | 0 | 0 |
+
+**Downstream-first now dominates.** The two targets where it looked strictly
+worse were `small-electric-pole@5` on am1 and am2 — and those are exactly the
+layouts where UPSTREAM shipped a validator-clean factory measured at **2.52/s
+against a planned 5.00/s**. Downstream was never worse there; it was better, and
+the instrument could not tell. The Outcome table above records the pre-fix
+numbers, and they were honest measurements of what the engine could then see.
+
+Two consequences:
+
+- The two-arm `Search` is now **equivalent to a fixed `Downstream`** on every
+  corpus target, so it buys nothing over flipping the default — KC4's own logic
+  ("do not ship matching machinery for a tie") applied one level up.
+- **The flip is not made here.** It needs sim verification of the targets it
+  improves first. The whole content of #520 is that validator-clean is not
+  evidence a layout works, and shipping a policy change on the strength of a
+  re-run of the same validator would repeat the mistake this RFC just made.
+
 ## Motivation
 
 > **Superseded by measurement (2026-07-31).** The `rail` case below does **not

--- a/docs/rfc-059-di-coupling-assignment.md
+++ b/docs/rfc-059-di-coupling-assignment.md
@@ -681,6 +681,26 @@ widespread and the optimum is static everywhere.
   the coupling count. Two arms is a constant factor on solves that have couplings
   at all, which is the same shape of cost #474 already accepted for DI itself.
 
+- *2026-07-31 — the default flip to `Downstream` is DEFERRED, not declined.*
+  Fixing #520's validator blind spot changed this RFC's measurement: the search
+  now beats fixed upstream on 6 targets and fixed downstream on **0**, so
+  downstream-first dominates and the two-arm `Search` is equivalent to simply
+  flipping the default — KC4's "do not ship machinery for a tie", one level up.
+  The two targets that made downstream look worse (`small-electric-pole@5` on am1
+  and am2) were the ones where UPSTREAM shipped a factory measured at 2.52/s
+  against a planned 5.00/s; downstream was never worse there, and the instrument
+  could not tell.
+
+  Not flipped in the same change, and the reason is this RFC's own lesson rather
+  than caution: the evidence for the flip is a re-run of the validator, and #520
+  is the demonstration that a clean validator is not evidence a layout works.
+  The flip needs sim verification of the targets it improves —
+  `display-panel@1`, `land-mine@1` at three tiers, `big-electric-pole@1`,
+  `medium-electric-pole@5` — of which only `display-panel@1` has been simmed.
+  Recorded here rather than only in Outcome because RFC-059 owns
+  `DiClaimOrder::default()`, so deferring a change to it is a call made on this
+  RFC's subject.
+
 - *2026-07-31 — `DiClaimOrder::Pinned` kept although P2/P3 were dropped.* It is
   measurement machinery for a policy that will not ship, which normally argues
   for deleting it. Kept because it is the instrument that produced the negative,

--- a/docs/status.md
+++ b/docs/status.md
@@ -176,6 +176,40 @@ Calibration notes worth carrying forward:
 - The RFC's motivating case, `rail`, **never contends** — its couplings die at
   buildability, not at the contention check.
 
+**#520 — the validator shipped a half-rate factory (2026-07-31).**
+`check_belt_flow_reachability` asked its question **per machine over the union of
+that machine's input belts**, so one fed input masked a starved one; and it did
+not model belt-to-belt lift inserters at all, so a lift's drop was not a source
+and its own pickup was never checked. Consequence, measured in a headless run:
+
+| `small-electric-pole@5` am1 | entities | planned | produced | verdict |
+|---|---:|---:|---:|---|
+| DI — what `main` shipped | 126 | 5.00/s | **2.52/s** | FAIL, −49.6% |
+| native — what ships with the fix | 163 | 5.00/s | **5.08/s** | PASS, +1.7% |
+
+Both converged, so the deficit is a steady state rather than a warmup artifact.
+The failing layout validated with **zero errors and zero warnings** and was 37
+entities denser, so `di_choice` preferred it — correctly, by every signal the
+engine had. `display-panel@1` am1 is the same defect at 0/s.
+
+Fixed by modelling lifts as both source and sink (which makes the check
+transitive and localises the fault at the starved pickup) and by replacing the
+per-machine BFS with one forward sweep from every source plus one backward sweep
+from every sink, tested per tile — stricter *and* cheaper. Recorded as instance
+**ten** in [`validator-reporting.md`](validator-reporting.md), with the rule it
+adds: a check that aggregates over a set must ask its question per element, not
+over the union.
+
+**Knock-on for RFC-059**: with the defect visible, downstream-first no longer
+loses on the two `small-electric-pole` targets — it dominates, and the two-arm
+search becomes equivalent to simply flipping the default. The flip is deliberately
+NOT made yet; it needs sim verification of the targets it improves, because the
+lesson here is precisely that a clean validator is not evidence a layout works.
+
+**Corpus-wide exposure is unmeasured.** Two shipped layouts are confirmed
+affected, found by following one lead. Sizing it means building every target on
+`origin/main` and on the fix and diffing shipped entity counts.
+
 **`rfc-057-topology-preserving-dense-repacking.md` multi-fold (2026-07-30,
 PR #500 — RFC ACTIVE, not closed)**: **multi-fold is Factorio-verified.**
 `chain-mil5ore` folds **three times**: 553x32 (17.3:1) to **153x141 (1.09:1)**

--- a/docs/validator-reporting.md
+++ b/docs/validator-reporting.md
@@ -2,9 +2,13 @@
 
 A check that runs, works, and finds the problem can still be useless — if the
 way it reports makes the problem invisible to whoever is reading. That failure
-mode hit this codebase **nine times**, was found in one day (2026-07-29), and
-three of the nine were written *while fixing the other six*. It is easy to
+mode hit this codebase **ten times**. Nine were found in one day (2026-07-29),
+and three of those were written *while fixing the other six*. It is easy to
 reintroduce, so it is written down.
+
+Number ten (2026-07-31) is the one that cost the most: it let `main` ship a
+factory running at **half its planned rate**, with the validator reporting zero
+errors and zero warnings.
 
 ## The shape
 
@@ -45,7 +49,7 @@ collapses N problems into one issue is therefore invisible to all of them —
    finds, so it reported 146/146 machines working for a blueprint that pastes
    as two dead halves.
 
-## The nine
+## The ten
 
 Kept as evidence that this is a pattern rather than a run of bad luck.
 
@@ -60,8 +64,48 @@ Kept as evidence that this is a pattern rather than a run of bad luck.
 | 7 | `check_belt_network_topology` | count in prose *and* origin-relative |
 | 8 | `claude-review` guard | asked "was this PR reviewed", not "was this code reviewed" |
 | 9 | a PR-watch monitor | reported `passing: 0` for CI that had not started |
+| 10 | `check_belt_flow_reachability` | asked per MACHINE over the union of its input belts; one fed input masked a starved one |
 
 Numbers 6, 8 and 9 were written during the session that fixed 1–5. Number 7 was
 found in the same audit and fixed last, in
 [#491](https://github.com/storkme/spaghettio/pull/491) — so all six of the
 others are fixed on `main`.
+
+### Number ten in detail (2026-07-31, #520)
+
+Worth more than a table row, because it is the first one with a measured cost in
+a real Factorio, and because the shape is subtler than "a count in a message".
+
+`check_belt_flow_reachability` seeded one BFS with **all** of a machine's input
+belts and asked whether the union reached a source. On `display-panel`
+(iron-plate + electronic-circuit) the iron-plate belt's path back to the furnaces
+satisfied the test, so the electronic-circuit belt — which nothing fed, because
+the only drop onto it was *downstream* of the pickup — was never examined. A
+per-machine question cannot distinguish **"every input is fed"** from **"some
+input is fed"**, which is rule 1's problem wearing different clothes: the check
+did not collapse N issues into one, it collapsed N *questions* into one.
+
+Compounding it, belt-to-belt lift inserters were not modelled at all. The
+classifier recognised only machine→belt and belt→machine, so a lift's drop was
+not a source of its belt and its own pickup was never checked — which is why the
+fault localised nowhere even when something downstream was visibly starving.
+
+**Measured cost.** `small-electric-pole@5` on am1 shipped a 126-entity DI layout,
+denser than native's 163 and clean on every channel, that a headless run measured
+at **2.52/s against a planned 5.00/s** — converged, so a steady state. Native
+measures 5.08/s. `di_choice` preferred the broken one correctly, by every signal
+the engine had.
+
+**The rule this adds.** Rules 1 and 2 are about how many issues a check emits.
+This one is about how many questions it asks: **a check that aggregates over a
+set must ask its question per element of that set, not over the union.** The
+union form is strictly weaker and its weakness is invisible — it reports success
+whenever *any* element passes. Both directions of this check are now one forward
+sweep from every source and one backward sweep from every sink, tested per tile;
+that is also cheaper than the per-machine BFS it replaced.
+
+**And the fix's own near-miss**, kept because it is the same lesson one level
+down: the first version seeded those sweeps with the source tiles themselves,
+which let a boundary output tile count as its own sink. The check's existing
+`flow_reachability_output_dead_end_fails` unit test caught it. The sweeps are now
+seeded one step in.


### PR DESCRIPTION
Closes #520.

## Intent

`main` has been shipping a `small-electric-pole@5` layout that runs at **half its planned rate**, with the validator reporting zero errors and zero warnings. Two compounding defects in `check_belt_flow_reachability` made it invisible.

## The bug

1. **It asked its question per MACHINE, over the union of that machine's input belts.** One BFS seeded with all of them, then "did the union reach a source?". On `display-panel` (iron-plate + electronic-circuit), the iron-plate belt's path back to the furnaces satisfied the test, so the electronic-circuit belt — which nothing fed, because the only drop onto it was *downstream* of the pickup — was never examined. A per-machine question cannot distinguish **"every input is fed"** from **"some input is fed"**.

2. **Belt-to-belt lift inserters were not modelled at all.** The classifier recognised only machine→belt and belt→machine, so a lift's drop was not a source of its belt and its own pickup was never checked. That is why the fault localised nowhere even when something downstream was visibly starving.

## Measured cost

Controlled headless runs — same recipe, tier, harness, `--warmup 288000`, and external inputs; only the layout differs:

| `small-electric-pole@5` am1 | entities | planned | produced | delivered | verdict |
|---|---:|---:|---:|---:|---|
| **DI — what `main` ships** | 126 | 5.00/s | **2.52/s** | 2.55/s | **FAIL, −49.6%** |
| native — what ships with this fix | 163 | 5.00/s | **5.08/s** | 5.15/s | **PASS, +1.7%** |

Both **converged** (`drift=+0.8%` / `+1.7%`), so the deficit is a steady state, not a short-warmup artifact. The failing layout was 37 entities denser and clean on every channel, so `di_choice` preferred it — correctly, by every signal the engine had. `display-panel@1` am1 is the same defect at 0/s.

## Scope

- **In:** model a lift as **both** a source (its drop) and a sink that must itself be fed (its pickup) — which makes the check transitive and puts the issue at the starved tile rather than at the machine three rows downstream; replace the per-machine BFS with one forward sweep from every source plus one backward sweep from every sink, tested per tile. Stricter *and* cheaper: one sweep instead of one per machine.
- **Out:** repairing the DI cell geometry. This stops the broken layout being *chosen*; it does not make DI work there. Same posture as every other DI refusal, and it converts a silent 50%-rate factory into an honest decline. Worth its own issue.
- **Out:** flipping RFC-059's default — see below.

## Knock-on: this reverses RFC-059's conclusion

Re-running that RFC's own corpus verdict with the defect visible:

| | before | after |
|---|---:|---:|
| search beats fixed **upstream** | 6 | **6** |
| search beats fixed **downstream** | 2 | **0** |
| search worse than either arm | 0 | 0 |

**Downstream-first now dominates.** The two targets where it looked strictly worse were `small-electric-pole@5` on am1 and am2 — exactly the layouts where *upstream* shipped the half-rate factory. Downstream was never worse there; it was better, and the instrument could not tell. The two-arm `Search` is now equivalent to a fixed `Downstream` everywhere, so it buys nothing over flipping the default (KC4's own logic, one level up).

**The flip is deliberately not made here.** It needs sim verification of the targets it improves, and the entire content of #520 is that validator-clean is not evidence a layout works. Shipping a policy change on a re-run of the same validator would repeat the mistake this RFC just made.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — **1047 passed, 0 failed** (single invocation)
- [x] `cargo clippy --manifest-path crates/core/Cargo.toml --workspace -- -D warnings` — clean
- [x] `wasm-pack build` — clean
- [x] **The check discriminates**, which is the thing that matters: it fires on both jammed layouts (`display-panel@1` am1 at (8,26); `small-electric-pole@5` am1 at (5,13) and am2 at (4,13)+(5,13)) and stays silent on both working ones (native 221 and native 163).
- [x] **Two controlled sims** (table above) — the check's verdict matches the game's.
- [x] Three existing unit tests filtered on the old message wording and were retargeted. One of them asserts *emptiness*, so it would have passed vacuously against a filter matching nothing; that was fixed rather than left.
- [ ] Browser eyeball — the shipped layout for the affected targets *changes* (126 → 163), so this is worth a look, but the change is "DI declines, native ships" and native is the pre-DI layout that has always rendered.

## Deviations from intent

**I got the scope wrong in public first, and corrected it.** My first assessment on #520 concluded *"no layout a caller receives today contains this cell… not a live production defect."* That was wrong because I swept for the specific **cell** rather than for the **defect class** — the same starved-pickup geometry ships in a different coupling (`copper-plate → copper-cable`). Corrected on the issue with the reasoning, then confirmed in-game.

**The fix's own near-miss**, kept in the docs because it is the same lesson one level down: the first version seeded the sweeps with the source tiles themselves, letting a boundary output tile count as its own sink. This check's existing `flow_reachability_output_dead_end_fails` unit test caught it. The sweeps are now seeded one step in.

**Corpus-wide exposure — now measured, and the answer is clean.** Every producible item at 1 and 5/s across three machine tiers, built as production builds them (`Candidate`, default order), counting reachability issues and splitting by whether the layout was *already* failing:

```
REGRESSION-CANDIDATES (0 errors + 0 other warnings, now flagged):   0
ALREADY-DIRTY         (already carrying errors before this check):  45+
```

**No previously-clean shipped layout is newly flagged.** Every layout the check fires on was already failing validation — overwhelmingly the Space Age biological chains (`raw-fish@1`: 190 errors before this check; `jellynut-seed@1`: 126; `artillery-turret@1` am2: 80 errors and 1996 warnings). The check adds detail to layouts that were already broken; it does not introduce noise into working ones.

That measurement is also what the review's two findings were distorting: before they were fixed, the same sweep reported 44 dirty layouts with totals like 4912, and I was midway through investigating a defect that did not exist.

## Models / contracts touched

- **[`validator-reporting.md`](../blob/main/docs/validator-reporting.md)** — recorded as instance **ten**, the first with a measured cost in a real Factorio, with the rule it adds: *a check that aggregates over a set must ask its question per element of that set, not over the union.* The union form is strictly weaker and its weakness is invisible, because it reports success whenever any element passes.
- `docs/rfc-059-di-coupling-assignment.md` — re-measurement section; the merged Outcome table's numbers stand as honest measurements of what the engine could then see.
- `docs/status.md` — close-out entry with the sim table and the unmeasured-exposure caveat.
