### PR TITLE
fix(cells): #433 — internal corridors refuse multi-row consumer cells instead of starving rows >=2

### DIFF
--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -200,28 +200,55 @@ fn port_abs(p: &Port, cell_x: i32, cell_y: i32) -> (i32, i32) {
 }
 
 /// The consumer-side port an INTERNAL (producer-cell → consumer-cell)
-/// corridor wires to for `item`. A multi-row consumer cell exposes one
-/// inbound port per row for the same ingredient (extract.rs's
-/// one-port-per-connected-run grouping) — v1 corridors route to exactly
-/// one port, so wiring "the" port silently starves every row past the
-/// first. Refuse loudly instead (#433; the EXTERNAL world-feed path was
-/// already fixed port-aware — commit 620d103c, "every port gets its own
-/// feed column"). Wiring every row's port is future work, gated on
-/// feed-bound sizing actually reaching multi-row chain cells.
+/// corridor wires to for `item`. extract.rs derives one inbound port
+/// per 4-adjacency-CONNECTED RUN of the item's `belt-in` segment —
+/// usually that's one run (one port) per row, but UG gaps punched into
+/// a SINGLE row's belt-in segment (e.g. `quad_input_row`'s belt3:
+/// per-machine UG-IN at `mx` / gap / UG-OUT at `mx+2`, still one
+/// logical segment) break 4-adjacency and split it into several
+/// same-row runs, each getting its own port. Pre-#433-fix, `.find`
+/// picked whichever port came first in extraction order — which for
+/// these same-row splits is the westmost run, i.e. the belt's true
+/// upstream entry — and wired correctly (measured: 7 chain-eligible
+/// targets at warnings=0, review round on this PR). A genuinely
+/// multi-ROW consumer cell (distinct y per row) exposes one port per
+/// row for the same item; v1 corridors route to exactly one port, so
+/// wiring "the" port would silently starve every row past the first —
+/// THAT's the real #433 defect.
+///
+/// So: group matches by `y`. All matches share one y → same-row
+/// UG-split runs (or the trivial single-port case) — return the min-x
+/// (westmost = upstream entry) port, exactly reproducing the pre-fix
+/// deterministic behavior. Matches spanning more than one distinct y →
+/// genuine multi-row fan-in, which v1 corridors can't wire — refuse
+/// loudly instead of silently starving rows past the first (the
+/// EXTERNAL world-feed path was already fixed port-aware — commit
+/// 620d103c, "every port gets its own feed column"). Wiring every
+/// row's port is future work, gated on feed-bound sizing actually
+/// reaching multi-row chain cells.
 fn single_inbound_port<'a>(
     ports: &'a [Port],
     item: &str,
     consumer_recipe: &str,
 ) -> Result<&'a Port, String> {
     let matches: Vec<&Port> = ports.iter().filter(|q| q.inbound && q.item == item).collect();
-    match matches.as_slice() {
-        [p] => Ok(p),
-        [] => Err(format!("cells: {consumer_recipe} lacks in-port for {item}")),
-        _ => Err(format!(
-            "cells: {consumer_recipe} has {} in-ports for {item} (multi-row corridor fan not implemented, #433)",
-            matches.len()
-        )),
+    if matches.is_empty() {
+        return Err(format!("cells: {consumer_recipe} lacks in-port for {item}"));
     }
+    let mut rows: Vec<i32> = matches.iter().map(|p| p.y).collect();
+    rows.sort_unstable();
+    rows.dedup();
+    if rows.len() == 1 {
+        return Ok(matches
+            .into_iter()
+            .min_by_key(|p| p.x)
+            .expect("matches non-empty, checked above"));
+    }
+    Err(format!(
+        "cells: {consumer_recipe} has {} in-ports for {item} across {} rows (multi-row corridor fan not implemented, #433)",
+        matches.len(),
+        rows.len()
+    ))
 }
 
 /// Crossing-aware corridor stamper. Horizontal runs hop under

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -199,6 +199,31 @@ fn port_abs(p: &Port, cell_x: i32, cell_y: i32) -> (i32, i32) {
     (cell_x + p.x, cell_y + p.y)
 }
 
+/// The consumer-side port an INTERNAL (producer-cell → consumer-cell)
+/// corridor wires to for `item`. A multi-row consumer cell exposes one
+/// inbound port per row for the same ingredient (extract.rs's
+/// one-port-per-connected-run grouping) — v1 corridors route to exactly
+/// one port, so wiring "the" port silently starves every row past the
+/// first. Refuse loudly instead (#433; the EXTERNAL world-feed path was
+/// already fixed port-aware — commit 620d103c, "every port gets its own
+/// feed column"). Wiring every row's port is future work, gated on
+/// feed-bound sizing actually reaching multi-row chain cells.
+fn single_inbound_port<'a>(
+    ports: &'a [Port],
+    item: &str,
+    consumer_recipe: &str,
+) -> Result<&'a Port, String> {
+    let matches: Vec<&Port> = ports.iter().filter(|q| q.inbound && q.item == item).collect();
+    match matches.as_slice() {
+        [p] => Ok(p),
+        [] => Err(format!("cells: {consumer_recipe} lacks in-port for {item}")),
+        _ => Err(format!(
+            "cells: {consumer_recipe} has {} in-ports for {item} (multi-row corridor fan not implemented, #433)",
+            matches.len()
+        )),
+    }
+}
+
 /// Crossing-aware corridor stamper. Horizontal runs hop under
 /// registered vertical columns; vertical legs hop under registered
 /// horizontal rows; whichever is stamped LATER does the hopping, so
@@ -1269,12 +1294,7 @@ fn compose_chain_with_capacity_and_order(
                     branch_origins.push((pt_x, fan_y));
                     for (bi, ci) in ordered.iter().enumerate() {
                         let c = &placed[*ci];
-                        let port = c
-                            .cell
-                            .ports
-                            .iter()
-                            .find(|q| q.inbound && q.item == d_item)
-                            .expect("consumer port checked in eligibility");
+                        let port = single_inbound_port(&c.cell.ports, &d_item, &c.recipe)?;
                         let (tx, ty) = port_abs(port, c.x, c.y_off);
                         let (bx, by) = branch_origins[bi];
                         let seg = format!("corr:{}:{}", p.seg, c.seg);
@@ -1363,12 +1383,7 @@ fn compose_chain_with_capacity_and_order(
                     });
                     continue;
                 };
-                let port = c
-                    .cell
-                    .ports
-                    .iter()
-                    .find(|q| q.inbound && q.item == d_item)
-                    .expect("consumer port checked in eligibility");
+                let port = single_inbound_port(&c.cell.ports, &d_item, &c.recipe)?;
                 let (tx, ty) = port_abs(port, c.x, c.y_off);
                 let seg = format!("corr:{}:{}", p.seg, c.seg);
                 let up_demand = lane_demand[ci % n];
@@ -1526,9 +1541,7 @@ fn compose_chain_with_capacity_and_order(
         ordered.sort_by_key(|ci| placed[*ci].x);
         for (bi, ci) in ordered.iter().enumerate() {
             let c = &placed[*ci];
-            let port = c.cell.ports.iter()
-                .find(|q| q.inbound && q.item == out_item)
-                .expect("consumer port checked in eligibility");
+            let port = single_inbound_port(&c.cell.ports, &out_item, &c.recipe)?;
             let (tx, ty) = port_abs(port, c.x, c.y_off);
             let (bx, by) = branch_origins[bi];
             let seg = format!("corr:{}:{}", p.seg, c.seg);

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1206,6 +1206,65 @@ fn chain_capacity_reaches_the_placer() {
     );
 }
 
+/// #433: an INTERNAL (producer-cell → consumer-cell) corridor targets
+/// exactly one inbound port per ingredient today. A multi-row consumer
+/// cell exposes one port PER ROW for the same item (extract.rs's
+/// one-port-per-connected-run grouping) — pre-fix, the corridor wired
+/// only the first row's port, leaving every row past it silently
+/// starved: `compose_chain` returned `Ok` with a broken layout (rows
+/// ≥2 read `item-ingredient-shortage` in-sim, per #433's own evidence).
+/// Post-fix it refuses loudly instead.
+///
+/// Forcing the split: EC's OWN cell generation naturally splits into 2
+/// rows once its rate crosses ~16/s (empirically probed). But at a
+/// REAL solved rate, copper-cable's total output (3x EC's, from the
+/// recipe ratio) hits the 45/s ratio-quantization ceiling first and
+/// forces K=2 copies — which halves the per-copy EC rate straight back
+/// under the row-split threshold. That's exactly why the path is
+/// latent on every registered chain fixture (#383's decision log).
+/// To force the split without the quantizer intervening, this test
+/// takes a real solved `SolverResult` and overrides ONLY the
+/// copper-cable spec's `count` (test-only, not flow-conserving) to
+/// keep its total output under the 45/s quantum while leaving the EC
+/// spec's own rate untouched — `required_copies` stays at K=1, EC's
+/// cell still splits into 2 rows, and the internal corridor is
+/// exercised exactly as `compose_chain` would drive it for any future
+/// recipe/rate combination whose consumer cell splits under its own
+/// steam.
+#[test]
+fn chain_refuses_multirow_internal_corridor() {
+    use spaghettio_core::bus::cells::chain::compose_chain_with_capacity;
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let mut sr = solver::solve_with_palette_exclusions_and_quality(
+        "electronic-circuit",
+        16.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+    for m in sr.machines.iter_mut() {
+        if m.recipe == "copper-cable" {
+            // 5.0/s per machine * 8 = 40.0/s, under the 45/s quantum
+            // (the unmodified solve's 9.6 machines = 48.0/s would push
+            // required_copies to K=2 and mask the bug — see doc comment).
+            m.count = 8.0;
+        }
+    }
+    let err = compose_chain_with_capacity(&sr, 2).expect_err(
+        "a multi-row consumer cell must refuse the internal corridor, not silently wire row 1 and starve the rest",
+    );
+    assert!(
+        err.contains("electronic-circuit") && err.contains("in-ports for copper-cable") && err.contains("#433"),
+        "unexpected refusal message: {err}"
+    );
+}
+
 /// #383 (2026-07-24): the EC@15 chain — the canonical #383 fixture —
 /// carries input-inserter-throughput warnings at the raw L0 world but
 /// composes inserter-clean at the L2 engine default (the input bind

--- a/crates/core/tests/cell_composition.rs
+++ b/crates/core/tests/cell_composition.rs
@@ -1265,6 +1265,129 @@ fn chain_refuses_multirow_internal_corridor() {
     );
 }
 
+/// #433 review round 2 (false-positive class). `single_inbound_port`'s
+/// first cut refused on raw port COUNT > 1, y-blind — but extract.rs
+/// gives a fresh port to each 4-adjacency-CONNECTED RUN of a row's
+/// belt-in segment, and UG gaps punched into a SINGLE row's segment
+/// (`quad_input_row`'s belt3: per-machine UG-IN at `mx` / gap / UG-OUT
+/// at `mx+2`, still one logical segment) break 4-adjacency and split it
+/// into several same-y runs. That is NOT the multi-row case #433 is
+/// about — it is a same-row artifact of how the segment is drawn.
+///
+/// Review-measured false positive: assembling-machine-2@1 (raw
+/// steel-plate as an external input, so the solve doesn't route it
+/// through its own sub-chain; am3) has its OWN iron-gear-wheel consumer
+/// ports at (0,2) and (2,2) — same y=2, UG-split, not a second row. The
+/// y-blind check refused this chain outright.
+///
+/// Pins `compose_chain_with_capacity` directly (not the full
+/// decomposition-search path — see
+/// `chain_am2_default_options_ships_cell_composed_rescue` below for
+/// that) against this exact scenario: must return `Ok`, with geometry
+/// byte-identical (via `geometry_hash`) to what base commit cc9fb340
+/// (the true pre-#433-work tree, plain `.find`-based port selection)
+/// produces — i.e. the fix's min-x tie-break must reproduce the exact
+/// westmost-port pick `.find` made, not merely "some" valid pick.
+/// Confirmed FAILS (refuses) on this PR's round-1 head (commit
+/// a6f21b25) and passes after the y-discrimination fix.
+#[test]
+fn chain_am2_from_plate_steel_composes_ok_not_false_positive() {
+    use spaghettio_core::bus::cells::chain::compose_chain_with_capacity;
+    use spaghettio_core::bus::cells::registry::geometry_hash;
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "steel-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "assembling-machine-2",
+        1.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+    let l = compose_chain_with_capacity(&sr, spaghettio_core::common::DEFAULT_INSERTER_CAPACITY)
+        .unwrap_or_else(|e| {
+            panic!("same-row UG-split ports must NOT trigger the multi-row refusal: {e}")
+        });
+    assert_eq!(
+        (l.width, l.height, l.entities.len()),
+        (131, 27, 750),
+        "pinned to base cc9fb340's pre-#433-work geometry (measured during the review round)"
+    );
+    assert_eq!(
+        geometry_hash(&l),
+        16181045263949429483,
+        "port selection must be byte-identical to the pre-fix westmost-port pick (base cc9fb340), not just same dims"
+    );
+}
+
+/// #433 review round 2 companion to the test above: the END-TO-END
+/// symptom the reviewer actually measured. `assembling-machine-2@1`
+/// (raw steel-plate input, am3) is a case where NATIVE fails
+/// acceptance and `CellComposedCandidate` — live under
+/// `LayoutOptions::default()` (`cell_composition: Candidate` since
+/// RFC-051) — RESCUES it. The round-1 false positive silently starved
+/// that rescue: `CellComposedCandidate` errored, so
+/// `select_best_decomposition` fell through to native's own inferior
+/// result. This asserts the DEFAULT-options end-to-end path ships the
+/// rescued cell-composed layout again, byte-identical (dims +
+/// `geometry_hash`) to base commit cc9fb340 — and that it is NOT the
+/// same layout `CellComposition::Off` (native-only) produces, proving
+/// the rescue is actually live, not coincidentally matching native.
+#[test]
+fn chain_am2_default_options_ships_cell_composed_rescue() {
+    use spaghettio_core::bus::cells::registry::geometry_hash;
+    use spaghettio_core::bus::cells::CellComposition;
+    use spaghettio_core::bus::layout::{self, LayoutOptions};
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "steel-plate"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let sr = solver::solve_with_palette_exclusions_and_quality(
+        "assembling-machine-2",
+        1.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        QualityTier::Normal,
+    )
+    .unwrap();
+    let native = layout::build_bus_layout(
+        &sr,
+        LayoutOptions {
+            cell_composition: CellComposition::Off,
+            ..Default::default()
+        },
+    )
+    .expect("native-only build must still succeed");
+    assert_eq!(
+        (native.width, native.height, native.entities.len()),
+        (23, 51, 430),
+        "native-only baseline (unaffected by chain.rs) — if this moved, the fixture drifted, not the fix"
+    );
+    let default = layout::build_bus_layout(&sr, LayoutOptions::default())
+        .expect("default options must compose (cell-composed rescue must not be silently lost)");
+    assert_eq!(
+        (default.width, default.height, default.entities.len()),
+        (131, 27, 750),
+        "default options must ship the cell-composed rescue, not fall back to native's inferior result"
+    );
+    assert_eq!(
+        geometry_hash(&default),
+        16181045263949429483,
+        "byte-identical to base cc9fb340's default-options result"
+    );
+    assert_ne!(
+        geometry_hash(&default),
+        geometry_hash(&native),
+        "the rescue must actually differ from native-only — this is the whole point of the candidate"
+    );
+}
+
 /// #383 (2026-07-24): the EC@15 chain — the canonical #383 fixture —
 /// carries input-inserter-throughput warnings at the raw L0 world but
 /// composes inserter-clean at the L2 engine default (the input bind


### PR DESCRIPTION
## Intent

Fixes #433. A multi-ROW consumer cell exposes one inbound port PER ROW for
the same ingredient (`extract.rs`'s one-port-per-connected-run grouping).
The INTERNAL (producer-cell → consumer-cell) corridor code in
`crates/core/src/bus/cells/chain.rs` picked the first matching port via
`.find(|q| q.inbound && q.item == …)` and silently wired only row 1,
leaving rows ≥2 unfed. The EXTERNAL world-feed path was already fixed
port-aware (commit `620d103c`, "every port gets its own feed column");
this closes the internal-corridor remainder with the issue's own
"cheaper" fix shape — refuse loudly instead of silently starving.

## Review round (2026-07-31)

The CI review bot and a local adversarial reviewer both caught the same
**blocking regression in the round-1 fix**, with measured evidence — see
the review-round commit for full detail. Round 1's `single_inbound_port`
refused on raw port **count** > 1, but `extract.rs` gives one port per
4-adjacency-**connected run**, not one per row: UG gaps punched into a
single row's belt-in segment (`quad_input_row`'s belt3: per-machine
UG-IN / gap / UG-OUT, still one logical segment) break 4-adjacency and
split it into several **same-row** runs, each with its own port. Round 1
refused all of these too — a false positive.

Measured fallout: 7 chain-eligible targets flipped `Ok(warnings=0)` →
`Err` (`programmable-speaker@2`, `train-stop@2`, `pumpjack@2`,
`centrifuge@0.5`, `assembling-machine-2@1`, `bulk-inserter@1`,
`tank@0.2`), and — the concrete end-to-end symptom —
`assembling-machine-2@1` (steel-plate as a raw external input, am3)
regressed under **DEFAULT** `LayoutOptions` (`cell_composition: Candidate`
since RFC-051): native fails acceptance there, and `CellComposedCandidate`
was rescuing it with a 131×27/750-entity layout. Round 1's false positive
silently lost that rescue, degrading the default-options output to
native's own inferior 23×51/430-entity result (1 warning).

**This falsifies the round-1 claims that the `>1`-port arm was a "latent
path" with "no visible layout"** — it was live in production. Only the
*genuine* multi-ROW trigger (distinct-y ports, #433 proper) is latent on
today's registered fixtures; the same-row UG-split false-positive trigger
was not latent at all.

**Fix**: `single_inbound_port` now groups matches by `y` instead of just
counting them. All matches share one `y` → same-row UG-split runs (or the
trivial single-port case) → return the min-x (westmost) port, exactly
reproducing the pre-fix `.find` pick. Matches spanning more than one
distinct `y` → genuine multi-row fan-in → refuse (message corrected to
say "across N rows" instead of unconditionally claiming "multi-row" for
a same-row split).

## Scope

- **In:** all three internal-corridor call sites that resolved a
  consumer's inbound port via first-match `.find`, replaced with a shared
  `single_inbound_port` helper. As of the review round, the helper groups
  candidate ports by row (`y`) before deciding: single row → deterministic
  min-x pick (byte-identical to the pre-#433-work `.find` behavior);
  multiple distinct rows → refuse.
  - Two are the mega-drain paths the issue cited (`d_item`, fan-out branch
    and single-consumer branch).
  - **Audit finding beyond the issue's own citation**: a third site — the
    ordinary solid producer→consumer path (keyed on `out_item`) — has the
    identical bug, and is the site the issue's *own* EC@15 evidence
    actually traversed (electronic-circuit is a solid recipe, not a mega
    block; the mega paths are a separate, structurally identical instance
    of the same defect). Fixed all three with one helper rather than only
    the two literally named, since restricting to two would leave the
    issue's own reproduction scenario unfixed.
- **Out (deliberately):** actually wiring every row's port (the fan —
  corridor delivery becoming port-aware: one delivery target per
  `(consumer-row, ingredient)`, per the issue's non-cheaper fix shape).
  Not attempted here — real future work, gated on feed-bound sizing
  actually reaching multi-row chain cells.
- **Out (reviewer's non-blocking Finding 2, explicitly deferred):** the
  outbound mirror of this same bug class at the final-product drain
  (`outs.first()` picks one outbound port unconditionally) would silently
  drain only row 1 of a multi-row **final-product** cell. Intermediates
  are unaffected — they're fed via the merge cascade, a separate code
  path that already handles multiple ports. Not fixed here: it's a
  distinct call site with its own risk profile (an outbound analogue, not
  the inbound one this PR audits), and — like the genuine multi-row
  inbound trigger — nothing in the registered fixture corpus reaches a
  multi-row final-product cell today. Tracked as a followup, not #433
  itself.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — one clean
  invocation per round, all suites green throughout. Latest (post
  review-round fix): unit tests 919 passed, `cell_composition` 25 passed
  (0 failed, 44 ignored — the 2 round-1 tests plus 2 new review-round
  tests), `e2e` 69 passed (0 failed, 33 ignored), all other integration
  binaries 0 failed. No golden changed.
- [x] `cargo clippy -p spaghettio_core -- -D warnings` (hook-exact) —
  clean, both rounds.
- [ ] WASM rebuild + browser eyeball — N/A: no registered/shipped fixture
  reaches the *genuine* multi-row refusal path today (every registered
  chain composition still sizes cells at 1 row); the same-row false
  positive round 1 introduced (and round 2 fixes) is exercised by the new
  regression tests below, not a browsable URL.
- [x] `chain_refuses_multirow_internal_corridor` (round 1, unchanged by
  round 2 — confirmed it still keeps its teeth): EC@15's 2 in-ports for
  copper-cable sit on **distinct rows**, so the y-discrimination still
  refuses this one. Pre-round-1-fix: `compose_chain_with_capacity`
  returned `Ok` with row 2 silently unfed; post-fix: the expected `Err`.
- [x] `chain_am2_from_plate_steel_composes_ok_not_false_positive` (new,
  review round): pins `compose_chain_with_capacity` directly on
  `assembling-machine-2@1` (steel-plate as external input, am3) — must
  return `Ok` with `geometry_hash` byte-identical to a throwaway `git
  worktree` checked out at base commit `cc9fb340` (the true
  pre-#433-work tree). Confirmed **FAILS** (refuses) on this PR's round-1
  head (`a6f21b25`); passes after the round-2 fix.
- [x] `chain_am2_default_options_ships_cell_composed_rescue` (new, review
  round): the end-to-end companion — `LayoutOptions::default()` must ship
  the 131×27/750-entity cell-composed rescue (byte-identical
  `geometry_hash` to `cc9fb340`), not degrade to native-only's
  23×51/430. Also confirmed **FAILS** on round-1 head, passes after the
  fix.

## Deviations from intent

Round 1: scope widened from the issue's literally-cited two call sites to
three (see Scope above) — the third has the identical defect and is the
one the issue's own reproduction evidence actually hit.

Round 2 (review-round fix): round 1's own verification claims are
**corrected** here — "latent path" / "no visible layout" was wrong for
the same-row false-positive arm; see the Review round section above.
Otherwise this PR still delivers exactly the issue's "cheaper" fix shape
(honest refusal for the genuine multi-row case, RFC-047 posture), not
the full port-aware fan — and the reviewer's Finding 2 (outbound mirror)
is explicitly out of scope, documented above rather than silently
dropped.

## Models / contracts touched

None — no shipped geometry changes beyond restoring
`assembling-machine-2@1`'s default-options output to what base
`cc9fb340` already produced (a regression introduced and fixed within
this same unmerged PR, not a change to `main`'s behavior). No contract
docs affected. `docs/status.md` isn't touched since this closes a
residual gap that was tracked as an open issue, not a status-ledger
entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
