### PR TITLE
fix(ci): #538 — structural guards: async-tool bans + mechanism-agnostic auto-retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
           # block scalar since).
           grep -q -- 'number }} --comment' "$f" || { echo "::error file=$f::prompt missing --comment — plugin contract is 'do not post' without it (#329)"; fail=1; }
           grep -q -- '--allowedTools' "$f" || { echo "::error file=$f::claude_args missing --allowedTools — every posting/diff call denied (#331)"; fail=1; }
+          grep -q -- '--disallowedTools' "$f" || { echo "::error file=$f::claude_args missing --disallowedTools — async-family ban gone, silent-park class 6 reopens (#538)"; fail=1; }
+          r=.github/workflows/claude-review-auto-retry.yml
+          [ -f "$r" ] || { echo "::error file=$r::auto-retry workflow missing — silent-park runs red without automatic recovery (#538)"; fail=1; }
           g=.github/workflows/claude.yml
           grep -q 'github.event.sender.login == github.repository_owner' "$g" || { echo "::error file=$g::missing owner-only sender gate — public repo, outsiders can burn tokens via @claude"; fail=1; }
           if [ "$fail" -eq 1 ]; then

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -186,6 +186,15 @@ jobs:
           claude_args: |
             --model claude-sonnet-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*)"
+            --disallowedTools "ScheduleWakeup,Task,TaskCreate,TaskGet,TaskList,TaskOutput,TaskStop,TaskUpdate,CronCreate,CronDelete,CronList,RemoteTrigger,Workflow,PushNotification"
+          # --disallowedTools is #538's structural guard: the silent-park
+          # class (failure class 6, four occurrences) kept finding new
+          # defer-and-end mechanisms after each prompt-level ban, and the
+          # #535 run artifact proved these tools stay reachable via
+          # ToolSearch even when absent from --allowedTools. None of the
+          # banned family has a legitimate use in a one-shot review run.
+          # Agent is deliberately NOT banned: the plugin's own eligibility
+          # gate dispatches through it (see #538 for the canary plan).
 
       # Full session transcript (includes every permission denial) — the
       # difference between forensics and guesswork when a run misbehaves.

--- a/.github/workflows/claude-review-auto-retry.yml
+++ b/.github/workflows/claude-review-auto-retry.yml
@@ -1,0 +1,39 @@
+# Mechanism-agnostic recovery for the review bot's silent-park class
+# (#538, failure class 6 in docs/review-bot.md): the orchestrator defers
+# (async agents, wakeups, bare intent), ends with zero review activity,
+# and the #522 guard fails the check. Four occurrences; a manual re-run
+# recovered every one. This automates exactly that re-run, capped so a
+# genuinely broken run still reds to a human after three attempts.
+#
+# Safety properties (verified in the #538 investigation):
+# - Triggers only on conclusion == 'failure'; every benign skip (draft,
+#   workflow-file PR, small diff, already-reviewed) exits 0 and never
+#   fires this.
+# - `gh run rerun --failed` re-runs the SAME run (new attempt) — the
+#   required check re-enters in_progress, no gap in gate semantics.
+# - workflow_run workflows always execute the default-branch version of
+#   this file, so a PR editing it cannot hijack the retry behavior.
+name: Claude Review Auto-Retry
+
+on:
+  workflow_run:
+    workflows: ["Claude Code Review"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed review jobs (attempt ${{ github.event.workflow_run.run_attempt }} of max 3)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Re-running failed jobs of run ${{ github.event.workflow_run.id }} (attempt ${{ github.event.workflow_run.run_attempt }} just failed)"
+          gh run rerun ${{ github.event.workflow_run.id }} --failed -R ${{ github.repository }}

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -390,6 +390,47 @@ The tally is what matters here: a prohibition on parking has now been defeated
 three times, by a wakeup call, by prose, and by a tool's async return. Each fix
 addressed the mechanism in front of it. Only the obligation generalises.
 
+### Failure class 6: fourth recurrence, prompt mitigation exhausted, structural fix (2026-07-31)
+
+The fourth occurrence (run `30650165439` attempt 1, PR #535) defeated even the
+unconditional posting contract: two async `Agent` launches, a `ScheduleWakeup`,
+then the run *cancelled its own wakeup* — reasoning that background
+notifications would arrive on their own — and ended with zero activity. The
+contract was in the run's own prompt and was stepped over, not missed. Filed
+and investigated as [#538](https://github.com/storkme/spaghettio/issues/538);
+two findings settled the prompt-vs-structure question:
+
+1. The model wasn't disobeying — it was **misjudging its own state** (occurrence
+   2 waited for results already in its transcript; occurrence 4 believed no
+   wakeup was needed). No prompt phrasing corrects a confidently-held wrong
+   belief about what is pending.
+2. The #535 run artifact proved `Agent` (and the whole async family) is
+   **reachable via `ToolSearch` despite being absent from `--allowedTools`** —
+   no configuration had ever actually removed a parking capability.
+
+**Structural fixes shipped (#538):**
+
+1. `--disallowedTools` in `claude-code-review.yml` bans the non-`Agent` async
+   family (`ScheduleWakeup`, `Task*`, `Cron*`, `RemoteTrigger`, `Workflow`,
+   `PushNotification`) — none has a legitimate use in a one-shot review.
+   `Agent` itself stays allowed: the plugin's eligibility gate dispatches
+   through it; banning it needs a canary run first (tracked in #538's thread).
+2. `claude-review-auto-retry.yml` — a `workflow_run`-triggered job that reruns
+   failed review jobs automatically, capped at 3 attempts. Mechanism-agnostic:
+   it keys off the guard's red, not off predicting the next parking tool, and
+   automates the manual re-run that recovered all four occurrences. Benign
+   skips exit 0 and never trigger it; a genuinely broken run still reds to a
+   human at the cap.
+3. `workflow-guard` (ci.yml) now also asserts `--disallowedTools` is present
+   and the auto-retry workflow file exists, so a stock-template overwrite
+   (class 4) cannot silently drop either.
+
+If a fifth parking mechanism appears, expect the auto-retry to absorb it (the
+rerun has recovered 4/4 so far); the signature to watch for is repeated
+same-run attempts each failing the guard — that means the parking is
+deterministic for that PR, and the canary-gated `Agent` ban becomes the next
+lever.
+
 ## Forensics playbook
 
 **Run signatures** (from the action's result JSON in the job log — grep the


### PR DESCRIPTION
## Intent

Structural (non-prompt) mitigation for #538 — the review orchestrator's silent-park class, four occurrences, three defeated prompt fixes. Implements options B + C from the investigation posted on the issue; option A (banning `Agent`) is deliberately deferred behind a canary, since the plugin's own eligibility gate dispatches through `Agent`.

## Scope

- `.github/workflows/claude-code-review.yml` — `--disallowedTools` for the non-`Agent` async family (`ScheduleWakeup`, `Task*`, `Cron*`, `RemoteTrigger`, `Workflow`, `PushNotification`). None has a legitimate use in a one-shot review; the #535 run artifact proved they stay reachable via `ToolSearch` regardless of `--allowedTools`.
- `.github/workflows/claude-review-auto-retry.yml` (new) — `workflow_run`-triggered rerun of failed review jobs, capped at 3 attempts. Automates the manual re-run that has recovered 4/4 occurrences. Fires only on `conclusion == 'failure'` (benign skips exit 0 → never fires); reruns the same run so the required check re-enters `in_progress` with no gate gap; `workflow_run` executes the default-branch version, so a PR editing this file cannot hijack retry behavior.
- `.github/workflows/ci.yml` — workflow-guard gains two assertions (`--disallowedTools` present; auto-retry file exists) so a stock-template overwrite (`/install-github-app`, class 4) cannot silently drop either.
- `docs/review-bot.md` — class 6 close-out entry: the fourth occurrence, why prompt fixes kept failing (state misjudgment, not disobedience), the shipped fixes, and the fifth-occurrence playbook (repeated same-run guard failures → the canary-gated `Agent` ban is the next lever).

## Verification actually run

- All three YAML files parse (`python3 -c yaml.safe_load` on each).
- Assertion styles mirror the existing four workflow-guard checks; grepped the new patterns against the modified review workflow to confirm they match (`--disallowedTools` present; file exists).
- Trigger-condition safety argued from the guard's exit codes (benign skips exit 0 at claude-code-review.yml's draft/workflow-file/small-diff/already-reviewed branches) — verified in the #538 investigation, cited on the issue.
- NOT verified live: the `workflow_run` retry firing end-to-end (needs a real failed review run to trigger; the next silent-park occurrence is the test). The rerun command itself (`gh run rerun <id> --failed`) matches what recovered all four historical occurrences manually.

## Deviations

This PR touches workflow files, so the review bot will benign-skip it (by design). Reviewed instead via the #538 investigation that specified these changes and a maintainer-side read of the diff. Per CLAUDE.md's live trap: this PR is itself the diff-against-stock-template to preserve — do not re-run `/install-github-app` over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
