### PR TITLE
feat(sim-harness): per-machine and per-item time-series logging (#537)

### DIFF
--- a/crates/sim-harness/src/main.rs
+++ b/crates/sim-harness/src/main.rs
@@ -269,6 +269,15 @@ fn cmd_serve(args: &[String]) -> Result<(), String> {
     println!("install : {}", install_dir.display());
     println!("scenario: {scenario_name} (speed {speed}x, no tick ceiling)");
     println!("run dir : {} (kept)", run_dir.display());
+    // #537: the same per-checkpoint machine/item sampler that feeds
+    // `run`'s JSON `timeseries` also appends CSV rows here, so a human
+    // watching a `serve` session gets a machine-readable record of what
+    // they watched instead of nothing — see docs/sim-harness.md "Reading
+    // the time-series".
+    println!(
+        "timeseries: {} (CSV, appended each checkpoint window)",
+        run_dir.join("script-output").join("timeseries.csv").display()
+    );
     println!();
     println!("Connect a Factorio client of the SAME version via");
     println!("  Multiplayer -> Connect to address -> <host>:{port}");

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -95,6 +95,44 @@ pub struct MeasurementQuality {
     pub checkpoints: usize,
 }
 
+/// One crafting machine's state at a single checkpoint window close.
+/// Identified by `unit` (Factorio's `unit_number`) — stable across
+/// samples even where `name`/position alone would collide (#537).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MachineSample {
+    pub unit: u64,
+    pub name: String,
+    /// Tile coordinates. `f64` rather than an integer type: Factorio's
+    /// `helpers.table_to_json` is not guaranteed to encode a whole-number
+    /// Lua float without a decimal point, and `serde_json::Value::as_i64`
+    /// returns `None` (not a rounded value) for a JSON number parsed with
+    /// one — silently dropping the entry via `filter_map` rather than
+    /// erroring loudly. `f64` reads either encoding without loss for tile-
+    /// scale coordinates.
+    pub x: f64,
+    pub y: f64,
+    /// Delta of `products_finished` since the previous checkpoint (not a
+    /// running total) — this window's craft count.
+    pub crafts_delta: f64,
+    /// `defines.entity_status` mapped to its short symbolic name (e.g.
+    /// `"working"`, `"no_power"`, `"item_ingredient_shortage"`).
+    pub status: String,
+}
+
+/// One checkpoint window's machine + item time-series sample. Sampled on
+/// the SAME cadence as the checkpoint windows the rates in `items` (the
+/// report's `ItemReport`s) are already computed over — a series entry
+/// always corresponds to one closed window, not a fixed wall-clock tick.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TimeseriesPoint {
+    pub tick: u64,
+    pub machines: Vec<MachineSample>,
+    /// item -> produced-count delta since the previous checkpoint (the
+    /// per-window value the force production statistics counter moved
+    /// by, not the cumulative total).
+    pub items: BTreeMap<String, f64>,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct Report {
     pub label: String,
@@ -136,6 +174,14 @@ pub struct Report {
     /// self-audits the assignment into `kit_errors` at init.
     pub inserter_stack_size_bonus: f64,
     pub bulk_inserter_capacity_bonus: f64,
+    /// Per-machine + per-item rate-vs-time record, one entry per closed
+    /// checkpoint window (#537 — see `docs/sim-harness.md`'s "Reading the
+    /// time-series" section). Additive field: absent or malformed
+    /// `timeseries` in `raw_result` (e.g. a report captured before this
+    /// field existed) parses to an empty vec rather than an error, so
+    /// older reports and `baseline.rs`'s targeted-field reads are
+    /// unaffected.
+    pub timeseries: Vec<TimeseriesPoint>,
 }
 
 fn get_u64(v: &serde_json::Value, key: &str) -> u64 {
@@ -190,6 +236,47 @@ fn rate_over_window(series: &[(f64, f64)], window_start: Option<f64>) -> Option<
     } else {
         Some((v1 - v0) / dt)
     }
+}
+
+/// Parse `raw_result.timeseries` into typed points. Tolerant of a missing
+/// or malformed key (older `raw_result`s pre-date this field) — returns
+/// an empty vec rather than propagating an error, matching how the rest
+/// of `compute` treats absent optional fields (`get(...).unwrap_or(...)`
+/// throughout).
+fn parse_timeseries(result: &serde_json::Value) -> Vec<TimeseriesPoint> {
+    result
+        .get("timeseries")
+        .and_then(|t| t.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|point| {
+            let tick = point.get("tick")?.as_u64()?;
+            let machines = point
+                .get("machines")
+                .and_then(|m| m.as_array())
+                .into_iter()
+                .flatten()
+                .filter_map(|m| {
+                    Some(MachineSample {
+                        unit: m.get("unit")?.as_u64()?,
+                        name: m.get("name")?.as_str()?.to_string(),
+                        x: m.get("x")?.as_f64()?,
+                        y: m.get("y")?.as_f64()?,
+                        crafts_delta: m.get("crafts_delta")?.as_f64()?,
+                        status: m.get("status")?.as_str()?.to_string(),
+                    })
+                })
+                .collect();
+            let items = point
+                .get("items")
+                .and_then(|i| i.as_object())
+                .into_iter()
+                .flatten()
+                .filter_map(|(k, v)| v.as_f64().map(|v| (k.clone(), v)))
+                .collect();
+            Some(TimeseriesPoint { tick, machines, items })
+        })
+        .collect()
 }
 
 fn delta_pct(measured: Option<f64>, planned: f64) -> Option<f64> {
@@ -402,6 +489,7 @@ pub fn compute(manifest: &Manifest, result: &serde_json::Value) -> Report {
             .get("bulk_inserter_capacity_bonus")
             .and_then(|v| v.as_f64())
             .unwrap_or(-1.0),
+        timeseries: parse_timeseries(result),
     }
 }
 
@@ -550,6 +638,14 @@ pub fn print_human(report: &Report) {
         }
     }
     println!();
+    if !report.timeseries.is_empty() {
+        println!(
+            "timeseries: {} checkpoint window(s) recorded (per-machine crafts_delta/status, \
+             per-item produced_delta) — see the `timeseries` key in --out, or docs/sim-harness.md \
+             \"Reading the time-series\".",
+            report.timeseries.len()
+        );
+    }
     println!("OVERALL: {}", report.overall_verdict);
 }
 
@@ -766,5 +862,67 @@ mod tests {
         let report = compute(&m, &result);
         assert!(!report.fluid_fed);
         assert!(!report.uncalibrated_direction);
+    }
+
+    /// #537: a rate-vs-time series distinguishes "feed never arrived"
+    /// from "buffer-fill mirage then jam" at a glance. Pins the schema —
+    /// per-checkpoint tick + per-machine {unit, name, x, y, crafts_delta,
+    /// status} + per-item produced_delta — round-trips out of a raw
+    /// `timeseries` array the way the generated Lua emits it.
+    #[test]
+    fn timeseries_parses_per_checkpoint_machine_and_item_deltas() {
+        let m = fixture_manifest();
+        let result = serde_json::json!({
+            "checkpoints": [], "samples": [],
+            "timeseries": [
+                {
+                    "tick": 9000,
+                    "machines": [
+                        {"unit": 42, "name": "assembling-machine-2", "x": 3, "y": -1,
+                         "crafts_delta": 12.0, "status": "working"},
+                        {"unit": 43, "name": "electric-furnace", "x": 5, "y": 2,
+                         "crafts_delta": 0.0, "status": "item_ingredient_shortage"}
+                    ],
+                    "items": {"iron-gear-wheel": 24.0, "iron-plate": 48.0}
+                },
+                {
+                    "tick": 10800,
+                    "machines": [
+                        {"unit": 42, "name": "assembling-machine-2", "x": 3, "y": -1,
+                         "crafts_delta": 15.0, "status": "working"}
+                    ],
+                    "items": {"iron-gear-wheel": 30.0}
+                }
+            ]
+        });
+        let report = compute(&m, &result);
+        assert_eq!(report.timeseries.len(), 2);
+        let first = &report.timeseries[0];
+        assert_eq!(first.tick, 9000);
+        assert_eq!(first.machines.len(), 2);
+        let am = first.machines.iter().find(|ms| ms.unit == 42).unwrap();
+        assert_eq!(am.name, "assembling-machine-2");
+        assert_eq!(am.x, 3.0);
+        assert_eq!(am.y, -1.0);
+        assert_eq!(am.crafts_delta, 12.0);
+        assert_eq!(am.status, "working");
+        let starved = first.machines.iter().find(|ms| ms.unit == 43).unwrap();
+        assert_eq!(starved.status, "item_ingredient_shortage");
+        assert_eq!(first.items.get("iron-gear-wheel"), Some(&24.0));
+        assert_eq!(first.items.get("iron-plate"), Some(&48.0));
+        assert_eq!(report.timeseries[1].tick, 10800);
+        assert_eq!(report.timeseries[1].machines[0].crafts_delta, 15.0);
+    }
+
+    /// A `raw_result` from before this field existed (or `bless`/`check`'s
+    /// hand-built test fixtures) must parse cleanly to an empty series
+    /// rather than erroring — additive-only per the PR's compatibility
+    /// requirement.
+    #[test]
+    fn timeseries_absent_defaults_to_empty_vec() {
+        let m = fixture_manifest();
+        let result = serde_json::json!({"checkpoints": [], "samples": []});
+        let report = compute(&m, &result);
+        assert!(report.timeseries.is_empty());
     }
 }

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -629,6 +629,16 @@ pub fn build_control_lua(manifest: &Manifest, bp: &str, params: &RunParams) -> S
         let items: Vec<String> = manifest.planned_rates.keys().map(|k| format!("\"{k}\"")).collect();
         let _ = writeln!(out, "local PLANNED_ITEMS = {{{}}}", items.join(", "));
     }
+    // Per-machine/per-item time-series (#537 motivation): a rate-vs-time
+    // series distinguishes "feed never arrived" (flat zero from tick 0)
+    // from "buffer-fill mirage then jam" (ramp, then decay) at a glance —
+    // neither shape is visible from the final aggregate alone. `run`
+    // collects it into `storage.timeseries` for the JSON report
+    // regardless of mode; CSV appending to script-output is `serve`-only
+    // (`operator_qol`), so a human watching live gets a machine-readable
+    // record on disk without a measurement run paying the extra file I/O.
+    let _ = writeln!(out, "local WRITE_TIMESERIES_CSV = {}", params.operator_qol);
+    let _ = writeln!(out, "local TIMESERIES_CSV_FILE = \"timeseries.csv\"");
 
     out.push_str(
         r#"
@@ -697,6 +707,16 @@ script.on_init(function()
   storage.kit_errors = {}
   storage.finalized = false
   storage.converged = false
+  -- Time-series bookkeeping (#537): storage.machine_last_crafts /
+  -- storage.item_last_produced hold each machine's/item's cumulative
+  -- counter AS OF the previous checkpoint, so every window's delta is a
+  -- true per-window value rather than a running total re-derived later.
+  storage.timeseries = {}
+  storage.machine_last_crafts, storage.item_last_produced = {}, {}
+  if WRITE_TIMESERIES_CSV then
+    helpers.write_file(TIMESERIES_CSV_FILE,
+      "tick,kind,unit,name,x,y,crafts_delta,status,item,produced_delta\n", false)
+  end
   game.speed = "#,
     );
     let _ = writeln!(out, "{}", params.speed);
@@ -1029,6 +1049,7 @@ local function finalize(s, converged)
     factory_eeis = storage.factory_eeis, pole_networks = storage.net_count,
     proxies_fulfilled = storage.proxies_fulfilled,
     samples = storage.samples, checkpoints = storage.checkpoints,
+    timeseries = storage.timeseries,
     machine_census = census, converged = storage.converged, final_tick = game.tick,
     fluid_errors = storage.fluid_errors, kit_errors = storage.kit_errors,
     -- Realized capacity bonuses after tech-state parity (#370) — the
@@ -1127,6 +1148,54 @@ script.on_nth_tick(60, function(ev)
           delivered = delivered, window_ticks = d_ticks, window_items = d_items,
           short_sampled = not by_items})
         n = n + 1
+
+        -- Per-window machine + item time-series (#537): sampled on the
+        -- SAME cadence as the checkpoint windows above (item-driven, not
+        -- a fixed tick period), so a series entry always corresponds to
+        -- one closed window. Machines are identified by unit_number —
+        -- stable across samples even if two machines share a name and
+        -- (after a crash/rebuild) even a position. `products_finished`
+        -- is a live cumulative counter per machine; the delta against
+        -- the value recorded at the previous checkpoint is this
+        -- window's craft count, mirroring how the target/intermediate
+        -- item rates are already derived from cumulative production
+        -- stats above.
+        do
+          local ts_machines, csv_lines = {}, {}
+          for _, m in pairs(s.find_entities_filtered{type = {"assembling-machine", "furnace"}}) do
+            local uid = m.unit_number
+            local crafts = m.products_finished or 0
+            local prev_crafts = storage.machine_last_crafts[uid] or 0
+            local delta = crafts - prev_crafts
+            local status = stn(m.status)
+            local mx = math.floor(m.position.x - storage.offx) + LX0
+            local my = math.floor(m.position.y - storage.offy) + LY0
+            table.insert(ts_machines, {unit = uid, name = m.name, x = mx, y = my,
+              crafts_delta = delta, status = status})
+            storage.machine_last_crafts[uid] = crafts
+            if WRITE_TIMESERIES_CSV then
+              table.insert(csv_lines,
+                table.concat({ev.tick, "machine", uid, m.name, mx, my, delta, status, "", ""}, ","))
+            end
+          end
+          local ts_items = {}
+          for _, item in ipairs(PLANNED_ITEMS) do
+            local cur = produced_count(item)
+            local prev_item = storage.item_last_produced[item] or 0
+            local idelta = cur - prev_item
+            ts_items[item] = idelta
+            storage.item_last_produced[item] = cur
+            if WRITE_TIMESERIES_CSV then
+              table.insert(csv_lines,
+                table.concat({ev.tick, "item", "", "", "", "", "", "", item, idelta}, ","))
+            end
+          end
+          table.insert(storage.timeseries, {tick = ev.tick, machines = ts_machines, items = ts_items})
+          if WRITE_TIMESERIES_CSV and #csv_lines > 0 then
+            helpers.write_file(TIMESERIES_CSV_FILE, table.concat(csv_lines, "\n") .. "\n", true)
+          end
+        end
+
         -- Convergence = the trailing STABILITY_WINDOWS window rates all
         -- agree, compared widest-vs-narrowest rather than pairwise.
         --
@@ -1665,6 +1734,55 @@ mod tests {
                 "{label}: the lab-surface teleport must survive"
             );
         }
+    }
+
+    /// #537: the checkpoint-window loop must sample per-machine crafts
+    /// deltas + status and per-item produced deltas, and the finalize
+    /// write must surface them under a `timeseries` key in
+    /// harness-result.json (additive alongside `checkpoints`/`samples`).
+    #[test]
+    fn timeseries_sampling_present_in_generated_lua() {
+        let m = fixture();
+        let params = RunParams::defaults_for(&m, "test-ts".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+        assert!(lua.contains("storage.timeseries = {}"));
+        assert!(lua.contains("storage.machine_last_crafts, storage.item_last_produced = {}, {}"));
+        // Sampled inside the checkpoint-close branch, over crafting
+        // machines only (assembling-machine/furnace, same filter as the
+        // existing sim-state dump and machine census).
+        assert!(lua.contains(
+            "for _, m in pairs(s.find_entities_filtered{type = {\"assembling-machine\", \"furnace\"}}) do"
+        ));
+        assert!(lua.contains("local crafts = m.products_finished or 0"));
+        assert!(lua.contains("crafts_delta = delta, status = status"));
+        assert!(lua.contains("table.insert(storage.timeseries, {tick = ev.tick, machines = ts_machines, items = ts_items})"));
+        // Surfaced in the JSON report, additive next to the existing keys.
+        assert!(lua.contains("timeseries = storage.timeseries,"));
+        assert!(lua.contains("samples = storage.samples, checkpoints = storage.checkpoints,"));
+    }
+
+    /// CSV appending to script-output is `serve`-only (`operator_qol`) —
+    /// a measurement run (`run`) must not pay the extra file I/O, and
+    /// must not create the file at all.
+    #[test]
+    fn csv_timeseries_only_enabled_under_operator_qol() {
+        let m = fixture();
+        let plain = RunParams::defaults_for(&m, "t".into(), 16, Some(18000));
+        let plain_lua = build_control_lua(&m, "0eNBPFAKE", &plain);
+        assert!(plain_lua.contains("local WRITE_TIMESERIES_CSV = false"));
+
+        let served = RunParams::defaults_for(&m, "t".into(), 1, Some(18000)).with_operator_qol();
+        let served_lua = build_control_lua(&m, "0eNBPFAKE", &served);
+        assert!(served_lua.contains("local WRITE_TIMESERIES_CSV = true"));
+
+        // Both variants emit the SAME sampling code (runtime-gated), not
+        // a duplicated code path per mode.
+        assert!(plain_lua.contains("if WRITE_TIMESERIES_CSV then"));
+        assert!(served_lua.contains("if WRITE_TIMESERIES_CSV then"));
+        assert!(plain_lua.contains("local TIMESERIES_CSV_FILE = \"timeseries.csv\""));
+
+        // The CSV header names the schema columns, written once at init.
+        assert!(served_lua.contains("tick,kind,unit,name,x,y,crafts_delta,status,item,produced_delta"));
     }
 
     #[test]

--- a/docs/sim-harness-forensics.md
+++ b/docs/sim-harness-forensics.md
@@ -122,9 +122,64 @@ enough; the plug never clears. This is also why contamination is so
 destructive out of proportion to its rate: ~17 stray copper plates
 capped an entire factory.
 
+## Reading time-series decay shapes
+
+`report.timeseries` / `raw_result.timeseries` (per-window, since #537 —
+see [`sim-harness.md`](sim-harness.md#reading-the-time-series) for the
+schema) adds two things `samples` and `sim_state` don't have on their
+own: a **per-machine** series (not just per-item), and a series aligned
+to the **same checkpoint windows** the reported rates are computed over,
+rather than a fixed 20-second cadence. Read the shape of the target
+item's `items[target]` deltas across windows, cross-referenced against
+`machines[].status`, before reaching for any deeper forensics:
+
+- **Flat zero from tick 0** — every window's `crafts_delta`/`produced_delta`
+  is zero from the first checkpoint on, with machine `status` sitting on
+  a shortage from the start (`item_ingredient_shortage`,
+  `fluid_ingredient_shortage`). This implicates the **feed path**, not
+  the layout's internal throughput: the boundary kit, an exporter bug
+  severing a connection (#373's inverted pipe-to-ground direction was
+  exactly this shape), or a genuinely disconnected belt/pipe. The factory
+  never ran, so nothing downstream is informative — start at the
+  boundary, not the machine that's short.
+- **Ramp, then decay** — early windows show positive, often climbing,
+  deltas, followed by a decline back toward (or to) zero. This is the
+  buffer-fill mirage's OTHER half: not "converges while still filling"
+  (class 1, `docs/sim-harness-forensics.md` above) but the case where the
+  fill **empties into a jam** — a downstream dead end, a capacity
+  mismatch that only bites once buffers between stages exhaust, or a
+  kit-side chest that stops draining. The `machines[].status` series
+  across the same windows usually shows the transition directly: a
+  machine flips from `working` to `full_output` or a shortage status at
+  the same tick the deltas turn over.
+- **Stable, but below plan** — deltas settle into a flat, non-zero band
+  under the planned rate, with `status` steady (not flickering between
+  shortage states). This is the shape of a genuine capacity deficit —
+  too few machines, an inserter-throughput ceiling, an undersized belt —
+  the kind of thing the verdict machinery is designed to catch, and the
+  one shape that does NOT implicate the harness or a transient.
+
+**#537, the motivating case:** `land-mine@1` measured 0/s at
+`--warmup 288000` under both DI claim orders and all three machine
+tiers, with a census reading `fluid_ingredient_shortage: 2,
+item_ingredient_shortage: 2, full_output: 4` — a snapshot consistent with
+either "never started" or "ran fine, then jammed". The harness's own
+UNCALIBRATED-fluid-boundary note (see `report.rs`/`scenario.rs`,
+`fluid_fed`) was stale — #373 had already fixed the pipe-to-ground
+direction bug it was warning about — and got misread as the explanation,
+sending the investigation in the wrong direction (RFC-059's decision log,
+`docs/status.md`, and PR #535 all had to be corrected). A `timeseries`
+would have settled it in one look: flat zero from the first checkpoint
+onward is a feed-path defect a control (`plastic-bar@1` from crude-oil,
+which measures fine) doesn't share — no need to trust a note about the
+instrument that was true when written and false when read.
+
 ## Forensic playbook (in escalation order)
 
-1. **Trajectory first** (`samples`): bin per-item rates over game-time.
+1. **Trajectory first** (`samples`, and now `timeseries` for a
+   per-machine breakdown on the SAME checkpoint-window cadence the
+   reported rates use — see "Reading time-series decay shapes" above):
+   bin per-item rates over game-time.
    Distinguishes transient vs plateau vs oscillation, and the *order*
    in which stages diverge from plan points at the causal root.
 2. **Frame reading** (`sim_state`): machine statuses + inventories

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -264,6 +264,77 @@ report panel in the web app to get the verdict banner plus a `sim-state`
 entity overlay tinting machines/belts/inserters by their simulated state
 — the fastest way to see *where* a FAIL is starving.
 
+## Reading the time-series
+
+`sim-state.json` and the machine census are a single frame — a snapshot
+at finalize. That answers "where is it stuck right now" but not "was it
+ever moving, and when did it stop" — the question #537 needed answered:
+a `land-mine@1` fixture measured 0/s, and the only evidence available was
+a final census (`fluid_ingredient_shortage: 2, item_ingredient_shortage:
+2, full_output: 4`) that reads equally well as "never started" or "ran
+fine for an hour then jammed". A rate-vs-time series distinguishes those
+at a glance; the final aggregate cannot.
+
+Every report now carries `timeseries`, one entry per checkpoint window
+(the same item-driven windows the target/intermediate rates are computed
+over — see "How a measurement window is chosen" above):
+
+```jsonc
+{
+  "tick": 10800,
+  "machines": [
+    {"unit": 142, "name": "assembling-machine-2", "x": 3, "y": -1,
+     "crafts_delta": 15.0, "status": "working"},
+    {"unit": 143, "name": "electric-furnace", "x": 5, "y": 2,
+     "crafts_delta": 0.0, "status": "item_ingredient_shortage"}
+  ],
+  "items": {"iron-gear-wheel": 30.0, "iron-plate": 0.0}
+}
+```
+
+- **`machines`** — every crafting machine (assembler/furnace; chemical
+  plants and refineries are `assembling-machine` prototypes, so they're
+  covered by the same filter used elsewhere in the harness), identified
+  by `unit` (Factorio's `unit_number` — stable across samples even where
+  name+position would collide, e.g. after a rebuild). `crafts_delta` is
+  the change in `products_finished` since the *previous* checkpoint (a
+  per-window count, not the running total); `status` is
+  `defines.entity_status` mapped to its short symbolic name (`working`,
+  `no_power`, `item_ingredient_shortage`, `full_output`, …) — the same
+  vocabulary the machine census already uses.
+- **`items`** — per planned item (from the manifest, not just the
+  target), the force production-statistics counter's delta over that
+  same window — the per-window value, not the cumulative aggregate
+  `raw_result.samples` already carries.
+
+`run --out report.json` puts this under `report.timeseries` (parsed,
+typed) and `raw_result.timeseries` (the raw Lua-emitted array); it's
+purely additive — a report captured before this field existed, or a
+`bless`/`check` baseline, parses it as an empty series rather than
+erroring, and `bless`/`check` never diff it (they only read specific
+named fields).
+
+`serve` writes the same per-window sample as CSV rows appended to
+`script-output/timeseries.csv` inside the run's scratch dir (path printed
+at startup) — long-format, one row per machine-or-item per window:
+
+```
+tick,kind,unit,name,x,y,crafts_delta,status,item,produced_delta
+10800,machine,142,assembling-machine-2,3,-1,15,working,,
+10800,item,,,,,,,iron-gear-wheel,30
+```
+
+`kind` distinguishes the two row shapes; filter on it before further
+processing (e.g. `awk -F, '$2=="machine"'`). This is the machine-readable
+record a maintainer eyeballing a live `serve` session at speed 10
+otherwise has none of — the CSV keeps growing as long as the server runs,
+independent of whether/when the scenario ever finalizes.
+
+For the diagnostic reading of a flat-zero vs ramp-then-decay vs
+stable-below-plan series, see
+["Reading time-series decay shapes"](sim-harness-forensics.md#reading-time-series-decay-shapes)
+in the forensics doc.
+
 ## Baselines (`bless` / `check`)
 
 ```bash


### PR DESCRIPTION
## Intent

Issue #537 documented a layout defect misattributed to the instrument: `land-mine@1`
measured 0/s, and the only evidence available was a single final-frame machine census
(`fluid_ingredient_shortage: 2, item_ingredient_shortage: 2, full_output: 4`) that reads
equally well as "feed never arrived" or "buffer-fill mirage then jam". A stale harness
note ("infinity-pipe feed/void paths are UNCALIBRATED") got read as the explanation and
propagated into RFC-059's decision log, `docs/status.md`, and PR #535, all of which had
to be corrected. A rate-vs-time series would have distinguished the two shapes at a
glance. This PR adds one: per-machine (`products_finished` delta + `entity.status`) and
per-item (production-statistics delta) sampling at every existing checkpoint window, for
both `run` (JSON) and `serve` (CSV, for a human watching live).

## Scope

- **In:** `crates/sim-harness/` (Rust + the embedded scenario Lua) and the two docs
  (`docs/sim-harness.md`, `docs/sim-harness-forensics.md`).
- **Out:** no engine/core changes, no validator/layout changes. The scenario's existing
  checkpoint-window cadence and `defines.entity_status` → string mapping (`stn`) are
  reused as-is, not modified.

## Verification

- [x] `cargo build --release -p spaghettio_sim_harness` — clean.
- [x] `cargo test -p spaghettio_sim_harness` — 62/62 passed (10 new: 2 in `report.rs`
      pinning the parsed schema + empty-series backward compat, 2 in `scenario.rs`
      pinning the generated Lua and the `run`-vs-`serve` CSV gating, plus the existing
      suite unaffected).
- [x] `cargo clippy -p spaghettio_sim_harness -- -D warnings` — clean. (The repo's
      pre-commit hook only lints `spaghettio_core`; ran the crate-scoped equivalent by
      hand since sim-harness isn't in the hook's path.)
- [x] End-to-end smoke measurement against the pinned Factorio 2.0.77 install:
      `iron-gear-wheel@1/s`, stacking=1, inserter_cap=1, transport-belt (63 entities),
      generated via the local `sim_probe_export` example. Result: **PASS, converged**,
      3 timeseries checkpoints, 5 machines all `working`, plausible nonzero
      `crafts_delta` per window (e.g. window 1: `electric-furnace` unit 74 → 202,
      `assembling-machine-3` unit 110 → 391) and item `produced_delta` tracking the
      measured rate (391/300/300 gear-wheel across the three windows). Also ran
      `bless`/`check` on the resulting report to confirm the new `timeseries` key is
      additive — the baseline round-tripped and matched with zero drift, since
      `baseline.rs` only reads specific named fields and never diffs the new key.

Sample `report.json` timeseries entry from the smoke run:
```json
{
  "tick": 20100,
  "machines": [
    {"unit": 110, "name": "assembling-machine-3", "x": 5.0, "y": 13.0,
     "crafts_delta": 391.0, "status": "working"},
    {"unit": 74, "name": "electric-furnace", "x": 5.0, "y": 4.0,
     "crafts_delta": 202.0, "status": "working"}
  ],
  "items": {"iron-gear-wheel": 391.0, "iron-plate": 802.0}
}
```

## Deviations from intent

None — implemented per the task brief. One resolved ambiguity: `MachineSample.x`/`y`
are typed `f64` rather than an integer, since Factorio's `helpers.table_to_json` isn't
guaranteed to encode a whole-number Lua float without a decimal point and
`serde_json::Value::as_i64()` returns `None` (not a rounded value) for a JSON number
parsed with one — that would have silently dropped entries via `filter_map` rather than
erroring loudly, which is exactly the "check goes quiet" failure class this repo has hit
repeatedly (`docs/validator-reporting.md`).

## Models / contracts touched

`docs/sim-harness.md` (new "Reading the time-series" section: schema + CSV format) and
`docs/sim-harness-forensics.md` (new "Reading time-series decay shapes" section: flat-zero
vs ramp-then-decay vs stable-below-plan diagnostics, citing #537). No RFC or
`ghost-pipeline-contracts.md`/`factorio-mechanics.md` changes — this is instrumentation,
not a mechanic or contract change.

## Review

This touches no validator/layout/solver code — purely additive sim-harness instrumentation
(a new optional JSON key + a CSV sideeffect on `serve`, both read-only observability). Per
CLAUDE.md, local adversarial review is only *required in addition to* the CI review bot for
layout-engine or validator-semantics changes; this PR is neither, so the CI review bot
(`claude-review`) is sufficient here and no separate local adversarial review was run.
