### PR TITLE
docs(rfc-059): the flip was blamed for a CI failure it probably did not cause

### DIFF
--- a/docs/rfc-059-di-coupling-assignment.md
+++ b/docs/rfc-059-di-coupling-assignment.md
@@ -760,6 +760,46 @@ widespread and the optimum is static everywhere.
   repaired factory. The deferral was still right — it is what bought the sim runs
   that found this.
 
+- *2026-07-31 — the flip was blamed for a CI failure it probably did not cause.*
+  `main` went red on `chain_am2_default_options_ships_cell_composed_rescue`
+  immediately after the flip merged (`94cb5dd9`), and I attributed it to the flip
+  on sight. The reasoning was sound as far as it went: that test asserts an exact
+  `(width, height, entities)` triple for a layout built with
+  `cell_composition: Off, ..Default::default()`, and `..Default::default()` now
+  carries `Downstream` — `cell_composition: Off` disables cell composition, not
+  DI, so the golden genuinely does depend on the claim order.
+
+  **Plausible, and probably wrong.** The failing value (23, 50, 424) is not
+  reproducible from the tree under any local axis — warm cache, empty cache,
+  CI-pinned cache, debug, 2-core — by me or by a second investigator. `main` then
+  went green at the next commit (#539), which did not touch that golden.
+
+  The mechanism that fits is a **shared-cache race, not torn writes**. The zone
+  cache appends with `O_APPEND` and one `write_all` per 100–300-byte record, well
+  under `PIPE_BUF`, so concurrent processes get interleaved-but-intact records by
+  design. What is not handled: `resolve_cache_path()` honours
+  `SPAGHETTIO_ZONE_CACHE_PATH`, so **CI writes into its own pinned baseline
+  during the run**, and [`status.md`](status.md) separately records that
+  "slow/loaded machines record spurious timeouts that then *cache*". Under
+  nextest's process-per-test parallelism, whether a given test reads a
+  freshly-solved zone or another process's load-induced `Timeout` entry is
+  scheduling luck — which makes the fail/pass/pass sequence luck too, not a
+  bisection.
+
+  The brittle pins are retired as of `61bad814` (#543), which reached the same
+  conclusion independently and from the other end, attributing them to #533 as
+  "host-relative". Left open, and worth its own change: making the CI cache
+  read-only or per-process would surface the race loudly instead of letting it
+  masquerade as a layout regression. Both halves of the mechanism were already
+  documented in `status.md`; nobody had joined them.
+
+  **The lesson is about attribution, not about the cache.** "My change plausibly
+  explains this failure" and "my change caused this failure" are different
+  claims, and a golden that *could* move is not evidence that it *did*. I also
+  quoted "1053 pass" as verification for the flip when my local run was not
+  reproducing CI at all — the number was real and the confidence it carried was
+  not.
+
 - *2026-07-31 — `DiClaimOrder::Pinned` kept although P2/P3 were dropped.* It is
   measurement machinery for a policy that will not ship, which normally argues
   for deleting it. Kept because it is the instrument that produced the negative,


### PR DESCRIPTION
## Intent

`main` went red on `chain_am2_default_options_ships_cell_composed_rescue` immediately after RFC-059's flip merged (`94cb5dd9`), and I attributed it to the flip on sight. That attribution is probably wrong, and RFC-059's decision log is the place it belongs — it is the record of calls made on that RFC's subject, including the mistaken ones.

Docs only. No code.

## Why the attribution was plausible

The test asserts an exact `(width, height, entities)` triple for a layout built with `cell_composition: Off, ..Default::default()`. `Off` disables cell composition, **not** DI — so `..Default::default()` carries the flipped `di_claim_order`, and the golden genuinely does depend on it. My change could have moved that number.

## Why it probably didn't

- **(23, 50, 424) does not reproduce from the tree under any local axis** — warm cache, empty cache, CI-pinned cache, debug, 2-core — for me or for a second investigator.
- `main` went green at the next commit (#539), which did not touch that golden.
- #543 / `61bad814` retired the pins independently and from the other end, calling them **"host-relative"** and attributing them to #533.

## The mechanism, and it is not torn writes

The zone cache appends with `O_APPEND` and one `write_all` per 100–300-byte record — well under `PIPE_BUF`, so concurrent processes get *"interleaved-but-intact records, never torn ones"* by explicit design.

What is **not** handled: `resolve_cache_path()` honours `SPAGHETTIO_ZONE_CACHE_PATH`, so **CI appends into its own pinned baseline during the run**. `docs/status.md` separately records that *"slow/loaded machines record spurious timeouts that then cache"*. Under `nextest`'s process-per-test parallelism, whether a given test reads a freshly-solved zone or another process's load-induced `Timeout` entry is scheduling luck — which makes the fail/pass/pass sequence luck as well, not a bisection.

**Both halves were already documented in `status.md`; nobody had joined them.**

## Left open

A **read-only or per-process CI cache** would surface this race loudly instead of letting it masquerade as a layout regression. Not done here — it is a CI change with its own blast radius, and #543 has already removed the pins that were exposing it. Flagged rather than silently dropped.

## Deviations from intent

None — this is the deviation, written down.

Two things I got wrong that the entry records:

1. **"Plausibly explains" is not "caused."** A golden that *could* move under my change is not evidence that it *did*, and I skipped straight from the first to the second.
2. **I quoted "1053 pass" as verification for the flip while my local run was not reproducing CI at all.** The number was real; the confidence it carried was not. That is the same shape as everything else this RFC has been about — a measurement that is accurate and misleading in relation to something else.

## Models / contracts touched

`docs/rfc-059-di-coupling-assignment.md` decision log only. No engine or CI behaviour changes.