### PR TITLE
docs(sim-harness): retire the stale infinity-pipe UNCALIBRATED note (#537)

### DIFF
--- a/crates/sim-harness/src/manifest.rs
+++ b/crates/sim-harness/src/manifest.rs
@@ -156,9 +156,16 @@ impl Manifest {
         serde_json::from_str(s).map_err(|e| format!("manifest parse error: {e}"))
     }
 
-    /// True if any boundary (input, output, or surplus exit) is fluid —
-    /// the RFC requires fluid-fed runs to be flagged UNCALIBRATED in the
-    /// report (no fixture has exercised the infinity-pipe feed/void paths).
+    /// True if any boundary (input, output, or surplus exit) is fluid.
+    /// Surfaced in the report as context (`Report::fluid_fed`), not as a
+    /// calibration warning: the infinity-pipe feed/void path was flagged
+    /// UNCALIBRATED through RFC-050 Phase 1, but #373 found and fixed the
+    /// actual defect (an exporter pipe-to-ground direction inversion), and
+    /// `plastic-bar` (crude-oil), `sulfur` (water + crude-oil, two fluid
+    /// boundaries on one edge), and `land-mine` (mixed fluid+item boundary)
+    /// have all since exercised it and PASSed — see #537. A run with a
+    /// non-south fluid boundary is still covered by
+    /// `has_uncalibrated_direction` below, which remains live.
     pub fn has_fluid_boundary(&self) -> bool {
         self.boundary_inputs.iter().any(|b| b.is_fluid)
             || self.boundary_outputs.iter().any(|b| b.is_fluid)

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -595,9 +595,6 @@ pub fn print_human(report: &Report) {
             .collect();
         println!("external inputs: {}", inputs.join(", "));
     }
-    if report.fluid_fed {
-        println!("NOTE: this run has fluid boundaries — infinity-pipe feed/void paths are UNCALIBRATED (no fixture has exercised them; RFC-050 Phase 1).");
-    }
     if report.uncalibrated_direction {
         println!("NOTE: at least one boundary is not south-facing — the jog geometry is a faithful vector generalization of the calibrated south-only prototype, but has never been measured live.");
     }

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -23,7 +23,10 @@
 //! this module's own golden-fragment tests). Non-south directions are
 //! geometrically faithful but UNCALIBRATED — nothing has measured them
 //! against a live server yet (`Manifest::has_uncalibrated_direction`
-//! flags this for the report, same treatment as fluid boundaries).
+//! flags this for the report). Fluid boundaries used to carry the same
+//! kind of flag, but that note went stale once #373 fixed the defect it
+//! was warning about and later fixtures exercised the path clean — see
+//! `Manifest::has_fluid_boundary` and #537.
 //!
 //! # Feed vs. drain pickup-side asymmetry
 //!
@@ -461,9 +464,11 @@ end
 /// further along it, so no column can ever reach a jog row's height —
 /// the issue's proven consumer-side workaround ("order boundary_inputs
 /// west->east") becomes the harness's own default instead of a caller
-/// obligation. Fluid records don't jog (a single adjacent infinity-pipe
-/// tile — see `add_fluid_feed`) so they're excluded and don't consume a
-/// slot.
+/// obligation. Fluid records don't use this lateral jog mechanism (they
+/// place a single adjacent infinity-pipe tile via `add_fluid_feed`,
+/// staggered by depth instead) — but they DO consume a slot, ordered
+/// first within each direction group, ahead of items (see the depth
+/// layout below).
 fn feed_slots(records: &[BoundaryRecord]) -> Vec<i32> {
     // ONE ladder per direction, fluids FIRST (PR #515 review finding: a
     // separate fluid counter staggered fluids only against each other, so


### PR DESCRIPTION
## Intent

Documentation-accuracy fix per #537's uncontested "Suggested fixes" section. #537's framing: *"a self-report is evidence about the instrument at authoring time, not at printing time."* `report.rs` unconditionally printed a NOTE that fluid boundaries (infinity-pipe feed/void paths) are UNCALIBRATED because "no fixture has exercised them" — true when RFC-050 Phase 1 wrote it, false since #373 fixed the actual defect (an exporter pipe-to-ground direction inversion). #537 went on to record three PASS runs that have since exercised the path clean:

- `plastic-bar@1` (crude-oil only) — PASS, 1.70/s produced against 1.00/s planned, converged
- `sulfur@1` (water + crude-oil, two fluid boundaries on the same edge) — PASS, +20.0%, converged
- `land-mine@1` (mixed fluid+item boundary) at am1/am2/am3 on merged `origin/main` — PASS at all three tiers

This PR retires the note and fixes a self-contradicting doc comment flagged in the same issue thread.

## Scope

- **In:**
  - Drop the unconditional `report.rs` NOTE print for `report.fluid_fed`.
  - Rewrite `Manifest::has_fluid_boundary`'s doc comment (`manifest.rs`) to stop claiming UNCALIBRATED and instead point at the evidence above; `Manifest::has_uncalibrated_direction` (#363, non-south feed rigs) is a **separate, still-live** flag and is untouched — its own NOTE still prints.
  - Fix `feed_slots`' self-contradicting doc comment in `scenario.rs`: one paragraph said fluid records "are excluded and don't consume a slot," the next said "fluids take slots 0..f-1." The code does the latter; reworded the first paragraph to match.
  - Updated `scenario.rs`'s module-level doc, which cited the now-retired note as fluid boundaries' "same treatment" as the direction flag — would otherwise have become a second stale claim introduced by this same PR.
- **Out:** `docs/sim-harness.md` has no matching claim (checked via grep). `docs/sim-harness-forensics.md` and `docs/status.md` already narrate the note as stale in past tense ("was stale" / "which is stale") — accurate as written, no changes needed. RFC decision logs (`docs/rfc-059-*.md`, `docs/rfc-048-*.md`) that quote the note historically are left untouched — they're the canonical record of what was believed at the time, not something to retcon. Diagnosing `land-mine@1`'s originally-reported 0/s is #537's second ask and is out of scope here — the issue's own comment thread has since resolved it as non-reproducing on merged main (three-tier PASS matrix), and the issue stays open for the filer's ack.

## Verification

- [x] `cargo build --release -p spaghettio_sim_harness`
- [x] `cargo test -p spaghettio_sim_harness` — 62 passed, 0 failed
- [x] `cargo clippy -p spaghettio_sim_harness --all-targets -- -D warnings` — clean
- [ ] WASM rebuild + browser eyeball — not applicable, sim-harness only, no layout-engine change
- [ ] Snapshot inspection — not applicable, no layout-engine change

## Deviations from intent

None — matches #537's "Suggested fixes" section (drop/narrow the note) and the `feed_slots` contradiction flagged in the same thread.

## Models / contracts touched

None. Doc-comment and printed-report-text only; no behavior change (`has_fluid_boundary()`'s logic, `Report::fluid_fed`'s value, and `has_uncalibrated_direction()` are all unchanged).

---

Ref #537 — left open for the filer's ack, not closed by this PR.
