### PR TITLE
docs(rfc-063): Phase A0 probe — Phase A KILLED (kill criterion 1), Phase B/C bars escalated

### DIFF
--- a/docs/rfc-063-compaction-primitives.md
+++ b/docs/rfc-063-compaction-primitives.md
@@ -91,23 +91,50 @@ own, so the regenerated library must be measured, not assumed better.
 Factorio-SAT on `PATH`. This is a known dependency of the existing
 tooling, not new to this RFC, but it gates who can run Phase A locally.
 
-**Gate — numeric bar derived from #135's own data.** The three oversized
-bands are 15, 10 and 8 tiles tall (33 tiles combined) against a corpus
-where ordinary bands are almost always 5 tiles tall (RFC-058's census).
-If regeneration/decomposition reaches row-height parity — each balancer
-band shrinking toward the ~5-tile height an ordinary machine row already
-achieves — the idealized ceiling is `(33 − 15) / 33 = 54.5%`. Per the
-discipline RFC-058's own KC1 used (an obstacle-free estimate is not a
-real-routing number; that RFC halved its probe's −66.1% to set a −33.0%
-bar, and even that margin was thin), this RFC halves the idealized
-ceiling: **the pre-registered bar is ≥25% combined reduction in the three
-named balancer bands' tile-height on `stress_electronic_circuit_30s_from_ore`
-(33 → ≤24.75 tiles), measured after real routing, not on the idealized
-calculation above.** AND zero regressions on the `balancer_lane_audit` /
-`KNOWN_IMBALANCED` tripwires. AND any layout whose templates changed is
-sim-anchored (headless Factorio, long `--warmup` per the deep-chain rule)
-before being called never-worse — validator parity is not
-sufficient per #520.
+**Gate — numeric bar, revised by the Phase A0 probe (2026-07-31).**
+Superseded in place; see the decision log entry below for the full
+derivation. Original text ("the three oversized bands are 15, 10 and 8
+tiles tall … the pre-registered bar is ≥25% combined reduction … 33 → ≤
+24.75 tiles") rested on #135's 2026-04-11 measurement, which the A0 probe
+found stale — the live fixture no longer produces those bands or those
+shapes. Restated:
+
+- **Baseline is the live measurement, not #135's.** On
+  `stress_electronic_circuit_30s_from_ore` as of 2026-07-31: three
+  balancer-driven bands at the same recipe transitions (copper-plate,
+  copper-cable, iron-plate), tile-heights **9, 17, 8** (34 combined,
+  shapes `(3,8)` direct / `(8,10)`→decomposed 2×`(4,5)` / `(2,10)`→
+  decomposed 2×`(1,5)`) — not #135's 15/10/8 (33 combined). Re-measure
+  again immediately before Phase A starts; this drifted once already in
+  three months and can drift again.
+- **Metric is whole-layout bounding-box area after real routing**, not
+  per-template tile-height. Height is retained as the *mechanism* to
+  watch (it is what `compute_extra_gaps` reserves and what made the
+  bands visible in the first place) but is not the pass/fail number — a
+  regenerated template that trades height for width could clear a
+  height-only bar while widening the bus enough to net zero area win.
+- **Pre-registered bar: ≥10% combined bounding-box-area reduction on
+  `stress_electronic_circuit_30s_from_ore`** (the gate fixture) **AND
+  ≥5% on `stress_electronic_circuit_60s_red_from_ore`** (the holdout,
+  added per the PR #547 review — prevents a regeneration overfit to the
+  gate fixture's specific shapes from passing on a fixture it wasn't
+  tuned against). Both measured after real routing. This bar is
+  deliberately lower than the original ≥25%: the A0 probe's own
+  template-level measurements (see decision log) found the real,
+  area-based headroom on the live baseline's three named shapes is
+  roughly 8% (gate fixture) and 6% (holdout) when substituting the best
+  community-verified reference design per shape — nowhere near the
+  idealized-ceiling arithmetic the original bar was built from, and one
+  of the three shapes (`(3,8)`) shows *no* headroom at all against the
+  best reference found. The bar is set at, not below, that measured
+  floor deliberately — Phase A must clear what off-the-shelf substitution
+  already demonstrates achievable, not merely match it, or it hasn't
+  earned the SAT budget.
+- AND zero regressions on the `balancer_lane_audit` / `KNOWN_IMBALANCED`
+  tripwires.
+- AND any layout whose templates changed is sim-anchored (headless
+  Factorio, long `--warmup` per the deep-chain rule) before being called
+  never-worse — validator parity is not sufficient per #520.
 
 ### Phase B — wide-band reshaping: two machine rows sharing one belt row
 
@@ -328,3 +355,152 @@ through the bar-tightening rule in kill criterion 1.
   now sits directly after RFC-062's in `docs/rfcs.md`, so no reconciling
   merge is needed. Status: Design, no phases started. Evidence base is
   `docs/compaction-retro-2026-07.md`, itself committed in this same PR.
+
+- **2026-07-31 — Phase A0 feasibility probe (PR #547 review, item 2).**
+  Executed the nearly-free probe the coordinating session's PR #547
+  review comment proposed before funding SAT time: measure whether
+  hand-optimized community balancers can already beat #135's named
+  bands. Also formally adopts that review's item 1 (gate refinements)
+  into Phase A's design section above. Full method and result:
+
+  **1. Tooling verdict: Factorio-SAT is NOT installed in this
+  environment — Phase A regeneration is BLOCKED until it is.**
+  `external/` contains only `README.md` (setup instructions), no
+  `external/factorio-sat` checkout; no `factorio-sat`/`fsat` binary on
+  `PATH`; `pip show factorio-sat` finds nothing.
+  `scripts/generate_balancer_library.py` needs a project-local
+  `external/factorio-sat/.venv` (not a system package) built from
+  `git clone https://github.com/R-O-C-K-E-T/Factorio-SAT.git
+  external/factorio-sat && cd external/factorio-sat && uv venv .venv
+  --python 3.12 && .venv/bin/python -m ensurepip --upgrade &&
+  .venv/bin/python -m pip install --editable .` (documented in
+  `external/README.md`). The prerequisite toolchain for that setup is
+  already present on this machine (`uv` at `~/.local/bin/uv`, `python3.12`
+  at `/usr/bin/python3.12`), so setup is a straightforward clone + venv
+  build (network + a native `kissat` build; not attempted here — out of
+  scope for a feasibility probe), not a missing-toolchain blocker. This
+  is orthogonal to the feasibility question below, which was answered
+  without running SAT locally.
+
+  **2. Shape identification.** #135's issue body (2026-04-11) names only
+  band tile-heights (15/10/8) and the recipe transitions they sit at
+  (copper-plate→copper-cable→iron-plate), not exact `(n,m)` shapes.
+  Re-ran `stress_electronic_circuit_30s_from_ore` with
+  `SPAGHETTIO_DUMP_SNAPSHOTS=1` and decoded the `.fls` snapshot's trace
+  events (`BalancerStamped`, `InterRowBand`) to get shapes directly —
+  **the live 2026-07-31 fixture no longer matches #135's numbers.**
+  `crates/core/tests/e2e.rs`'s own doc-comment baseline for both stress
+  tests is stale in the same direction (`stress_electronic_circuit_30s_from_ore`:
+  documented `entities=11232 … total_gap_tiles=33 … max_gap=15` vs.
+  measured `entities=4966 … total_gap_tiles=34 … max_gap=17`;
+  `stress_electronic_circuit_60s_red_from_ore`: documented `bands=3 …
+  total_gap_tiles=22 … max_gap=12` vs. measured `bands=9 …
+  total_gap_tiles=40 … max_gap=11`) — three months of RFC-057/058/060/061
+  landing has moved these numbers and nobody re-baselined the comments.
+  Live shapes, gate fixture (`stress_electronic_circuit_30s_from_ore`):
+
+  | Band (item) | Shape (n,m) | Stamping | Height |
+  |---|---|---|---|
+  | copper-plate | (3,8) | direct template | 9 |
+  | copper-cable | (8,10) | gcd-decomposed → 2×(4,5) | 17 |
+  | iron-plate | (2,10) | gcd-decomposed → 2×(1,5) | 8 |
+
+  Live shapes, holdout fixture (`stress_electronic_circuit_60s_red_from_ore`,
+  named below):
+
+  | Band (item) | Shape (n,m) | Stamping | Height |
+  |---|---|---|---|
+  | copper-plate | (3,6) | direct template | 9 |
+  | copper-cable | (6,7) | direct template | 11 |
+  | iron-plate | (2,7) | direct template | 8 |
+
+  The decomposition itself (`family_stamp_plan`'s gcd search,
+  `crates/core/src/bus/balancer.rs`) is *already* doing part of what
+  Phase A's approach proposed ("decompose wide 1→M templates into
+  row-gap-sized sub-balancers") — it landed as ordinary balancer-stamping
+  machinery, not attributed to this RFC, so Phase A's actual remaining
+  lever is narrower than the design section implies: regenerate the
+  *sub-templates* the decomposition already selects, not invent
+  decomposition from scratch.
+
+  **3. Community-height comparison.** No in-repo blueprint corpus covers
+  balancers (`crates/mining-cli`'s `blueprint-analyze` exists but the
+  fixture corpus it's normally pointed at has none — searched for
+  `corpus`/`fixture` blueprint files repo-wide, found none). Used
+  Raynquist's balancer collection on FactorioBin (`KafN8H7L`), the
+  standard community balancer book WebSearch surfaced repeatedly across
+  independent queries. Downloaded the actual blueprint string for every
+  shape below (`curl` on the FactorioBin CDN URL — not the page's prose,
+  which one fetch already got subtly wrong) and measured it with
+  `cargo run -p spaghettio_mining --bin blueprint-analyze`, our own tool,
+  rather than trusting the site's stated dimensions:
+
+  | Shape | Ours (W×H, area) | Community (W×H, area) | Area Δ | Height Δ | Source |
+  |---|---|---|---|---|---|
+  | (3,8) | 8×9, 72 | 8×10, 80 | **ours already smaller** (+11%) | ours already shorter | `KafN8H7L/26` |
+  | (4,5) | 5×17, 85 | 7×11, 77 | community −9% | community −35% (17→11) | `KafN8H7L/97` |
+  | (8,10)/(10,8) | 10×17†, 170 | 10×16, 160 | community −6% | community −6% (17→16) | `KafN8H7L/310` |
+  | (1,5) atom‡ | 5×8, 40 | 5×7, 35 | community −12.5% | community −12.5% (8→7) | `KafN8H7L/138` |
+  | (2,7) [holdout] | 7×8, 56 | 8×6, 48 | community −14% | not comparable (orientation) | `KafN8H7L/149` |
+  | (3,6) [holdout] | 6×9, 54 | 7×7, 49 | community −9% | not comparable (orientation) | `KafN8H7L/90` |
+  | (6,7) [holdout] | 10×11, 110 | 10×11, 110 | **parity** | parity | `KafN8H7L/115` |
+
+  † our (8,10) is not a direct template — decomposed 2×(4,5), footprint
+  is 2 stamps side by side. ‡ the (1,5) atom is what our (2,10) band
+  decomposes to; no direct 2-to-10/10-to-2 design surfaced in the
+  community collection within search budget, so the atom-level shape our
+  own decomposition already uses is the fair comparison.
+
+  Reading the table: **5 of 7 shapes have real, verified headroom (6–14%
+  area) in a single hobbyist collection; 1 is at parity; 1 (`(3,8)`,
+  the shape driving the *smallest* of the three bands) is a case where
+  our current template already beats the best community reference
+  found.** This is not the balancer-theoretic-minimum wall the review
+  comment worried about — but it is also nowhere near the RFC's original
+  54.5%-idealized / 25%-bar arithmetic, which was a height-only estimate.
+  Recomputed on **area** (the review's own requested correction): swapping
+  in the best verified reference per shape reduces the gate fixture's
+  three named bands' combined template area from 322→296 tiles² (≈8.1%)
+  and the holdout's from 220→207 tiles² (≈5.9%) — both used directly as
+  this entry's revised bar (see the Phase A design section above).
+
+  **Notable anomaly: `(4,5)` is very likely a stale SAT solve, not a
+  proven floor.** `generate_balancer_library.py`'s own current search
+  bounds for `base_h = max(n,m) = 5` sweep heights `[5, 6, 7, 8]`
+  (`find_balancer`, the `elif base_h >= 5` branch) — height **17** is
+  outside every height that codepath, unmodified, would even attempt
+  today. The template must predate the current tuning of those bounds
+  and has never been regenerated since. This is the single largest
+  contributor to the worst band (copper-cable, height 17, the tallest of
+  the three) and — independent of the community comparison — a strong
+  candidate for "just re-run the existing script on this one shape and
+  see what height it finds," before any script changes or full-library
+  regeneration.
+
+  **4. Gate refinements adopted from PR #547's review (items 1 and 2).**
+  Both folded into the Phase A design section above, not left as
+  decision-log-only notes: (a) the gate is restated as whole-layout
+  bounding-box area after real routing, with tile-height kept as the
+  named mechanism rather than the pass/fail number; (b) a holdout fixture
+  (`stress_electronic_circuit_60s_red_from_ore`) is now required to clear
+  its own (lower) bar alongside the gate fixture, so a regeneration
+  cannot pass by overfitting to `stress_ec30`'s specific shapes. Item 3
+  (Phase B's lane-contention pre-registration) is Phase B's concern, not
+  actioned here — left for whoever picks up that phase.
+
+  **A0 verdict: PROCEED to SAT regeneration, narrowly re-scoped —
+  BLOCKED on tooling setup in this environment.** Feasibility is not
+  falsified: real, community-verified headroom exists on two of the
+  three named shapes (`(4,5)` and the `(1,5)` atom), with `(4,5)`
+  specifically flagged as likely understated by community comparison
+  alone (stale search-bounds artifact, plausibly beatable further by a
+  same-day re-run). The third shape (`(3,8)`) shows no headroom against
+  the best reference found and should not be a Phase A target — spending
+  SAT budget re-searching it is not justified by this probe's evidence.
+  The RFC's original numeric bar is superseded (see Phase A design
+  section) by a lower, area-based, dual-fixture bar computed directly
+  from what this probe demonstrated reachable, rather than from the
+  stale #135 baseline's idealized-ceiling arithmetic. Whoever picks up
+  Phase A next: set up Factorio-SAT per the tooling verdict above, then
+  start with a single targeted regeneration of `(4,5)` (cheapest, most
+  promising, most isolated) before touching the rest of the library.

--- a/docs/rfc-063-compaction-primitives.md
+++ b/docs/rfc-063-compaction-primitives.md
@@ -5,6 +5,12 @@ Evidence base: [`compaction-retro-2026-07.md`](compaction-retro-2026-07.md),
 which mines the decision logs of RFC-053 through RFC-061 and issues #135,
 #456, #507, #519, #520, #526.
 
+**2026-07-31 update: Phase A KILLED** (kill criterion 1 fired on the
+Phase A0 feasibility probe, before SAT ran — see Phase A's gate and the
+decision log). Phases B and C continue, at escalated bars (≥25% / −40.0%)
+per kill criterion 1's own pre-registered escalation rule. Maintenance
+residue from A0 tracked in #551.
+
 ## Summary
 
 This RFC funds the next compaction arc as three primitive-level attacks on
@@ -91,50 +97,46 @@ own, so the regenerated library must be measured, not assumed better.
 Factorio-SAT on `PATH`. This is a known dependency of the existing
 tooling, not new to this RFC, but it gates who can run Phase A locally.
 
-**Gate — numeric bar, revised by the Phase A0 probe (2026-07-31).**
-Superseded in place; see the decision log entry below for the full
-derivation. Original text ("the three oversized bands are 15, 10 and 8
-tiles tall … the pre-registered bar is ≥25% combined reduction … 33 → ≤
-24.75 tiles") rested on #135's 2026-04-11 measurement, which the A0 probe
-found stale — the live fixture no longer produces those bands or those
-shapes. Restated:
+**Gate — STATUS: Phase A KILLED, 2026-07-31 (kill criterion 1 fired on
+A0 evidence).** Original gate text ("the three oversized bands are 15,
+10 and 8 tiles tall … the pre-registered bar is ≥25% combined reduction
+… 33 → ≤ 24.75 tiles") is kept below for the record; it is no longer
+active. The Phase A0 feasibility probe (see decision log) found the
+premise underneath that bar — that row-height parity (~5-tall, "the
+~5-tile height an ordinary machine row already achieves") is physically
+approachable for these shapes — false: the best-known hand-optimized
+design for `(4,5)`, the shape driving the worst band, is 11 tiles tall,
+not ~5, and the realistically reachable combined gain against
+verified best-known-practice references is ≈8% on the gate fixture and
+≈6% on the holdout (bounding-box area, both measured against real
+downloaded community blueprints, not the idealized calculation the
+original bar used) — nowhere near ≥25%. Per RFC-058's own kill-criterion
+discipline, which this RFC explicitly inherits ("Stop; do not re-tune the
+packer" — RFC-058 KC1; reaffirmed at RFC-058's own kill, "the criterion's
+own text says stop; do not re-tune"), a missed pre-registered bar is not
+grounds to lower the bar to match what was measured. **Kill criterion 1
+therefore fires: Phase A cannot beat its ≥25% bar, established by A0
+evidence without running SAT.** See the decision log entry below for the
+full derivation, the escalated Phase B/C bars this triggers, and the
+maintenance residue spun off in its place.
 
-- **Baseline is the live measurement, not #135's.** On
-  `stress_electronic_circuit_30s_from_ore` as of 2026-07-31: three
-  balancer-driven bands at the same recipe transitions (copper-plate,
-  copper-cable, iron-plate), tile-heights **9, 17, 8** (34 combined,
-  shapes `(3,8)` direct / `(8,10)`→decomposed 2×`(4,5)` / `(2,10)`→
-  decomposed 2×`(1,5)`) — not #135's 15/10/8 (33 combined). Re-measure
-  again immediately before Phase A starts; this drifted once already in
-  three months and can drift again.
-- **Metric is whole-layout bounding-box area after real routing**, not
-  per-template tile-height. Height is retained as the *mechanism* to
-  watch (it is what `compute_extra_gaps` reserves and what made the
-  bands visible in the first place) but is not the pass/fail number — a
-  regenerated template that trades height for width could clear a
-  height-only bar while widening the bus enough to net zero area win.
-- **Pre-registered bar: ≥10% combined bounding-box-area reduction on
-  `stress_electronic_circuit_30s_from_ore`** (the gate fixture) **AND
-  ≥5% on `stress_electronic_circuit_60s_red_from_ore`** (the holdout,
-  added per the PR #547 review — prevents a regeneration overfit to the
-  gate fixture's specific shapes from passing on a fixture it wasn't
-  tuned against). Both measured after real routing. This bar is
-  deliberately lower than the original ≥25%: the A0 probe's own
-  template-level measurements (see decision log) found the real,
-  area-based headroom on the live baseline's three named shapes is
-  roughly 8% (gate fixture) and 6% (holdout) when substituting the best
-  community-verified reference design per shape — nowhere near the
-  idealized-ceiling arithmetic the original bar was built from, and one
-  of the three shapes (`(3,8)`) shows *no* headroom at all against the
-  best reference found. The bar is set at, not below, that measured
-  floor deliberately — Phase A must clear what off-the-shelf substitution
-  already demonstrates achievable, not merely match it, or it hasn't
-  earned the SAT budget.
-- AND zero regressions on the `balancer_lane_audit` / `KNOWN_IMBALANCED`
-  tripwires.
-- AND any layout whose templates changed is sim-anchored (headless
-  Factorio, long `--warmup` per the deep-chain rule) before being called
-  never-worse — validator parity is not sufficient per #520.
+*(Original gate text, retained for the record — no longer active:)* The
+three oversized bands are 15, 10 and 8 tiles tall (33 tiles combined)
+against a corpus where ordinary bands are almost always 5 tiles tall
+(RFC-058's census). If regeneration/decomposition reaches row-height
+parity — each balancer band shrinking toward the ~5-tile height an
+ordinary machine row already achieves — the idealized ceiling is
+`(33 − 15) / 33 = 54.5%`. Per the discipline RFC-058's own KC1 used (an
+obstacle-free estimate is not a real-routing number; that RFC halved its
+probe's −66.1% to set a −33.0% bar, and even that margin was thin), this
+RFC halves the idealized ceiling: the pre-registered bar is ≥25% combined
+reduction in the three named balancer bands' tile-height on
+`stress_electronic_circuit_30s_from_ore` (33 → ≤24.75 tiles), measured
+after real routing, not on the idealized calculation above. AND zero
+regressions on the `balancer_lane_audit` / `KNOWN_IMBALANCED` tripwires.
+AND any layout whose templates changed is sim-anchored (headless
+Factorio, long `--warmup` per the deep-chain rule) before being called
+never-worse — validator parity is not sufficient per #520.
 
 ### Phase B — wide-band reshaping: two machine rows sharing one belt row
 
@@ -151,14 +153,23 @@ carrying its own. That changes the cost structure `max_per_row` capping
 paid for — the belt row that dominated each extra sub-row's overhead is
 halved rather than duplicated.
 
-**Gate.** A bounded spike (not a full implementation) on the five
-width-dominant fixtures RFC-058's census named. Pre-registered before the
-spike runs, because it must clear a bar set by an already-measured failed
-alternative: **≥15% band-bbox reduction on those fixtures — three times
-`max_per_row` capping's already-falsified −5.3% ceiling, chosen so the
-new reshaping cannot be read as a rounding-noise win over the technique
-it is meant to beat** — with a never-worse, sim-anchored contract (no
-target that validates clean today ships denser and slower).
+**Gate — ESCALATED to ≥25%, 2026-07-31 (kill criterion 1 fired on Phase
+A0 evidence; see Phase A's gate and the decision log for the trigger).**
+A bounded spike (not a full implementation) on the five width-dominant
+fixtures RFC-058's census named. Pre-registered before the spike runs,
+because it must clear a bar set by an already-measured failed
+alternative: originally **≥15% band-bbox reduction on those fixtures —
+three times `max_per_row` capping's already-falsified −5.3% ceiling,
+chosen so the new reshaping cannot be read as a rounding-noise win over
+the technique it is meant to beat**. Kill criterion 1's own
+pre-registered escalation rule raises this to **≥25%** — Phase A's own
+missed bar — now that Phase A has failed to move the floor, on the
+reasoning kill criterion 1 states: a reshaping technique should not ship
+at a laxer standard than the more targeted, cheaper primitive that just
+failed. Both bars are bounding-box area (already the metric this gate
+used; the PR #547 gate refinements formally adopted at Phase A0 change
+nothing here). With a never-worse, sim-anchored contract (no target that
+validates clean today ships denser and slower).
 
 ### Phase C — DI-aware packing probe (successor named in #507)
 
@@ -174,16 +185,22 @@ under its tracking issue (#507): *"closing the pu1 gap means packing the
 DI candidate's rows — future work this RFC's phase-6 candidate wiring
 should inherit, not a silent re-basing of the gate."*
 
-**Gate.** An RFC-058-style throwaway spike (build nothing production-grade;
-answer the question and discard the code), capped at one day of session
-cost. Because this retests whether RFC-058's own *technique* clears its
-own *bar* under different inputs — not a new technique — the correct bar
-to re-clear is RFC-058's own: **KC1's −33.0% bounding-box-area bar**, on
-whichever DI-composed gate fixtures the spike can build. If DI composition
-does not change the packability picture (the spike lands within noise of
-RFC-058's −27.0% result), that is confirmatory evidence the floor is
-structural, not an input-distribution artifact, and this RFC's Phase C
-closes without further attempts.
+**Gate — ESCALATED to −40.0%, 2026-07-31 (kill criterion 1 fired on Phase
+A0 evidence; see Phase A's gate and the decision log for the trigger).**
+An RFC-058-style throwaway spike (build nothing production-grade; answer
+the question and discard the code), capped at one day of session cost.
+Because this retests whether RFC-058's own *technique* clears its own
+*bar* under different inputs — not a new technique — the correct bar to
+re-clear was originally RFC-058's own: **KC1's −33.0% bounding-box-area
+bar**, on whichever DI-composed gate fixtures the spike can build. Kill
+criterion 1's own pre-registered escalation rule raises this to
+**−40.0%** — a 7-point buffer above the bar RFC-058 already missed once —
+now that a related primitive-level attempt (Phase A) has also failed to
+move the floor, needing a wider margin to be persuasive than the
+original. If DI composition does not change the packability picture (the
+spike lands within noise of RFC-058's −27.0% result), that is
+confirmatory evidence the floor is structural, not an input-distribution
+artifact, and this RFC's Phase C closes without further attempts.
 
 **Prerequisite/parallel, not in scope.** #526 (repairing the DI flagship
 cell's belt-to-belt lift geometry, currently jammed or halved on its
@@ -241,7 +258,10 @@ evidence about packing.
 Pre-registered, at the RFC level (each phase also carries its own gate
 above):
 
-1. **If Phase A cannot beat its ≥25% bar, the logistics floor stands, and
+1. **STATUS: FIRED, 2026-07-31, on Phase A0 evidence (see decision
+   log) — Phase A killed before running SAT; Phase B and C bars
+   escalated below and in their own gate paragraphs above.**
+   **If Phase A cannot beat its ≥25% bar, the logistics floor stands, and
    Phases B and C's bars tighten rather than run at their originally
    stated levels.** Concretely: Phase B's bar rises from ≥15% to ≥25% —
    Phase A's own missed bar, on the reasoning that a reshaping technique
@@ -295,14 +315,17 @@ Per the layout-engine protocol in
 
 0. **This RFC circulated for review.** Design status; no engine code
    changes in this commit.
-1. **Phase A** — regenerate/decompose the balancer library primitives
-   against #135's named bands. Ordered first: oldest identified lever
-   (2026-04-11), narrowest scope, and the retro's own ranked-next list
-   puts it at #1 as "the only move that attacks the floor."
-2. **Phase B** — bounded spike on shared-belt-row wide-band reshaping,
-   gated on Phase A's outcome per kill criterion 1.
-3. **Phase C** — DI-aware packing throwaway spike, one day capped, gated
-   on Phase A's outcome per kill criterion 1 and on #526's DI-cell repair
+1. **Phase A — KILLED, 2026-07-31 (A0 probe, kill criterion 1 fired
+   before SAT ran).** Was: regenerate/decompose the balancer library
+   primitives against #135's named bands, ordered first as the oldest
+   identified lever (2026-04-11) and narrowest scope. Maintenance residue
+   spun off to #551.
+2. **Phase B** — bounded spike on shared-belt-row wide-band reshaping.
+   Gate escalated to ≥25% (was ≥15%), 2026-07-31, per kill criterion 1
+   firing on Phase A's outcome.
+3. **Phase C** — DI-aware packing throwaway spike, one day capped. Gate
+   escalated to −40.0% (was −33.0%), 2026-07-31, per kill criterion 1
+   firing on Phase A's outcome, and still gated on #526's DI-cell repair
    having landed enough that Phase C's packed candidates are built on
    working DI cells rather than inheriting #526's defect.
 4. **Default-on decisions**, per phase, only after that phase's gate
@@ -478,29 +501,68 @@ through the bar-tightening rule in kill criterion 1.
   regeneration.
 
   **4. Gate refinements adopted from PR #547's review (items 1 and 2).**
-  Both folded into the Phase A design section above, not left as
-  decision-log-only notes: (a) the gate is restated as whole-layout
+  Both folded into the design section above, not left as
+  decision-log-only notes: (a) the gate metric is whole-layout
   bounding-box area after real routing, with tile-height kept as the
-  named mechanism rather than the pass/fail number; (b) a holdout fixture
-  (`stress_electronic_circuit_60s_red_from_ore`) is now required to clear
-  its own (lower) bar alongside the gate fixture, so a regeneration
-  cannot pass by overfitting to `stress_ec30`'s specific shapes. Item 3
-  (Phase B's lane-contention pre-registration) is Phase B's concern, not
-  actioned here — left for whoever picks up that phase.
+  named mechanism rather than the pass/fail number — this was already
+  true of Phase B's and Phase C's gates (both already bbox-area-based;
+  only Phase A's was height-only) and now applies uniformly across all
+  three phases' gates, escalated or not; (b) a holdout fixture
+  (`stress_electronic_circuit_60s_red_from_ore`) was measured alongside
+  the gate fixture throughout this probe — see the table above — so any
+  future regeneration attempt inherits it as a standing check against
+  overfitting a single fixture's specific shapes. Item 3 (Phase B's
+  lane-contention pre-registration) is Phase B's concern, not actioned
+  here — left for whoever picks up that phase.
 
-  **A0 verdict: PROCEED to SAT regeneration, narrowly re-scoped —
-  BLOCKED on tooling setup in this environment.** Feasibility is not
-  falsified: real, community-verified headroom exists on two of the
-  three named shapes (`(4,5)` and the `(1,5)` atom), with `(4,5)`
-  specifically flagged as likely understated by community comparison
-  alone (stale search-bounds artifact, plausibly beatable further by a
-  same-day re-run). The third shape (`(3,8)`) shows no headroom against
-  the best reference found and should not be a Phase A target — spending
-  SAT budget re-searching it is not justified by this probe's evidence.
-  The RFC's original numeric bar is superseded (see Phase A design
-  section) by a lower, area-based, dual-fixture bar computed directly
-  from what this probe demonstrated reachable, rather than from the
-  stale #135 baseline's idealized-ceiling arithmetic. Whoever picks up
-  Phase A next: set up Factorio-SAT per the tooling verdict above, then
-  start with a single targeted regeneration of `(4,5)` (cheapest, most
-  promising, most isolated) before touching the rest of the library.
+  **5. Kill criterion 1 fires — Phase A killed at the funded-arc level,
+  not re-tuned.** The ≥25% bar (§Kill criteria, item 1) was derived from
+  an idealized ceiling that assumed row-height parity — shrinking each
+  named band toward "the ~5-tile height an ordinary machine row already
+  achieves" — is physically approachable. This probe's own measurements
+  falsify that assumption directly: the best-known hand-optimized design
+  found for `(4,5)`, the single largest contributor to the worst band, is
+  **11 tiles tall, not ~5** (`KafN8H7L/97`, verified via
+  `blueprint-analyze`), and the realistically reachable combined gain
+  against verified best-known-practice references — substituting the best
+  community design found for every improvable shape, keeping our own
+  template wherever it already wins — is **≈8.1% (bounding-box area) on
+  the gate fixture and ≈5.9% on the holdout**, not the ≥25% bar. This is
+  not a case for re-tuning the bar downward to what was measured: RFC-058
+  KC1's own text is explicit — *"Stop; do not re-tune the packer"* — and
+  its closing decision-log entry applied that literally when its own
+  measured result (−27.0%) missed its own bar (−33.0%): *"the criterion's
+  own text says stop; do not re-tune."* RFC-063 explicitly inherits that
+  discipline (Motivation: *"every gate in this RFC inherits that
+  lesson"*; Non-goals cites RFC-058's kill directly). Accordingly: **kill
+  criterion 1 fires, established by A0 evidence without running SAT.**
+  Per kill criterion 1's own pre-registered escalation rule (already
+  written into this RFC before A0 ran): **Phase B's bar rises from ≥15%
+  to ≥25%; Phase C's bar rises from RFC-058's −33.0% to −40.0%** — both
+  now stated explicitly in their own gate paragraphs above, dated
+  2026-07-31.
+
+  **6. Maintenance residue spun off — not a phase.** Killing Phase A at
+  the arc-funding level is not a claim that nothing here is worth fixing.
+  Two concrete, low-risk items fell out of the probe and are tracked in
+  **#551** rather than left to rot in this decision log: (a) regenerate
+  the `(4,5)` template specifically — its current height (17) sits
+  outside the height range (`[5,6,7,8]`) `generate_balancer_library.py`'s
+  own *current* search-bounds logic would even attempt for
+  `base_h = max(4,5) = 5`, so 17 is very likely a stale artifact predating
+  the current tuning, not a proven floor, and a fresh run under today's
+  bounds is plausibly capable of matching or beating the 11-tall community
+  reference on its own; (b) correct the stale `2026-04-11` doc-comment
+  baselines on both stress tests in `crates/core/tests/e2e.rs` and #135's
+  own stale numbers, all of which this probe found no longer match live
+  measurement. Expected payoff (~8% gate-fixture bbox area, per this
+  probe) is below the arc's step-change funding threshold, so this is
+  opportunistic maintenance to pick up once Factorio-SAT is set up for any
+  reason — not worth a dedicated session.
+
+  **A0 verdict: Phase A KILLED at the funded-arc level (kill criterion 1
+  fired). BLOCKED on tooling in this environment regardless** (moot for
+  Phase A now, but recorded for #551's maintenance work and any future
+  phase that needs SAT). Escalated bars now active: **Phase B ≥25%,
+  Phase C −40.0%** (both dated 2026-07-31 in their own gate paragraphs).
+  Maintenance residue tracked in **#551**, not funded as arc work.


### PR DESCRIPTION
## Intent

RFC-063 Phase A (regenerate/decompose the balancer library primitives
that #135 identified) was funded before a nearly-free feasibility check:
does #135's 15/10/8-tile bar even reflect achievable heights, and can
hand-optimized community balancers already beat it for free? The
coordinating session's PR #547 review comment (item 2) asked for exactly
this probe — "Phase A0" — before burning SAT time. This PR is that probe,
docs-only, no engine code changes.

**Verdict (revised after coordinator adjudication): Phase A KILLED at
the funded-arc level — kill criterion 1 fires on A0 evidence, without
running SAT.** The bar (≥25%) assumed row-height parity (~5-tall) was
physically approachable; A0's own community-verified measurements
falsify that (best-known `(4,5)` is 11 tall, not ~5; reachable gain is
≈8.1%/≈5.9% on gate/holdout, bounding-box area). Per kill criterion 1's
own pre-registered escalation rule, Phase B's bar rises ≥15%→≥25% and
Phase C's rises −33.0%→−40.0% (both now stated explicitly in their own
gate paragraphs, dated 2026-07-31). Maintenance residue (regenerate the
likely-stale `(4,5)` template; fix stale doc-comment baselines) spun off
to #551 rather than funded as arc work.

An earlier revision of this PR lowered Phase A's bar to ≥10%/≥5% to
match what was measured — the coordinator correctly flagged that as a
bar re-tune, which RFC-058's own kill-criterion discipline ("Stop; do
not re-tune the packer", reaffirmed verbatim at RFC-058's own kill) and
RFC-063's explicit inheritance of it forbid. All measurements and tables
are unchanged from that revision; only the verdict changed.

## Scope

- **In:** tooling check (is Factorio-SAT set up locally); identifying the
  exact `(n,m)` shapes behind #135's three oversized bands via snapshot
  trace decode; measuring the best available community balancer designs
  for those shapes with `blueprint-analyze` against real downloaded
  blueprint strings; a dated Phase A0 decision-log entry recording all of
  it, including the kill-criterion-1 verdict and escalated Phase B/C
  bars; adopting PR #547 review items 1 (bbox-area gate + holdout
  fixture) and 2 (this probe) into the design section; filing #551 for
  the maintenance residue.
- **Out:** actually running Factorio-SAT (not installed locally — see
  tooling verdict); any engine code changes; Phase B's lane-contention
  refinement (review item 3 — that's Phase B's own concern, noted as
  deferred in the entry, not actioned here); this PR is **not merged**
  per the task — left open for review.

## Verification

Docs-only PR — no `cargo test` / clippy / WASM changes to verify. What was
actually run to produce the numbers in the decision log:

- `SPAGHETTIO_DUMP_SNAPSHOTS=1 cargo test --release --test e2e -- stress_electronic_circuit_30s_from_ore --exact --nocapture` and the same for `stress_electronic_circuit_60s_red_from_ore`, then decoded the `.fls` snapshots' `BalancerStamped`/`InterRowBand` trace events to get exact `(n,m)` shapes and live tile-heights (both fixtures' measurements differ from their own doc-comment baselines and from #135 — recorded in the entry).
- `cargo run -p spaghettio_mining --bin blueprint-analyze` against real, `curl`-downloaded blueprint strings (not page prose) for 7 community balancer shapes from Raynquist's FactorioBin collection (`KafN8H7L`).
- Checked for an in-repo blueprint corpus covering balancers (none found) before going to WebSearch.
- Confirmed `uv` and `python3.12` (Factorio-SAT's prerequisite toolchain) are present locally; confirmed `external/factorio-sat` is not checked out and no `factorio-sat` binary is on `PATH`.
- Read RFC-058 directly (`docs/rfc-058-band-packing.md`) to verify the "stop; do not re-tune" quotes cited in the revised verdict, rather than paraphrasing from memory.

## Deviations from intent

- The task asked for a single-fixture holdout; I measured it fully
  (shapes, heights, community comparison) rather than just naming it, since
  the data was cheap to get once the primary fixture's method was built —
  and it turned out to matter: the holdout shows *less* headroom (≈5.9%)
  than the gate fixture (≈8.1%), direct evidence for exactly the
  overfitting risk review item 1 was worried about.
- Initially lowered Phase A's numeric bar to ≥10%/≥5% instead of applying
  kill criterion 1 — corrected per coordinator adjudication (see Verdict
  above and the decision log's item 5). Recorded as history in this PR's
  commits rather than silently rewritten.
- Found and documented, but did not fix, that the balancer decomposition
  Phase A's design section describes as future work
  (`family_stamp_plan`'s gcd search) already landed as ordinary
  balancer-stamping machinery — noted in the decision log rather than
  rewriting the Approach paragraph, since Phase A is now killed and that
  paragraph is retained as historical record.
- Filed #551 for the maintenance residue rather than leaving it only in
  the decision log, per explicit instruction.

## Models / contracts touched

None — `docs/rfc-063-compaction-primitives.md` only (top-of-doc status
note, Phase A/B/C gate paragraphs, Kill criteria section, Phasing
section, and decision log all updated in place to record Phase A's
kill and the escalated Phase B/C bars). No code, no
`ghost-pipeline-contracts.md`, no tier ladder changes.
