### PR TITLE
feat(solver): RFC-062 Phase 1 — multi-seed net-flow solver

### DIFF
--- a/crates/core/src/netflow.rs
+++ b/crates/core/src/netflow.rs
@@ -340,10 +340,72 @@ pub fn solve_netflow(
 
 /// Like [`solve_netflow`] but accepts [`NetflowOptions`] (Fulgora
 /// scrap-economy spike — additive, both flags default `false`).
+///
+/// RFC-062 Phase 1: a thin one-element-slice caller of
+/// [`solve_netflow_multi_with_options`] — this and every function that
+/// forwards to it (the 8 scalar wrappers in `solver.rs`) share the single
+/// N-target implementation, so N=1 bit-identity is a construction
+/// guarantee, not a tested coincidence.
 #[allow(clippy::too_many_arguments)]
 pub fn solve_netflow_with_options(
     target_item: &str,
     target_rate: f64,
+    available_inputs: &FxHashSet<String>,
+    palette: &MachinePalette,
+    default_machine: &str,
+    excluded_recipes: &FxHashSet<String>,
+    scope: RecipeScope<'_>,
+    costs: &CostTable,
+    options: &NetflowOptions,
+) -> Result<SolverResult, SolverError> {
+    solve_netflow_multi_with_options(
+        &[(target_item.to_string(), target_rate)],
+        available_inputs,
+        palette,
+        default_machine,
+        excluded_recipes,
+        scope,
+        costs,
+        options,
+    )
+}
+
+/// Multi-target entry point (RFC-062 Phase 1,
+/// `docs/rfc-062-multi-target-outputs.md` §Solver): solve for N ≥ 1
+/// simultaneous targets in one LP instead of gluing together N independent
+/// solves. `targets` is `(item, rate)` pairs; an item requested more than
+/// once has its rates summed into a single demand row (RFC-062 Phase 1
+/// decision log — summing rather than refusing duplicates).
+#[allow(clippy::too_many_arguments)]
+pub fn solve_netflow_multi(
+    targets: &[(String, f64)],
+    available_inputs: &FxHashSet<String>,
+    palette: &MachinePalette,
+    default_machine: &str,
+    excluded_recipes: &FxHashSet<String>,
+    scope: RecipeScope<'_>,
+    costs: &CostTable,
+) -> Result<SolverResult, SolverError> {
+    solve_netflow_multi_with_options(
+        targets,
+        available_inputs,
+        palette,
+        default_machine,
+        excluded_recipes,
+        scope,
+        costs,
+        &NetflowOptions::default(),
+    )
+}
+
+/// Like [`solve_netflow_multi`] but accepts [`NetflowOptions`]. This is the
+/// single choke point every scalar entry point (`solve_netflow`,
+/// `solve_netflow_with_options`, and transitively the 8 wrappers in
+/// `solver.rs`) now forwards to via a one-element `targets` slice — see
+/// [`solve_netflow_with_options`].
+#[allow(clippy::too_many_arguments)]
+pub fn solve_netflow_multi_with_options(
+    targets: &[(String, f64)],
     available_inputs: &FxHashSet<String>,
     palette: &MachinePalette,
     default_machine: &str,
@@ -359,6 +421,10 @@ pub fn solve_netflow_with_options(
     // producers and re-solve. Genuinely forced cycles (kovarex with
     // uranium-processing excluded) still refuse with a typed error. Each
     // retry removes at least one recipe, so the cap is just a backstop.
+    //
+    // Target-count-agnostic by construction (RFC-062 Phase 1): every branch
+    // below inspects `r.machines` / `r.surplus_outputs` post-solve, never a
+    // single `target_idx`, so this loop needed no changes to generalize.
     let mut extra_excluded: FxHashSet<String> = FxHashSet::default();
     let mut attempt_options = *options;
     let mut last_refusal: Option<SolverError> = None;
@@ -366,8 +432,7 @@ pub fn solve_netflow_with_options(
     // exclusivity re-solve (#476).
     for _ in 0..9 {
         match solve_attempt(
-            target_item,
-            target_rate,
+            targets,
             available_inputs,
             palette,
             default_machine,
@@ -421,15 +486,22 @@ pub fn solve_netflow_with_options(
         }
     }
     Err(last_refusal.unwrap_or_else(|| SolverError::LpFailed {
-        target: target_item.to_string(),
+        target: target_label(targets),
         detail: "acyclic fallback did not converge".to_string(),
     }))
 }
 
+/// Human-readable label for an error's `target` field when more than one
+/// target is in play — joins every requested item name. Bit-identical to
+/// the single-item label (`target_item.to_string()`) when `targets.len() ==
+/// 1`, since `join` on a one-element slice is a no-op.
+fn target_label(targets: &[(String, f64)]) -> String {
+    targets.iter().map(|(item, _)| item.as_str()).collect::<Vec<_>>().join(", ")
+}
+
 #[allow(clippy::too_many_arguments)]
 fn solve_attempt(
-    target_item: &str,
-    target_rate: f64,
+    targets: &[(String, f64)],
     available_inputs: &FxHashSet<String>,
     palette: &MachinePalette,
     default_machine: &str,
@@ -523,8 +595,30 @@ fn solve_attempt(
         candidates.push(Candidate { recipe, net: net_vec });
     }
 
-    // Ensure the target item has a row even if nothing in scope touches it.
-    let target_idx = items.intern(target_item, false);
+    // Ensure every target item has a row even if nothing in scope touches
+    // it, and build the demand vector (RFC-062 Phase 1 multi-seed
+    // generalization). `target_order` is deduplicated, first-seen order —
+    // requesting the same item twice sums its rates into one row rather
+    // than adding a second row or refusing the request (Phase 1 decision
+    // log: summing, not a typed duplicate-target error). `target_order`
+    // also drives the demand-closure seed and output-assembly DFS seed
+    // below, and `external_outputs`'s order, so a caller's first-requested
+    // target is visited/emitted first — matching the N=1 single-target
+    // traversal exactly when `targets.len() == 1`.
+    let mut target_order: Vec<usize> = Vec::new();
+    let mut target_rate_of: FxHashMap<usize, f64> = FxHashMap::default();
+    for (name, rate) in targets {
+        let idx = items.intern(name, false);
+        match target_rate_of.entry(idx) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                *e.get_mut() += rate;
+            }
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert(*rate);
+                target_order.push(idx);
+            }
+        }
+    }
 
     // NOTE (RFC-044): the closure below runs on RAW nets, before module
     // resolution. Productivity only ever increases product coefficients,
@@ -534,8 +628,11 @@ fn solve_attempt(
     // that shape (Phase 3 review, NIT 5).
     // Demand closure over net-signed edges: a candidate joins when it
     // net-produces a demanded item; its net-consumed items become demanded.
+    // RFC-062 Phase 1: seeded from every target, not just one.
     let mut demanded = vec![false; items.len()];
-    demanded[target_idx] = true;
+    for &idx in &target_order {
+        demanded[idx] = true;
+    }
     let mut in_closure = vec![false; candidates.len()];
     loop {
         let mut grew = false;
@@ -779,24 +876,29 @@ fn solve_attempt(
             row.push((o, -1.0));
         }
         if row.is_empty() {
-            // An untouched non-target item simply has no flow. The TARGET
+            // An untouched non-target item simply has no flow. A TARGET
             // row going empty means nothing can produce or supply it —
             // skipping it would let the LP "solve" with an empty plan.
             // Surface the stored machine-incompatibility (the usual cause:
             // every producer column was dropped for the configured
-            // machine) or an explicit unproducible error.
-            if i == target_idx {
+            // machine) or an explicit unproducible error. RFC-062 Phase 1:
+            // any of the N targets can hit this, not just a single one —
+            // report the specific item whose row is empty (more precise
+            // than the old single-target error, and identical to it when
+            // `targets.len() == 1`, since `items.names[target_idx] ==
+            // target_item` there).
+            if target_rate_of.contains_key(&i) {
                 if let Some(err) = dropped_incompat.into_iter().next() {
                     return Err(AttemptError::Hard(err));
                 }
                 return Err(AttemptError::Hard(SolverError::LpFailed {
-                    target: target_item.to_string(),
+                    target: items.names[i].to_string(),
                     detail: "target has no producer, no external supply, and no surplus sink".to_string(),
                 }));
             }
             continue;
         }
-        let rhs = if i == target_idx { target_rate } else { 0.0 };
+        let rhs = target_rate_of.get(&i).copied().unwrap_or(0.0);
         problem.add_constraint(row.as_slice(), ComparisonOp::Eq, rhs);
     }
 
@@ -810,7 +912,7 @@ fn solve_attempt(
             return AttemptError::Hard(err);
         }
         AttemptError::Hard(SolverError::LpFailed {
-            target: target_item.to_string(),
+            target: target_label(targets),
             detail: format!("{e:?}"),
         })
     })?;
@@ -1041,7 +1143,10 @@ fn solve_attempt(
         Item(usize),
         Col(usize),
     }
-    let mut stack = vec![Work::Item(target_idx)];
+    // RFC-062 Phase 1: seeded from every target, reverse-pushed so the
+    // first-requested target pops (and is thus visited/emitted) first —
+    // bit-identical to the old single-item seed when `targets.len() == 1`.
+    let mut stack: Vec<Work> = target_order.iter().rev().map(|&idx| Work::Item(idx)).collect();
     while let Some(w) = stack.pop() {
         match w {
             Work::Item(i) => {
@@ -1115,7 +1220,7 @@ fn solve_attempt(
             .expect("mismatch implies at least one unreachable column");
         return Err(AttemptError::Cycle {
             refusal: SolverError::LpFailed {
-                target: target_item.to_string(),
+                target: target_label(targets),
                 detail: format!(
                     "surplus-processor exclusion did not converge (last: {first_unreachable})"
                 ),
@@ -1124,6 +1229,18 @@ fn solve_attempt(
         });
     }
 
+    // Byproduct produced beyond internal demand + target-row RHS. RFC-062
+    // Phase 1 semantics (decision log): this is NOT mutually exclusive with
+    // `external_outputs` — a target item can appear in BOTH when its net
+    // production (driven by another target's recipe tree) exceeds its own
+    // requested rate; `o_of(i)` is computed identically regardless of
+    // whether `i` is a target (no code branch here checks target
+    // membership). `external_outputs` conveys the guaranteed per-target
+    // export rate (the row's RHS); `surplus_outputs` conveys any additional
+    // production of that same item beyond what internal consumers + the
+    // target RHS need. Phase 2 (layout) must give a target item that also
+    // carries surplus two physical exports of the same item, exactly as it
+    // already must for a non-target byproduct today.
     let surplus_outputs: Vec<ItemFlow> = (0..items.len())
         .filter(|&i| o_of(i) > ACTIVE_TOL)
         .map(|i| ItemFlow {
@@ -1134,7 +1251,14 @@ fn solve_attempt(
         })
         .collect();
 
-    let target_is_fluid = items.is_fluid[target_idx];
+    // RFC-062 Phase 1 DI-coupling guard: an item that is itself one of the
+    // requested targets must never be stamped as a direct-insertion
+    // coupling, even if it otherwise qualifies (exactly one active
+    // producer, exactly one active consumer, no external supply/surplus,
+    // matching rates) — DI fuses producer straight into consumer with no
+    // exposed belt, and the item's export path (still demanded by its row's
+    // RHS) would have nowhere to attach. See `detect_di_couplings`.
+    let target_index_set: FxHashSet<usize> = target_order.iter().copied().collect();
 
     // Direct-insertion coupling detection (RFC decomposition-search Phase 3).
     // For each item with exactly one active producer and one active consumer,
@@ -1142,12 +1266,14 @@ fn solve_attempt(
     // coupling. Fluids are excluded (inserter DI only; pipe adjacency is a
     // separate concern). Voider columns are excluded as consumers (they
     // destroy items, they don't use them to make something). Self-loop items
-    // within a single recipe are not producer↔consumer pairs.
+    // within a single recipe are not producer↔consumer pairs. Target items
+    // are excluded (RFC-062 Phase 1, above).
     let di_couplings = detect_di_couplings(
         &columns,
         &active,
         &producers_of,
         &items,
+        &target_index_set,
         &|i| s_of(i),
         &|i| o_of(i),
         &|c| x_of(c),
@@ -1156,12 +1282,19 @@ fn solve_attempt(
     Ok(SolverResult {
         machines,
         external_inputs,
-        external_outputs: vec![ItemFlow {
-            item: target_item.to_string(),
-            rate: target_rate,
-            is_fluid: target_is_fluid,
-            module_id: 0,
-        }],
+        // RFC-062 Phase 1: one ItemFlow per unique requested target, in
+        // first-seen order, rate = the (possibly summed) demand this
+        // attempt's LP rows were built against. Bit-identical to the old
+        // single-element vec when `targets.len() == 1`.
+        external_outputs: target_order
+            .iter()
+            .map(|&idx| ItemFlow {
+                item: items.names[idx].to_string(),
+                rate: target_rate_of[&idx],
+                is_fluid: items.is_fluid[idx],
+                module_id: 0,
+            })
+            .collect(),
         surplus_outputs,
         dependency_order,
         di_couplings,
@@ -1191,15 +1324,30 @@ fn snap_value(v: f64) -> f64 {
 /// - no external supply (`s_of(i)` ≈ 0)
 /// - no surplus (`o_of(i)` ≈ 0)
 /// - the item is not a fluid (inserter DI only; pipe DI is separate)
+/// - the item is not itself one of the requested export targets (RFC-062
+///   Phase 1 — see `target_indices` below)
 /// - supply rate ≈ demand rate (producer's output matches consumer's input)
 ///
 /// Emits one `DICoupling` per qualifying (producer, consumer, item) triple.
 /// The placer MAY use these; presence does not force DI layout.
+///
+/// `target_indices` (RFC-062 Phase 1,
+/// `docs/rfc-062-multi-target-outputs.md` §Solver "Correctness gap"): under
+/// single-target solving a target item never qualified here by construction
+/// (its export is a property of the row's RHS, invisible to this function).
+/// Under multi-target, an item can legitimately have exactly one producer
+/// and one consumer AND be a target simultaneously — stamping that pair as
+/// DI would let the placer fuse producer directly into consumer with no
+/// exposed belt, leaving the item's still-demanded export path with nowhere
+/// to attach. Membership in `target_indices` is checked first and refuses
+/// the pair outright, before the supply/demand rate comparison runs (which
+/// is not itself a reliable guard here — see the Phase 1 decision log).
 fn detect_di_couplings(
     columns: &[Column],
     active: &[usize],
     producers_of: &FxHashMap<usize, Vec<usize>>,
     items: &Items,
+    target_indices: &FxHashSet<usize>,
     s_of: &dyn Fn(usize) -> f64,
     o_of: &dyn Fn(usize) -> f64,
     x_of: &dyn Fn(usize) -> f64,
@@ -1216,6 +1364,12 @@ fn detect_di_couplings(
 
     let mut couplings = Vec::new();
     for (&i, producers) in producers_of {
+        // RFC-062 Phase 1: an item that's itself a requested export target
+        // must never be DI-coupled, regardless of how the rest of the
+        // eligibility check would score it.
+        if target_indices.contains(&i) {
+            continue;
+        }
         // Must be exactly one producer and one consumer.
         let consumers = match consumers_of.get(&i) {
             Some(cs) if cs.len() == 1 => &cs[..],
@@ -1380,4 +1534,109 @@ fn find_active_cycle_indices(columns: &[Column], active: &[usize]) -> Option<Vec
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::module_policy::MachineModuleEffects;
+    use crate::recipe_db::db;
+
+    /// RFC-062 Phase 1 (`docs/rfc-062-multi-target-outputs.md` §Solver,
+    /// "Correctness gap"): `detect_di_couplings` must refuse to stamp a
+    /// producer→consumer pair when the intermediate item is itself a
+    /// requested export target, even when supply and demand happen to
+    /// match exactly (the shape that would otherwise qualify for DI).
+    ///
+    /// The live KC2 fixture (EC@10/s + AC@3/s, see
+    /// `crates/core/tests/solver_multi_target.rs`) never actually exercises
+    /// this branch: EC's target rate forces the producer's gross output to
+    /// exceed AC's ingredient draw by exactly the target rate, so
+    /// supply != demand there regardless of the guard (confirmed by
+    /// probing the live solve with the guard temporarily removed — see the
+    /// Phase 1 decision log). This test constructs the supply == demand
+    /// coincidence directly with synthetic columns, so the guard is proven
+    /// on its own terms rather than relying on a numeric accident in one
+    /// fixture.
+    #[test]
+    fn di_coupling_guard_suppresses_target_item_coupling() {
+        let ec_recipe = db().recipes.get("electronic-circuit").expect("electronic-circuit recipe");
+        let ac_recipe = db().recipes.get("advanced-circuit").expect("advanced-circuit recipe");
+
+        let mut items = Items::default();
+        let ec_idx = items.intern("electronic-circuit", false);
+        let ac_idx = items.intern("advanced-circuit", false);
+
+        // Column 0: EC producer, net +1 EC/craft. Column 1: AC consumer,
+        // net -2 EC/craft (AC's real per-craft EC coefficient) and +1
+        // AC/craft. x-rates (6.0, 3.0) are chosen so supply (6*1=6) exactly
+        // equals demand (3*2=6) — the coincidence the guard must catch
+        // regardless of whether EC's row also carries a nonzero target
+        // rate (irrelevant here, since this test calls
+        // `detect_di_couplings` directly rather than solving a full LP).
+        let columns = vec![
+            Column {
+                recipe: ec_recipe,
+                machine: "assembling-machine-2".to_string(),
+                crafting_speed: 0.75,
+                net: vec![(ec_idx, 1.0)],
+                effects: MachineModuleEffects::none(),
+            },
+            Column {
+                recipe: ac_recipe,
+                machine: "assembling-machine-2".to_string(),
+                crafting_speed: 0.75,
+                net: vec![(ec_idx, -2.0), (ac_idx, 1.0)],
+                effects: MachineModuleEffects::none(),
+            },
+        ];
+        let active = vec![0usize, 1usize];
+        let mut producers_of: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+        producers_of.insert(ec_idx, vec![0]);
+        producers_of.insert(ac_idx, vec![1]);
+
+        let x_of = |c: usize| if c == 0 { 6.0 } else { 3.0 };
+        let s_of = |_i: usize| 0.0;
+        let o_of = |_i: usize| 0.0;
+
+        // Control: EC is NOT a target — the pair qualifies for DI exactly
+        // like plain single-target AC-from-EC solving does today.
+        let no_targets: FxHashSet<usize> = FxHashSet::default();
+        let couplings = detect_di_couplings(
+            &columns,
+            &active,
+            &producers_of,
+            &items,
+            &no_targets,
+            &s_of,
+            &o_of,
+            &x_of,
+        );
+        assert_eq!(
+            couplings.len(),
+            1,
+            "expected EC->AC coupling when EC is not a target, got {couplings:?}"
+        );
+        assert_eq!(couplings[0].producer_recipe, "electronic-circuit");
+        assert_eq!(couplings[0].consumer_recipe, "advanced-circuit");
+        assert_eq!(couplings[0].item, "electronic-circuit");
+
+        // EC as a requested target — the guard must suppress the coupling.
+        let mut ec_is_target: FxHashSet<usize> = FxHashSet::default();
+        ec_is_target.insert(ec_idx);
+        let couplings2 = detect_di_couplings(
+            &columns,
+            &active,
+            &producers_of,
+            &items,
+            &ec_is_target,
+            &s_of,
+            &o_of,
+            &x_of,
+        );
+        assert!(
+            couplings2.is_empty(),
+            "EC as target must suppress the EC->AC coupling, got {couplings2:?}"
+        );
+    }
 }

--- a/crates/core/tests/solver_multi_target.rs
+++ b/crates/core/tests/solver_multi_target.rs
@@ -1,0 +1,474 @@
+//! RFC-062 Phase 1: multi-seed solver.
+//! See docs/rfc-062-multi-target-outputs.md — §Solver and kill criterion 2.
+//!
+//! The DI-coupling guard's dedicated unit test
+//! (`di_coupling_guard_suppresses_target_item_coupling`) lives in
+//! `crates/core/src/netflow.rs` itself, since it needs white-box access to
+//! the private `Column`/`Items`/`detect_di_couplings` types — see that
+//! module's `tests` block.
+
+use rustc_hash::FxHashSet;
+use spaghettio_core::models::{ItemFlow, SolverResult};
+use spaghettio_core::netflow::{
+    solve_netflow, solve_netflow_multi, CostTable, RecipeScope,
+};
+use spaghettio_core::recipe_db::MachinePalette;
+use spaghettio_core::solver::SolverError;
+use std::collections::HashMap;
+
+fn set(items: &[&str]) -> FxHashSet<String> {
+    items.iter().map(|s| s.to_string()).collect()
+}
+
+fn machine_count(r: &SolverResult, recipe: &str) -> f64 {
+    r.machines
+        .iter()
+        .find(|m| m.recipe == recipe)
+        .unwrap_or_else(|| panic!("no {recipe} machines in result; machines present: {:?}",
+            r.machines.iter().map(|m| &m.recipe).collect::<Vec<_>>()))
+        .count
+}
+
+fn rate_of<'a>(flows: &'a [ItemFlow], item: &str) -> Option<&'a ItemFlow> {
+    flows.iter().find(|f| f.item == item)
+}
+
+fn summed_rates(flows: &[ItemFlow]) -> HashMap<String, f64> {
+    let mut out: HashMap<String, f64> = HashMap::new();
+    for f in flows {
+        *out.entry(f.item.clone()).or_insert(0.0) += f.rate;
+    }
+    out
+}
+
+/// KC2 (`docs/rfc-062-multi-target-outputs.md` kill criterion 2): the
+/// multi-seed LP on the canonical `electronic-circuit@10/s` +
+/// `advanced-circuit@3/s` (from ore, AM2) case must reproduce the
+/// naive-concatenation per-item machine totals exactly — copper-cable
+/// 20.0, NOT the hand-sum shortcut's 16.0 — for every item consumed by
+/// more than one target's recipe tree. Numbers mirror the RFC's inlined
+/// probe table (Motivation section) and the Phase 0 decision log's
+/// re-derivation, confirmed independently here via crafting-speed/energy
+/// arithmetic: AM2 speed 0.75, electric-furnace speed 2.0 (smelting is
+/// hardcoded off the `default_machine` palette regardless of the AM2
+/// passed in).
+#[test]
+fn kc2_ec_ac_shared_copper_cable_exact() {
+    let inputs = set(&["iron-ore", "copper-ore", "coal", "water", "crude-oil"]);
+    let targets = vec![
+        ("electronic-circuit".to_string(), 10.0),
+        ("advanced-circuit".to_string(), 3.0),
+    ];
+    let r = solve_netflow_multi(
+        &targets,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("EC+AC from ore should solve");
+
+    // Combined EC demand = 10 (own target) + 6 (AC's 2-per-craft ingredient
+    // draw at AC's 3 crafts/s) = 16/s. AM2: 0.75/0.5 = 1.5 crafts/s/machine.
+    let ec = machine_count(&r, "electronic-circuit");
+    assert!(
+        (ec - 16.0 / 1.5).abs() < 1e-9,
+        "electronic-circuit machines: expected {}, got {ec}",
+        16.0 / 1.5
+    );
+
+    // Combined copper-cable demand = EC's 3-per-craft * 16 crafts/s (48/s)
+    // + AC's 4-per-craft * 3 crafts/s (12/s) = 60/s. AM2: 0.75/0.5 =
+    // 1.5 crafts/s/machine, 2 cable/craft = 3/s/machine.
+    let cable = machine_count(&r, "copper-cable");
+    assert!(
+        (cable - 20.0).abs() < 1e-9,
+        "copper-cable machines: expected 20.0 (naive-concatenation total, NOT the \
+         hand-sum shortcut's 16.0), got {cable}"
+    );
+
+    // iron-plate demand = EC's 1-per-craft * 16 crafts/s = 16/s.
+    // electric-furnace: speed 2.0, energy 3.2 -> 0.625 crafts/s/machine.
+    let iron_plate = machine_count(&r, "iron-plate");
+    assert!(
+        (iron_plate - 25.6).abs() < 1e-9,
+        "iron-plate machines: expected 25.6, got {iron_plate}"
+    );
+
+    // copper-plate demand = copper-cable's 1-per-craft * 30 crafts/s (60/s
+    // cable / 2 per craft) = 30/s. electric-furnace: 0.625 crafts/s/machine.
+    let copper_plate = machine_count(&r, "copper-plate");
+    assert!(
+        (copper_plate - 48.0).abs() < 1e-9,
+        "copper-plate machines: expected 48.0, got {copper_plate}"
+    );
+}
+
+/// Dependency-order sanity for the coupled KC2 case: electronic-circuit
+/// (the shared upstream item) must be resolved before advanced-circuit
+/// (its consumer) in `dependency_order`, matching the DFS's target-order
+/// seeding (EC requested first).
+#[test]
+fn kc2_dependency_order_ec_before_ac() {
+    let inputs = set(&["iron-ore", "copper-ore", "coal", "water", "crude-oil"]);
+    let targets = vec![
+        ("electronic-circuit".to_string(), 10.0),
+        ("advanced-circuit".to_string(), 3.0),
+    ];
+    let r = solve_netflow_multi(
+        &targets,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("EC+AC from ore should solve");
+
+    let ec_pos = r
+        .dependency_order
+        .iter()
+        .position(|r| r == "electronic-circuit")
+        .expect("electronic-circuit in dependency_order");
+    let ac_pos = r
+        .dependency_order
+        .iter()
+        .position(|r| r == "advanced-circuit")
+        .expect("advanced-circuit in dependency_order");
+    assert!(
+        ec_pos < ac_pos,
+        "expected electronic-circuit ({ec_pos}) before advanced-circuit ({ac_pos}): {:?}",
+        r.dependency_order
+    );
+
+    // external_outputs carries both targets, each at its own requested
+    // rate (RFC-062 Phase 1 semantics: not netted against each other).
+    assert_eq!(r.external_outputs.len(), 2);
+    assert_eq!(rate_of(&r.external_outputs, "electronic-circuit").unwrap().rate, 10.0);
+    assert_eq!(rate_of(&r.external_outputs, "advanced-circuit").unwrap().rate, 3.0);
+}
+
+/// Two targets with non-overlapping recipe trees (`electronic-circuit` and
+/// `iron-gear-wheel`, solved from plates so neither pulls in smelting):
+/// the multi-target solve's machine mix must equal the union of the two
+/// independent single-target solves, with identical per-recipe counts —
+/// no merging should occur because nothing is actually shared upstream of
+/// the raw external inputs.
+#[test]
+fn disjoint_targets_equal_independent_sums() {
+    let inputs = set(&["iron-plate", "copper-plate"]);
+
+    let ec_only = solve_netflow(
+        "electronic-circuit",
+        10.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("EC-only should solve");
+    let gear_only = solve_netflow(
+        "iron-gear-wheel",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("gear-only should solve");
+
+    let targets = vec![
+        ("electronic-circuit".to_string(), 10.0),
+        ("iron-gear-wheel".to_string(), 5.0),
+    ];
+    let multi = solve_netflow_multi(
+        &targets,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("disjoint multi-target should solve");
+
+    // No recipe overlap between the two closures, so the multi-target
+    // machine list is exactly the concatenation of the two independent
+    // solves' machine lists (same recipes, same counts).
+    assert_eq!(
+        multi.machines.len(),
+        ec_only.machines.len() + gear_only.machines.len(),
+        "expected disjoint machine sets to concatenate with no merging"
+    );
+    for single in [&ec_only, &gear_only] {
+        for m in &single.machines {
+            let count = machine_count(&multi, &m.recipe);
+            assert!(
+                (count - m.count).abs() < 1e-9,
+                "recipe {}: independent solve had {}, multi-target had {count}",
+                m.recipe,
+                m.count
+            );
+        }
+    }
+
+    // external_inputs: rates sum across both singles (iron-plate is drawn
+    // by both EC and gear-wheel; copper-plate only by EC).
+    let expected_inputs = {
+        let mut m = summed_rates(&ec_only.external_inputs);
+        for (k, v) in summed_rates(&gear_only.external_inputs) {
+            *m.entry(k).or_insert(0.0) += v;
+        }
+        m
+    };
+    let actual_inputs = summed_rates(&multi.external_inputs);
+    assert_eq!(
+        expected_inputs.len(),
+        actual_inputs.len(),
+        "external_inputs item set mismatch: expected {expected_inputs:?}, got {actual_inputs:?}"
+    );
+    for (item, expected_rate) in &expected_inputs {
+        let actual_rate = actual_inputs.get(item).unwrap_or_else(|| {
+            panic!("missing external input {item} in multi-target result")
+        });
+        assert!(
+            (actual_rate - expected_rate).abs() < 1e-9,
+            "external input {item}: expected {expected_rate}, got {actual_rate}"
+        );
+    }
+
+    // external_outputs: both targets present at their own requested rates.
+    assert_eq!(multi.external_outputs.len(), 2);
+    assert_eq!(rate_of(&multi.external_outputs, "electronic-circuit").unwrap().rate, 10.0);
+    assert_eq!(rate_of(&multi.external_outputs, "iron-gear-wheel").unwrap().rate, 5.0);
+}
+
+/// N=1 equivalence (kill criterion 5): calling the new multi-target entry
+/// point with a one-element slice must produce a field-level-identical
+/// `SolverResult` to the old scalar `solve_netflow` path. This is a
+/// construction guarantee (both bottom out in the same `solve_attempt`
+/// call with a one-element `targets` slice), not a coincidence — this test
+/// pins it, and the full existing suite passing with zero golden churn is
+/// the systemic proof.
+#[test]
+fn n1_equivalence_multi_matches_scalar() {
+    let inputs = set(&["iron-ore", "copper-ore"]);
+    let scalar = solve_netflow(
+        "electronic-circuit",
+        10.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("scalar solve");
+
+    let targets = vec![("electronic-circuit".to_string(), 10.0)];
+    let multi = solve_netflow_multi(
+        &targets,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("one-element multi-target solve");
+
+    assert_solver_results_bit_identical(&scalar, &multi);
+}
+
+/// Same equivalence check on a coupled multi-recipe target (advanced
+/// circuit from ore — exercises the DI-coupling path and self-loop-free
+/// but multi-hop closure) to make sure N=1 identity holds beyond the
+/// simplest single-recipe case.
+#[test]
+fn n1_equivalence_holds_on_multi_hop_target() {
+    let inputs = set(&["iron-ore", "copper-ore", "coal", "water", "crude-oil"]);
+    let scalar = solve_netflow(
+        "advanced-circuit",
+        5.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("scalar solve");
+
+    let targets = vec![("advanced-circuit".to_string(), 5.0)];
+    let multi = solve_netflow_multi(
+        &targets,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("one-element multi-target solve");
+
+    assert_solver_results_bit_identical(&scalar, &multi);
+}
+
+/// Duplicate-item targets (RFC-062 Phase 1 decision log): requesting the
+/// same item twice sums the rates into one demand row and one
+/// `external_outputs` entry, rather than erroring or emitting two entries.
+/// Splitting a single-target rate across two duplicate requests must
+/// reproduce the equivalent single request exactly.
+#[test]
+fn duplicate_target_item_rates_are_summed() {
+    let inputs = set(&["iron-plate", "copper-plate"]);
+    let combined = solve_netflow(
+        "electronic-circuit",
+        10.0,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("combined-rate solve");
+
+    let targets = vec![
+        ("electronic-circuit".to_string(), 4.0),
+        ("electronic-circuit".to_string(), 6.0),
+    ];
+    let split = solve_netflow_multi(
+        &targets,
+        &inputs,
+        &MachinePalette::default(),
+        "assembling-machine-2",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect("split-rate solve");
+
+    assert_eq!(
+        split.external_outputs.len(),
+        1,
+        "duplicate target item must collapse to one external_outputs entry, got {:?}",
+        split.external_outputs
+    );
+    assert_eq!(split.external_outputs[0].item, "electronic-circuit");
+    assert_eq!(split.external_outputs[0].rate, 10.0);
+
+    assert_solver_results_bit_identical(&combined, &split);
+}
+
+/// Typed-refusal review under multi-target: a machine-incompatibility
+/// error for one of two targets must still surface as the same typed
+/// error it would under single-target solving — not be masked or dropped
+/// because the OTHER target is perfectly satisfiable. Mirrors
+/// `solver::tests::am1_palette_for_advanced_circuit_returns_incompatible_error`,
+/// extended with a second, unrelated, trivially-satisfiable target
+/// (`iron-gear-wheel`).
+#[test]
+fn multi_target_incompatible_machine_error_not_masked_by_other_target() {
+    let available = set(&[
+        "iron-plate",
+        "copper-plate",
+        "plastic-bar",
+        "electronic-circuit",
+    ]);
+    let mut palette = MachinePalette::default();
+    palette.by_category.insert("electronics".into(), "assembling-machine-1".into());
+
+    let targets = vec![
+        ("advanced-circuit".to_string(), 1.0),
+        ("iron-gear-wheel".to_string(), 5.0),
+    ];
+    let err = solve_netflow_multi(
+        &targets,
+        &available,
+        &palette,
+        "assembling-machine-3",
+        &FxHashSet::default(),
+        RecipeScope::Free,
+        &CostTable::default(),
+    )
+    .expect_err("AM1-pinned advanced-circuit should still be rejected under multi-target");
+
+    match err {
+        SolverError::IncompatibleMachine { machine, .. } => {
+            assert_eq!(machine, "assembling-machine-1");
+        }
+        other => panic!("expected IncompatibleMachine, got {other:?}"),
+    }
+}
+
+/// Field-level equality between two `SolverResult`s (neither type derives
+/// `PartialEq` — deliberately manual so f64 fields are compared bit-exact
+/// via `to_bits()`, proving byte-identical output, not merely
+/// approximately-equal).
+fn assert_solver_results_bit_identical(a: &SolverResult, b: &SolverResult) {
+    assert_eq!(a.machines.len(), b.machines.len(), "machines.len()");
+    for (ma, mb) in a.machines.iter().zip(b.machines.iter()) {
+        assert_eq!(ma.entity, mb.entity, "machine entity");
+        assert_eq!(ma.recipe, mb.recipe, "machine recipe");
+        assert_eq!(
+            ma.count.to_bits(),
+            mb.count.to_bits(),
+            "machine {} count: {} vs {}",
+            ma.recipe,
+            ma.count,
+            mb.count
+        );
+        assert_eq!(ma.voider, mb.voider, "machine {} voider", ma.recipe);
+        assert_item_flows_bit_identical(&ma.inputs, &mb.inputs, &format!("{} inputs", ma.recipe));
+        assert_item_flows_bit_identical(&ma.outputs, &mb.outputs, &format!("{} outputs", ma.recipe));
+        assert_eq!(ma.self_loop.len(), mb.self_loop.len(), "machine {} self_loop len", ma.recipe);
+        assert_eq!(ma.game_modules.len(), mb.game_modules.len(), "machine {} game_modules len", ma.recipe);
+    }
+    assert_item_flows_bit_identical(&a.external_inputs, &b.external_inputs, "external_inputs");
+    assert_item_flows_bit_identical(&a.external_outputs, &b.external_outputs, "external_outputs");
+    assert_item_flows_bit_identical(&a.surplus_outputs, &b.surplus_outputs, "surplus_outputs");
+    assert_eq!(a.dependency_order, b.dependency_order, "dependency_order");
+    assert_eq!(a.di_couplings.len(), b.di_couplings.len(), "di_couplings.len()");
+    for (ca, cb) in a.di_couplings.iter().zip(b.di_couplings.iter()) {
+        assert_eq!(ca.producer_recipe, cb.producer_recipe, "di_coupling producer_recipe");
+        assert_eq!(ca.consumer_recipe, cb.consumer_recipe, "di_coupling consumer_recipe");
+        assert_eq!(ca.item, cb.item, "di_coupling item");
+        assert_eq!(
+            ca.producer_count.to_bits(),
+            cb.producer_count.to_bits(),
+            "di_coupling {} producer_count",
+            ca.item
+        );
+        assert_eq!(
+            ca.consumer_count.to_bits(),
+            cb.consumer_count.to_bits(),
+            "di_coupling {} consumer_count",
+            ca.item
+        );
+    }
+}
+
+fn assert_item_flows_bit_identical(a: &[ItemFlow], b: &[ItemFlow], label: &str) {
+    assert_eq!(a.len(), b.len(), "{label}: item flow count differs ({a:?} vs {b:?})");
+    for (fa, fb) in a.iter().zip(b.iter()) {
+        assert_eq!(fa.item, fb.item, "{label}: item name");
+        assert_eq!(
+            fa.rate.to_bits(),
+            fb.rate.to_bits(),
+            "{label}: {} rate {} vs {}",
+            fa.item,
+            fa.rate,
+            fb.rate
+        );
+        assert_eq!(fa.is_fluid, fb.is_fluid, "{label}: {} is_fluid", fa.item);
+        assert_eq!(fa.module_id, fb.module_id, "{label}: {} module_id", fa.item);
+    }
+}

--- a/docs/rfc-062-multi-target-outputs.md
+++ b/docs/rfc-062-multi-target-outputs.md
@@ -389,3 +389,177 @@ needed to look at the result, not a UI feature.
   to address simultaneous multi-target solving or layout; the complexity
   ladder in `docs/status.md` and every existing RFC/issue are single-target
   throughout.
+
+- *2026-07-31 — Phase 1 solver generalization landed: kill criterion 2
+  confirmed (exact), kill criterion 5 holds by construction.*
+
+  **Scope.** `crates/core/src/netflow.rs` only, per the RFC's §Solver plan.
+  No layout, harness, or interface changes — Phase 2's shared-row fix
+  (Phase 0's three-site list) is untouched and still pending.
+
+  **New entry point.** `solve_netflow_multi(targets: &[(String, f64)], ...)`
+  and `solve_netflow_multi_with_options(...)` (same trailing args as the
+  existing scalar functions, plus `NetflowOptions`) are the new choke
+  point. `solve_netflow_with_options` — the inner of the two scalar
+  entry points named in the RFC's "3 layered entry points in netflow.rs" —
+  now has a two-line body: `solve_netflow_multi_with_options(&[(target_item
+  .to_string(), target_rate)], ...)`. `solve_netflow` is untouched (it
+  already only calls `solve_netflow_with_options`) and inherits the
+  guarantee transitively. Because none of the **8 scalar wrappers in
+  `solver.rs`** call anything below `solve_netflow`/
+  `solve_netflow_with_options`, **zero lines in `solver.rs` changed** —
+  every one of the 11 wrappers the RFC named now bottoms out in the same
+  `solve_attempt(targets: &[(String, f64)], ...)` implementation via a
+  one-element slice, by construction. This is what makes kill criterion 5
+  (N=1 bit-identical) a compile-time guarantee rather than a tested
+  coincidence: there is exactly one code path from any scalar wrapper to
+  the LP, and the N=1 case is that path's literal special case.
+
+  **The three internal sites**, all in `solve_attempt`:
+  1. Target interning now builds `target_order: Vec<usize>` (deduplicated,
+     first-seen order) and `target_rate_of: FxHashMap<usize, f64>` (summed
+     per unique item) in one pass, replacing the single `target_idx`.
+  2. Demand-closure seed: `demanded[idx] = true` for every `idx` in
+     `target_order` (was: `demanded[target_idx] = true`).
+  3. Output-assembly DFS seed: `target_order.iter().rev().map(|&idx|
+     Work::Item(idx)).collect()` (was: `vec![Work::Item(target_idx)]`) —
+     reverse-pushed so the first-requested target pops (and is thus
+     visited/emitted) first, matching the existing "reverse-push so the
+     first producer pops first" convention used elsewhere in the same
+     function.
+  4. Row RHS (`netflow.rs`, LP constraint assembly): `target_rate_of.get(&i)
+     .copied().unwrap_or(0.0)` (was: `if i == target_idx { target_rate }
+     else { 0.0 }`). The empty-row-is-an-error check now tests
+     `target_rate_of.contains_key(&i)` instead of `i == target_idx`, and
+     reports `items.names[i]` (the specific empty row) rather than the
+     caller's original string — strictly more precise under N targets,
+     and bit-identical to the old message when `targets.len() == 1`.
+
+  **Semantics decision: duplicate target items are summed, not refused.**
+  Requesting the same item twice (`&[("electronic-circuit", 4.0),
+  ("electronic-circuit", 6.0)]`) collapses to one demand row and one
+  `external_outputs` entry at the summed rate (10.0), verified
+  bit-identical to requesting `electronic-circuit@10.0` directly
+  (`duplicate_target_item_rates_are_summed` in
+  `crates/core/tests/solver_multi_target.rs`). Rejected alternative: a
+  typed `DuplicateTarget` refusal — summing is strictly less surprising to
+  a caller building a target list programmatically (e.g. a future UI that
+  lets a user add the same item twice with different rates meaning
+  "at least this much") and requires no new error variant threaded through
+  every caller.
+
+  **Semantics decision: `external_outputs` and `surplus_outputs` are not
+  mutually exclusive.** `external_outputs` now carries one `ItemFlow` per
+  unique requested target, in first-seen order, at the (possibly summed)
+  demand rate that row's RHS was solved against. `surplus_outputs`
+  continues to be computed identically regardless of target membership —
+  `o_of(i)` has no target-aware branch anywhere in `solve_attempt`. This
+  means a target item CAN legitimately appear in both lists at once: if
+  another target's recipe tree forces net production of item `i` above
+  `i`'s own requested rate (e.g. a byproduct that is itself a low-rate
+  target while a sibling target's demand drives its producer harder), the
+  LP satisfies the row via `o[i] > 0` rather than reducing production,
+  since reducing production would violate the other target's higher
+  draw. Verified this is reachable in principle by direct row-algebra
+  (`net_production − consumption + s − o = target_rate` has a legitimate
+  `o > 0` solution whenever some *other* column's demand for `i` forces
+  gross production above `i`'s own RHS) — not exercised by the KC2 fixture
+  itself (EC and AC's coupling runs the other direction: EC's export adds
+  to the row's demand rather than exceeding it). **For Phase 2**: a target
+  item carrying surplus needs two physical exports of the same item — the
+  guaranteed target export plus the surplus export — exactly as a
+  non-target byproduct already needs one today; this is a new *instance*
+  of dual-purpose-lane provisioning to plan for, not a new mechanism.
+
+  **DI-coupling guard** (`detect_di_couplings`, RFC's "Correctness gap").
+  Added a `target_indices: &FxHashSet<usize>` parameter; the very first
+  check inside the per-item loop is `if target_indices.contains(&i) {
+  continue; }`, before the one-producer/one-consumer/no-surplus/rate-match
+  checks run. Verified with a dedicated unit test,
+  `netflow::tests::di_coupling_guard_suppresses_target_item_coupling`
+  (white-box — needs the private `Column`/`Items` types, so it lives in
+  `netflow.rs` itself rather than the integration test file): synthetic
+  EC-producer/AC-consumer columns with `x` rates chosen so supply (6.0)
+  exactly equals demand (6.0), proving the guard suppresses the coupling
+  when EC is in `target_indices` and the same setup couples when it isn't.
+  **Finding, not just implementation**: the live KC2 fixture
+  (EC@10/s + AC@3/s) does **not** actually exercise this guard — verified
+  by temporarily removing the `target_indices` check and re-running the
+  probe (`crates/core/examples/rfc062_phase1_kc2_probe.rs`, gitignored).
+  Row algebra explains why: for a target item with exactly one producer
+  and one consumer and no external supply/surplus, the row constraint
+  forces `producer_output − consumer_input = target_rate`, so `supply !=
+  demand` in `detect_di_couplings`'s own tolerance check for any nonzero
+  target rate — the existing rate-match check already happens to reject
+  the pairing before the new guard would need to. The guard is still
+  correct and necessary defense-in-depth (a future recipe-graph shape, a
+  target requested at an effectively-zero rate, or a different DI
+  eligibility refinement could reach the coincidence this guard exists
+  to close), and the RFC's own text frames it as a correctness gap to
+  close regardless of whether one specific fixture reaches it — but Phase
+  2/3 readers should not expect the KC2 fixture's validator/sim behavior
+  to visibly change because of this guard; its payoff is defensive.
+
+  **Typed-refusal review.** The acyclic-fallback / oil-path-physical retry
+  loop (now `solve_netflow_multi_with_options`) needed no logic changes —
+  confirmed target-count-agnostic exactly as the RFC predicted, since every
+  branch inspects `r.machines`/`r.surplus_outputs` post-solve. Error
+  `target` fields that used to read `target_item.to_string()` now read
+  `target_label(targets)` (joins every requested item name;
+  bit-identical to the old string when `targets.len() == 1`). Verified the
+  machine-incompatibility typed-refusal path still surfaces correctly under
+  N=2 with one satisfiable and one unsatisfiable target
+  (`multi_target_incompatible_machine_error_not_masked_by_other_target`):
+  AM1-pinned `advanced-circuit` alongside a perfectly solvable
+  `iron-gear-wheel@5` still returns `SolverError::IncompatibleMachine`,
+  not a silent partial success. Did not construct a dedicated multi-target
+  cycle-refusal test beyond this — the retry loop's cycle-handling code is
+  unchanged (not just unchanged-in-effect but literally the same lines),
+  and constructing a deterministic multi-target cycle fixture is
+  materially more fragile than the machine-incompatibility case for the
+  same evidentiary value; flagging as an explicit scope stop rather than a
+  silent gap.
+
+  **Kill criterion 2 — measured, exact.** Canonical probe
+  (`electronic-circuit@10/s` + `advanced-circuit@3/s`, from ore, AM2,
+  `RecipeScope::Free`), `kc2_ec_ac_shared_copper_cable_exact` in
+  `crates/core/tests/solver_multi_target.rs`:
+
+  | Item | Multi-seed LP (this phase) | Naive-concatenation total (Motivation table) |
+  |---|---:|---:|
+  | copper-cable | **20.000000** | 20.0 |
+  | electronic-circuit | **10.666667** (16/1.5 exact) | — (10.667 in the RFC's rounded table) |
+  | iron-plate | **25.600000** | 25.6 |
+  | copper-plate | **48.000000** | 48.0 |
+
+  All four asserted to within `1e-9` of the closed-form expected value
+  (derived independently from crafting-speed/energy arithmetic, not copied
+  from the RFC table, then cross-checked against it) — none within 1e-9 of
+  the hand-sum shortcut's wrong numbers (16.0 copper-cable machines).
+  `advanced-circuit` itself solves to 24.0 machines and `dependency_order`
+  places `electronic-circuit` before `advanced-circuit`
+  (`kc2_dependency_order_ec_before_ac`), confirming the shared upstream is
+  genuinely deduplicated rather than solved twice and concatenated.
+
+  **Kill criterion 5 — pinned, not just argued.** Beyond the construction
+  guarantee above,
+  `n1_equivalence_multi_matches_scalar`/`n1_equivalence_holds_on_multi_hop_target`
+  assert full field-level bit-identity (`f64::to_bits()` on every rate/
+  count field, not approximate equality) between `solve_netflow_multi`
+  called with a one-element slice and the existing scalar `solve_netflow`,
+  on both a single-recipe target and a multi-hop coupled target
+  (`advanced-circuit` from ore). Combined with the full existing suite
+  passing at zero golden churn (below), this is the systemic proof the RFC
+  asked for.
+
+  **Verification.** `cargo test --manifest-path crates/core/Cargo.toml` —
+  one clean invocation, all non-ignored tests, 0 failures: lib 920 passed
+  (919 pre-existing + 1 new DI-guard unit test), `solver_netflow_parity`
+  11 passed (unchanged), `solver_multi_target` 7 passed (new), every other
+  suite unchanged. `cargo clippy -p spaghettio_core -- -D warnings` (the
+  exact pre-commit hook invocation) clean. `cargo build -p spaghettio_wasm`
+  clean (native-target sanity check only — the wasm bindings' public
+  surface was not touched, so a full `wasm-pack` rebuild was judged
+  unnecessary for a solver-internals-only change; Phase 5 is where the
+  wasm/URL surface actually changes and gets the real wasm-pack + browser
+  verification pass). No `.fls` snapshot or golden file changed.


### PR DESCRIPTION
## Intent

Implements Phase 1 of [RFC-062](docs/rfc-062-multi-target-outputs.md) (multi-target output support): generalize the net-flow solver to accept N ≥ 1 simultaneous targets in one LP, replacing the "solve N times and glue results together by hand" workaround the RFC's Motivation section shows is either wasteful (naive concatenation, ~10% machine overhead) or silently wrong (the hand-sum shortcut undercounts shared intermediates). Solver only — the layout collision this creates (a shared row claimed by both an export and an internal tap-off) was already characterized and scoped for Phase 2 by [PR #549](https://github.com/storkme/spaghettio/pull/549)'s Phase 0 spike.

## Scope

- **In:** new `solve_netflow_multi`/`solve_netflow_multi_with_options` entry points in `crates/core/src/netflow.rs` taking `targets: &[(String, f64)]`; the three internal single-item seeds (demand-closure fixpoint, output-assembly DFS, LP row RHS) generalized to loops/lookups over all targets; `external_outputs` built from every unique target; the `detect_di_couplings` target-membership guard (RFC's "Correctness gap"); a Phase 1 decision-log entry appended to the RFC.
- **Out:** layout (Phase 2), harness per-item verification plumbing (Phase 3), the end-to-end EC+AC fixture / sim measurement (Phase 4), URL/wasm surface (Phase 5). No changes outside `crates/core/src/netflow.rs`, the new test file, and the RFC doc — in particular **zero lines changed in `solver.rs`**: all 8 scalar wrappers there bottom out in `solve_netflow`/`solve_netflow_with_options`, which now forward to the new multi-target entry point via a one-element slice, so N=1 bit-identity is a construction guarantee rather than something that needed separate wiring.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — one clean invocation, 0 failures. lib 920 passed (919 pre-existing + 1 new DI-coupling-guard unit test), `solver_netflow_parity` 11 passed (unchanged), `solver_multi_target` 7 passed (new file), every other suite unchanged, zero golden/snapshot churn.
- [x] `cargo clippy -p spaghettio_core -- -D warnings` — the exact pre-commit hook invocation — clean.
- [x] `cargo build -p spaghettio_wasm` — native-target sanity check (public wasm surface untouched by this phase; real wasm-pack + browser verification is Phase 5's job once the URL/wasm surface actually changes).
- [ ] WASM rebuild + browser eyeball — N/A, no layout/UI change this phase.
- [x] KC2 (kill criterion 2) measured exactly on the canonical probe (EC@10/s + AC@3/s, from ore, AM2): copper-cable 20.000000, electronic-circuit 10.666667, iron-plate 25.600000, copper-plate 48.000000 — matches naive-concatenation totals exactly, not the hand-sum shortcut's wrong 16.0 copper-cable count. See `kc2_ec_ac_shared_copper_cable_exact` in `crates/core/tests/solver_multi_target.rs` and the RFC's Phase 1 decision-log entry for full detail.
- [x] Kill criterion 5 (N=1 bit-identical) pinned with full field-level `to_bits()` equality tests (`n1_equivalence_multi_matches_scalar`, `n1_equivalence_holds_on_multi_hop_target`), beyond the construction guarantee above.

## Deviations from intent

- **Duplicate target items are summed, not refused.** The RFC left this an open decision ("decide and document; refusing duplicates with a typed error is also acceptable"). Chose summing — see the RFC's Phase 1 decision log for the reasoning (less surprising for a caller building a target list programmatically; no new error variant needed). Verified bit-identical to the equivalent single combined-rate request.
- **DI-coupling guard's payoff is defensive, not exercised by the KC2 fixture.** Row algebra shows the live EC+AC numbers never actually reach the false-coupling coincidence the guard exists to close (supply != demand there for any nonzero target rate, verified by temporarily removing the guard and re-running). Proved the guard directly with a synthetic unit test instead (`netflow::tests::di_coupling_guard_suppresses_target_item_coupling`) rather than relying on a fixture that happens not to trigger it. Documented in the RFC's decision log so Phase 2/3 don't expect a visible fixture-level effect from this specific change.
- **No dedicated multi-target cycle-refusal test.** The retry loop's cycle-handling code is literally unchanged (confirmed target-count-agnostic, matching the RFC's prediction). Tested the machine-incompatibility typed-refusal path under N=2 instead (one satisfiable target alongside one that isn't) as the representative typed-refusal proof; a deterministic multi-target cycle fixture would cost materially more to build for the same evidentiary value. Called out explicitly as a scope stop, not a silent gap.
- **`surplus_outputs`/`external_outputs` overlap semantics documented, not exercised by a passing test.** A target item can legitimately appear in both lists (surplus beyond its own requested rate, driven by a sibling target's higher demand for the same item) — verified by direct row-algebra, not by a constructed live example (constructing one deterministically through the free-cost LP's oil-path retry logic was judged not worth the fragility for this phase). Flagged for Phase 2 as a new *instance* of dual-purpose-lane provisioning, not a new mechanism.

## Models / contracts touched

`SolverResult.external_outputs`/`surplus_outputs` semantics under multi-target (documented in netflow.rs doc comments and the RFC decision log — no field/type changes). `docs/rfc-062-multi-target-outputs.md` gets its Phase 1 decision-log entry. No other contract docs touched.