### PR TITLE
ci(review): second-opinion reviewer (DeepSeek/OpenRouter) — phase 1: add workflow

### DIFF
--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -1,8 +1,9 @@
 # Independent PR reviewer: the storkme/second-opinion action driving DeepSeek
-# V4 Flash via OpenRouter. Replaced claude-code-review.yml as the CI reviewer
-# on 2026-08-01 — CI reviews were consuming the Claude subscription's usage
-# windows; this runs on metered OpenRouter credit (~cents/PR) instead.
-# claude-code-review.yml is parked, not deleted — see docs/review-bot.md.
+# V4 Flash via OpenRouter. Takes over from claude-code-review.yml as the CI
+# reviewer (2026-08-01) — CI reviews were consuming the Claude subscription's
+# usage windows; this runs on metered OpenRouter credit (~cents/PR) instead.
+# The claude workflow is parked (not deleted) in the phase-2 PR of the swap;
+# until that merges both reviewers run. See docs/review-bot.md.
 #
 # Needs one repo secret: OPENROUTER_API_KEY.
 name: Second Opinion
@@ -10,6 +11,13 @@ name: Second Opinion
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    # KNOWN GAP (from this workflow's own first review, #561): no `edited`
+    # type, so a base-branch retarget — which rewrites the effective diff
+    # without a new head SHA — keeps the old SHA's green check. Adding the
+    # trigger wouldn't help yet: the runner's per-SHA marker comment would
+    # suppress the re-review anyway, and the action exposes no force input.
+    # Until upstream grows one, re-review base-retargeted PRs session-side
+    # (the stacked-PR retarget-to-main case is the one that occurs here).
 
 # One run per PR; a new push supersedes the old run's SHA, so cancelling is
 # safe. No `edited` trigger (unlike the parked claude-review workflow): this
@@ -28,9 +36,12 @@ jobs:
     # The gates live lower instead: the runner itself skips drafts with a
     # real green conclusion (exit 0), and the fork gate is on the step.
     runs-on: ubuntu-latest
-    # Worst case is K=3 sequential passes at the 900s per-pass timeout,
-    # plus the union merge call.
-    timeout-minutes: 50
+    # Worst case is K=3 sequential passes at the 900s per-pass timeout
+    # (45 min), plus the union-merge call (its own 600s HTTP timeout) and
+    # the docker-action image build. 50 left ~5 min of headroom and could
+    # kill a legitimately slow run of a required check (#561 review
+    # finding); typical observed runtime is ~15-20 min.
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -1,0 +1,65 @@
+# Independent PR reviewer: the storkme/second-opinion action driving DeepSeek
+# V4 Flash via OpenRouter. Replaced claude-code-review.yml as the CI reviewer
+# on 2026-08-01 — CI reviews were consuming the Claude subscription's usage
+# windows; this runs on metered OpenRouter credit (~cents/PR) instead.
+# claude-code-review.yml is parked, not deleted — see docs/review-bot.md.
+#
+# Needs one repo secret: OPENROUTER_API_KEY.
+name: Second Opinion
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+# One run per PR; a new push supersedes the old run's SHA, so cancelling is
+# safe. No `edited` trigger (unlike the parked claude-review workflow): this
+# reviewer files no description-scoped findings, so the event-class keying
+# saga (#521) does not apply here — a plain per-PR group is correct.
+concurrency:
+  group: second-opinion-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  second-opinion:
+    # NO job-level `if` — same reasoning as the parked claude-review job
+    # (#497): this check is REQUIRED on main, and a job skipped by a
+    # job-level `if` publishes a check run with conclusion `skipped`, whose
+    # required-check semantics are not something to bet a merge queue on.
+    # The gates live lower instead: the runner itself skips drafts with a
+    # real green conclusion (exit 0), and the fork gate is on the step.
+    runs-on: ubuntu-latest
+    # Worst case is K=3 sequential passes at the 900s per-pass timeout,
+    # plus the union merge call.
+    timeout-minutes: 50
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Second opinion review
+        # Fork PRs get no secrets on `pull_request` (by design, not a leak),
+        # so the action would fail on an empty key and red an unclearable
+        # required check for an outside contributor. Such PRs need
+        # session-side review — same rule as workflow-file PRs (CLAUDE.md
+        # "Workflow"). The skipped step still yields a real job conclusion.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: storkme/second-opinion@v1
+        with:
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          # DeepSeek V4 Flash (2026-07-31 release): 1M context, priced at
+          # ~$0.14/M input. Pinned rather than left to the action's default
+          # for the same reason claude-review pinned its model: review
+          # quality and cost both depend on it.
+          model: deepseek/deepseek-v4-flash-0731
+          # Flash-tier model, so union 3 independent agentic passes — the
+          # recall lever the second-opinion README prescribes for weaker
+          # models. Passes are sampled; the union keeps a finding if ANY
+          # pass raises it. Still ~cents per PR at this pricing.
+          k: "3"
+          # The 60k default was sized for 128k-context models. This model
+          # has 1M context, and layout-engine PRs here routinely exceed
+          # 60k chars of diff.
+          max-diff-chars: "200000"
+          # guidance-file: .github/review-guidance.md
+          # ^ enable once the checklist is bootstrapped from review history
+          #   (second-opinion-bootstrap) and committed.

--- a/scripts/review-gate.sh
+++ b/scripts/review-gate.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# review-gate.sh — wait for the claude-review check correctly, and (optionally)
+# review-gate.sh — wait for the CI review check correctly, and (optionally)
 # make it a required status check on main.
+#
+# The check is `second-opinion` since 2026-08-01 (DeepSeek via OpenRouter —
+# see .github/workflows/second-opinion.yml); it was `claude-review` before
+# that, and the incident below is from that era. Override with CHECK=.
 #
 # Why this exists: on 2026-07-29 a session polled a PR's merge readiness with a
 # hand-rolled loop testing `mergeStateStatus != "PENDING"`. GitHub reports a
@@ -15,15 +19,16 @@
 # for the absence of a value you guessed at.
 #
 # Usage:
-#   scripts/review-gate.sh wait <pr>       # block until claude-review completes
+#   scripts/review-gate.sh wait <pr>       # block until the review check completes
 #   scripts/review-gate.sh status          # report main's protection state
-#   scripts/review-gate.sh require         # make claude-review required on main
+#   scripts/review-gate.sh require         # make the review check required on main
 #   scripts/review-gate.sh unrequire       # remove that protection
 set -euo pipefail
 
 REPO="${REPO:-storkme/spaghettio}"
-CHECK="${CHECK:-claude-review}"
-TIMEOUT="${TIMEOUT:-1500}"   # 25 min; a full review runs 8-11.
+CHECK="${CHECK:-second-opinion}"
+TIMEOUT="${TIMEOUT:-1500}"   # 25 min; claude-review ran 8-11, second-opinion's
+                             # K=3 flash passes should land well inside this.
 
 usage() { sed -n '2,25p' "$0"; exit 2; }
 

--- a/scripts/review-gate.sh
+++ b/scripts/review-gate.sh
@@ -27,8 +27,11 @@ set -euo pipefail
 
 REPO="${REPO:-storkme/spaghettio}"
 CHECK="${CHECK:-second-opinion}"
-TIMEOUT="${TIMEOUT:-1500}"   # 25 min; claude-review ran 8-11, second-opinion's
-                             # K=3 flash passes should land well inside this.
+TIMEOUT="${TIMEOUT:-3900}"   # 65 min: outlasts the second-opinion job's own
+                             # 60-min timeout-minutes, so `wait` reports the
+                             # check's real conclusion instead of a false
+                             # timeout (#561 review finding). Typical runs
+                             # are ~15-20 min; claude-review's were 8-11.
 
 usage() { sed -n '2,25p' "$0"; exit 2; }
 
@@ -79,7 +82,7 @@ cmd_status() {
 #     bypass the requirement, so `gh pr merge` still merges through a pending
 #     review. Blocks nobody here; effectively cosmetic for this repo.
 #   enforce_admins=true  — the requirement actually binds. It also blocks direct
-#     pushes to main for everyone, and if claude-review cannot run at all
+#     pushes to main for everyone, and if the review check cannot run at all
 #     (secret rotated, action outage) nothing merges until protection is
 #     loosened. That is the point, and it is a real operational cost.
 #


### PR DESCRIPTION
## Intent

CI PR reviews currently run on the Claude subscription (claude-code-review.yml) and are eating its usage windows. Swap the CI reviewer to the [second-opinion](https://github.com/storkme/second-opinion) action driving `deepseek/deepseek-v4-flash-0731` via OpenRouter (~cents/PR, metered credit, no subscription impact). User-requested 2026-08-01.

## Scope

- **In:** `.github/workflows/second-opinion.yml` (new check: `second-opinion`; K=3 union, 200k diff cap, fork-gated at step level, no job-level `if` per #497); `scripts/review-gate.sh` default `CHECK` → `second-opinion`, `TIMEOUT` → 3900s.
- **Out (phase 2, #562):** parking claude-code-review.yml, CLAUDE.md + docs/review-bot.md updates. Two-phase because `pull_request` runs use workflow versions from the PR merge ref — a single PR de-triggering claude-review could never satisfy the currently-required `claude-review` check and would deadlock.
- **Out:** `.github/review-guidance.md` bootstrap (commented hook left in the workflow); base-retarget re-review (documented known gap in the workflow — needs an upstream `force` input past the runner's per-SHA marker).

## Verification

- Live end-to-end test on this PR itself: the `second-opinion` check ran (12m9s), posted a K=3 union review, and passed; the pre-secret draft run correctly FAILED the check (fail-on-degraded tripwire proven).
- Round-1 findings from that self-review triaged and fixed in 2a882d7e (see PR comment for dispositions).
- Independent session-side adversarial review (required for workflow-file PRs): verified action input names against action.yml, draft/fork gating by source trace, check-run name = job id `second-opinion` live, ci.yml workflow-guard unaffected.
- Rust/web checkboxes: N/A — no code touched.

## Deviations from intent

The deferred plan in session memory was ENGINE=claude on the desktop watcher; superseded by user request today: OpenRouter/DeepSeek via the GitHub Action instead (also removes the licensing question entirely).

## Decisions (recorded per CLAUDE.md — no RFC owns this pipeline)

- Making `second-opinion` a **required** check deliberately overrides the upstream README's "advisory, never a merge gate" guidance — continuing the claude-review precedent (required since 2026-07-29), accepting that K=3 sequential OpenRouter passes widen the SPOF surface of an admin-binding block. Escape hatch: `scripts/review-gate.sh unrequire`. Also recorded in docs/review-bot.md's status header (#562).

## Models / contracts touched

Merge-protocol contract: required check on main becomes `second-opinion` after the flip below.

## Sequencing (do not deviate)

1. ~~Set `OPENROUTER_API_KEY` repo secret~~ ✅ → ~~mark ready~~ ✅ → checks pass → merge.
2. `scripts/review-gate.sh require` (flips required context to `second-opinion`).
3. **Only then** mark #562 ready-for-review: its merge ref strips claude-review's triggers and second-opinion isn't on its base until this merges, so marking it ready early leaves its head with NO review check — after the flip it would sit "Expected — waiting for status" indefinitely (adversarial-review finding). The post-flip `ready_for_review` event fires a fresh second-opinion run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)