### PR TITLE
docs(rfc-064): Phase 2 Stage A dry-sweep results + Stage B pick-up notes

### DIFF
--- a/docs/rfc-064-spaghetti-objective.md
+++ b/docs/rfc-064-spaghetti-objective.md
@@ -1,9 +1,9 @@
 # RFC-064: The spaghetti objective — aspect ratio + belt-transit under sim-anchored never-worse gates
 
-Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phase 1 complete
-(2026-08-01): spike measured admissibility below the 25% bar; folding ships
-as an explicit user knob (this PR). Next: Phase 2 (undergroundify default-on
-sweep).**
+Registry: [`rfcs.md`](rfcs.md). Status: **Active — Phases 0–1 complete;
+Phase 2 Stage A (dry sweep) complete 2026-08-01 with zero new errors
+corpus-wide, Stage B (68-run sim campaign) PARKED with pick-up notes in the
+decision log. Resume at "Stage B pick-up notes"; merge PR #565 first.**
 Successor-in-reframing to
 [`rfc-063-compaction-primitives.md`](rfc-063-compaction-primitives.md), whose
 Phase A/B kills answered a different question honestly and stand. Evidence
@@ -955,3 +955,56 @@ nothing else cross-depends). A phase's kill does not cancel the others.
   auto-selection wiring remains open to a future phase only via the
   finding-2 baseline-comparison rule and per-fixture sim-anchoring (Gate
   step 4).
+
+- **2026-08-01 — Phase 2 Stage A (dry sweep) executed: gate-relevant
+  results in hand; Stage B (sim campaign) specified and PARKED for session
+  wrap — pick-up notes below.** Dry sweep: all 35 corpus fixtures (the
+  enumeration is `survey_fixtures()` in `crates/core/tests/e2e.rs`,
+  currently on PR #565's branch), native vs `compact_layout: true` from
+  identical solves, release build, no sims. Findings: (1) 34/35 change
+  geometry; the exception (`stress_advanced_circuit_45s_from_plates`,
+  11,863 entities, the corpus's largest) is byte-identical and drops out
+  of the sim bill. (2) **Zero new Error-severity categories corpus-wide**
+  — the dry half of the never-worse gate holds everywhere. (3) Two
+  fixtures that are belt-detour-clean at native each gain one
+  `belt-detour` warning when compacted (`tier2_electronic_circuit_from_ore`
+  0→1, `tier5_processing_unit_from_ore_am3` 0→1) — compaction *creates*
+  detours; new finding, neither fixture among the known detour pathologies.
+  (4) AR_score range −0.467 to +0.286, **9/35 fixtures regress on aspect
+  ratio** (worst: `tier3_advanced_oil_processing_multi_machine`, pure-pipe)
+  — undergroundify optimizes area, not shape; relevant to Phase 3+ tension,
+  not to this phase's throughput-only gate. (5) Transit proxy (run-level
+  total belt/UG length — explicitly NOT the gated rate-weighted per-edge
+  metric; basis flagged per-row in the results) never negative: 0 to
+  +0.119. (6) ΔEntities% 0 to −30.45%, median −9.13%, nothing near the
+  +52% WARN. (7) All 5 existing blessed sim baselines are stale against
+  today's geometry (gear10 ≈5% entity drift; ec10 ≈38% and likely a
+  different configuration per RFC-050's own text) → every fixture needs a
+  fresh native run. **Sim bill: 34 fixtures × 2 runs = 68.** Artifacts:
+  scratch (ephemeral); driver + full per-fixture JSON preserved host-local
+  at `crates/core/examples/rfc064_phase2_dry_sweep.rs` /
+  `..._results.json` (gitignored); this entry is the durable record and the
+  sweep re-runs in under a minute. **Stage B pick-up notes (next session
+  starts here):** batch alpha = first 10 of the cheapest-informative-first
+  order (`tier3_heavy_oil_cracking`, `tier3_advanced_oil_processing_multi_machine`,
+  `tier3_sulfuric_acid`, the three self-loop fixtures,
+  `tier1_iron_gear_wheel`, then `tier4_advanced_circuit_from_plates`
+  (best-AR), `tier1_iron_gear_wheel_from_ore` (worst-AR-with-belts), and
+  the two belt-detour-interaction fixtures pulled forward), native+compact
+  per fixture, warmup triaged (deep/from_ore/tier4+/stress = 288000;
+  genuinely shallow may use harness default, choice documented per
+  fixture), ≤3 concurrent runs, adjudication = compacted ≥ native's own
+  measured throughput within ±2% noise (both-miss-plan equally =
+  pre-existing issue, not a Phase 2 regression). Kill criterion unchanged:
+  any regression on a today-clean fixture → stays opt-in + tracked defect,
+  no gate-weakening. A batch-alpha agent was launched and aborted
+  pre-first-sim during session wrap (nothing measured, nothing spent).
+  Blocked-adjacent: PR #565 (belt-detour check + the corpus enumeration
+  this sweep reuses) is approved-by-checks but waiting on the new
+  `second-opinion` required context, which failed once on
+  infrastructure (K=3 passes ran; the merge step returned no usable
+  content → fail-on-degraded) with a re-run in flight at wrap time —
+  merge it before Stage B, and if the reviewer flakes again, that is a
+  reliability defect in the required check to raise with its owner, not a
+  reason to hand-poll or weaken gates ad hoc (escape hatch, owner-authorized
+  only: `scripts/review-gate.sh unrequire`).

--- a/docs/spare-compute-playbook.md
+++ b/docs/spare-compute-playbook.md
@@ -1,0 +1,103 @@
+# Spare-compute playbook
+
+**Followups-class doc.** Jobs for when there is lots of local compute but
+little frontier-agent budget — each executable by a basic local agent
+(qwen-class, e.g. the pi-coding-agent container in this repo) following the
+recipe verbatim. Written 2026-08-01. Status: none started.
+
+## Ground rules for the local agent (read first, apply to every job)
+
+- **Capture, don't interpret.** Save every raw output (JSON, logs, .fls,
+  bp.txt, PNGs). A later session does the analysis. Never summarize-and-
+  discard; disk is the cheap resource.
+- **Read-only repo.** No commits, no branch changes, no golden blessing
+  (`SPAGHETTIO_STRESS_GOLDEN` stays unset), no cache blessing. Artifacts go
+  to a dated directory under `~/spaghettio-corpora/<job>/<date>/`.
+- **Stamp provenance in every artifact dir**: `git rev-parse HEAD`, `rustc
+  --version`, Factorio version, and the exact command used. (Sim results
+  are tech-state- and version-sensitive; unstamped data is undiagnosable.)
+- **One row per instance** in any index file — never aggregate counts only.
+- **Fixed retry rule**: any command that fails gets exactly one retry; a
+  second failure is recorded as a row (`status: failed`, stderr tail
+  attached) and the loop continues. Never debug, never tune.
+
+## Job 1 — Scaling atlas (highest value per compute-hour)
+
+**What**: sweep recipe × rate × options; record metrics + snapshot + PNG
+per cell so scaling behavior becomes *visible*.
+
+**Grid**: ~10 representative recipes (gear, EC, AC, plastic, sulfur, PU,
+low-density-structure, chem/util science, mil science) × rates
+{1, 2, 5, 10, 15, 22, 30, 45, 60}/s × options {native, `compact=1`,
+`fold=1`} × belt tier per rate feasibility. ~800–1200 cells.
+
+**How**: a Rust driver modeled on
+`crates/core/examples/rfc064_phase2_dry_sweep.rs` (preserved on the dev
+host; the pattern: build solve → layout per option → collect) emitting per
+cell: dims, AR, entities, belts, machine count, validator issue categories
+(per category, per instance), belt-detour count, refusal/error if the build
+fails, wall-time. Dump `.fls` via `SPAGHETTIO_DUMP_SNAPSHOTS` machinery and
+`export_blueprint` string. PNGs: the dev server + a playwright screenshot
+loop over snapshot loads (the RFC-064 Phase 0 calibration built exactly
+this pipeline: load .fls, hide sidebar, zoom-to-fit, screenshot). Finish
+with a contact-sheet HTML (labels + thumbnails, grouped by recipe, rate
+ascending) so a human can scan 1000 layouts in minutes.
+
+**Later consumption**: where does AR blow up, where do refusals cluster,
+at which rates does lane-splitting/balancer machinery kick in and what
+does it cost. Directly feeds RFC-064 Phases 3–5 targeting.
+
+## Job 2 — Sim baseline bank (RFC-064 Phase 2 Stage B and beyond)
+
+**What**: the 68-run Phase 2 campaign (spec: RFC-064 decision log, "Stage
+B pick-up notes") and then measured native baselines for the full corpus.
+Every run: `cargo run --release -p spaghettio_sim_harness -- run --bp ...
+--manifest ... --warmup <per spec> --out <dir>/fixture__variant.json`,
+≤3 concurrent, poll report files to completion. Adjudication rows only
+(compacted-vs-native produced/delivered); verdicts are for a smart session.
+A complete baseline bank makes every future layout change regression-
+checkable by rerunning and diffing — the single most durable asset spare
+compute can buy this repo.
+
+## Job 3 — Whole-recipe-DB robustness fuzz
+
+**What**: every recipe in `crates/core/data/recipes.json` × a small rate
+ladder × input-set variants → run solve+layout+validate, bucket outcomes:
+OK-clean / OK-with-warnings (categories listed) / typed refusal (which) /
+panic (backtrace saved) / timeout. Output: one CSV row per attempt + a
+reproducer URL per non-clean outcome (the web app URL scheme encodes
+everything). **Why**: the tetris direction's declared risk is engine
+robustness; this maps the refusal/panic surface exhaustively so router
+investment is aimed by data. A panic corpus with reproducers is gold.
+
+## Job 4 — Fold + detour maps over the full DB
+
+**What**: (a) `search_snake_fold` admissibility over every recipe/rate in
+Job 3's grid (which shapes fold, dominant refusal otherwise — extends the
+14-fixture Phase 1 spike to the whole space); (b) belt-detour measurement
+(`measure_belt_runs`, on main once PR #565 merges) over the same grid —
+detour hotspot map by recipe/rate/strategy. Both are pure loops over
+existing pub APIs.
+
+## Job 5 — Community blueprint survey
+
+**What**: run `blueprint-analyze --batch --json` over large community
+blueprint collections (user supplies the dumps; the tool already expands
+books). Record per blueprint: entity mix, dims, AR, belt/UG counts,
+machine spacing stats. **Why**: empirical anchors for the spaghetti
+objective — what do *human*-built factories measure as on AR and belt
+length? Currently the objective is calibrated on N=1 owner judgment;
+a distribution over thousands of human designs is the cheapest possible
+second calibration source.
+
+## Job 6 — Long-horizon soak sims
+
+**What**: flagship fixtures (mil5ore folded, EC@30, PU@2) at very long
+sim horizons (hours of game time, checkpoint series on) to catch slow
+drift the standard measurement window misses (buffer oscillation,
+gradual starvation). Low priority; run when Jobs 1–2 are done.
+
+## Suggested order
+
+Job 2 (unblocks RFC-064 Phase 2 directly) → Job 1 (atlas) → Job 3 (fuzz)
+→ Job 4 → Job 5 (needs user-supplied dumps) → Job 6.


### PR DESCRIPTION
## Intent

Record Phase 2's dry-stage results and park Stage B with complete pick-up notes (session wrap; owner running low on usage). A cold session resumes from the decision log's "Stage B pick-up notes" without rediscovery.

## Scope

Docs only: decision-log entry + status banner in docs/rfc-064-spaghetti-objective.md.

## Verification

Numbers from the dry-sweep driver run (release, all 35 fixtures, 0 skipped); driver + full JSON preserved host-local (gitignored examples). Key gate-relevant result: zero new Error-severity categories corpus-wide under compact_layout.

## Deviations

Stage B batch alpha was launched then aborted pre-first-sim for the wrap — nothing measured, nothing spent, restart is cheap by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeZALshRuEnoDRpy3sYTbe