### PR TITLE
fix(meter): F5a stacked-PTG isolation edge (#570 follow-up)

### DIFF
--- a/crates/meter/src/fluid.rs
+++ b/crates/meter/src/fluid.rs
@@ -175,16 +175,17 @@ pub fn build_networks(
         // underground pairing handled by F4 below.
         let dir = n.dir.unwrap();
         let surf = (x + dir.delta().0, y + dir.delta().1);
-        if is_pipe(surf) {
-            union(&mut parent, &mut rank, (x, y), surf);
-        }
-        // F5b: two PTGs whose surface mouths face each other across a shared
-        // edge merge (no `pipe` entity needed).
-        let mouth = (x + dir.delta().0, y + dir.delta().1);
-        if let Some(m) = pipe.get(&mouth) {
-            if m.ptg && m.dir.map(|md| md == Dir::opp_dir(dir)).unwrap_or(false) {
-                union(&mut parent, &mut rank, (x, y), mouth);
+        match pipe.get(&surf) {
+            // A regular pipe opens on every side, so it joins the mouth.
+            Some(p) if !p.ptg => union(&mut parent, &mut rank, (x, y), surf),
+            // F5b: a PTG whose surface mouth faces back toward this PTG merges
+            // across their shared edge.
+            Some(p) if p.ptg && p.dir == Some(Dir::opp_dir(dir)) => {
+                union(&mut parent, &mut rank, (x, y), surf)
             }
+            // A PTG that does NOT open back (e.g. a same-facing stacked PTG)
+            // does not connect to this mouth (F5a): the lines stay isolated.
+            _ => {}
         }
     }
 
@@ -390,6 +391,35 @@ mod tests {
         assert_ne!(
             ids[0], ids[1],
             "perpendicular-adjacent PTGs must not merge (F5a)"
+        );
+    }
+
+    /// F5a/F5b: a PTG whose surface mouth rests against ANOTHER PTG that does
+    /// not open back must not merge — the mouth only joins a regular pipe or a
+    /// back-facing PTG (F5b). Pins the stacked-trunk isolation that a plain
+    /// "union whatever is on the mouth tile" would break. (No underground
+    /// partner is present, so F4 pairing stays out of the way.)
+    #[test]
+    fn stacked_same_facing_ptgs_stay_isolated() {
+        // B at (0,0) faces North (mouth (0,-1), port there). A at (0,1) also
+        // faces North, so A's mouth (0,0) rests on B's back — B does not open
+        // toward A. If A's mouth wrongly joined B, they would be ONE network.
+        let pipes = vec![
+            (0i32, 0i32, "pipe-to-ground", Dir::North),
+            (0i32, 1i32, "pipe-to-ground", Dir::North),
+        ];
+        let ports = vec![MachPort {
+            machine: 0,
+            x: 0,
+            y: -1,
+            item: 1,
+            is_input: true,
+        }];
+        let sys = build_networks(&pipes, &ports, &[]);
+        assert_eq!(
+            sys.networks.len(),
+            2,
+            "B's pipe and A's pipe must remain separate components"
         );
     }
 }

--- a/docs/meter-divergence.md
+++ b/docs/meter-divergence.md
@@ -49,3 +49,17 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
   cracking chemical-plants run slightly starved (hold ~75% of a per-craft
   need). Worth a calibration fixture one day; not a regression vs Phase A
   (which could not route fluids at all).
+
+## Deliberately-not-modelled (decision log)
+
+- **Byproduct backpressure.** The meter drains every unconsumed producer fluid
+  unit as `delivered` and never stalls a producer on a full fluid output, so a
+  multi-output recipe (AOP heavy/light/petroleum) with an unhandled byproduct
+  reads its *maximum* throughput rather than stalling as real Factorio would.
+  This is a **conscious choice, not a bug**: the meter's stated philosophy
+  (see `factory.rs` header) is to drain outputs so measurement is not falsified
+  by backpressure, matching the sim harness's remove-mode-chest methodology that
+  the meter calibrates against. Consistent with that, all 8 fluid-target corpus
+  fixtures are uncompared (no sim baseline), so this divergence is unverifiable
+  and would only matter if a sim-baselined byproduct-loop fixture joined the
+  corpus. Revisit then; recorded so the call is explicit. (2026-08-03)

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -1,9 +1,10 @@
 # Meter fluid modelling — follow-ups (#570)
 
-**Status (2026-08-03): Phase A landed (machine fluid + port-adjacency);
-Phase B LANDED — pipe networks + pipe-fast/balanced delivery. Calibration now
-within ±10pp on the whole compared corpus EXCEPT `tier5_processing_unit_from_ore_am3`
-(−13%, a solid belt-delivery residual, not fluid).** #570.
+**Status (2026-08-03, follow-up `f5a-ptg-edge`): Phase A + B LANDED and merged
+(#571). Calibration within ±10pp on the whole compared corpus EXCEPT
+`tier5_processing_unit_from_ore_am3` (−13%, a solid belt-delivery residual, not
+fluid). CI second-opinion findings triaged: F5a stacked-PTG edge FIXED;
+byproduct backpressure consciously rejected (see below).** #570.
 
 Phase B replaced Phase A's port-adjacency `tick_fluids` (which delivered fluid
 one unit a tick and throttled petroleum→plastic→AC→PU to ~20%) with a real pipe
@@ -63,23 +64,43 @@ closed — keeps crossing/stacked fluid lines isolated).
   belt cycle — see [`meter-divergence.md`](meter-divergence.md)).
 - Log any residual divergence in [`meter-divergence.md`](meter-divergence.md).
 
-## Next steps (uncommitted for this thread)
+## Next steps / open items (2026-08-03)
 
-1. **Confirm/close the PU-from-ore −13%.** Its census shows 30 `item_ingredient_shortage`
-   and only 1 fluid-short machine — petroleum/fluid are not the limit. Investigate
-   as a belt-model divergence (the fixture notes "26 tiles in a belt cycle").
-2. **Fluid byproduct backpressure (open gap, flagged by CI second-opinion).**
-   `tick_fluids` drains every unconsumed producer fluid unit as `delivered`, so a
-   machine whose fluid byproduct has no consumer (or more byproduct than consumer
-   capacity) never backs up: the excess drains and the producer keeps crafting at
-   full speed. In-game, excess heavy/light oil would fill the pipe and stall the
-   refinery, capping the target petroleum output too. This is entangled with the
-   sweep's `delivered_per_s` metric for fluid targets (AOP relies on the drain),
-   so it needs a deliberate design (e.g. only count drained surplus as delivered
-   when the item is a declared boundary-output/target, plus a fluid-output
-   full-output stall on the producer) — a follow-up, not a rushed change. The
-   current corpus has no over-capacity byproduct, so ±10pp stands.
-3. Re-bless any golden/snapshot baselines the corpus ingest tests depend on.
+### F5a stacked-PTG edge — FIXED
+A pipe-to-ground's surface mouth now only joins a regular pipe or a **back-facing**
+pipe-to-ground (F5b); a same-facing stacked PTG no longer merges the two lines.
+Previously the mouth unioned *any* pipe on its tile, breaking stacked-trunk
+isolation. New regression test (`stacked_same_facing_ptgs_stay_isolated`). Corpus
+sweep unchanged (zero regression).
+
+### Fluid byproduct backpressure — consciously REJECTED (kept drain philosophy)
+CI second-opinion flags that `tick_fluids` drains every unconsumed producer fluid
+unit as `delivered`, so a machine whose fluid byproduct has no consumer never
+backs up (in-game it would stall the producer). **Decision (2026-08-03): keep the
+documented max-throughput philosophy** — `factory.rs`'s header states outputs drain
+at the layout edge so "backpressure cannot falsify the measurement", matching the
+sim harness's remove-mode-chest methodology the meter calibrates against. Adding
+backpressure would make the meter *diverge* from its own reference instrumentation,
+and no compared fixture exercises a byproduct loop (all 8 fluid-target fixtures
+are NaN — no sim baseline), so it is unverifiable. The in-game viewpoint is valid
+Factorio physics but a different measurement philosophy; recorded here so the call
+is explicit, not accidental. Revisit only if a sim-baselined byproduct-loop fixture
+ever enters the corpus.
+
+### Confirm/close the PU-from-ore −13%
+Its census shows 30 `item_ingredient_shortage` and only 1 fluid-short machine —
+petroleum/fluid are not the limit. Investigate as a belt-model divergence (the
+fixture notes "26 tiles in a belt cycle"). See [`meter-divergence.md`](meter-divergence.md).
+
+### Remaining latent minors (recorded, not chased)
+- Fluid port *binding* keyed on machine name (always mirrored for refinery/foundry/
+  cryo) rather than actual orientation; a direction-0 instance would swap multi-fluid
+  faces. Not in the corpus (engine always mirrors those machines).
+- A machine short of both a solid and a fluid is classified `ItemIngredientShortage`
+  (solids checked first), under-counting `fluid_ingredient_shortage` in the census.
+- A chem-plant's two input ports feed one internal fluid box in-game; a single-fluid
+  pipe to the *other* port tile would silently starve it here.
+- Re-bless any golden/snapshot baselines the corpus ingest tests depend on.
 
 ## Constraints / gates
 


### PR DESCRIPTION
## Intent

Close the top follow-up from #570 / PR #571's CI review: a pipe-to-ground's
surface mouth unioned *any* pipe on its mouth tile, so a same-facing stacked
PTG merged two fluid lines that must stay isolated (F5a's "stacked/crossing
trunk lines" guarantee).

## Scope

- **In:** `fluid.rs` — a PTG's surface mouth now joins only a regular pipe or a
  back-facing PTG (F5b); a same-facing stacked PTG stays separate. New
  non-vacuous regression test. Docs: records the deliberately-kept backpressure
  philosophy (decision log) + updated follow-ups.
- **Out:** the fluid byproduct backpressure change is **consciously rejected**
  (keeps the meter's max-throughput drain philosophy, matching the sim harness);
  the PU-from-ore −13% and other latent minors remain documented follow-ups.

## Verification

- `cargo test --manifest-path crates/meter/Cargo.toml --lib` → 55 pass (incl.
  new `stacked_same_facing_ptgs_stay_isolated` + existing `perpendicular_ptg_neighbours_stay_isolated`)
- `cargo clippy --all-targets` (meter) clean
- Corpus sweep over `~/spaghettio-corpora/job2-sim-baselines/2026-08-01`:
  **zero regression** — all compared rows' percentages identical; only the
  documented PU-from-ore −13% outside ±10pp.

## Deviations

- Chose NOT to implement byproduct backpressure after analysis: it reverses the
  documented drain-outputs philosophy and would make the meter diverge from the
  sim harness's remove-mode methodology; all fluid-target fixtures are
  uncompared (no sim baseline), so it's unverifiable. Recorded as an explicit
  decision in `meter-divergence.md` + `meter-fluid-followups.md`.

## Models / contracts touched

- `docs/meter-fluid-followups.md`, `docs/meter-divergence.md` (decision log).