### PR TITLE
docs(meter): follow-up triage record + PU-from-ore deep dive (#570)

### DIFF
--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -186,11 +186,11 @@ impl Factory {
                     // x-descending (the measured rule in `spaghettio_core::
                     // fluid_ports`). The meter's blueprint decoder does not yet
                     // parse the `mirror` flag, so it keys the reversal on the
-                    // mirrored-machine set unconditionally — a known
+                    // mirrored-machine name unconditionally — a known
                     // simplification (a genuinely-unmirrored single instance of
                     // those three at some orientations would mis-bind), which a
                     // future change should fix by parsing `mirror` rather than
-                    // guessing from direction. For a single-fluid face
+                    // matching on the machine name. For a single-fluid face
                     // n-1-k == k, so this only matters for multi-fluid faces.
                     let mirrored = matches!(
                         e.name.as_str(),

--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -190,9 +190,10 @@ impl Factory {
                     // simplification (a genuinely-unmirrored single instance of
                     // those three at some orientations would mis-bind). A
                     // complete fix must key on BOTH a parsed mirror flag AND
-                    // the engine's direction+8 wire form (which the exporter
-                    // uses in place of mirror for these machines); the meter
-                    // currently reads neither. For a single-fluid face
+                    // the engine's direction+8 wire form (the engine exporter
+                    // omits the mirror key entirely for these rotation-mirrored
+                    // machines and encodes the mirror as the +8 rotation; the
+                    // meter reads neither today). For a single-fluid face
                     // n-1-k == k, so this only matters for multi-fluid faces.
                     let mirrored = matches!(
                         e.name.as_str(),

--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -195,12 +195,6 @@ impl Factory {
                         "oil-refinery" | "foundry" | "cryogenic-plant"
                     );
                     let mirrored = mirror_entity && e.direction == Dir::South;
-                    // chemical-plant / biochamber have TWO fluid ports per box
-                    // that share ONE internal fluid box in-game, so a
-                    // single-fluid recipe may feed (or draw) through EITHER
-                    // port tile — bind the one fluid to all of them, not just
-                    // its x-ordered tile.
-                    let shared_box = matches!(e.name.as_str(), "chemical-plant" | "biochamber");
                     let mi = machines.len();
                     if let Some(rdb) = db.recipes.get(recipe) {
                         let mut in_fluids: Vec<String> = Vec::new();
@@ -231,28 +225,15 @@ impl Factory {
                         // (i.e. fluid at recipe-index k -> port index n-1-k).
                         let n = in_fluids.len();
                         for (k, name) in in_fluids.iter().enumerate() {
-                            let item = items.intern(name).0;
-                            if shared_box && n == 1 {
-                                for &(px, py) in in_ports.iter() {
-                                    machine_ports.push(MachPort {
-                                        machine: mi,
-                                        x: e.x + px,
-                                        y: e.y + py,
-                                        item,
-                                        is_input: true,
-                                    });
-                                }
-                            } else {
-                                let pk = if mirrored { n - 1 - k } else { k };
-                                if let Some(&(px, py)) = in_ports.get(pk) {
-                                    machine_ports.push(MachPort {
-                                        machine: mi,
-                                        x: e.x + px,
-                                        y: e.y + py,
-                                        item,
-                                        is_input: true,
-                                    });
-                                }
+                            let pk = if mirrored { n - 1 - k } else { k };
+                            if let Some(&(px, py)) = in_ports.get(pk) {
+                                machine_ports.push(MachPort {
+                                    machine: mi,
+                                    x: e.x + px,
+                                    y: e.y + py,
+                                    item: items.intern(name).0,
+                                    is_input: true,
+                                });
                             }
                         }
                         // outputs
@@ -265,28 +246,15 @@ impl Factory {
                         out_ports.sort_by_key(|p| p.0);
                         let n = out_fluids.len();
                         for (k, name) in out_fluids.iter().enumerate() {
-                            let item = items.intern(name).0;
-                            if shared_box && n == 1 {
-                                for &(px, py) in out_ports.iter() {
-                                    machine_ports.push(MachPort {
-                                        machine: mi,
-                                        x: e.x + px,
-                                        y: e.y + py,
-                                        item,
-                                        is_input: false,
-                                    });
-                                }
-                            } else {
-                                let pk = if mirrored { n - 1 - k } else { k };
-                                if let Some(&(px, py)) = out_ports.get(pk) {
-                                    machine_ports.push(MachPort {
-                                        machine: mi,
-                                        x: e.x + px,
-                                        y: e.y + py,
-                                        item,
-                                        is_input: false,
-                                    });
-                                }
+                            let pk = if mirrored { n - 1 - k } else { k };
+                            if let Some(&(px, py)) = out_ports.get(pk) {
+                                machine_ports.push(MachPort {
+                                    machine: mi,
+                                    x: e.x + px,
+                                    y: e.y + py,
+                                    item: items.intern(name).0,
+                                    is_input: false,
+                                });
                             }
                         }
                     }
@@ -452,15 +420,14 @@ impl Factory {
     fn tick_fluids(&mut self) {
         let mut drained: FxHashMap<u16, u64> = FxHashMap::default();
         for net in &self.fluids.networks {
-            // Group ports by item. A shared-box machine (chem-plant/biochamber)
-            // contributes multiple ports for the same fluid in the same network
-            // — dedupe so it is not credited twice as a consumer/producer.
+            // Group ports by item.
             let mut by_item: FxHashMap<u16, (Vec<usize>, Vec<usize>)> = FxHashMap::default();
             for p in &net.ports {
                 let e = by_item.entry(p.item).or_default();
-                let bucket = if p.is_input { &mut e.1 } else { &mut e.0 };
-                if !bucket.contains(&p.machine) {
-                    bucket.push(p.machine);
+                if p.is_input {
+                    e.1.push(p.machine);
+                } else {
+                    e.0.push(p.machine);
                 }
             }
             for (item, (producers, consumers)) in by_item {

--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -188,9 +188,11 @@ impl Factory {
                     // parse the `mirror` flag, so it keys the reversal on the
                     // mirrored-machine name unconditionally — a known
                     // simplification (a genuinely-unmirrored single instance of
-                    // those three at some orientations would mis-bind), which a
-                    // future change should fix by parsing `mirror` rather than
-                    // matching on the machine name. For a single-fluid face
+                    // those three at some orientations would mis-bind). A
+                    // complete fix must key on BOTH a parsed mirror flag AND
+                    // the engine's direction+8 wire form (which the exporter
+                    // uses in place of mirror for these machines); the meter
+                    // currently reads neither. For a single-fluid face
                     // n-1-k == k, so this only matters for multi-fluid faces.
                     let mirrored = matches!(
                         e.name.as_str(),

--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -181,17 +181,26 @@ impl Factory {
                     // Collect this machine's fluid ports, bound to the recipe's
                     // fluid items (RFC-054 Phase B). Port fluid binding is
                     // x-ascending over each IO face EXCEPT on the machines the
-                    // engine mirrors (oil-refinery, foundry, cryogenic-plant),
-                    // whose exported orientation binds recipe fluids
-                    // x-descending (the measured rule in `spaghettio_core::
-                    // fluid_ports`; the exporter encodes the mirrored machine
-                    // as direction+8 with no mirror flag). For a single-fluid
-                    // face (basic-oil, plastic) n-1-k == k, so this only
-                    // matters for the multi-fluid faces those machines run.
-                    let mirrored = matches!(
+                    // engine mirrors, whose exported orientation binds recipe
+                    // fluids x-descending (the measured rule in
+                    // `spaghettio_core::fluid_ports`; the exporter encodes the
+                    // mirrored machine as direction+8 / South). `mirrored` is
+                    // therefore keyed on the machine being one of the mirrored
+                    // set AND actually placed in the mirrored (South)
+                    // orientation — a North-facing instance is unmirrored and
+                    // binds x-ascending. For a single-fluid face n-1-k == k, so
+                    // the distinction only matters for multi-fluid faces.
+                    let mirror_entity = matches!(
                         e.name.as_str(),
                         "oil-refinery" | "foundry" | "cryogenic-plant"
                     );
+                    let mirrored = mirror_entity && e.direction == Dir::South;
+                    // chemical-plant / biochamber have TWO fluid ports per box
+                    // that share ONE internal fluid box in-game, so a
+                    // single-fluid recipe may feed (or draw) through EITHER
+                    // port tile — bind the one fluid to all of them, not just
+                    // its x-ordered tile.
+                    let shared_box = matches!(e.name.as_str(), "chemical-plant" | "biochamber");
                     let mi = machines.len();
                     if let Some(rdb) = db.recipes.get(recipe) {
                         let mut in_fluids: Vec<String> = Vec::new();
@@ -222,15 +231,28 @@ impl Factory {
                         // (i.e. fluid at recipe-index k -> port index n-1-k).
                         let n = in_fluids.len();
                         for (k, name) in in_fluids.iter().enumerate() {
-                            let pk = if mirrored { n - 1 - k } else { k };
-                            if let Some(&(px, py)) = in_ports.get(pk) {
-                                machine_ports.push(MachPort {
-                                    machine: mi,
-                                    x: e.x + px,
-                                    y: e.y + py,
-                                    item: items.intern(name).0,
-                                    is_input: true,
-                                });
+                            let item = items.intern(name).0;
+                            if shared_box && n == 1 {
+                                for &(px, py) in in_ports.iter() {
+                                    machine_ports.push(MachPort {
+                                        machine: mi,
+                                        x: e.x + px,
+                                        y: e.y + py,
+                                        item,
+                                        is_input: true,
+                                    });
+                                }
+                            } else {
+                                let pk = if mirrored { n - 1 - k } else { k };
+                                if let Some(&(px, py)) = in_ports.get(pk) {
+                                    machine_ports.push(MachPort {
+                                        machine: mi,
+                                        x: e.x + px,
+                                        y: e.y + py,
+                                        item,
+                                        is_input: true,
+                                    });
+                                }
                             }
                         }
                         // outputs
@@ -243,15 +265,28 @@ impl Factory {
                         out_ports.sort_by_key(|p| p.0);
                         let n = out_fluids.len();
                         for (k, name) in out_fluids.iter().enumerate() {
-                            let pk = if mirrored { n - 1 - k } else { k };
-                            if let Some(&(px, py)) = out_ports.get(pk) {
-                                machine_ports.push(MachPort {
-                                    machine: mi,
-                                    x: e.x + px,
-                                    y: e.y + py,
-                                    item: items.intern(name).0,
-                                    is_input: false,
-                                });
+                            let item = items.intern(name).0;
+                            if shared_box && n == 1 {
+                                for &(px, py) in out_ports.iter() {
+                                    machine_ports.push(MachPort {
+                                        machine: mi,
+                                        x: e.x + px,
+                                        y: e.y + py,
+                                        item,
+                                        is_input: false,
+                                    });
+                                }
+                            } else {
+                                let pk = if mirrored { n - 1 - k } else { k };
+                                if let Some(&(px, py)) = out_ports.get(pk) {
+                                    machine_ports.push(MachPort {
+                                        machine: mi,
+                                        x: e.x + px,
+                                        y: e.y + py,
+                                        item,
+                                        is_input: false,
+                                    });
+                                }
                             }
                         }
                     }
@@ -417,14 +452,15 @@ impl Factory {
     fn tick_fluids(&mut self) {
         let mut drained: FxHashMap<u16, u64> = FxHashMap::default();
         for net in &self.fluids.networks {
-            // Group ports by item.
+            // Group ports by item. A shared-box machine (chem-plant/biochamber)
+            // contributes multiple ports for the same fluid in the same network
+            // — dedupe so it is not credited twice as a consumer/producer.
             let mut by_item: FxHashMap<u16, (Vec<usize>, Vec<usize>)> = FxHashMap::default();
             for p in &net.ports {
                 let e = by_item.entry(p.item).or_default();
-                if p.is_input {
-                    e.1.push(p.machine);
-                } else {
-                    e.0.push(p.machine);
+                let bucket = if p.is_input { &mut e.1 } else { &mut e.0 };
+                if !bucket.contains(&p.machine) {
+                    bucket.push(p.machine);
                 }
             }
             for (item, (producers, consumers)) in by_item {

--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -181,20 +181,21 @@ impl Factory {
                     // Collect this machine's fluid ports, bound to the recipe's
                     // fluid items (RFC-054 Phase B). Port fluid binding is
                     // x-ascending over each IO face EXCEPT on the machines the
-                    // engine mirrors, whose exported orientation binds recipe
-                    // fluids x-descending (the measured rule in
-                    // `spaghettio_core::fluid_ports`; the exporter encodes the
-                    // mirrored machine as direction+8 / South). `mirrored` is
-                    // therefore keyed on the machine being one of the mirrored
-                    // set AND actually placed in the mirrored (South)
-                    // orientation — a North-facing instance is unmirrored and
-                    // binds x-ascending. For a single-fluid face n-1-k == k, so
-                    // the distinction only matters for multi-fluid faces.
-                    let mirror_entity = matches!(
+                    // engine mirrors (oil-refinery, foundry, cryogenic-plant),
+                    // whose exported orientation binds recipe fluids
+                    // x-descending (the measured rule in `spaghettio_core::
+                    // fluid_ports`). The meter's blueprint decoder does not yet
+                    // parse the `mirror` flag, so it keys the reversal on the
+                    // mirrored-machine set unconditionally — a known
+                    // simplification (a genuinely-unmirrored single instance of
+                    // those three at some orientations would mis-bind), which a
+                    // future change should fix by parsing `mirror` rather than
+                    // guessing from direction. For a single-fluid face
+                    // n-1-k == k, so this only matters for multi-fluid faces.
+                    let mirrored = matches!(
                         e.name.as_str(),
                         "oil-refinery" | "foundry" | "cryogenic-plant"
                     );
-                    let mirrored = mirror_entity && e.direction == Dir::South;
                     let mi = machines.len();
                     if let Some(rdb) = db.recipes.get(recipe) {
                         let mut in_fluids: Vec<String> = Vec::new();

--- a/crates/meter/src/machine.rs
+++ b/crates/meter/src/machine.rs
@@ -285,22 +285,6 @@ impl Machine {
                 .all(|(id, amount)| self.fluid_input.get(id).copied().unwrap_or(0) >= *amount)
     }
 
-    /// The first unmet ingredient: an item id if a SOLID is short,
-    /// `None` if the machine has everything it needs.
-    fn missing(&self) -> Option<(u16, bool)> {
-        for (id, amount) in &self.ingredients {
-            if self.input.get(&id.0).copied().unwrap_or(0) < *amount {
-                return Some((id.0, false));
-            }
-        }
-        for (id, amount) in &self.fluid_needs {
-            if self.fluid_input.get(id).copied().unwrap_or(0) < *amount {
-                return Some((*id, true));
-            }
-        }
-        None
-    }
-
     /// Advance one tick.
     pub fn tick(&mut self) {
         self.emitted_this_tick.clear();
@@ -310,13 +294,17 @@ impl Machine {
         }
         if self.progress <= 0.0 {
             if !self.has_ingredients() {
-                // Distinguish a missing fluid from a missing solid so the
-                // census is comparable to the sim's.
-                self.state = if self
-                    .missing()
-                    .map(|(_, is_fluid)| is_fluid)
-                    .unwrap_or(false)
-                {
+                // Which shortage to report. The meter's purpose is surfacing
+                // fluid-starved machines, so a machine short on a fluid reads
+                // `FluidIngredientShortage` even when it is short on a solid
+                // too — the machine is blocked either way, and the fluid bind
+                // is the more actionable signal. (Census labels only; the
+                // rate measurement is unaffected.)
+                let fluid_short = self
+                    .fluid_needs
+                    .iter()
+                    .any(|(id, amt)| self.fluid_input.get(id).copied().unwrap_or(0) < *amt);
+                self.state = if fluid_short {
                     MachineState::FluidIngredientShortage
                 } else {
                     MachineState::ItemIngredientShortage
@@ -558,6 +546,30 @@ mod tests {
                 m.crafts > 0,
                 "fluid-fed sulfuric-acid must craft once water is delivered"
             );
+        }
+    }
+
+    /// When a machine is short on BOTH a solid and a fluid, the census must
+    /// report `FluidIngredientShortage` (the fluid bind is the actionable
+    /// signal) rather than letting the solid shortage mask it.
+    #[test]
+    fn both_fluids_and_solids_short_reports_fluid_shortage() {
+        let mut items = ItemInterner::default();
+        let m = Machine::new(
+            "chemical-plant",
+            "sulfuric-acid",
+            (0, 0),
+            (3, 3),
+            &mut items,
+            DEFAULT_BUFFER_CRAFTS,
+        );
+        if let Some(mut m) = m {
+            // Deliver nothing: every solid and the water are missing.
+            for _ in 0..600 {
+                m.tick();
+            }
+            assert_eq!(m.crafts, 0);
+            assert_eq!(m.state, MachineState::FluidIngredientShortage);
         }
     }
 

--- a/crates/meter/src/machine.rs
+++ b/crates/meter/src/machine.rs
@@ -311,8 +311,7 @@ impl Machine {
         if self.progress <= 0.0 {
             if !self.has_ingredients() {
                 // Distinguish a missing fluid from a missing solid so the
-                // census is comparable to the sim's (which labels a machine by
-                // whichever ingredient actually blocks next, solids-ordered).
+                // census is comparable to the sim's.
                 self.state = if self
                     .missing()
                     .map(|(_, is_fluid)| is_fluid)

--- a/crates/meter/src/machine.rs
+++ b/crates/meter/src/machine.rs
@@ -285,6 +285,22 @@ impl Machine {
                 .all(|(id, amount)| self.fluid_input.get(id).copied().unwrap_or(0) >= *amount)
     }
 
+    /// The first unmet ingredient: an item id if a SOLID is short,
+    /// `None` if the machine has everything it needs.
+    fn missing(&self) -> Option<(u16, bool)> {
+        for (id, amount) in &self.ingredients {
+            if self.input.get(&id.0).copied().unwrap_or(0) < *amount {
+                return Some((id.0, false));
+            }
+        }
+        for (id, amount) in &self.fluid_needs {
+            if self.fluid_input.get(id).copied().unwrap_or(0) < *amount {
+                return Some((*id, true));
+            }
+        }
+        None
+    }
+
     /// Advance one tick.
     pub fn tick(&mut self) {
         self.emitted_this_tick.clear();
@@ -294,17 +310,14 @@ impl Machine {
         }
         if self.progress <= 0.0 {
             if !self.has_ingredients() {
-                // Which shortage to report. The meter's purpose is surfacing
-                // fluid-starved machines, so a machine short on a fluid reads
-                // `FluidIngredientShortage` even when it is short on a solid
-                // too — the machine is blocked either way, and the fluid bind
-                // is the more actionable signal. (Census labels only; the
-                // rate measurement is unaffected.)
-                let fluid_short = self
-                    .fluid_needs
-                    .iter()
-                    .any(|(id, amt)| self.fluid_input.get(id).copied().unwrap_or(0) < *amt);
-                self.state = if fluid_short {
+                // Distinguish a missing fluid from a missing solid so the
+                // census is comparable to the sim's (which labels a machine by
+                // whichever ingredient actually blocks next, solids-ordered).
+                self.state = if self
+                    .missing()
+                    .map(|(_, is_fluid)| is_fluid)
+                    .unwrap_or(false)
+                {
                     MachineState::FluidIngredientShortage
                 } else {
                     MachineState::ItemIngredientShortage
@@ -546,30 +559,6 @@ mod tests {
                 m.crafts > 0,
                 "fluid-fed sulfuric-acid must craft once water is delivered"
             );
-        }
-    }
-
-    /// When a machine is short on BOTH a solid and a fluid, the census must
-    /// report `FluidIngredientShortage` (the fluid bind is the actionable
-    /// signal) rather than letting the solid shortage mask it.
-    #[test]
-    fn both_fluids_and_solids_short_reports_fluid_shortage() {
-        let mut items = ItemInterner::default();
-        let m = Machine::new(
-            "chemical-plant",
-            "sulfuric-acid",
-            (0, 0),
-            (3, 3),
-            &mut items,
-            DEFAULT_BUFFER_CRAFTS,
-        );
-        if let Some(mut m) = m {
-            // Deliver nothing: every solid and the water are missing.
-            for _ in 0..600 {
-                m.tick();
-            }
-            assert_eq!(m.crafts, 0);
-            assert_eq!(m.state, MachineState::FluidIngredientShortage);
         }
     }
 

--- a/docs/meter-divergence.md
+++ b/docs/meter-divergence.md
@@ -24,10 +24,11 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
     all ≈ −10%; petroleum-gas −17%); only the PU target reaches 99%. So plan is
     not the reference; the sim is.
   - The meter matches sim within ±4% on the whole direct chain: copper-plate
-    69.5 vs 71.98 (−3.4%, actually *better* than the sim), copper-cable 139 vs
-    143.9, iron-plate 41.9 vs 43.4, EC 41.5 vs 43.2, plastic 7.2 vs 7.2 (=),
-    AC 3.45 vs 3.59.
-  - The entire extra loss is in delivering EC to the PU machine: producer `m#310`
+    69.5 vs sim 71.98 (−3.4% — the meter is slightly *further* below plan),
+    copper-cable 139 vs 143.9, iron-plate 41.9 vs 43.4, EC 41.5 vs 43.2,
+    plastic 7.2 vs 7.2 (=), AC 3.45 vs 3.59. So the direct-production chain
+    tracks the sim closely; the order-of-magnitude-larger shortfall is PU alone.
+  - The extra loss is in delivering EC to the PU machine: producer `m#310`
     sits short on EC (12 of a 20/craft need) despite EC production (41.5/s)
     meeting total demand (AC ~6.9 + PU ~34 = ~41/s). The sim feeds PU fully.
   - The machine census is dominated by `full_output` + `working`; only ~9 are
@@ -38,13 +39,12 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
     many-EC-producers merge trunk into the few PU/AC consumers), which the meter
     steps in an arbitrary-but-deterministic order and which is the strong
     candidate for the delivery shortfall.
-- **Verdict**: a genuine belt-model divergence in the RFC-064 Phase 2 already-open
-  "input-delivery" class, on a single fixture whose sim baseline is itself noisy
-  (≈ −10% on everything). **Deferred, deliberately**: fixing it needs a
-  speculative belt-cycle-update-order / merge-priority model change that cannot
-  be validated against a clean reference on this fixture and would risk the ~40
-  fixtures that do agree. Track it under RFC-064 input-delivery; do not chase it
-  inside this meter-fluid thread. (See `rfc064-phase2-followups.md`.)
+- **Verdict**: a genuine belt-model divergence, on a single fixture whose sim
+  baseline is itself noisy (≈ −10% on everything). **Deferred, deliberately**:
+  fixing it needs a speculative belt-cycle-update-order / merge-priority model
+  change that cannot be validated against a clean reference on this fixture and
+  would risk the ~40 fixtures that do agree. Tracked as item 7 in
+  `rfc064-phase2-followups.md`; do not chase it inside this meter-fluid thread.
 - **Next**: investigate as a belt-throughput/cycle divergence, not a fluid one.
   Re-measure after any belt-network changes.
 

--- a/docs/meter-divergence.md
+++ b/docs/meter-divergence.md
@@ -32,8 +32,10 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
     sits short on EC (12 of a 20/craft need) despite EC production (41.5/s)
     meeting total demand (AC ~6.9 + PU ~34 = ~41/s). The sim feeds PU fully.
   - The machine census is dominated by `full_output` + `working`; only ~9 are
-    left short on a solid and one on a fluid, all downstream of the EC belt
-    (a precedence-sensitive number, so not a stable discriminator on its own).
+    left short on a solid and one on a fluid, all downstream of the EC belt.
+    Caveat: this "~9/1" split was captured on code that had the (later-reverted)
+    census-precedence change active, so it is precedence-sensitive and not
+    re-verified on the merged solids-first code — it is diagnostic, not load-bearing.
   - The fixture's wiring produces the **only** topology note in the corpus:
     *"26 tiles in a belt cycle; update order arbitrary"* — a cyclic belt (the
     many-EC-producers merge trunk into the few PU/AC consumers), which the meter
@@ -42,8 +44,11 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
 - **Verdict**: a genuine belt-model divergence, on a single fixture whose sim
   baseline is itself noisy (≈ −10% on everything). **Deferred, deliberately**:
   fixing it needs a speculative belt-cycle-update-order / merge-priority model
-  change that cannot be validated against a clean reference on this fixture and
-  would risk the ~40 fixtures that do agree. Tracked as item 7 in
+  change that cannot be validated against a clean reference on this fixture.
+  (Blast radius is lower than "the whole corpus": this fixture carries the only
+  cycle note, so a change gated on `CycleInUpdateOrder` would touch ~nothing
+  else — but it is still an unverifiable change on a fixture whose own sim is
+  noisy, which are the binding reasons to defer.) Tracked as item 7 in
   `rfc064-phase2-followups.md`; do not chase it inside this meter-fluid thread.
 - **Next**: investigate as a belt-throughput/cycle divergence, not a fluid one.
   Re-measure after any belt-network changes.

--- a/docs/meter-divergence.md
+++ b/docs/meter-divergence.md
@@ -30,8 +30,9 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
   - The entire extra loss is in delivering EC to the PU machine: producer `m#310`
     sits short on EC (12 of a 20/craft need) despite EC production (41.5/s)
     meeting total demand (AC ~6.9 + PU ~34 = ~41/s). The sim feeds PU fully.
-  - The machine census is `full_output 31`, `item_ingredient_shortage 9`,
-    `working 271`, `fluid_ingredient_shortage 1`.
+  - The machine census is dominated by `full_output` + `working`; only ~9 are
+    left short on a solid and one on a fluid, all downstream of the EC belt
+    (a precedence-sensitive number, so not a stable discriminator on its own).
   - The fixture's wiring produces the **only** topology note in the corpus:
     *"26 tiles in a belt cycle; update order arbitrary"* — a cyclic belt (the
     many-EC-producers merge trunk into the few PU/AC consumers), which the meter

--- a/docs/meter-divergence.md
+++ b/docs/meter-divergence.md
@@ -17,18 +17,33 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
 ### `tier5_processing_unit_from_ore_am3` — meter ≈ −13% (`produced`)
 
 - **meter**: processing-unit 1.716/s vs sim produced 1.987/s / delivered 1.961/s.
-- **Direction**: underproduction, not a fluid gap.
-- **Evidence it is not the fluid model**: the fixture's machine census shows
-  `product_column item_ingredient_shortage ≈ 30`, `fluid_ingredient_shortage = 1`,
-  and the refineries hold `crude=1400` / `water=700` (full buffers, never
-  starved) while crafting at the correct 300-tick cadence. All downstream items
-  (electronic-circuit 41.5/48, copper-cable 139/160, plastic 7.2/8) sit at
-  ~86–90%, i.e. the choke is upstream of fluid, in the solid belt delivery.
-- **Probable cause**: a solid-side belt-model gap on this deep/complex layout,
-  which the fixture itself flags with *"26 tiles in a belt cycle; update order
-  arbitrary"*. The sim (real Factorio) sustains ~98% here; the meter's belt
-  transport under-delivers ~13%. This is an RFC-064 Phase 2 open item
-  ("input-delivery … class items open"), orthogonal to the Phase B fluid work.
+- **Direction**: underproduction in the **downstream solid belt delivery**, not a
+  fluid gap. Deep-dive (2026-08-03) established this precisely:
+  - The **sim itself** under-produces almost everything on this fixture
+    (copper-plate 71.98/80, copper-cable 143.9/160, EC 43.2/48, plastic 7.2/8 —
+    all ≈ −10%; petroleum-gas −17%); only the PU target reaches 99%. So plan is
+    not the reference; the sim is.
+  - The meter matches sim within ±4% on the whole direct chain: copper-plate
+    69.5 vs 71.98 (−3.4%, actually *better* than the sim), copper-cable 139 vs
+    143.9, iron-plate 41.9 vs 43.4, EC 41.5 vs 43.2, plastic 7.2 vs 7.2 (=),
+    AC 3.45 vs 3.59.
+  - The entire extra loss is in delivering EC to the PU machine: producer `m#310`
+    sits short on EC (12 of a 20/craft need) despite EC production (41.5/s)
+    meeting total demand (AC ~6.9 + PU ~34 = ~41/s). The sim feeds PU fully.
+  - The machine census is `full_output 31`, `item_ingredient_shortage 9`,
+    `working 271`, `fluid_ingredient_shortage 1`.
+  - The fixture's wiring produces the **only** topology note in the corpus:
+    *"26 tiles in a belt cycle; update order arbitrary"* — a cyclic belt (the
+    many-EC-producers merge trunk into the few PU/AC consumers), which the meter
+    steps in an arbitrary-but-deterministic order and which is the strong
+    candidate for the delivery shortfall.
+- **Verdict**: a genuine belt-model divergence in the RFC-064 Phase 2 already-open
+  "input-delivery" class, on a single fixture whose sim baseline is itself noisy
+  (≈ −10% on everything). **Deferred, deliberately**: fixing it needs a
+  speculative belt-cycle-update-order / merge-priority model change that cannot
+  be validated against a clean reference on this fixture and would risk the ~40
+  fixtures that do agree. Track it under RFC-064 input-delivery; do not chase it
+  inside this meter-fluid thread. (See `rfc064-phase2-followups.md`.)
 - **Next**: investigate as a belt-throughput/cycle divergence, not a fluid one.
   Re-measure after any belt-network changes.
 

--- a/docs/meter-divergence.md
+++ b/docs/meter-divergence.md
@@ -10,7 +10,8 @@ or reveals a new one. Currently **one** residual.
 
 `meter sweep: 70 layouts measured, 41 compared`. Every compared fixture is
 within ±10pp of sim except the one below. AC/PU families that were −80% in
-Phase A are now within ±2% (AC) / −13% (PU-from-ore).
+Phase A are now within ±2% (the dedicated AC fixtures) / −13% (PU-from-ore; its
+in-fixture AC reads −3.9%).
 
 ## Open residual
 
@@ -23,10 +24,10 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
     (copper-plate 71.98/80, copper-cable 143.9/160, EC 43.2/48, plastic 7.2/8 —
     all ≈ −10%; petroleum-gas −17%); only the PU target reaches 99%. So plan is
     not the reference; the sim is. (Intermediates here are *measured production*
-    and do not reconcile arithmetically with the consumers — e.g. copper-cable
-    needs ~140 copper-plate/s but only ~72/s is produced, so copper-plate is
-    partly a boundary feed; treat the intermediate figures as indicative, not
-    load-bearing for the deferral's rationale.)
+    and do not always reconcile arithmetically with consumers — e.g. EC demand
+    from PU+AC ≈ 47/s vs ~43/s reported produced; the copper-plate→cable pair does
+    reconcile (1 plate → 2 cable). Treat the intermediate figures as indicative,
+    not load-bearing for the deferral's rationale.)
   - The meter matches sim within ±4% on the whole direct chain: copper-plate
     69.5 vs sim 71.98 (−3.4% — the meter is slightly *further* below plan),
     copper-cable 139 vs 143.9, iron-plate 41.9 vs 43.4, EC 41.5 vs 43.2,
@@ -60,7 +61,8 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
 ## Closed / moved entries
 
 - **AC / PU / AC-partitioned (~−80%)**: closed by Phase B pipe-fast, fair,
-  buffer-absorbing fluid routing. AC variants are now ±0–2%.
+  buffer-absorbing fluid routing. AC variants are now ±0–2% (the PU-from-ore
+  exception fixture's own AC is −3.9% by the same meter).
 - **`tier3_plastic_bar_from_crude` (~−80%)**: closed (now 10 = plan).
 - **AOP / refinery / sulfur / heavy-oil cracking (delivered)**: no divergence;
   the fluid networks (incl. the forced-pipe-isolation AOP) route correctly.

--- a/docs/meter-divergence.md
+++ b/docs/meter-divergence.md
@@ -22,7 +22,11 @@ Phase A are now within ±2% (AC) / −13% (PU-from-ore).
   - The **sim itself** under-produces almost everything on this fixture
     (copper-plate 71.98/80, copper-cable 143.9/160, EC 43.2/48, plastic 7.2/8 —
     all ≈ −10%; petroleum-gas −17%); only the PU target reaches 99%. So plan is
-    not the reference; the sim is.
+    not the reference; the sim is. (Intermediates here are *measured production*
+    and do not reconcile arithmetically with the consumers — e.g. copper-cable
+    needs ~140 copper-plate/s but only ~72/s is produced, so copper-plate is
+    partly a boundary feed; treat the intermediate figures as indicative, not
+    load-bearing for the deferral's rationale.)
   - The meter matches sim within ±4% on the whole direct chain: copper-plate
     69.5 vs sim 71.98 (−3.4% — the meter is slightly *further* below plan),
     copper-cable 139 vs 143.9, iron-plate 41.9 vs 43.4, EC 41.5 vs 43.2,

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -23,7 +23,7 @@ Result over the corpus (meter `delivered_per_s`/`produced_per_s` vs sim):
 gear exact; EC + stress-EC ±0–2%; AOP/refinery exact; **all AC variants now
 ±0–2% (were −80%)**; PU from ore −80% → −13%. The lone residual is PU-from-ore,
 whose census is dominated by `full_output`/`working` with ~9 machines left short
-on a solid and a 26-tile belt
+on a solid (diagnostic, pre-revert census code — see the PU entry) plus a 26-tile belt
 cycle — a solid-side belt-model gap (open RFC-064 Phase 2 item), not a fluid
 gap. Full divergence log:
 [`meter-divergence.md`](meter-divergence.md).
@@ -67,7 +67,8 @@ closed — keeps crossing/stacked fluid lines isolated).
 **Phase C — calibration (close to done; one open residual).**
 - Re-run the meter corpus sweep (`examples/sweep_corpus.rs`); all compared
   fixtures within ±10pp EXCEPT `tier5_processing_unit_from_ore_am3` at −13%
-  (a solid belt-delivery gap: ~9 machines short on a solid, 26-tile
+  (a solid belt-delivery gap: ~9 machines short on a solid (diagnostic, not
+  re-verified post-revert), 26-tile
   belt cycle — see [`meter-divergence.md`](meter-divergence.md)).
 - Log any residual divergence in [`meter-divergence.md`](meter-divergence.md).
 
@@ -113,11 +114,13 @@ An attempt to key `mirrored` on orientation (`mirror_entity && direction == Sout
 was proposed and then **reverted on review**: community blueprints re-freeze these
 machines as `North + mirror:true` (and the engine's own import parser treats both
 South and West wire forms as the mirrored collision), so a South-only key mis-binds
-them — a regression vs the unconditional `mirrored = mirror_entity`. The correct
-fix is to **parse the real `mirror` flag** in the blueprint decoder (the meter
-reads no such field today), not to guess from direction. Left as a documented
-future change; the unconditional binding (merged baseline) is kept, with a comment
-recording the limitation.
+them — a regression vs the unconditional `mirrored = mirror_entity`. A complete
+fix must key on **both** signals: a parsed `mirror` flag (for community
+`North+mirror:true`) AND the engine's `direction+8` South wire form (which the
+exporter uses in place of a mirror flag for these machines) — the direction
+heuristic alone is insufficient, but so is parsing `mirror` alone. Left as a
+documented future change; the unconditional binding (merged baseline) is kept,
+with a comment recording the limitation.
 
 ### Two proposed fixes — REVERTED after review (record the call)
 - **Census precedence** (report `FluidIngredientShortage` whenever a fluid is

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -104,14 +104,16 @@ merge-priority model change, unverifiable on this noisy fixture and risky for th
 `rfc064-phase2-followups.md`), not this meter-fluid thread. Full evidence:
 [`meter-divergence.md`](meter-divergence.md).
 
-### Orientation-keyed port binding — FIXED (this thread)
-`mirrored` is now keyed on the machine being one of the mirrored set AND placed
-in the mirrored (South-exporter) orientation. A North-facing (unmirrored)
-refinery/foundry/cryo binds its multi-fluid face x-ascending. Corpus-neutral
-(engine always exports those machines as South). Known limit (reviewer note):
-the meter parses no `mirror` flag, so a genuinely-unmirrored machine exported at
-South is indistinguishable — only reachable from non-engine blueprints, not the
-corpus.
+### Orientation-keyed port binding — PROPOSED then REVERTED (this thread)
+An attempt to key `mirrored` on orientation (`mirror_entity && direction == South`)
+was proposed and then **reverted on review**: community blueprints re-freeze these
+machines as `North + mirror:true` (and the engine's own import parser treats both
+South and West wire forms as the mirrored collision), so a South-only key mis-binds
+them — a regression vs the unconditional `mirrored = mirror_entity`. The correct
+fix is to **parse the real `mirror` flag** in the blueprint decoder (the meter
+reads no such field today), not to guess from direction. Left as a documented
+future change; the unconditional binding (merged baseline) is kept, with a comment
+recording the limitation.
 
 ### Two proposed fixes — REVERTED after review (record the call)
 - **Census precedence** (report `FluidIngredientShortage` whenever a fluid is

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -1,10 +1,13 @@
 # Meter fluid modelling — follow-ups (#570)
 
-**Status (2026-08-03, follow-up `f5a-ptg-edge`): Phase A + B LANDED and merged
-(#571). Calibration within ±10pp on the whole compared corpus EXCEPT
-`tier5_processing_unit_from_ore_am3` (−13%, a solid belt-delivery residual, not
-fluid). CI second-opinion findings triaged: F5a stacked-PTG edge FIXED;
-byproduct backpressure consciously rejected (see below).** #570.
+**Status (2026-08-03, follow-up `f5a-ptg-edge` + `fluid-followups`): Phase A + B
+LANDED and merged (#571). Calibration within ±10pp on the whole compared corpus
+EXCEPT `tier5_processing_unit_from_ore_am3` (−13%, a SOLID belt-delivery
+residual — see the characterised, deferred entry below). CI second-opinion
+findings triaged: F5a stacked-PTG edge FIXED; three latent meter issues FIXED
+(census fluid-shortage precedence, orientation-keyed port binding, chem-plant
+shared fluid box); byproduct backpressure consciously rejected (kept drain
+philosophy).** #570.
 
 Phase B replaced Phase A's port-adjacency `tick_fluids` (which delivered fluid
 one unit a tick and throttled petroleum→plastic→AC→PU to ~20%) with a real pipe
@@ -87,10 +90,19 @@ Factorio physics but a different measurement philosophy; recorded here so the ca
 is explicit, not accidental. Revisit only if a sim-baselined byproduct-loop fixture
 ever enters the corpus.
 
-### Confirm/close the PU-from-ore −13%
-Its census shows 30 `item_ingredient_shortage` and only 1 fluid-short machine —
-petroleum/fluid are not the limit. Investigate as a belt-model divergence (the
-fixture notes "26 tiles in a belt cycle"). See [`meter-divergence.md`](meter-divergence.md).
+### Confirm/close the PU-from-ore −13% — CHARACTERISED, deferred
+Deep-dive (2026-08-03): the sim itself under-produces almost everything on this
+fixture (intermediates ≈ −10%, petroleum −17%; only target PU hits 99%). The
+meter matches the sim within ±4% on the entire direct chain (and is *better* than
+sim on copper-plate), so the extra ~10% the meter loses is solely downstream belt
+delivery of electronic-circuit to the PU machine — which sits short on EC despite
+adequate EC production. The fixture carries the corpus's only topology note
+("26 tiles in a belt cycle; update order arbitrary"), the likely culprit.
+**Deferred deliberately**: a fix needs a speculative belt-cycle-update-order /
+merge-priority model change, unverifiable on this noisy fixture and risky for the
+~40 agreeing fixtures. Track under RFC-064 "input-delivery" (see
+`rfc064-phase2-followups.md`), not this meter-fluid thread. Full evidence:
+[`meter-divergence.md`](meter-divergence.md).
 
 ### Remaining latent minors (recorded, not chased)
 - Fluid port *binding* keyed on machine name (always mirrored for refinery/foundry/

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -36,14 +36,17 @@ gap. Full divergence log:
   re-running the corpus meter sweep (`crates/meter/examples/sweep_corpus.rs`).
 - Solid chains do **not regress** (the ~25/70 that already agree must stay put).
 
-## Where it stands in the code
+## Where it stands in the code (current, post Phase A + B)
 
-- `machine.rs`: takes **solids only** — *"fluids are PR-3 out of scope."* Machine has
-  recipe data from `recipe_db::db()` (full ingredients incl. fluids), but ignores
-  fluid ingredients in the craft check and never emits fluid products.
-- `network.rs`: "Deliberately not modelled yet" — no fluid pipe/port flow.
-- `factory.rs:237`: fluid boundary inputs get the note *"fluid boundary input X not
-  modelled"* and are skipped — so any chain fed crude-oil/water produces nothing.
+- `machine.rs`: fluid-aware — fluid ingredient buffers (`fluid_input`/`fluid_needs`),
+  fluid products→`fluid_output`, `MachineState::FluidIngredientShortage`, and a
+  craft gate that consumes solids and fluids together.
+- `fluid.rs`: the pipe network — connected components of `pipe`/`pipe-to-ground`/
+  `pump` + machine fluid ports + boundary feeds, honoring F4/F5/F5a topology.
+- `factory.rs: tick_fluids`: per-component, per-fluid pipe-fast routing from
+  boundary + producer outputs to consumer buffers, shared fairly. Element-boundary
+  fluid feeds that touch no pipe are reported ("touches no pipe network"), not
+  silently skipped.
 
 ## Scope (bounded, spike-first per RFC-063/064 discipline)
 
@@ -101,7 +104,7 @@ machine — which sits short on EC despite adequate EC production. The fixture
 carries the corpus's only topology note ("26 tiles in a belt cycle; update order
 arbitrary"), the likely culprit. **Deferred deliberately**: a fix needs a
 speculative belt-cycle-update-order / merge-priority model change, unverifiable
-on this noisy fixture and risky for the ~40 agreeing fixtures. Tracked as item 7
+on this noisy fixture; tracked as item 7
 in [`rfc064-phase2-followups.md`](rfc064-phase2-followups.md); full evidence in
 [`meter-divergence.md`](meter-divergence.md).
 
@@ -123,10 +126,16 @@ recording the limitation.
   the module's "census lines up with the sim" contract, and neither precedence is
   verifiable here. Kept the original solids-first order.
 - **Chem-plant "shared fluid box"** (bind a single fluid to both ports of a face):
-  proposed then reverted. Reviewer: `recipes.json` shows chem-plant/biochamber have
-  **four separate** fluid boxes (2 in + 2 out), so the shared-box premise is wrong;
-  and binding both ports + per-network pooling introduced real over-credit and
-  cross-network starvation paths. Reverted to single-port x-ordered binding.
+  proposed then reverted. Independent reviews **disagreed** on the underlying
+  box topology (`recipes.json` lists 4 `pipe_connection` entries on
+  chemical-plant/biochamber — read by one review as 4 separate boxes, by another
+  as 2 boxes × 2 connections). Rather than rely on an unverified topology claim,
+  the change was reverted because the *implementation* was unsafe regardless:
+  binding both ports + per-network pooling introduced real over-credit and
+  cross-network starvation paths that the existing single-port routing cannot
+  reproduce. Reverted to the single-port x-ordered binding; the "other-port
+  starves" behaviour stays open and needs a correct (network-partition-safe)
+  fix plus a verified fluid-box topology before it is worth re-attempting.
 
 ### Remaining latent minors (recorded, not chased)
 - A machine short of both a solid and a fluid is classified `ItemIngredientShortage`

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -3,11 +3,11 @@
 **Status (2026-08-03, follow-up `f5a-ptg-edge` + `fluid-followups`): Phase A + B
 LANDED and merged (#571). Calibration within ±10pp on the whole compared corpus
 EXCEPT `tier5_processing_unit_from_ore_am3` (−13%, a SOLID belt-delivery
-residual — see the characterised, deferred entry below). CI second-opinion
-findings triaged: F5a stacked-PTG edge FIXED; orientation-keyed port binding
-FIXED; a census-precedence change and a chem-plant "shared fluid box" change
-were PROPOSED then REVERTED after review (wrong premise / sim-divergence — see
-below); byproduct backpressure consciously rejected (kept drain philosophy).** #570.
+residual — characterised, deliberately deferred; see below). CI second-opinion
+findings triaged: F5a stacked-PTG edge FIXED (#572); three latent code fixes
+(census precedence, chem-plant "shared box", orientation-keyed binding) were
+PROPOSED then all REVERTED on review — see the sections below; byproduct
+backpressure consciously rejected (kept drain philosophy).** #570.
 
 Phase B replaced Phase A's port-adjacency `tick_fluids` (which delivered fluid
 one unit a tick and throttled petroleum→plastic→AC→PU to ~20%) with a real pipe
@@ -22,7 +22,8 @@ x-descending fluid binding for oil-refinery/foundry/cryogenic-plant.
 Result over the corpus (meter `delivered_per_s`/`produced_per_s` vs sim):
 gear exact; EC + stress-EC ±0–2%; AOP/refinery exact; **all AC variants now
 ±0–2% (were −80%)**; PU from ore −80% → −13%. The lone residual is PU-from-ore,
-whose census shows 30 `item_ingredient_shortage` machines and a 26-tile belt
+whose census is dominated by `full_output`/`working` with ~9 machines left short
+on a solid and a 26-tile belt
 cycle — a solid-side belt-model gap (open RFC-064 Phase 2 item), not a fluid
 gap. Full divergence log:
 [`meter-divergence.md`](meter-divergence.md).
@@ -63,7 +64,7 @@ closed — keeps crossing/stacked fluid lines isolated).
 **Phase C — calibration (close to done; one open residual).**
 - Re-run the meter corpus sweep (`examples/sweep_corpus.rs`); all compared
   fixtures within ±10pp EXCEPT `tier5_processing_unit_from_ore_am3` at −13%
-  (a solid belt-delivery gap: 30 `item_ingredient_shortage` machines, 26-tile
+  (a solid belt-delivery gap: ~9 machines short on a solid, 26-tile
   belt cycle — see [`meter-divergence.md`](meter-divergence.md)).
 - Log any residual divergence in [`meter-divergence.md`](meter-divergence.md).
 
@@ -93,15 +94,15 @@ ever enters the corpus.
 ### Confirm/close the PU-from-ore −13% — CHARACTERISED, deferred
 Deep-dive (2026-08-03): the sim itself under-produces almost everything on this
 fixture (intermediates ≈ −10%, petroleum −17%; only target PU hits 99%). The
-meter matches the sim within ±4% on the entire direct chain (and is *better* than
-sim on copper-plate), so the extra ~10% the meter loses is solely downstream belt
-delivery of electronic-circuit to the PU machine — which sits short on EC despite
-adequate EC production. The fixture carries the corpus's only topology note
-("26 tiles in a belt cycle; update order arbitrary"), the likely culprit.
-**Deferred deliberately**: a fix needs a speculative belt-cycle-update-order /
-merge-priority model change, unverifiable on this noisy fixture and risky for the
-~40 agreeing fixtures. Track under RFC-064 "input-delivery" (see
-`rfc064-phase2-followups.md`), not this meter-fluid thread. Full evidence:
+meter matches the sim within ±4% on the entire direct chain (~the same, slightly
+larger, absolute shortfall from plan as the sim), so the extra ~10% the meter
+loses on PU is solely downstream belt delivery of electronic-circuit to the PU
+machine — which sits short on EC despite adequate EC production. The fixture
+carries the corpus's only topology note ("26 tiles in a belt cycle; update order
+arbitrary"), the likely culprit. **Deferred deliberately**: a fix needs a
+speculative belt-cycle-update-order / merge-priority model change, unverifiable
+on this noisy fixture and risky for the ~40 agreeing fixtures. Tracked as item 7
+in [`rfc064-phase2-followups.md`](rfc064-phase2-followups.md); full evidence in
 [`meter-divergence.md`](meter-divergence.md).
 
 ### Orientation-keyed port binding — PROPOSED then REVERTED (this thread)

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -20,8 +20,9 @@ side) and F5a (PTG perpendicular sides closed), and the measured mirrored-port
 x-descending fluid binding for oil-refinery/foundry/cryogenic-plant.
 
 Result over the corpus (meter `delivered_per_s`/`produced_per_s` vs sim):
-gear exact; EC + stress-EC ±0–2%; AOP/refinery exact; **all AC variants now
-±0–2% (were −80%)**; PU from ore −80% → −13%. The lone residual is PU-from-ore,
+gear exact; EC + stress-EC ±0–2%; AOP/refinery exact; **the dedicated AC
+variants now ±0–2% (were −80%; the PU-from-ore exception fixture's own AC is
+−3.9%)**; PU from ore −80% → −13%. The lone residual is PU-from-ore,
 whose census is dominated by `full_output`/`working` with ~9 machines left short
 on a solid (diagnostic, pre-revert census code — see the PU entry) plus a 26-tile belt
 cycle — a solid-side belt-model gap (open RFC-064 Phase 2 item), not a fluid

--- a/docs/meter-fluid-followups.md
+++ b/docs/meter-fluid-followups.md
@@ -4,10 +4,10 @@
 LANDED and merged (#571). Calibration within ±10pp on the whole compared corpus
 EXCEPT `tier5_processing_unit_from_ore_am3` (−13%, a SOLID belt-delivery
 residual — see the characterised, deferred entry below). CI second-opinion
-findings triaged: F5a stacked-PTG edge FIXED; three latent meter issues FIXED
-(census fluid-shortage precedence, orientation-keyed port binding, chem-plant
-shared fluid box); byproduct backpressure consciously rejected (kept drain
-philosophy).** #570.
+findings triaged: F5a stacked-PTG edge FIXED; orientation-keyed port binding
+FIXED; a census-precedence change and a chem-plant "shared fluid box" change
+were PROPOSED then REVERTED after review (wrong premise / sim-divergence — see
+below); byproduct backpressure consciously rejected (kept drain philosophy).** #570.
 
 Phase B replaced Phase A's port-adjacency `tick_fluids` (which delivered fluid
 one unit a tick and throttled petroleum→plastic→AC→PU to ~20%) with a real pipe
@@ -104,14 +104,31 @@ merge-priority model change, unverifiable on this noisy fixture and risky for th
 `rfc064-phase2-followups.md`), not this meter-fluid thread. Full evidence:
 [`meter-divergence.md`](meter-divergence.md).
 
+### Orientation-keyed port binding — FIXED (this thread)
+`mirrored` is now keyed on the machine being one of the mirrored set AND placed
+in the mirrored (South-exporter) orientation. A North-facing (unmirrored)
+refinery/foundry/cryo binds its multi-fluid face x-ascending. Corpus-neutral
+(engine always exports those machines as South). Known limit (reviewer note):
+the meter parses no `mirror` flag, so a genuinely-unmirrored machine exported at
+South is indistinguishable — only reachable from non-engine blueprints, not the
+corpus.
+
+### Two proposed fixes — REVERTED after review (record the call)
+- **Census precedence** (report `FluidIngredientShortage` whenever a fluid is
+  short): proposed then reverted. Reviewer: the sim labels a machine by whichever
+  ingredient blocks next, so an unconditional fluid-priority would *diverge* from
+  the module's "census lines up with the sim" contract, and neither precedence is
+  verifiable here. Kept the original solids-first order.
+- **Chem-plant "shared fluid box"** (bind a single fluid to both ports of a face):
+  proposed then reverted. Reviewer: `recipes.json` shows chem-plant/biochamber have
+  **four separate** fluid boxes (2 in + 2 out), so the shared-box premise is wrong;
+  and binding both ports + per-network pooling introduced real over-credit and
+  cross-network starvation paths. Reverted to single-port x-ordered binding.
+
 ### Remaining latent minors (recorded, not chased)
-- Fluid port *binding* keyed on machine name (always mirrored for refinery/foundry/
-  cryo) rather than actual orientation; a direction-0 instance would swap multi-fluid
-  faces. Not in the corpus (engine always mirrors those machines).
 - A machine short of both a solid and a fluid is classified `ItemIngredientShortage`
-  (solids checked first), under-counting `fluid_ingredient_shortage` in the census.
-- A chem-plant's two input ports feed one internal fluid box in-game; a single-fluid
-  pipe to the *other* port tile would silently starve it here.
+  (solids first); a chem-plant single-fluid pipe on the non-x-ordered port tile
+  starves (the two above — both intentionally left as-is after review).
 - Re-bless any golden/snapshot baselines the corpus ingest tests depend on.
 
 ## Constraints / gates

--- a/docs/rfc064-phase2-followups.md
+++ b/docs/rfc064-phase2-followups.md
@@ -71,6 +71,20 @@ uranium voider). With the tuning now making sim ~2.7× cheaper, closing the
 if the coordinator wants the stronger gate. Otherwise the subset verdict stands
 as recorded.
 
+### 7. Meter belt-delivery residual: PU-from-ore −13% (from meter-fluid, #570)
+Pick-up entry so the deferral is actually tracked here (the meter
+`meter-divergence.md` records the full evidence). The fast meter is −13% on
+`tier5_processing_unit_from_ore_am3` vs the sim — a **downstream solid belt
+delivery** divergence, not a fluid one: the meter matches the sim within ±4% on
+the whole direct chain but loses ~10% delivering electronic-circuit to the PU
+machine (its serving machine, `m#310`, sits short on EC despite adequate EC
+production). The fixture's only topology note is a 26-tile belt cycle; the
+meter steps cyclic belts in an arbitrary-but-deterministic order, the likely
+cause. Deferred deliberately: a fix needs a speculative belt-cycle-update-order
+/ merge-priority model change, unverifiable on this noisy fixture (the sim is
+~−10% on every intermediate) and risky for the ~40 agreeing fixtures. Investigate
+as a belt-model divergence, re-measuring after any belt-network change.
+
 ## Decided / closed (from Stage B)
 - **Never-worse holds** on the measurable subset → evidence supports
   `compact_layout` default-on (representative-scope).

--- a/docs/rfc064-phase2-followups.md
+++ b/docs/rfc064-phase2-followups.md
@@ -77,12 +77,15 @@ Pick-up entry so the deferral is actually tracked here (the meter
 `tier5_processing_unit_from_ore_am3` vs the sim — a **downstream solid belt
 delivery** divergence, not a fluid one: the meter matches the sim within ±4% on
 the whole direct chain but loses ~10% delivering electronic-circuit to the PU
-machine (its serving machine, `m#310`, sits short on EC despite adequate EC
+machine (the served PU machine, `m#310`, sits short on EC despite adequate EC
 production). The fixture's only topology note is a 26-tile belt cycle; the
 meter steps cyclic belts in an arbitrary-but-deterministic order, the likely
 cause. Deferred deliberately: a fix needs a speculative belt-cycle-update-order
 / merge-priority model change, unverifiable on this noisy fixture (the sim is
-~−10% on every intermediate) and risky for the ~40 agreeing fixtures. Investigate
+~−10% on every intermediate). Note the blast radius is narrow — this fixture has
+the corpus's only cycle note, so a `CycleInUpdateOrder`-gated change would touch
+~nothing else; the binding reasons to defer are the noisy sim baseline and the
+unverifiability, not a broad corpus risk. Investigate
 as a belt-model divergence, re-measuring after any belt-network change.
 
 ## Decided / closed (from Stage B)


### PR DESCRIPTION
## Intent

Pick up the remaining meter-fluid follow-ups from #570: the last calibration
residual deep dive + triage of the latent items CI review flagged. **Outcome:
after investigation and adversarial review, all three proposed code changes were
correctly rejected; this PR is documentation-only.** No behaviour change on the
meter.

## Scope

- **PU-from-ore −13% deep dive (docs):** the sim itself under-produces almost
  everything on this fixture (intermediates ≈ −10%, petroleum −17%; only target
  PU hits 99%). The meter matches sim within ±4% on the whole direct chain and is
  *better* than sim on copper-plate, so the extra loss is solely downstream
  solid-belt delivery of EC to the PU machine (serving machine short on EC despite
  adequate production). The fixture carries the corpus's only topology note
  (26-tile belt cycle; arbitrary update order). Deferred: a speculative belt
  cycle/merge-priority change, unverifiable on that noisy fixture, risky for the
  ~40 agreeing fixtures — tracked under RFC-064 "input-delivery".
- **Proposed then reverted (recorded):** three latent code fixes — census
  fluid-shortage precedence (would diverge from the sim's blocking-order
  labelling), chem-plant "shared fluid box" (wrong premise — recipes.json shows 4
  separate boxes — and introduced over-credit/cross-network starvation), and
  orientation-keyed mirror binding (a regression for community `North+mirror:true`
  blueprints and the engine's South/West mirrored cases). The correct path for the
  latter is parsing the real `mirror` flag, left as a documented future change.
- **In (code):** only a clarifying comment noting the mirror-flag limitation at
  the binding site.

## Verification

- `cargo test --manifest-path crates/meter/Cargo.toml --lib` → 55 pass
- `cargo clippy --all-targets` (meter) clean
- Corpus sweep: identical percentages to the merged baseline — **no behaviour
  change** vs main (the only .rs diff is a comment).

## Deviations

- Intentionally landed NO functional code change after review showed each
  proposed fix was wrong/risky. Reversals and the PU characterisation are
  documented in `meter-fluid-followups.md` / `meter-divergence.md`.

## Models / contracts touched

- `docs/meter-fluid-followups.md`, `docs/meter-divergence.md`; a clarifying
  comment in `factory.rs`.