### PR TITLE
sim-harness: probe realized productivity bonus — settles RFC-064 item 7

### DIFF
--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -174,6 +174,18 @@ pub struct Report {
     /// self-audits the assignment into `kit_errors` at init.
     pub inserter_stack_size_bonus: f64,
     pub bulk_inserter_capacity_bonus: f64,
+    /// RFC-064 item 7 productivity-parity probe (2026-08-06). The scenario
+    /// calls `research_all_technologies()` while the tech-state parity block
+    /// corrects only inserter capacity (#370) and belt stacking (#385) —
+    /// nothing corrects productivity. The fast meter models no productivity
+    /// at all, so any bonus here is a divergence between instrument and
+    /// reference rather than a layout property. Three channels because a
+    /// research source and a module source imply different fixes; carried as
+    /// raw JSON since the probe reads defensively and may report
+    /// `FIELD_ABSENT` for an API spelling this harness guessed wrong.
+    pub productivity_force: serde_json::Value,
+    pub productivity_entity: serde_json::Value,
+    pub productivity_modules: serde_json::Value,
     /// Per-machine + per-item rate-vs-time record, one entry per closed
     /// checkpoint window (#537 — see `docs/sim-harness.md`'s "Reading the
     /// time-series" section). Additive field: absent or malformed
@@ -550,6 +562,18 @@ pub fn compute(manifest: &Manifest, result: &serde_json::Value) -> Report {
             .get("bulk_inserter_capacity_bonus")
             .and_then(|v| v.as_f64())
             .unwrap_or(-1.0),
+        productivity_force: result
+            .get("productivity_force")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        productivity_entity: result
+            .get("productivity_entity")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        productivity_modules: result
+            .get("productivity_modules")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
         timeseries: parse_timeseries(result),
     }
 }

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -645,6 +645,101 @@ fn print_measurement(m: &MeasurementQuality, converged: bool) {
     }
 }
 
+/// Surface the productivity-parity probe (RFC-064 item 7).
+///
+/// Printed rather than merely stored, because this repo's own rule is that
+/// "a verification channel nobody checks is not a verification channel"
+/// (`scenario.rs`, the tech-state parity self-audit). A boosted recipe here
+/// means the sim and the fast meter — which models no productivity at all —
+/// are measuring different worlds on that recipe, so any rate comparison
+/// against the meter inherits the gap.
+///
+/// Only non-zero entries and probe faults are printed: a fully-zero result is
+/// the common case and says "no parity gap on the probed recipes", which the
+/// one-line summary covers.
+fn print_productivity_parity(report: &Report) {
+    let mut boosted: Vec<String> = Vec::new();
+    let mut faults: Vec<String> = Vec::new();
+    let mut numeric = 0usize;
+
+    // `productivity_force` maps recipe -> number (or a sentinel string).
+    if let Some(map) = report.productivity_force.as_object() {
+        for (name, v) in map {
+            match v.as_f64() {
+                Some(n) => {
+                    numeric += 1;
+                    if n.abs() > f64::EPSILON {
+                        boosted.push(format!("{name}={:+.1}% (force)", n * 100.0));
+                    }
+                }
+                // The Lua probe reports a missing/erroring field as a
+                // sentinel STRING rather than crashing the run.
+                None => faults.push(format!("force:{name}={v}")),
+            }
+        }
+    }
+    // `productivity_entity` maps recipe -> {min, max, n, faults}, aggregated
+    // over every machine of that recipe rather than the first one seen.
+    if let Some(map) = report.productivity_entity.as_object() {
+        for (name, v) in map {
+            let lo = v.get("min").and_then(|x| x.as_f64());
+            let hi = v.get("max").and_then(|x| x.as_f64());
+            let n = v.get("n").and_then(|x| x.as_u64()).unwrap_or(0);
+            let f = v.get("faults").and_then(|x| x.as_u64()).unwrap_or(0);
+            if n > 0 {
+                numeric += 1;
+                let (lo, hi) = (lo.unwrap_or(0.0), hi.unwrap_or(0.0));
+                if lo.abs() > f64::EPSILON || hi.abs() > f64::EPSILON {
+                    boosted.push(if (hi - lo).abs() > f64::EPSILON {
+                        format!("{name}={:+.1}..{:+.1}% (entity, n={n})", lo * 100.0, hi * 100.0)
+                    } else {
+                        format!("{name}={:+.1}% (entity, n={n})", lo * 100.0)
+                    });
+                }
+            }
+            if f > 0 {
+                faults.push(format!("entity:{name}={f} machine(s) faulted"));
+            }
+        }
+    }
+    let modules = report
+        .productivity_modules
+        .as_object()
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    if numeric == 0 && faults.is_empty() {
+        return; // probe absent entirely (e.g. a report from before it existed)
+    }
+    if numeric == 0 {
+        // Self-audit: every channel faulted. Without this line an all-sentinel
+        // run is indistinguishable from a genuine "no productivity anywhere",
+        // which would silently license a wrong conclusion.
+        println!(
+            "productivity parity: PROBE FAILED — no channel returned a number \
+             ({} fault(s): {}). Treat any productivity claim from this run as \
+             unmeasured.",
+            faults.len(),
+            faults.join(", ")
+        );
+        return;
+    }
+    if boosted.is_empty() && modules == 0 {
+        println!("productivity parity: none on the probed recipes ({numeric} read, 0 boosted)");
+    } else {
+        println!(
+            "productivity parity: BOOSTED [{}]{} — the fast meter models no \
+             productivity, so meter-vs-sim rates on these recipes are not \
+             like-for-like (RFC-064 item 7)",
+            boosted.join(", "),
+            if modules > 0 { format!(", {modules} module slot group(s)") } else { String::new() }
+        );
+    }
+    if !faults.is_empty() {
+        println!("  probe faults: {}", faults.join(", "));
+    }
+}
+
 pub fn print_human(report: &Report) {
     println!("=== spaghettio-sim report: {} ===", report.label);
     println!(
@@ -672,6 +767,7 @@ pub fn print_human(report: &Report) {
         report.inserter_stack_size_bonus,
         report.bulk_inserter_capacity_bonus
     );
+    print_productivity_parity(report);
     if !report.external_inputs.is_empty() {
         let inputs: Vec<String> = report
             .external_inputs

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -657,14 +657,31 @@ fn print_measurement(m: &MeasurementQuality, converged: bool) {
 /// Only non-zero entries and probe faults are printed: a fully-zero result is
 /// the common case and says "no parity gap on the probed recipes", which the
 /// one-line summary covers.
-fn print_productivity_parity(report: &Report) {
+fn productivity_parity_lines(
+    force: &serde_json::Value,
+    entity: &serde_json::Value,
+    modules: &serde_json::Value,
+) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
     let mut boosted: Vec<String> = Vec::new();
     let mut faults: Vec<String> = Vec::new();
     let mut numeric = 0usize;
 
     // `productivity_force` maps recipe -> number (or a sentinel string).
-    if let Some(map) = report.productivity_force.as_object() {
+    // Recipes the layout actually crafts, from the entity channel. The force
+    // channel probes a fixed list, so without this a run that never crafts
+    // processing-unit would still print a processing-unit banner (PR #580
+    // review). Empty entity channel → report everything rather than nothing,
+    // since suppressing on missing evidence is the worse failure here.
+    let crafted: Option<Vec<&String>> = entity
+        .as_object()
+        .map(|m| m.keys().collect())
+        .filter(|k: &Vec<&String>| !k.is_empty());
+    if let Some(map) = force.as_object() {
         for (name, v) in map {
+            if crafted.as_ref().is_some_and(|c| !c.contains(&name)) {
+                continue;
+            }
             match v.as_f64() {
                 Some(n) => {
                     numeric += 1;
@@ -680,7 +697,7 @@ fn print_productivity_parity(report: &Report) {
     }
     // `productivity_entity` maps recipe -> {min, max, n, faults}, aggregated
     // over every machine of that recipe rather than the first one seen.
-    if let Some(map) = report.productivity_entity.as_object() {
+    if let Some(map) = entity.as_object() {
         for (name, v) in map {
             let lo = v.get("min").and_then(|x| x.as_f64());
             let hi = v.get("max").and_then(|x| x.as_f64());
@@ -702,42 +719,48 @@ fn print_productivity_parity(report: &Report) {
             }
         }
     }
-    let modules = report
-        .productivity_modules
-        .as_object()
-        .map(|m| m.len())
-        .unwrap_or(0);
+    let modules = modules.as_object().map(|m| m.len()).unwrap_or(0);
 
     if numeric == 0 && faults.is_empty() {
-        return; // probe absent entirely (e.g. a report from before it existed)
+        return out; // probe absent entirely (e.g. a report from before it existed)
     }
     if numeric == 0 {
         // Self-audit: every channel faulted. Without this line an all-sentinel
         // run is indistinguishable from a genuine "no productivity anywhere",
         // which would silently license a wrong conclusion.
-        println!(
+        out.push(format!(
             "productivity parity: PROBE FAILED — no channel returned a number \
              ({} fault(s): {}). Treat any productivity claim from this run as \
              unmeasured.",
             faults.len(),
             faults.join(", ")
-        );
-        return;
+        ));
+        return out;
     }
-    if boosted.is_empty() && modules == 0 {
-        println!("productivity parity: none on the probed recipes ({numeric} read, 0 boosted)");
+    // BOOSTED is gated on a non-empty boost list ALONE. Folding the module
+    // count into this condition made a layout with any module at all print
+    // "BOOSTED []" — an empty boost list under a boosted header, claiming a
+    // parity gap that the numbers do not show (PR #580 review, 3/3).
+    if boosted.is_empty() {
+        out.push(format!("productivity parity: none on the probed recipes ({numeric} read, 0 boosted)"));
     } else {
-        println!(
-            "productivity parity: BOOSTED [{}]{} — the fast meter models no \
+        out.push(format!(
+            "productivity parity: BOOSTED [{}] — the fast meter models no \
              productivity, so meter-vs-sim rates on these recipes are not \
              like-for-like (RFC-064 item 7)",
-            boosted.join(", "),
-            if modules > 0 { format!(", {modules} module slot group(s)") } else { String::new() }
-        );
+            boosted.join(", ")
+        ));
+    }
+    if modules > 0 {
+        // Informational and separate: these are productivity-family modules
+        // only (the Lua side filters), reported as distinct (recipe, module)
+        // pairs rather than slot counts.
+        out.push(format!("  productivity modules present: {modules} (recipe, module) pair(s)"));
     }
     if !faults.is_empty() {
-        println!("  probe faults: {}", faults.join(", "));
+        out.push(format!("  probe faults: {}", faults.join(", ")));
     }
+    out
 }
 
 pub fn print_human(report: &Report) {
@@ -767,7 +790,13 @@ pub fn print_human(report: &Report) {
         report.inserter_stack_size_bonus,
         report.bulk_inserter_capacity_bonus
     );
-    print_productivity_parity(report);
+    for line in productivity_parity_lines(
+        &report.productivity_force,
+        &report.productivity_entity,
+        &report.productivity_modules,
+    ) {
+        println!("{line}");
+    }
     if !report.external_inputs.is_empty() {
         let inputs: Vec<String> = report
             .external_inputs
@@ -836,6 +865,84 @@ fn fmt_pct(v: Option<f64>) -> String {
 
 #[cfg(test)]
 mod tests {
+
+
+    fn productivity_parity_lines_of(
+        force: serde_json::Value,
+        entity: serde_json::Value,
+        modules: serde_json::Value,
+    ) -> Vec<String> {
+        productivity_parity_lines(&force, &entity, &modules)
+    }
+
+    /// All three branches of the productivity-parity summary, pinned.
+    ///
+    /// The review that prompted these noted every branch was unasserted — and
+    /// two of them were wrong at the time: `BOOSTED` fired on any module at
+    /// all (including speed/efficiency), printing an empty boost list under a
+    /// boosted header.
+    #[test]
+    fn productivity_parity_reports_boosted_only_when_something_is_boosted() {
+        let lines = productivity_parity_lines_of(
+            serde_json::json!({"processing-unit": 0.1, "electronic-circuit": 0.0}),
+            serde_json::json!({"processing-unit": {"min": 0.0, "max": 0.0, "n": 4, "faults": 0}}),
+            serde_json::json!({}),
+        );
+        assert!(lines[0].contains("BOOSTED"), "got {lines:?}");
+        assert!(lines[0].contains("processing-unit=+10.0%"), "got {lines:?}");
+        // electronic-circuit is probed but not crafted in this layout, and is
+        // 0.0 anyway — it must not appear.
+        assert!(!lines[0].contains("electronic-circuit"), "got {lines:?}");
+    }
+
+    #[test]
+    fn productivity_parity_reports_none_when_nothing_is_boosted() {
+        let lines = productivity_parity_lines_of(
+            serde_json::json!({"iron-plate": 0.0}),
+            serde_json::json!({"iron-plate": {"min": 0.0, "max": 0.0, "n": 2, "faults": 0}}),
+            serde_json::json!({}),
+        );
+        assert_eq!(lines.len(), 1, "got {lines:?}");
+        assert!(lines[0].contains("none on the probed recipes"), "got {lines:?}");
+        assert!(!lines[0].contains("BOOSTED"), "got {lines:?}");
+    }
+
+    /// A module present but zero productivity is NOT a parity gap. This is the
+    /// case that used to print "BOOSTED []".
+    #[test]
+    fn productivity_parity_does_not_claim_boost_from_modules_alone() {
+        let lines = productivity_parity_lines_of(
+            serde_json::json!({"iron-plate": 0.0}),
+            serde_json::json!({"iron-plate": {"min": 0.0, "max": 0.0, "n": 1, "faults": 0}}),
+            serde_json::json!({"iron-plate/productivity-module": 2}),
+        );
+        assert!(lines[0].contains("none on the probed recipes"), "got {lines:?}");
+        assert!(
+            lines.iter().any(|l| l.contains("productivity modules present")),
+            "module presence must still be reported, separately: {lines:?}"
+        );
+    }
+
+    /// Self-audit: an all-sentinel run must say so, not read as "no productivity".
+    #[test]
+    fn productivity_parity_flags_a_wholly_failed_probe() {
+        let lines = productivity_parity_lines_of(
+            serde_json::json!({"processing-unit": "FIELD_ABSENT"}),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        );
+        assert!(lines[0].contains("PROBE FAILED"), "got {lines:?}");
+    }
+
+    /// A report predating the probe prints nothing rather than a false "none".
+    #[test]
+    fn productivity_parity_is_silent_when_the_probe_is_absent() {
+        let lines = productivity_parity_lines_of(
+            serde_json::Value::Null, serde_json::Value::Null, serde_json::Value::Null,
+        );
+        assert!(lines.is_empty(), "got {lines:?}");
+    }
+
     use super::*;
     use crate::manifest::Manifest;
 

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1172,6 +1172,12 @@ local function finalize(s, converged)
     if v == nil then return "NIL" end
     return v
   end
+  -- MEASURED 2026-08-06, against a review claim that `LuaRecipe` exposes no
+  -- such field and this channel "will always serialize as FIELD_ABSENT": it
+  -- returned 0.1 for processing-unit and 0.0 for the five others in the same
+  -- run. A non-existent field cannot produce a recipe-DISCRIMINATING value,
+  -- so the read is real. That discrimination is also the strongest evidence
+  -- the probe worked at all -- a broken probe returns uniform sentinels.
   local prod_force = {}
   for _, rn in ipairs({"processing-unit", "electronic-circuit", "advanced-circuit",
                        "iron-plate", "copper-plate", "copper-cable"}) do
@@ -1189,9 +1195,24 @@ local function finalize(s, converged)
       return r.name
     end)
     if type(rn) == "string" and rn ~= "NIL" and rn ~= "FIELD_ABSENT" then
-      if prod_entity[rn] == nil then
-        prod_entity[rn] = probe(function() return m.productivity_bonus end)
+      -- Aggregate across EVERY machine of the recipe, not just the first seen.
+      -- First-seen made the reported bonus an arbitrary run-to-run pick when
+      -- machines of one recipe carry different module loadouts, and a
+      -- first-machine probe fault suppressed every later machine that might
+      -- have exposed a real number (PR #580 review, 3/3). Numeric readings
+      -- collapse to min/max so a heterogeneous set is visible as a spread;
+      -- faults are counted separately so they cannot masquerade as zeros.
+      local eb = probe(function() return m.productivity_bonus end)
+      local agg = prod_entity[rn]
+      if agg == nil then agg = {min = nil, max = nil, n = 0, faults = 0} end
+      if type(eb) == "number" then
+        if agg.min == nil or eb < agg.min then agg.min = eb end
+        if agg.max == nil or eb > agg.max then agg.max = eb end
+        agg.n = agg.n + 1
+      else
+        agg.faults = agg.faults + 1
       end
+      prod_entity[rn] = agg
       local inv = probe(function() return m.get_module_inventory() end)
       if type(inv) ~= "string" then
         local contents = probe(function() return inv.get_contents() end)

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1152,6 +1152,63 @@ local function finalize(s, converged)
       if v == st then census[k] = (census[k] or 0) + 1 end
     end
   end
+  -- RFC-064 item 7 productivity-parity probe (2026-08-06).
+  -- The meter models NO productivity at all (crates/meter/src/machine.rs
+  -- deliberately takes nothing from module_policy and not
+  -- effective_crafting_speed), while this scenario calls
+  -- research_all_technologies() above and its tech-state parity block corrects
+  -- only inserter capacity (#370) and belt stacking (#385). If the sim carries
+  -- a productivity bonus the meter cannot see, the PU-from-ore -13% residual
+  -- may reduce to that parity gap rather than any layout or belt defect.
+  --
+  -- Read DEFENSIVELY: the exact 2.0 API spelling is not assumed here. A field
+  -- that does not exist reports "FIELD_ABSENT" instead of killing the run, so
+  -- a wrong guess costs a re-run, not a lost measurement. Both candidate
+  -- sources are probed separately -- force/research bonus per recipe, and
+  -- per-machine module contents -- because they imply different fixes.
+  local function probe(get)
+    local ok, v = pcall(get)
+    if not ok then return "FIELD_ABSENT" end
+    if v == nil then return "NIL" end
+    return v
+  end
+  local prod_force = {}
+  for _, rn in ipairs({"processing-unit", "electronic-circuit", "advanced-circuit",
+                       "iron-plate", "copper-plate", "copper-cable"}) do
+    prod_force[rn] = probe(function()
+      local r = game.forces.player.recipes[rn]
+      if r == nil then return nil end
+      return r.productivity_bonus
+    end)
+  end
+  local prod_entity, prod_modules = {}, {}
+  for _, m in pairs(s.find_entities_filtered{type = {"assembling-machine", "furnace"}}) do
+    local rn = probe(function()
+      local r = m.get_recipe()
+      if r == nil then return nil end
+      return r.name
+    end)
+    if type(rn) == "string" and rn ~= "NIL" and rn ~= "FIELD_ABSENT" then
+      if prod_entity[rn] == nil then
+        prod_entity[rn] = probe(function() return m.productivity_bonus end)
+      end
+      local inv = probe(function() return m.get_module_inventory() end)
+      if type(inv) ~= "string" then
+        local contents = probe(function() return inv.get_contents() end)
+        if type(contents) == "table" then
+          -- 2.0 returns an array of {name=,count=}; 1.1 returned name->count.
+          for k, c in pairs(contents) do
+            local nm, ct
+            if type(c) == "table" then nm, ct = c.name, c.count else nm, ct = k, c end
+            if nm ~= nil then
+              local key = rn .. "/" .. tostring(nm)
+              prod_modules[key] = (prod_modules[key] or 0) + (ct or 1)
+            end
+          end
+        end
+      end
+    end
+  end
   helpers.write_file("harness-result.json", helpers.table_to_json{
     import_rc = storage.import_rc, ghosts = storage.ghosts, revived = storage.revived,
     factory_eeis = storage.factory_eeis, pole_networks = storage.net_count,
@@ -1164,7 +1221,13 @@ local function finalize(s, converged)
     -- verification channel that the tech rollback actually took effect.
     inserter_stack_size_bonus = game.forces.player.inserter_stack_size_bonus,
     bulk_inserter_capacity_bonus = game.forces.player.bulk_inserter_capacity_bonus,
-    belt_stack_size_bonus = game.forces.player.belt_stack_size_bonus}, false)
+    belt_stack_size_bonus = game.forces.player.belt_stack_size_bonus,
+    -- RFC-064 item 7 probe (see the block above). Three separate channels so
+    -- a research source and a module source are distinguishable, and so an
+    -- API-spelling miss is visible as FIELD_ABSENT rather than a silent zero.
+    productivity_force = prod_force,
+    productivity_entity = prod_entity,
+    productivity_modules = prod_modules}, false)
   print("HARNESS_DONE")
   -- Deliberately NOT deregistering the tick handler here: runtime
   -- `script.on_nth_tick(60, nil)` makes the server's handler set differ

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1179,8 +1179,16 @@ local function finalize(s, converged)
   -- so the read is real. That discrimination is also the strongest evidence
   -- the probe worked at all -- a broken probe returns uniform sentinels.
   local prod_force = {}
+  -- The list spans the WHOLE tier5_processing_unit_from_ore chain, not just
+  -- its assembler legs: plastic-bar, sulfur and the oil steps are crafted in
+  -- chemical plants / refineries, and a productivity bonus on any of them
+  -- would move the target rate just as surely (PR #580 review). Probing a
+  -- recipe the run never crafts is harmless -- the printer only reports
+  -- bonuses for recipes the layout actually contains.
   for _, rn in ipairs({"processing-unit", "electronic-circuit", "advanced-circuit",
-                       "iron-plate", "copper-plate", "copper-cable"}) do
+                       "iron-plate", "copper-plate", "copper-cable",
+                       "plastic-bar", "sulfur", "sulfuric-acid",
+                       "basic-oil-processing", "advanced-oil-processing"}) do
     prod_force[rn] = probe(function()
       local r = game.forces.player.recipes[rn]
       if r == nil then return nil end
@@ -1188,7 +1196,9 @@ local function finalize(s, converged)
     end)
   end
   local prod_entity, prod_modules = {}, {}
-  for _, m in pairs(s.find_entities_filtered{type = {"assembling-machine", "furnace"}}) do
+  for _, m in pairs(s.find_entities_filtered{
+    type = {"assembling-machine", "furnace", "chemical-plant", "oil-refinery"}
+  }) do
     local rn = probe(function()
       local r = m.get_recipe()
       if r == nil then return nil end
@@ -1221,7 +1231,11 @@ local function finalize(s, converged)
           for k, c in pairs(contents) do
             local nm, ct
             if type(c) == "table" then nm, ct = c.name, c.count else nm, ct = k, c end
-            if nm ~= nil then
+            -- Productivity-family ONLY. Counting speed/efficiency/quality
+            -- modules here made a speed-moduled layout print a BOOSTED banner
+            -- with an empty boost list (PR #580 review, 3/3) -- a module is
+            -- only a productivity parity gap if it grants productivity.
+            if nm ~= nil and string.find(tostring(nm), "productivity", 1, true) then
               local key = rn .. "/" .. tostring(nm)
               prod_modules[key] = (prod_modules[key] or 0) + (ct or 1)
             end


### PR DESCRIPTION
## Intent

The sim scenario calls `force.research_all_technologies()`, and its tech-state parity block corrects exactly two axes: inserter capacity (#370) and belt stacking (#385). **Productivity was never corrected and never observed.** The fast meter models no productivity at all — deliberately, per `crates/meter/src/machine.rs`. So on any recipe the sim boosts, the instrument and its reference measure different worlds, with nothing in the report saying so.

This adds that missing verification channel, and uses it to close a residual open across three sessions.

## The measurement

Run against `tier5_processing_unit_from_ore_am3`:

| recipe | realized force/research productivity |
|---|---|
| **processing-unit** | **+10.0%** |
| advanced-circuit | 0.0% |
| electronic-circuit | 0.0% |
| iron-plate | 0.0% |
| copper-plate | 0.0% |
| copper-cable | 0.0% |

`productivity_modules: {}` — empty, so the source is **research, not modules**.

## What it settles (RFC-064 Phase 2 item 7)

The PU-from-ore −13% is an **instrument/reference parity gap** — not a layout, belt or distribution defect. Same failure class as #370 and #385, whose fixes already sit in this file.

- **Decomposition**: −3.9% EC deficit compounded with −9.1% unmodelled productivity = **−12.7%** against −13.6% observed, ~1pp inside the fixture's noise.
- **Selectivity confirmed**: EC/AC unboosted, which is exactly why the corpus shows them at ±0–2% while only PU diverges.
- **Kills the competing reading**: "sim-side reporting artifact" is out — there is a real bonus.
- **Resolves a recorded doubt**: `research_all_technologies()` does grant this, empirically.

The AC:PU ratio predicted **+10.7%** before measuring; actual is **+10.0%**.

## Scope

- **In**: three probe channels (force/recipe bonus, per-entity bonus, module inventory), surfaced on the report. Read defensively via `pcall` — a field this harness guessed wrong reports `FIELD_ABSENT` rather than killing the run, so a bad guess costs a re-run, not a lost measurement.
- **Out**: no fix for the parity gap itself. Whether to align the sim's productivity to the fixture's declared level or teach the meter productivity is a separate call, now made on evidence rather than inference.

## ⚠ Caveat for anyone reusing the run

It used `--warmup 600` to reach finalize quickly. Its **throughput numbers are buffer-fill artifacts** and must not be compared against recorded baselines. Only the productivity fields are load-bearing — they are force state set at init and warmup-independent.

## Verification

- [x] `cargo test -p spaghettio_sim_harness` — 68 passed / 0 failed
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Two live runs against the fixture (Factorio 2.0.77, matching `PINNED_VERSION`)
- [ ] Browser eyeball — N/A, no layout change
- [ ] Snapshot — N/A, no geometry change

## Models / contracts touched

`harness-result.json` and the report gain three additive fields. Nothing deserializes strictly, so older reports parse unchanged.