### PR TITLE
feat(meter): research productivity as a declared manifest axis

### DIFF
--- a/crates/core/src/blueprint.rs
+++ b/crates/core/src/blueprint.rs
@@ -208,7 +208,7 @@ pub fn export_with_manifest(
         }
     }
 
-    let manifest = serde_json::json!({
+    let mut manifest = serde_json::json!({
         "label": label,
         "targets": solver
             .external_outputs
@@ -233,7 +233,19 @@ pub fn export_with_manifest(
         // 1..=4 representation consumed by the sim harness.
         "stacking": layout.stacking.clamp(1, 4),
         "inserter_capacity": layout.inserter_capacity,
+        // Declared research productivity, per recipe. Omitted entirely when
+        // empty so pre-existing manifests and their golden comparisons are
+        // untouched. The sim harness reads the realized bonus and compares
+        // against this (see its productivity-parity probe); the meter applies
+        // it. Without a declared value the two agree only by coincidence,
+        // which is how RFC-064 Phase 2 item 7 happened.
+        "research_productivity": layout.research_productivity,
     });
+    if layout.research_productivity.is_empty() {
+        if let Some(obj) = manifest.as_object_mut() {
+            obj.remove("research_productivity");
+        }
+    }
     (bp, manifest)
 }
 

--- a/crates/core/src/bus/cells/chain.rs
+++ b/crates/core/src/bus/cells/chain.rs
@@ -1731,6 +1731,8 @@ fn compose_chain_with_capacity_and_order(
         width,
         height,
         stacking: 1,
+        // Declared axes travel with the rebuilt result — see row_rotation.
+        research_productivity: Default::default(),
         // The composed layout DECLARES the capacity its cells were sized
         // at — registry world-matching (`verification_note`) reads this.
         inserter_capacity,

--- a/crates/core/src/bus/cells/mega.rs
+++ b/crates/core/src/bus/cells/mega.rs
@@ -655,6 +655,8 @@ fn adapt_with_spacing(
         width,
         height,
         stacking: l.stacking,
+        // Declared axes travel with the rebuilt result — see row_rotation.
+        research_productivity: l.research_productivity.clone(),
         inserter_capacity: l.inserter_capacity,
         boundary_inputs: b_in,
         boundary_outputs: b_out,

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -489,6 +489,7 @@ impl DecompositionCandidate for ModuleSizeSplit {
         // existing `(item, module_id)` keying.
         let inner_opts = LayoutOptions {
             strategy: LayoutStrategy::Pooled,
+            research_productivity: opts.research_productivity.clone(),
             max_belt_tier: opts.max_belt_tier.clone(),
             row_layout: opts.row_layout,
             surplus_policy: opts.surplus_policy,
@@ -1645,6 +1646,7 @@ mod tests {
     fn empty_layout() -> LayoutResult {
         LayoutResult {
             entities: vec![],
+            research_productivity: Default::default(),
             width: 0,
             height: 0,
             boundary_inputs: vec![],

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -141,6 +141,10 @@ pub struct LayoutOptions {
     /// Plumbed through wasm-bindings `layout*` and the web UI (URL
     /// `st=`, sidebar "Belt stacking") since Phase 2.
     pub stacking: u8,
+    /// Research-sourced productivity to plan at, per recipe. Declared axis —
+    /// see [`crate::models::LayoutResult::research_productivity`]. Empty (the
+    /// default) is bit-identical to the pre-existing behaviour.
+    pub research_productivity: std::collections::BTreeMap<String, f64>,
     /// Inserter-capacity research level (RFC-049): 0 = unresearched
     /// (default; bit-identical to pre-RFC — kill 1), 1..=7 pinned
     /// schedule (`common::inserter_hand`). User-specified like its
@@ -245,6 +249,7 @@ impl Default for LayoutOptions {
             merge_tap: false,
             splitter_tap_spacers: false,
             stacking: 1,
+            research_productivity: Default::default(),
             // Default assumes L2 research (red+green science), not the raw
             // unresearched world — see `common::DEFAULT_INSERTER_CAPACITY`
             // (2026-07-24, #383). RFC-049's "L0 == pre-RFC" model invariant
@@ -1643,6 +1648,9 @@ fn layout_pass(
     Ok((
         LayoutResult {
             entities: all_entities,
+            // The layout records the axis it was planned at, so the manifest,
+            // the meter and the sim can all be held to the same world.
+            research_productivity: opts.research_productivity.clone(),
             width,
             height: max_y,
             warnings,

--- a/crates/core/src/bus/row_rotation.rs
+++ b/crates/core/src/bus/row_rotation.rs
@@ -1694,6 +1694,12 @@ fn finish_layout(mut work: RouteWork, native: &LayoutResult) -> Result<LayoutRes
         wire_mode: native.wire_mode,
         stacking: native.stacking,
         inserter_capacity: native.inserter_capacity,
+        // Declared research productivity travels with the other declared
+        // axes. Dropping it here would export a manifest claiming no
+        // productivity for a plan that assumed some — the exact
+        // instrument-vs-plan mismatch this axis exists to kill, and this
+        // rotation path is where the axis gets declared first.
+        research_productivity: native.research_productivity.clone(),
         ..Default::default()
     };
     layout.power_wires = Some(crate::power_wires::compute_pole_wires(

--- a/crates/core/src/models.rs
+++ b/crates/core/src/models.rs
@@ -10,6 +10,7 @@
 //! - [`PlacedEntity`] — a single entity placed on the tile grid (belt, machine, inserter, etc.)
 //! - [`LayoutResult`] — the complete spatial layout ready for blueprint export
 
+use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 /// An item flowing at a certain rate.
@@ -457,6 +458,25 @@ pub struct LayoutResult {
     /// unresearched; consumers clamp via `common::inserter_hand`.
     #[serde(default, skip_serializing_if = "u8_is_zero")]
     pub inserter_capacity: u8,
+    /// Research-sourced productivity this layout was planned at, per recipe
+    /// (e.g. `{"processing-unit": 0.10}` for one level of Space Age's
+    /// processing-unit productivity).
+    ///
+    /// A **declared axis**, exactly like [`Self::stacking`] and
+    /// [`Self::inserter_capacity`]: the engine takes it as an input and never
+    /// infers it, and it rides the manifest so the meter and the sim harness
+    /// can be held to the same world. Empty = no research productivity, which
+    /// is the pre-existing behaviour bit-for-bit.
+    ///
+    /// Distinct from module productivity, which `module_policy` already
+    /// covers. This is the axis nothing modelled: the sim runs
+    /// `research_all_technologies()`, so it had productivity the solver and
+    /// the meter did not know about — measured as +10% on `processing-unit`
+    /// and `plastic-bar` and 0% everywhere else on the PU-from-ore fixture,
+    /// which is the whole of RFC-064 Phase 2 item 7. See
+    /// `docs/meter-divergence.md`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub research_productivity: BTreeMap<String, f64>,
 }
 
 fn u8_is_zero(v: &u8) -> bool {

--- a/crates/meter/src/factory.rs
+++ b/crates/meter/src/factory.rs
@@ -176,6 +176,14 @@ impl Factory {
                 size,
                 &mut items,
                 DEFAULT_BUFFER_CRAFTS,
+                // Declared, not inferred: absent from the manifest means no
+                // research productivity, which is what every manifest written
+                // before this axis existed says.
+                manifest
+                    .research_productivity
+                    .get(recipe)
+                    .copied()
+                    .unwrap_or(0.0),
             ) {
                 Some(m) => {
                     // Collect this machine's fluid ports, bound to the recipe's

--- a/crates/meter/src/machine.rs
+++ b/crates/meter/src/machine.rs
@@ -650,4 +650,47 @@ mod tests {
             );
         }
     }
+
+    /// The declared axis must actually reach the product amounts.
+    ///
+    /// `productivity_matches_engine_formula` pins the replicated formula
+    /// against the engine's, and would keep passing if `Machine::new` ignored
+    /// its `research_productivity` argument entirely or the factory always
+    /// passed 0.0 — it proves the arithmetic, not the wiring. This drives the
+    /// constructor and asserts the products moved (PR #584 adversarial
+    /// review, "passes either way" finding).
+    #[test]
+    fn declared_productivity_reaches_the_product_amounts() {
+        let base = {
+            let mut items = ItemInterner::default();
+            Machine::new(
+                "assembling-machine-3", "electronic-circuit", (0, 0), (3, 3),
+                &mut items, DEFAULT_BUFFER_CRAFTS, 0.0,
+            )
+            .expect("EC on AM3 is a known recipe")
+            .products
+            .iter()
+            .map(|(_, n)| *n)
+            .sum::<f64>()
+        };
+        let boosted = {
+            let mut items = ItemInterner::default();
+            Machine::new(
+                "assembling-machine-3", "electronic-circuit", (0, 0), (3, 3),
+                &mut items, DEFAULT_BUFFER_CRAFTS, 0.10,
+            )
+            .expect("EC on AM3 is a known recipe")
+            .products
+            .iter()
+            .map(|(_, n)| *n)
+            .sum::<f64>()
+        };
+        assert!(base > 0.0, "fixture must produce something to compare");
+        assert!(
+            (boosted - base * 1.10).abs() < 1e-9,
+            "declared +10% must raise output per craft by exactly 1.1x: \
+             {base} -> {boosted}, expected {}",
+            base * 1.10
+        );
+    }
 }

--- a/crates/meter/src/machine.rs
+++ b/crates/meter/src/machine.rs
@@ -127,6 +127,20 @@ pub struct Machine {
     pub fluid_output: FxHashMap<u16, u32>,
 }
 
+
+/// Factorio's productivity rule: the bonus multiplies output per craft and
+/// leaves ingredients untouched, except for the catalyst portion a recipe
+/// declares `ignored_by_productivity`, which is returned unmultiplied.
+///
+/// Deliberately a local replication — see the call site.
+fn effective_product_amount(amount: f64, ignored_by_productivity: f64, prod_bonus: f64) -> f64 {
+    if prod_bonus == 0.0 {
+        return amount;
+    }
+    let ignored = ignored_by_productivity.clamp(0.0, amount);
+    (amount - ignored) * (1.0 + prod_bonus) + ignored
+}
+
 impl Machine {
     /// Build from a blueprint entity. `None` when the recipe is unknown.
     pub fn new(
@@ -136,6 +150,10 @@ impl Machine {
         size: (u32, u32),
         items: &mut ItemInterner,
         buffer_crafts: u32,
+        // Declared research productivity for THIS recipe, e.g. `0.10`. A
+        // manifest-declared axis, never inferred — see
+        // `Manifest::research_productivity`.
+        research_productivity: f64,
     ) -> Option<Self> {
         let db = recipe_db::db();
         let recipe = db.recipes.get(recipe_name)?;
@@ -171,7 +189,22 @@ impl Machine {
             // compared tick-for-tick against a deterministic baseline.
             // (Same expectation discipline for fluid products, which go to
             // `fluid_output` rather than belt delivery.)
-            let expect = p.amount * p.probability;
+            // Productivity multiplies OUTPUT per craft, leaving ingredients
+            // alone — and never applies to the catalyst portion a recipe
+            // marks `ignored_by_productivity`.
+            //
+            // The formula is replicated here rather than imported from
+            // `spaghettio_core::module_policy::effective_product_amount`, to
+            // hold this module's stated boundary: it takes Factorio prototype
+            // facts from `recipe_db` and nothing from `module_policy`, whose
+            // job is engine POLICY (which modules to fit) rather than game
+            // semantics. `productivity_matches_engine_formula` pins the two
+            // against each other so the replication cannot drift.
+            let expect = effective_product_amount(
+                p.amount,
+                p.ignored_by_productivity,
+                research_productivity,
+            ) * p.probability;
             if p.type_ == "fluid" {
                 fluid_products.push((id.0, expect));
             } else {
@@ -420,6 +453,7 @@ mod tests {
             (3, 3),
             items,
             DEFAULT_BUFFER_CRAFTS,
+            0.0,
         )
         .expect("EC on AM3 is a known recipe")
     }
@@ -533,6 +567,7 @@ mod tests {
             (3, 3),
             &mut items,
             DEFAULT_BUFFER_CRAFTS,
+            0.0,
         );
         if let Some(mut m) = m {
             assert!(!m.fluid_ingredients.is_empty(), "sulfuric acid needs water");
@@ -570,7 +605,8 @@ mod tests {
             (0, 0),
             (3, 3),
             &mut items,
-            14
+            14,
+            0.0
         )
         .is_none());
         assert!(Machine::new(
@@ -579,8 +615,39 @@ mod tests {
             (0, 0),
             (3, 3),
             &mut items,
-            14
+            14,
+            0.0
         )
         .is_none());
+    }
+
+    /// The productivity formula replicated in this module must agree with the
+    /// engine's canonical one exactly.
+    ///
+    /// `machine.rs` deliberately takes nothing from `module_policy` — its job
+    /// is engine POLICY (which modules to fit), and inheriting it would put a
+    /// calibrated number inside the instrument meant to check it. But the
+    /// *arithmetic* of productivity is Factorio prototype semantics, the same
+    /// class as `recipe_db`, which this module does take. So the formula is
+    /// replicated rather than imported, and pinned here so the copy cannot
+    /// drift from the original.
+    #[test]
+    fn productivity_matches_engine_formula() {
+        for (amount, ignored, bonus) in [
+            (1.0, 0.0, 0.0),
+            (1.0, 0.0, 0.10),
+            (2.0, 0.0, 0.10),
+            // Catalyst portion is never multiplied.
+            (5.0, 2.0, 0.10),
+            (5.0, 5.0, 0.50),
+            // Clamped: a recipe declaring more catalyst than output.
+            (1.0, 3.0, 0.25),
+        ] {
+            assert_eq!(
+                effective_product_amount(amount, ignored, bonus),
+                spaghettio_core::module_policy::effective_product_amount(amount, ignored, bonus),
+                "diverged at amount={amount} ignored={ignored} bonus={bonus}",
+            );
+        }
     }
 }

--- a/crates/meter/src/manifest.rs
+++ b/crates/meter/src/manifest.rs
@@ -55,6 +55,22 @@ pub struct Manifest {
     /// Declared belt stack size (1–4).
     #[serde(default = "one")]
     pub stacking: u8,
+    /// Declared research-sourced productivity, per recipe (e.g.
+    /// `{"processing-unit": 0.10}`).
+    ///
+    /// Same contract as the two axes above: an input the meter takes and
+    /// never infers. Empty = none, which is what every manifest written
+    /// before this field existed deserializes to, so their measurements are
+    /// unchanged.
+    ///
+    /// This exists because the sim runs `research_all_technologies()` and so
+    /// carried productivity that neither the solver nor this meter modelled —
+    /// the meter then under-produced by exactly that factor and the gap was
+    /// chased for three sessions as a belt/distribution defect. Declaring it
+    /// makes the two worlds match by construction rather than by luck. See
+    /// `docs/meter-divergence.md`.
+    #[serde(default)]
+    pub research_productivity: BTreeMap<String, f64>,
     #[serde(default)]
     pub entities: usize,
 }

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -80,6 +80,11 @@ fn layout_options(
     };
     LayoutOptions {
         strategy,
+        // The web UI exposes no research-productivity control yet, so the
+        // browser plans at none — identical to every layout before this axis
+        // existed. Wiring a control is a separate change; defaulting here
+        // keeps the boundary explicit rather than relying on `..Default`.
+        research_productivity: Default::default(),
         max_belt_tier,
         row_layout,
         surplus_policy: SurplusPolicy::default(),


### PR DESCRIPTION
## Intent

Owner decision (2026-08-06): **teach the meter productivity**, so it matches what the sim actually produces. This carries it the way `stacking` and `inserter_capacity` are already carried — as a **declared** axis, never inferred — so the meter and the sim are held to the same world *by construction* rather than by coincidence.

Coincidence is how RFC-064 Phase 2 item 7 happened: the sim runs `research_all_technologies()` and had +10% on `processing-unit` that nothing on the engine side modelled. That gap was chased across three sessions as a belt/distribution defect.

## Threading

Mirrors the two existing axes exactly. Empty is the default everywhere, so every existing manifest, golden and measurement is untouched.

```
LayoutOptions.research_productivity     (per-recipe map)
  → LayoutResult.research_productivity
  → manifest "research_productivity"     (omitted entirely when empty)
  → Manifest.research_productivity       (serde default = empty)
  → Machine::new(.., research_productivity)
```

## Measured effect

`tier5_processing_unit_from_ore_am3`, at the Stage B deep-chain warmup (108000 ticks):

| config | PU | EC | ceiling@EC | % of ceiling |
|---|---|---|---|---|
| declared none (today) | 1.7056/s | 41.49 | 1.7287 | 98.7% |
| **declared +10% PU & plastic** | **1.8500/s** | 41.49 | **1.9018** | 97.3% |
| sim reference | 1.987/s | 43.2 | — | — |

**The docs predicted 1.902 PU/s. The measured ceiling under productivity is 1.9018.** The productivity model is exactly right; the remaining gap is the meter not *reaching* its ceiling.

That gap decomposes cleanly, with no unexplained term:

| | |
|---|---|
| EC supply deficit (41.49 vs 43.2) | −3.9% |
| ceiling shortfall (distribution) | −2.7% |
| **combined** | **−6.6%** vs −6.9% observed |

Tie-off: `1.9018 × (43.2/41.49) = 1.980` — the sim's own 1.987. Given the sim's EC supply and its own ceiling, the meter lands on the sim's number.

**Bonus corroboration**: EC production is identical (41.49/s) in both configs, so declaring productivity does not move it — EC is genuinely unboosted and supply-limited, independently confirming the probe's `electronic-circuit: 0.0%`.

## One judgement call

The productivity formula is **replicated** in `machine.rs` rather than imported from `module_policy::effective_product_amount`. The meter's stated boundary is that it takes Factorio prototype facts from `recipe_db` and *nothing* from `module_policy` — because that module is engine *policy*, and inheriting it puts a calibrated number inside the instrument meant to check it. The arithmetic of productivity is prototype semantics, not policy, so replicating respects the boundary rather than dodging it. `productivity_matches_engine_formula` pins the copy against the original across the catalyst and clamp cases so it cannot drift.

## ⚠ Out of scope, and why the residual cannot fully close from here

**The solver does not model research productivity either** — `netflow.rs` covers modules and `base_effect` only. So the *plan* is over-provisioned on PU by the same factor the meter was short. That is the other half of the fix and wants its own change.

Nothing here pins the sim side either: the harness *reports* realized productivity (#580) but nothing compares it against this declared value. Adding that comparison — a `kit_error` on mismatch, the shape #370/#385 use — is the natural follow-up.

## Verification

- [x] `cargo test --workspace` — **1340 passed / 0 failed / 104 ignored**, single clean invocation
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Live meter runs on the fixture, both configs, quoted above
- [ ] Browser eyeball — N/A, no layout-geometry change (the web path declares empty)
- [ ] Snapshot — N/A, no geometry change

## Models / contracts touched

`LayoutOptions`, `LayoutResult` and the manifest gain one optional field; the meter's `Manifest` and `Machine::new` likewise. All default to empty/none, so pre-existing artifacts deserialize and measure unchanged.