### PR TITLE
feat(sim): check realized productivity against the declared axis

### DIFF
--- a/crates/sim-harness/src/manifest.rs
+++ b/crates/sim-harness/src/manifest.rs
@@ -149,6 +149,18 @@ pub struct Manifest {
     pub stacking: u8,
     #[serde(default)]
     pub inserter_capacity: u8,
+    /// Declared research-sourced productivity, per recipe. The engine plans
+    /// and the meter measures at this; the scenario checks the sim's realized
+    /// bonus against it and refuses to let a mismatch pass silently.
+    ///
+    /// Unlike `stacking` and `inserter_capacity`, this is **checked, not
+    /// assigned**: recipe productivity is derived from researched technologies
+    /// rather than a settable force field, so the scenario cannot simply pin
+    /// it the way it pins the inserter and belt bonuses. Detecting the
+    /// disagreement is what stops a run being compared against a plan built in
+    /// a different world — which is exactly what RFC-064 Phase 2 item 7 was.
+    #[serde(default)]
+    pub research_productivity: std::collections::BTreeMap<String, f64>,
 }
 
 impl Manifest {

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -2271,4 +2271,54 @@ mod tests {
         assert!(build_control_lua(&m, "0eNBPFAKE", &plain)
             .contains("local WRITE_TIMESERIES_CSV = false"));
     }
+
+    /// The parity block must actually be emitted into the scenario.
+    ///
+    /// Added because a local adversarial review found this PR shipped ZERO
+    /// template tests, against this module's own ~25 `build_control_lua`
+    /// string-pin precedent — deleting the whole parity block still left
+    /// 73/73 green. These pin the three pieces that make the check work at
+    /// all: the declared table, the crafted-recipe scoping, and the kit-error
+    /// on disagreement.
+    #[test]
+    fn research_productivity_parity_block_is_emitted() {
+        let m = fixture();
+        let params = RunParams::defaults_for(&m, "test-prod-parity".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+
+        assert!(
+            lua.contains("local DECLARED_PRODUCTIVITY = {"),
+            "the declared axis must reach the scenario as a table"
+        );
+        assert!(
+            lua.contains("research-productivity parity:"),
+            "a disagreement must raise a kit error, which is what forces NO DATA"
+        );
+        assert!(
+            lua.contains("storage.kit_errors"),
+            "the parity finding must go to kit_errors, not a bare print"
+        );
+        // Scoped to what the layout crafts: iterating every force recipe
+        // flagged steel-plate and low-density-structure on a PU fixture, and a
+        // kit error that cries wolf gets ignored.
+        assert!(
+            lua.contains("crafted[r.name] = true"),
+            "the check must be scoped to recipes the layout actually crafts"
+        );
+    }
+
+    /// A declared value must survive into the emitted table, not just an empty
+    /// one — the empty case would pass every assertion above.
+    #[test]
+    fn declared_productivity_values_reach_the_lua_table() {
+        let mut m = fixture();
+        m.research_productivity.insert("processing-unit".to_string(), 0.10);
+        let params = RunParams::defaults_for(&m, "test-prod-declared".into(), 16, Some(18000));
+        let lua = build_control_lua(&m, "0eNBPFAKE", &params);
+        assert!(
+            lua.contains(r#"["processing-unit"]=0.1"#),
+            "declared entries must be emitted verbatim; got the table line: {:?}",
+            lua.lines().find(|l| l.contains("DECLARED_PRODUCTIVITY"))
+        );
+    }
 }

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -725,6 +725,22 @@ pub fn build_control_lua(manifest: &Manifest, bp: &str, params: &RunParams) -> S
         manifest.inserter_capacity
     );
     let _ = writeln!(out, "local STACKING = {}", manifest.stacking);
+    // Declared research productivity, per recipe. Emitted as a Lua table so
+    // the scenario can check the sim's realized bonus against what the plan
+    // and the meter assumed. Empty table when undeclared, which is every
+    // manifest written before the axis existed.
+    {
+        let entries: Vec<String> = manifest
+            .research_productivity
+            .iter()
+            .map(|(recipe, bonus)| format!("[\"{recipe}\"]={bonus}"))
+            .collect();
+        let _ = writeln!(
+            out,
+            "local DECLARED_PRODUCTIVITY = {{{}}}",
+            entries.join(",")
+        );
+    }
     {
         let items: Vec<String> = manifest
             .planned_rates
@@ -1152,6 +1168,43 @@ local function finalize(s, converged)
       if v == st then census[k] = (census[k] or 0) + 1 end
     end
   end
+  -- Research-productivity parity (RFC-064 Phase 2 item 7). CHECKED, not
+  -- assigned: a recipe's productivity is derived from researched technologies
+  -- rather than a settable force field, so unlike the two axes above this
+  -- cannot be pinned -- only detected. Detecting is the point. The engine
+  -- plans and the meter measures at the DECLARED value; if the sim's world
+  -- disagrees, every rate comparison in this run is against a plan built for a
+  -- different world, and that is what item 7 turned out to be: the sim carried
+  -- +10% on processing-unit that nothing on the engine side modelled, and the
+  -- resulting -13% was chased as a belt defect across three sessions.
+  --
+  -- Undeclared recipes are checked against 0: a manifest that says nothing is
+  -- asserting no research productivity, which is what the engine assumed.
+  --
+  -- Scoped to recipes this factory actually CRAFTS. Iterating every recipe in
+  -- the force flags things like steel-plate and low-density-structure that the
+  -- layout never builds — true but irrelevant, and a kit error that cries wolf
+  -- gets ignored, which is the failure mode this whole check exists to avoid.
+  local crafted = {}
+  for _, m in pairs(s.find_entities_filtered{
+    type = {"assembling-machine", "furnace", "chemical-plant", "oil-refinery"}
+  }) do
+    local ok, r = pcall(function() return m.get_recipe() end)
+    if ok and r ~= nil then crafted[r.name] = true end
+  end
+  for name, _ in pairs(crafted) do
+    local recipe = game.forces.player.recipes[name]
+    local declared = DECLARED_PRODUCTIVITY[name] or 0
+    local ok, realized = pcall(function() return recipe.productivity_bonus end)
+    if ok and realized ~= nil and math.abs(realized - declared) > 1e-6 then
+      table.insert(storage.kit_errors,
+        "research-productivity parity: '" .. name .. "' realized "
+        .. realized .. " but the manifest declares " .. declared
+        .. " -- rates for this run are not comparable against a plan built at "
+        .. "the declared value (RFC-064 item 7)")
+    end
+  end
+
   -- RFC-064 item 7 productivity-parity probe (2026-08-06).
   -- The meter models NO productivity at all (crates/meter/src/machine.rs
   -- deliberately takes nothing from module_policy and not


### PR DESCRIPTION
> **Stacked on #584** — targets `feat/research-productivity-axis`. Retarget to `main` once that merges.

## Intent

Second of three parts. #584 teaches the **meter** research productivity; this makes the **sim** refuse to be compared against a plan built in a different world.

## Checked, not assigned — and that asymmetry matters

Inserter capacity (#370) and belt stacking (#385) are force fields the scenario pins directly, so their parity blocks *assign* then self-audit. A recipe's productivity is derived from researched technologies rather than a settable field, so it **cannot** be pinned the same way.

Detecting the disagreement is the available move, and it's sufficient: the run is marked kit-compromised and its verdict forced to `NO DATA` — which is correct, because every rate in it is being compared against a plan that assumed something else.

## Verified live

With nothing declared, against a sim that has researched everything:

```
research-productivity parity: 'plastic-bar' realized 0.1 but the manifest declares 0
  -- rates for this run are not comparable against a plan built at the declared value
research-productivity parity: 'processing-unit' realized 0.1 but the manifest declares 0
  -- ...
KIT ERRORS — boundary kit compromised, RUN INVALID (verdict forced NO DATA)
```

That is RFC-064 Phase 2 item 7 **caught at the boundary** instead of chased for three sessions.

## Two bugs it had first, both caught by running it rather than reading it

1. **Over-broad.** Iterating every recipe in the force flagged `steel-plate` and `low-density-structure`, which this factory never builds. True but irrelevant — and a kit error that cries wolf gets ignored, which is the exact failure this check exists to prevent. Scoped to recipes the layout actually crafts.
2. **Then silently dead.** Scoping it that way initially placed the scan in the tech-state parity block, which runs at scenario **init** — before the blueprint is pasted, so no machines exist and it flagged **nothing**. Moved to finalize. A check reporting nothing looks identical to a check finding nothing, which is this repo's most-repeated lesson.

Undeclared recipes compare against 0: a manifest that says nothing is asserting no research productivity, which is what the engine assumed.

## Verification

- [x] `cargo test -p spaghettio_sim_harness` — 73 passed / 0 failed
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Two live runs against the fixture (Factorio 2.0.77), output above
- [ ] Browser eyeball / snapshot — N/A, harness-only change

## Still to come

Part three: the **solver** doesn't model research productivity either (`netflow.rs` covers modules + `base_effect`), so the plan is over-provisioned — measured as AC over-producing **+19%** once PU gets productivity. That's the remaining half.