### PR TITLE
ci: send second-opinion review telemetry to Loki

### DIFF
--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -69,6 +69,19 @@ jobs:
         uses: storkme/second-opinion@v1
         with:
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          # Runtime monitoring (second-opinion v1.7.0+): one JSON event per review
+          # pushed to the estate's Grafana Cloud Loki, so cost, duration and
+          # degraded-rate are visible without opening individual run logs. Highest
+          # value here of the three consumers, because k:3 below means three passes
+          # can degrade independently — the event carries pass_statuses (e.g.
+          # "ok,timeout,ok") plus passes_ok/passes_degraded, so a review that quietly
+          # became a union of 2 instead of 3 is greppable rather than invisible.
+          # URL and instance id are repo variables (an unset var expands to "" and
+          # disables metrics with no network call — vars.LOKI_URL is the kill
+          # switch); only the token is a secret, scoped to logs:write.
+          loki-url: ${{ vars.LOKI_URL }}
+          loki-user: ${{ vars.LOKI_USER }}
+          loki-token: ${{ secrets.LOKI_TOKEN }}
           # DeepSeek V4 Flash (2026-07-31 release): 1M context, priced at
           # ~$0.14/M input. Pinned rather than left to the action's default
           # for the same reason claude-review pinned its model: review


### PR DESCRIPTION
The second-opinion reviewer runs unattended, so its cost, duration and degraded-rate are only visible by opening individual run logs. second-opinion v1.7.0 added an optional Loki emitter (one structured JSON event per review); this points it at the estate's Grafana Cloud stack.

## Why this repo gets the most out of it

`k: "3"` here means three passes degrade **independently**. The emitted event carries `pass_statuses` (e.g. `"ok,timeout,ok"`) alongside `passes_ok` / `passes_degraded` — so a review that quietly became a union of 2 instead of 3 (still green, still posted, just thinner) becomes greppable instead of invisible. The event also carries `diff_truncated` and `diff_chars`, which is the other failure mode this repo has already hit (#575: 1 of 16 files in the excerpt, check green).

## Config shape

| value | where | why |
|---|---|---|
| `LOKI_URL` | repo **variable** | not sensitive; unset ⇒ `""` ⇒ metrics fully off, no network call |
| `LOKI_USER` | repo **variable** | numeric instance id, already committed in infra's Alloy configs |
| `LOKI_TOKEN` | repo **secret** | scoped to `logs:write` only |

`vars.LOKI_URL` is the kill switch — unset it and this reverts to previous behaviour without a workflow edit.

## Notes

- Fail-soft by construction: the event is emitted *after* the review is posted, and a failed push is one log line — monitoring can never degrade or fail a review.
- Inert until the repo variables exist, so merging this changes nothing on its own.
- Placed above the `model:` pin deliberately, so the existing block of measured rationale (model / k / exclude-globs / diff cap) stays contiguous and readable.

Companion PRs: storkme/second-opinion#36, storkme/sisyphus#324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)