### PR TITLE
ci(second-opinion): cancel in-progress reviews only on synchronize

### DIFF
--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -19,13 +19,33 @@ on:
     # Until upstream grows one, re-review base-retargeted PRs session-side
     # (the stacked-PR retarget-to-main case is the one that occurs here).
 
-# One run per PR; a new push supersedes the old run's SHA, so cancelling is
-# safe. No `edited` trigger (unlike the parked claude-review workflow): this
-# reviewer files no description-scoped findings, so the event-class keying
-# saga (#521) does not apply here — a plain per-PR group is correct.
+# One concurrency group per PR; cancellation is CONDITIONAL on the event.
+# Only `synchronize` — the one trigger that means "a new head SHA exists" —
+# cancels the in-progress run: a superseded SHA's review is real money (this
+# action bills per review) and its check lands on a commit that can no longer
+# be merged, so cancelling there stays correct. Same-head re-events
+# (`reopened`, `ready_for_review`) must NOT cancel: an unconditional
+# cancel-in-progress let a close/reopen of #576 kill the in-progress run OF
+# THE SAME SHA ("Canceling since a higher priority waiting request for
+# second-opinion-576 exists", 2026-08-06), and a cancelled run leaves this
+# REQUIRED check with no successful conclusion — the PR is unmergeable until
+# someone overrides protection. Failure class 11 in docs/review-bot.md has
+# the forensics. Under the conditional, a same-head event queues behind the
+# running review (GitHub keeps one running + one pending per group) and is
+# near-free when its turn comes: the runner resolves the PR's head at
+# execution time and its per-SHA marker gate (`already_reviewed`, checked
+# before any model call) exits 0 green without spending.
+# NOT keyed on head.sha: that also fixes the same-SHA cancel, but it puts
+# each push in a fresh group, so a superseded run is never cancelled — the
+# exact spend the cancellation exists to stop. No `edited` trigger (unlike
+# the parked claude-review workflow): this reviewer files no
+# description-scoped findings, so the event-class keying saga (#521) does
+# not apply here — one group per PR remains correct.
 concurrency:
   group: second-opinion-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Evaluated on the NEWLY queued run: true only when that run carries a new
+  # head SHA worth yielding to.
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 jobs:
   second-opinion:

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -464,6 +464,52 @@ same-run attempts each failing the guard — that means the parking is
 deterministic for that PR, and the canary-gated `Agent` ban becomes the next
 lever.
 
+### Failure class 11: same-SHA event cancelled the required check (2026-08-06)
+
+The first second-opinion entry in this ledger, and the inverse of class 10:
+there the wrong run survived a cancellation race; here **nothing** survived,
+and the victim was a *required* check.
+
+On PR #576, at its final head `0d92f93a` (earlier SHAs had green reviews;
+this head had none yet), a close/reopen (times UTC):
+
+| run | created | outcome |
+|---|---|---|
+| `31124347719` | 17:51:39 | **cancelled** 17:54:47 — annotation: "Canceling since a higher priority waiting request for second-opinion-576 exists" |
+| `31124497214` attempt 1 | 17:54:41 | job cancelled 18:13:18 — "The job was not acquired by Runner of type hosted even after multiple attempts" |
+| `31124497214` attempt 2 (`gh run rerun`) | 18:31 | queued indefinitely |
+
+Two distinct causes composed. The first cancellation is the concurrency
+group: `second-opinion-<pr>` with an unconditional `cancel-in-progress: true`
+keys on the PR **number**, so a `reopened` event for the *same head SHA*
+cancelled the in-progress run — a cancellation that buys nothing (no newer
+SHA exists) and costs the head its only chance at a concluded check. The
+second and third are a platform runner-acquisition stall that day, not
+concurrency — but the group turned a transient stall into a dead end, because
+under it *any* subsequent same-PR event could keep killing recovery attempts.
+End state: `second-opinion` (required, `enforce_admins`) had no successful
+conclusion on the head and the PR was unmergeable without a protection
+override.
+
+**Fix:** `cancel-in-progress: ${{ github.event.action == 'synchronize' }}`.
+Cancellation was added for exactly one case — a new push supersedes the SHA
+under review, and reviewing a superseded SHA is billed spend — and
+`synchronize` is the only trigger in that case. Same-head events (`reopened`,
+`ready_for_review`) now queue behind the running review instead of killing
+it; when the queued duplicate runs, the runner's per-SHA marker gate
+(`already_reviewed`, checked before any model call, exit 0) makes it a green
+no-op. Keying the *group* on head SHA was considered and rejected: it fixes
+the same-SHA kill but isolates each push in its own group, so superseded
+runs would never be cancelled — reintroducing the spend the cancellation
+exists to stop.
+
+**Residual, accepted:** GitHub's own near-simultaneous-queue race (two runs
+entering one group at the same instant can cancel each other) still exists
+for bursts of pushes, and a run cancelled mid-flight by a genuine
+`synchronize` still leaves a `cancelled` conclusion on the *old* SHA — both
+fine, since the new head gets its own run. The recovery path is what the fix
+hardens: a `gh run rerun` can no longer be shot down by same-SHA event noise.
+
 ## Forensics playbook
 
 **Run signatures** (from the action's result JSON in the job log — grep the

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -477,7 +477,7 @@ this head had none yet), a close/reopen (times UTC):
 |---|---|---|
 | `31124347719` | 17:51:39 | **cancelled** 17:54:47 — annotation: "Canceling since a higher priority waiting request for second-opinion-576 exists" |
 | `31124497214` attempt 1 | 17:54:41 | job cancelled 18:13:18 — "The job was not acquired by Runner of type hosted even after multiple attempts" |
-| `31124497214` attempt 2 (`gh run rerun`) | 18:31 | queued indefinitely |
+| `31124497214` attempt 2 (`gh run rerun`) | 18:31:05 | job cancelled 20:03:00 — same runner-acquisition failure, after **92 min** queued |
 
 Two distinct causes composed. The first cancellation is the concurrency
 group: `second-opinion-<pr>` with an unconditional `cancel-in-progress: true`
@@ -485,8 +485,11 @@ keys on the PR **number**, so a `reopened` event for the *same head SHA*
 cancelled the in-progress run — a cancellation that buys nothing (no newer
 SHA exists) and costs the head its only chance at a concluded check. The
 second and third are a platform runner-acquisition stall that day, not
-concurrency — but the group turned a transient stall into a dead end, because
-under it *any* subsequent same-PR event could keep killing recovery attempts.
+concurrency — githubstatus.com carried Actions at **`major_outage`** through
+that evening (22:46 UTC check), so this is a confirmed platform incident
+rather than an inference from our own logs. But the group turned a transient
+stall into a dead end, because under it *any* subsequent same-PR event could
+keep killing recovery attempts.
 End state: `second-opinion` (required, `enforce_admins`) had no successful
 conclusion on the head and the PR was unmergeable without a protection
 override.


### PR DESCRIPTION
> **Stacked on #586** (which also edits this file). Retarget to `main` once that lands.
>
> **Workflow-file PR** — per `CLAUDE.md` this runs its own modified workflow with `OPENROUTER_API_KEY` and `LOKI_TOKEN`. The diff was eyeballed before pushing: it changes **only** `cancel-in-progress`. No change to the `with:` block, no new steps, no new secret surface.

## The bug, with the annotation

```yaml
concurrency:
  group: second-opinion-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

Keyed on the **PR number**, so any two overlapping events for one PR cancel each other — including when they concern the **same head SHA**. Observed on #576:

> `Canceling since a higher priority waiting request for second-opinion-576 exists`

A close/reopen killed the in-progress review **of the same SHA**. Since `second-opinion` is required on main with `enforce_admins=true`, that left the head with no successful conclusion and the PR unmergeable without a protection override — which is what happened.

## The fix

```yaml
cancel-in-progress: ${{ github.event.action == 'synchronize' }}
```

Group unchanged. Only `synchronize` — the one trigger that by definition carries a new head SHA — cancels. Same-head re-events queue behind the running review instead of killing it, and are near-free when their turn comes: the runner resolves the PR head at execution time and its per-SHA `already_reviewed` marker gate exits 0 green **before any model call**.

## Why not key the group on `head.sha`

It fixes the same-SHA kill, but puts each push in a **fresh** group — and cross-group cancellation doesn't exist, so a run reviewing a superseded SHA would never be cancelled and would always bill a full review. That's precisely the spend `cancel-in-progress` was installed to prevent, and it fires legitimately several times a day. Rejected, and recorded as rejected.

## Trigger walk-through

| event | behaviour |
|---|---|
| `synchronize` | cancels the superseded run, reviews the new head — unchanged |
| `reopened` / `ready_for_review` (same SHA) | does **not** cancel; queues, then exits green via the marker gate |
| `opened` | can't overlap anything in its group |
| `gh run rerun` | no longer shootable by same-SHA event noise |
| draft | exits 0 green fast, posts no marker, so a later `ready_for_review` still reviews |

## A correction to my own earlier account

I reported "three concurrency cancellations on one SHA". **That was wrong.** Forensics show exactly **one** was concurrency (annotation above). The other two were the repo-wide runner stall: *"The job was not acquired by Runner of type hosted even after multiple attempts"*, and a still-`queued` rerun. The concurrency bug is real and did destroy the one review that was running — but it did not cause the other two, and I'd have merged that overstatement into the record if the forensics hadn't been redone.

## Verification

- [x] YAML parses; triggers and concurrency block confirmed
- [x] `workflow-guard` unaffected — it asserts only `claude-code-review.yml` and `claude-review-auto-retry.yml`
- [x] `docs/review-bot.md` gains Failure class 11 with the run table and both annotations
- [ ] **Not exercised live** — Actions was stalled repo-wide while this was written. Reasoned from GitHub's docs on expressions in `cancel-in-progress` plus the annotation evidence; `actionlint` not available locally, YAML checked with PyYAML only.

## Residual, accepted

GitHub's near-simultaneous-queue race remains possible for push bursts; recoverable by rerun. Recorded in the doc entry rather than papered over.