### PR TITLE
fix(transit): measure mixed belt+DI edges; falsify the PTG follow-up

### DIFF
--- a/crates/core/src/bus/transit.rs
+++ b/crates/core/src/bus/transit.rs
@@ -39,7 +39,18 @@ pub struct EdgeTransit {
     pub consumer_terminals: usize,
     pub path_length: f64,
     pub weighted_cost: f64,
+    /// True only for a pure direct-insertion edge — solver-declared DI with
+    /// no transport network at all (§(b)'s port-to-port Manhattan case).
+    /// A mixed belt+DI edge reports `false` here and its bridge count in
+    /// [`Self::di_bridges`].
     pub direct_insertion: bool,
+    /// Direct-insertion bridges folded into this edge's consumer-terminal
+    /// mean: 0 for a belt/pipe-only edge, the full bridge count for a pure
+    /// DI edge, and the bridge count for a mixed edge. Reported separately
+    /// so a mixed measurement is visible as such rather than hiding inside
+    /// `consumer_terminals` (validator-reporting rule: named counts, never
+    /// blended ones).
+    pub di_bridges: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -155,8 +166,15 @@ impl TerminalBuckets {
 /// matching producer terminal to every distinct consumer terminal. Surface
 /// steps cost one tile; underground jumps cost their physical Manhattan span.
 /// A solver-declared direct-insertion edge with no transport terminals uses
-/// its actual machine-to-machine inserter span. Any other missing or
-/// unreachable terminal is an error, making the candidate inadmissible.
+/// its actual machine-to-machine inserter span. A **mixed** edge — declared
+/// DI with bridges present AND a transport network — folds each bridge into
+/// the same consumer-terminal mean as one more consumer terminal whose
+/// distance is its Manhattan span; both pure cases are the degenerate ends
+/// of that rule (RFC-064 §(b), amended 2026-08-06). The transport network
+/// participating in a mixed edge must still be well-formed: missing or
+/// unreachable terminals refuse exactly as they do without DI, and bridges
+/// never repair them. Any other missing or unreachable terminal is an
+/// error, making the candidate inadmissible.
 pub fn measure_realized_transit(
     layout: &LayoutResult,
     solver_result: &SolverResult,
@@ -201,49 +219,73 @@ pub fn measure_realized_transit(
                 && coupling.consumer_recipe == edge.consumer_recipe
                 && edge.producer_recipes.contains(&coupling.producer_recipe)
         });
-        let (path_length, producer_count, consumer_count, direct_insertion) = if sources.is_empty()
-            && consumers.is_empty()
-            && declared_di
-            && !direct_lengths.is_empty()
-        {
-            (
-                direct_lengths.iter().sum::<i64>() as f64 / direct_lengths.len() as f64,
-                direct_lengths.len(),
-                direct_lengths.len(),
-                true,
-            )
-        } else {
-            if sources.is_empty() {
-                return Err(TransitError::MissingProducerTerminal {
-                    item: edge.item.clone(),
-                    consumer_recipe: edge.consumer_recipe.clone(),
-                });
-            }
-            if consumers.is_empty() {
-                return Err(TransitError::MissingConsumerTerminal {
-                    item: edge.item.clone(),
-                    consumer_recipe: edge.consumer_recipe.clone(),
-                });
-            }
-            let distance = shortest_distances(&graph, &sources);
-            let mut total_length = 0i64;
-            for &terminal in &consumers {
-                let Some(&length) = distance.get(&terminal) else {
-                    return Err(TransitError::UnreachableConsumerTerminal {
+        // DI participates in this edge's measurement only when the solver
+        // declared the coupling AND the layout realized at least one
+        // machine-to-machine bridge. Declared-but-unrealized DI (the placer
+        // declined the coupling) measures as a plain belt edge; undeclared
+        // bridges never contribute (§(b): "a solver-declared direct-insertion
+        // edge").
+        let di_active = declared_di && !direct_lengths.is_empty();
+        let (path_length, producer_count, consumer_count, direct_insertion, di_bridges) =
+            if sources.is_empty() && consumers.is_empty() && di_active {
+                // Pure DI: §(b)'s "no transport network" Manhattan case.
+                (
+                    direct_lengths.iter().sum::<i64>() as f64 / direct_lengths.len() as f64,
+                    direct_lengths.len(),
+                    direct_lengths.len(),
+                    true,
+                    direct_lengths.len(),
+                )
+            } else {
+                // A transport network participates (or should). It must be
+                // well-formed on BOTH sides regardless of DI: a half-formed
+                // belt network is §(b)'s "broken routed edge", and DI bridges
+                // must not paper over it (decision log, 2026-08-06).
+                if sources.is_empty() {
+                    return Err(TransitError::MissingProducerTerminal {
                         item: edge.item.clone(),
                         consumer_recipe: edge.consumer_recipe.clone(),
-                        terminal,
                     });
-                };
-                total_length += length;
-            }
-            (
-                total_length as f64 / consumers.len() as f64,
-                sources.len(),
-                consumers.len(),
-                false,
-            )
-        };
+                }
+                if consumers.is_empty() {
+                    return Err(TransitError::MissingConsumerTerminal {
+                        item: edge.item.clone(),
+                        consumer_recipe: edge.consumer_recipe.clone(),
+                    });
+                }
+                let distance = shortest_distances(&graph, &sources);
+                let mut total_length = 0i64;
+                for &terminal in &consumers {
+                    let Some(&length) = distance.get(&terminal) else {
+                        return Err(TransitError::UnreachableConsumerTerminal {
+                            item: edge.item.clone(),
+                            consumer_recipe: edge.consumer_recipe.clone(),
+                            terminal,
+                        });
+                    };
+                    total_length += length;
+                }
+                // Mixed belt+DI edge (RFC-064 §(b), amended 2026-08-06): each
+                // DI bridge is one more consumer terminal whose distance is
+                // its port-to-port Manhattan span. The aggregate planned_rate
+                // stays and is apportioned evenly across belt terminals and
+                // bridges alike — the same equivalence §(b) states for the
+                // all-belt mean. Falling through to belt-only measurement
+                // here (the pre-fix behaviour) charged the full rate at the
+                // belt-only mean, silently apportioning DI machines' demand
+                // onto belt paths they do not use.
+                let bridges = if di_active { direct_lengths.len() } else { 0 };
+                if di_active {
+                    total_length += direct_lengths.iter().sum::<i64>();
+                }
+                (
+                    total_length as f64 / (consumers.len() + bridges) as f64,
+                    sources.len() + bridges,
+                    consumers.len() + bridges,
+                    false,
+                    bridges,
+                )
+            };
 
         let planned_rate = edge.rate as f64 / RATE_SCALE;
         let weighted_cost =
@@ -264,6 +306,7 @@ pub fn measure_realized_transit(
             path_length,
             weighted_cost,
             direct_insertion,
+            di_bridges,
         });
     }
     result.total = result.solid_total + result.fluid_total;
@@ -782,6 +825,184 @@ mod tests {
              'other-item' bridge in would move this off 2.0"
         );
         assert_eq!(measured.edges[0].producer_terminals, 1, "one matching bridge, not two");
+    }
+
+    /// A mixed belt+DI edge folds each DI bridge into the consumer-terminal
+    /// mean as one more terminal at its Manhattan span (RFC-064 §(b),
+    /// amended 2026-08-06).
+    ///
+    /// The fixture makes all three candidate behaviours produce DIFFERENT
+    /// numbers, so the primary assertion discriminates (the PR #582 round-2
+    /// lesson — a fixture where two behaviours coincide is not a regression
+    /// test): belt consumer terminal at Dijkstra distance 4, DI bridge at
+    /// Manhattan span 2, so
+    ///   - mixed mean (this rule):          (4 + 2) / 2 = 3.0
+    ///   - belt-only fall-through (pre-fix): 4.0
+    ///   - pure-DI fallback:                 2.0
+    #[test]
+    fn mixed_belt_and_di_edge_folds_bridges_into_the_consumer_mean() {
+        let mut sr = solver("part", 2.0, false);
+        sr.di_couplings.push(DICoupling {
+            producer_recipe: "producer".to_string(),
+            consumer_recipe: "consumer".to_string(),
+            item: "part".to_string(),
+            producer_count: 1.0,
+            consumer_count: 1.0,
+        });
+
+        let south = |entity: PlacedEntity| PlacedEntity {
+            direction: EntityDirection::South,
+            ..entity
+        };
+        let mut layout = LayoutResult {
+            entities: vec![
+                machine("producer", 0, 0),
+                // DI half: bridge into a consumer machine at Manhattan 2.
+                inserter(3, 1),
+                machine("consumer", 4, 0),
+                // Belt half: drop south of the producer ...
+                south(inserter(1, 3)),
+            ],
+            ..Default::default()
+        };
+        // ... down a 5-belt southward run (drop terminal (1,4), pickup
+        // terminal (1,8): Dijkstra distance 4) ...
+        layout
+            .entities
+            .extend((4..=8).map(|y| south(belt("transport-belt", 1, y, None))));
+        // ... into a second consumer machine of the same recipe.
+        layout
+            .entities
+            .extend([south(inserter(1, 9)), machine("consumer", 0, 10)]);
+
+        let measured = measure_realized_transit(&layout, &sr, 0.5)
+            .expect("a mixed belt+DI edge must measure, not refuse");
+        let edge = &measured.edges[0];
+        assert_eq!(
+            edge.path_length, 3.0,
+            "mean over belt terminal (4) and DI bridge (2); belt-only \
+             fall-through would report 4.0, pure-DI 2.0"
+        );
+        assert_eq!(
+            edge.consumer_terminals, 2,
+            "the DI-fed consumer must appear in the terminal count, not be \
+             silently dropped"
+        );
+        assert_eq!(edge.producer_terminals, 2);
+        assert_eq!(edge.di_bridges, 1, "the mixed edge reports its bridge count");
+        assert!(
+            !edge.direct_insertion,
+            "direct_insertion stays reserved for the pure no-network case"
+        );
+        assert_eq!(measured.total, 6.0, "full aggregate rate 2.0 x mean 3.0");
+    }
+
+    /// DI bridges must NOT repair a half-formed transport network: a
+    /// declared-DI edge whose belt side has producer drop terminals but no
+    /// consumer pickup terminal is §(b)'s "broken routed edge" and refuses,
+    /// exactly as it would without the bridges (decision log, 2026-08-06).
+    #[test]
+    fn di_bridges_do_not_repair_a_half_formed_belt_network() {
+        let mut sr = solver("part", 2.0, false);
+        sr.di_couplings.push(DICoupling {
+            producer_recipe: "producer".to_string(),
+            consumer_recipe: "consumer".to_string(),
+            item: "part".to_string(),
+            producer_count: 1.0,
+            consumer_count: 1.0,
+        });
+
+        let south = |entity: PlacedEntity| PlacedEntity {
+            direction: EntityDirection::South,
+            ..entity
+        };
+        // Same fixture as the mixed test, minus the pickup inserter: the
+        // southward belt run now feeds nothing, so the edge has a producer
+        // terminal but no consumer terminal.
+        let mut layout = LayoutResult {
+            entities: vec![
+                machine("producer", 0, 0),
+                inserter(3, 1),
+                machine("consumer", 4, 0),
+                south(inserter(1, 3)),
+            ],
+            ..Default::default()
+        };
+        layout
+            .entities
+            .extend((4..=8).map(|y| south(belt("transport-belt", 1, y, None))));
+
+        let error = measure_realized_transit(&layout, &sr, 0.5)
+            .expect_err("a half-formed belt network must refuse despite DI bridges");
+        assert_eq!(
+            error,
+            TransitError::MissingConsumerTerminal {
+                item: "part".to_string(),
+                consumer_recipe: "consumer".to_string(),
+            },
+            "the refusal must name the missing belt consumer terminal, not \
+             degrade to a pure-DI measurement"
+        );
+    }
+
+    /// Fluid transit must traverse a pipe-to-ground pair in BOTH directions:
+    /// Factorio fluid networks are undirected, so a routed path that crosses
+    /// the pair from its output-labelled end to its input-labelled end is
+    /// just as real as the canonical input-to-output crossing.
+    ///
+    /// Pins the follow-up recorded twice in RFC-064's decision log
+    /// (2026-08-05, bot rounds 2 and 4 on PR #575), which claimed
+    /// `find_ptg_pairs` maps input->output only and would falsely refuse the
+    /// reverse traversal. Inspection showed the claim false — the pair map
+    /// has inserted BOTH directions since its introduction, and `fluid_graph`
+    /// adds the underground arc from whichever end it iterates — but nothing
+    /// pinned it, so a future "fix" could introduce exactly the defect the
+    /// log describes. Producer sits on the output-PTG side, consumer on the
+    /// input-PTG side; if the underground arc existed only input->output the
+    /// consumer terminal would be unreachable and this would refuse.
+    #[test]
+    fn fluid_transit_traverses_ptg_pairs_output_to_input() {
+        let pipe = |x: i32, y: i32| PlacedEntity {
+            name: "pipe".to_string(),
+            x,
+            y,
+            carries: Some("water".to_string()),
+            ..Default::default()
+        };
+        let ptg = |x: i32, y: i32, direction: EntityDirection, io_type: &str| PlacedEntity {
+            name: "pipe-to-ground".to_string(),
+            x,
+            y,
+            direction,
+            io_type: Some(io_type.to_string()),
+            carries: Some("water".to_string()),
+            ..Default::default()
+        };
+        let layout = LayoutResult {
+            entities: vec![
+                // Producer output port (south face) at (1,3).
+                machine("producer", 0, 0),
+                pipe(1, 3),
+                pipe(2, 3),
+                pipe(3, 3),
+                // The pair: output-labelled PTG surfaces WEST toward the
+                // producer, input-labelled PTG surfaces EAST toward the
+                // consumer — so the flow crosses output -> input.
+                ptg(4, 3, EntityDirection::East, "output"),
+                ptg(10, 3, EntityDirection::West, "input"),
+                pipe(11, 3),
+                // Consumer input port (north face) at (11,3).
+                machine("consumer", 10, 4),
+            ],
+            ..Default::default()
+        };
+        let measured = measure_realized_transit(&layout, &solver("water", 10.0, true), 0.5)
+            .expect("output->input PTG traversal must measure, not refuse");
+        assert_eq!(
+            measured.edges[0].path_length, 10.0,
+            "3 surface steps + 6-tile underground span + 1 surface step"
+        );
+        assert_eq!(measured.fluid_total, 50.0, "rate 10.0 x weight 0.5 x length 10");
     }
 
     /// An unlabelled transport tile must NOT be traversable by every net.

--- a/crates/core/src/objective.rs
+++ b/crates/core/src/objective.rs
@@ -88,6 +88,11 @@ pub struct EdgeMeasurement {
     /// edge with no transport network (§(b)'s port-to-port Manhattan case)
     /// rather than over the belt/pipe graph.
     pub direct_insertion: bool,
+    /// Direct-insertion bridges folded into the consumer-terminal mean
+    /// (§(b)'s mixed-edge rule, amended 2026-08-06): 0 for a belt/pipe-only
+    /// edge, the full bridge count for a pure DI edge, the bridge count for
+    /// a mixed edge. Reported so a mixed measurement is visible as such.
+    pub di_bridges: usize,
 }
 
 /// Raw per-layout numbers RFC-064's Metrics section defines, computed on a
@@ -174,6 +179,7 @@ pub fn measure(layout: &LayoutResult, solver: &SolverResult) -> Result<LayoutMea
             producer_terminals: e.producer_terminals,
             consumer_terminals: e.consumer_terminals,
             direct_insertion: e.direct_insertion,
+            di_bridges: e.di_bridges,
         })
         .collect();
 
@@ -711,6 +717,7 @@ mod tests {
             producer_terminals: 1,
             consumer_terminals: 1,
             direct_insertion: false,
+            di_bridges: 0,
         };
         let mut native = measure_with(1.5, 100.0, 500);
         native.edges = vec![edge.clone()];
@@ -746,6 +753,7 @@ mod tests {
             producer_terminals: 1,
             consumer_terminals: 1,
             direct_insertion: false,
+            di_bridges: 0,
         };
         let mut native = measure_with(1.5, 200.0, 500);
         native.edges = vec![edge(100.0), edge(100.0)];
@@ -774,6 +782,7 @@ mod tests {
             producer_terminals: 1,
             consumer_terminals: 1,
             direct_insertion: false,
+            di_bridges: 0,
         }];
         let zero_edge_cand = measure_with(1.5, 0.0, 500);
         let scores = score_vs_native(&zero_edge_cand, &native);

--- a/docs/rfc-064-spaghetti-objective.md
+++ b/docs/rfc-064-spaghetti-objective.md
@@ -322,11 +322,21 @@ consumer recipe, so this is equivalent to apportioning that rate evenly over
 its identical placed consumer terminals. Surface cardinal steps cost 1;
 underground-belt and pipe-to-ground jumps cost their physical tile span, not
 one entity. A solver-declared direct-insertion edge with no transport network
-uses the Phase-0 precedent of port-to-port Manhattan distance. Any other
-unreachable terminal makes the metric unmeasurable and the candidate
-inadmissible — never silently fall back to Manhattan for a broken routed
-edge. Fluid edges use the same construction at `fluid_weight = 0.5`, the
-value Phase 0 chose and recorded below.
+uses the Phase-0 precedent of port-to-port Manhattan distance. A **mixed**
+edge — a declared DI coupling the layout realizes with bridges while a
+transport network also carries part of the demand — folds each DI bridge
+into the same mean as one more consumer terminal whose distance is its
+port-to-port Manhattan span; the aggregate `planned_rate` stays and is
+apportioned evenly across belt terminals and bridges alike, and both pure
+cases above are the degenerate ends of this one rule (amended 2026-08-06 —
+originally unstated, and two independent implementations diverged from each
+other in the gap). A transport network participating in a mixed edge must
+still be well-formed: a missing or unreachable terminal refuses exactly as
+below, and DI bridges never repair it. Any other unreachable terminal makes
+the metric unmeasurable and the candidate inadmissible — never silently fall
+back to Manhattan for a broken routed edge. Fluid edges use the same
+construction at `fluid_weight = 0.5`, the value Phase 0 chose and recorded
+below.
 
 ```text
 Transit_score(L) = 1 - Transit(L) / Transit(native)
@@ -1446,7 +1456,12 @@ nothing else cross-depends). A phase's kill does not cancel the others.
   true when `compatible` was made strict; the metric is now strict for both
   traversal and terminal discovery, and an unmeasurable edge refuses rather
   than reaching for a weaker match); and only a solver-declared DI edge with no transport
-  terminals may use its actual machine-to-machine inserter span. Every missing
+  terminals may use its actual machine-to-machine inserter span alone — a
+  declared DI edge that ALSO has a well-formed transport network folds each
+  bridge into the consumer-terminal mean at its Manhattan span (amended
+  2026-08-06; the freeze originally specified only the two pure cases, and the
+  implementation fell through to belt-only measurement at full aggregate
+  rate for the mixed one). Every missing
   or unreachable non-DI terminal is an error. Focused unit fixtures pin surface
   length, underground span length, fluid weighting, and DI fallback. The same
   instrument measured every native control successfully:
@@ -1882,3 +1897,78 @@ nothing else cross-depends). A phase's kill does not cancel the others.
   into an unmeasurable edge; accepting them re-admits a smaller version of the
   contamination the guard exists to stop. The deciding evidence is a count of
   unstamped DI inserters in real layouts, which nobody has taken.
+
+- **2026-08-06 — mixed belt+DI edges: DECIDED, fold the bridges into the
+  consumer-terminal mean rather than refuse.** The open question left by the
+  unification entry above — `transit.rs`'s DI branch required
+  `sources.is_empty() && consumers.is_empty()`, so an edge both belt-fed and
+  DI-fed fell through to belt-only measurement at the full aggregate
+  `planned_rate` (over-charging path length and silently dropping the DI
+  consumers from `consumer_terminals`), and two independent implementations
+  diverged in this exact gap. The two candidate answers were (a) refuse the
+  mixed edge outright, or (b) apportion the rate across both halves. **(b)
+  wins, in the specific form: each DI bridge is one more consumer terminal
+  whose distance is its port-to-port Manhattan span, folded into §(b)'s
+  existing arithmetic mean with the aggregate rate retained.** Reasoning
+  against §(b)'s own text, not taste:
+  1. §(b) justifies its mean by the equivalence "apportioning that rate
+     evenly over its identical placed consumer terminals". A DI bridge IS a
+     consumer-input terminal, and the distance §(b) itself assigns DI is the
+     Phase-0 port-to-port Manhattan span — so folding bridges into the same
+     mean is not a third rule: the all-belt case and the all-DI case both
+     fall out of it as degenerate ends. It is the unique reading under which
+     §(b)'s two stated constructions are one construction.
+  2. Refusal (a) is scoped by §(b) to unmeasurability — "any **other**
+     unreachable terminal", "never silently fall back to Manhattan for a
+     **broken routed** edge". A mixed edge has no unreachable terminal and no
+     unmeasurable component; refusing it would make physically valid,
+     fully-routed candidates inadmissible for a spec-gap reason and would
+     systematically firewall DI-bearing candidate families out of scored
+     fields — a search bias, not a physical judgment.
+  3. The pre-fix fall-through violated §(b)'s equivalence in the other
+     direction: charging the full aggregate rate at the belt-only mean
+     apportions the DI machines' demand onto belt paths they do not use.
+  **Retained refusal, decided not inherited**: a transport network that
+  participates in a declared-DI edge must still be well-formed — producer
+  drops with no consumer pickup (or vice versa) refuse with the same
+  `Missing*Terminal` errors as a DI-free edge, because a half-formed network
+  is exactly §(b)'s broken routed edge and bridges must not paper over it.
+  Reporting: `EdgeTransit`/`EdgeMeasurement` gain `di_bridges` (0 belt-only,
+  bridge count otherwise) so a mixed measurement is visible as such instead
+  of blending into `consumer_terminals`; `direct_insertion` stays reserved
+  for the pure no-network case. Pinned by
+  `mixed_belt_and_di_edge_folds_bridges_into_the_consumer_mean`, whose
+  fixture makes all three behaviours distinct (belt terminal at Dijkstra 4,
+  bridge at Manhattan 2: mixed mean 3.0, pre-fix fall-through 4.0, pure-DI
+  2.0) so the primary assertion discriminates, and by
+  `di_bridges_do_not_repair_a_half_formed_belt_network` for the retained
+  refusal. Negative controls run and failed on their named assertions:
+  belt-only fall-through restored → the mixed test fails `path_length`
+  4.0 ≠ 3.0 (that test alone); pure-DI-when-consumers-missing → the refusal
+  test alone fails, showing the silently-measured DI edge. §(b)'s text and
+  the Phase-3 freeze paragraph amended in the same commit.
+
+- **2026-08-06 — the PTG-unidirectionality follow-up is FALSE against the
+  code; pinned instead of fixed.** Recorded twice above (bot rounds 2 and 4
+  on PR #575): "`find_ptg_pairs` maps input→output only while Factorio fluid
+  networks are bidirectional — a valid output→input traversal would be
+  falsely refused as `UnreachableConsumerTerminal`." Inspection: the claim
+  does not hold and never did. `find_ptg_pairs` has inserted BOTH directions
+  (`pairs.insert(a, b); pairs.insert(b, a)`) since its introduction
+  (cb4712ef, pre-dating `transit.rs` entirely), its doc comment says
+  "returns a bidirectional map", and `fluid_graph` adds the underground arc
+  from whichever end it iterates — so both PTG tiles are keys and the jump
+  is traversable both ways. What IS input→output-only is pair *formation*
+  (only `io_type: "input"` PTGs initiate the search for a matching output),
+  which is an internal-annotation convention shared with the fluid
+  validators, not a traversal constraint. Since the defect is one deliberate
+  edit away (dropping the reverse insert) and the decision log described it
+  twice, it is now pinned by
+  `fluid_transit_traverses_ptg_pairs_output_to_input`: producer on the
+  output-labelled side, consumer on the input-labelled side, so the routed
+  path crosses the pair in the allegedly-refused direction (3 surface + 6
+  underground + 1 surface = 10.0). Negative control: removing
+  `pairs.insert(b, a)` makes exactly that test fail with
+  `UnreachableConsumerTerminal { terminal: (11, 3) }` — the precise false
+  refusal the follow-up predicted, confirming both that the pin detects the
+  defect and that the shipping code does not have it.


### PR DESCRIPTION
## Two follow-ups from #582's decision log. One was a real defect; the other was never real.

---

## 1. Mixed belt+DI edges — FIXED, with an explicit metric decision

`measure_realized_transit`'s DI branch required `sources.is_empty() && consumers.is_empty()`, so an edge that is **both** belt-fed and DI-fed fell through to belt-only measurement while `planned_rate` kept the full aggregate demand — over-charging path length and silently dropping the DI consumers.

Both reviewers on #575 and #569 found this same defect class in two independent implementations, which is what suggested RFC-064 §(b) under-specifies the duality rather than either author being careless. §(b) says DI-Manhattan applies *"with no transport network"* and is silent on the mixed case.

**Decision: fold each DI bridge into §(b)'s existing consumer-terminal mean** as one more consumer terminal whose distance is its port-to-port Manhattan span, keeping the aggregate `planned_rate`.

Why this reading rather than refusal:

- §(b) justifies its mean by *"apportioning that rate evenly over its identical placed consumer terminals"*. A DI bridge **is** a consumer-input terminal, and Manhattan is the distance §(b) itself assigns DI. So this isn't a third rule — the all-belt and all-DI constructions are its degenerate ends, and **all-belt and all-DI edges keep the values they had**.

  Mixed edges do change value, which is the entire point of the fix: the control table below shows the same fixture going 4.0 (belt-only fall-through) → 3.0 (folded). An earlier draft of this paragraph claimed *nothing* previously measurable changes value — false, and contradicted by that table. What is preserved is that no edge measurable under a *correct* reading of §(b) moves; the 4.0 was the defect.
- Refusal is scoped by §(b) to *unmeasurability* (*"never silently fall back to Manhattan for a **broken routed** edge"*). A mixed edge has no unmeasurable component. Refusing it would make valid candidates inadmissible and systematically firewall DI-bearing families out of scored fields — a search bias, not a physical judgment.

**One refusal retained, deliberately**: a half-formed transport network on a declared-DI edge (drops without pickups) still errors. Bridges must not paper over a broken belt half.

`di_bridges` is reported separately from `direct_insertion` so a mixed measurement is visible as mixed, rather than hiding inside `consumer_terminals` — the named-counts-never-blended rule from `docs/validator-reporting.md`.

§(b) and the Phase-3 freeze paragraph are amended in the same commit, per the precedent set when frozen text and code diverged in #575.

---

## 2. PTG unidirectionality — NOT A DEFECT, and the record was wrong twice

The recorded follow-up claimed `find_ptg_pairs` maps input→output only, so an output→input traversal would be falsely refused. **That is false against the code and always was:**

```rust
pairs.insert(a, b);
pairs.insert(b, a);   // validate/fluids.rs:237-238
```

Both directions have been inserted since the function was introduced (`cb4712ef`), pre-dating `transit.rs` entirely. What *is* input→output-only is pair **formation** — `io_type: "input"` initiates the search — an internal annotation convention shared with the validators, not a traversal constraint.

I propagated this into the decision log **twice** without checking it. It's now pinned by `fluid_transit_traverses_ptg_pairs_output_to_input` (producer on the output-labelled side; 3 surface + 6 UG + 1 surface = 10.0) and recorded as falsified, because a claim that survived two review rounds unchallenged deserves a test rather than a deletion.

---

## Negative controls — all three run, each failing on its own named assertion

| control | break applied | result |
|---|---|---|
| mixed | belt-only fall-through restored | fails primary `path_length`: `left: 4.0, right: 3.0` |
| refusal | pure-DI condition loosened | fails its `expect_err`, exposing the silently-measured DI edge |
| PTG pin | `pairs.insert(b, a)` removed | `UnreachableConsumerTerminal { terminal: (11, 3) }` — the exact predicted false refusal |

The mixed fixture deliberately puts all three candidate behaviours at **distinct** values (mixed 3.0 / belt-only 4.0 / pure-DI 2.0) so the primary assertion discriminates. That's the #582 round-2 trap, where a fixture made both outcomes 2.0 and the control passed for the wrong reason.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — **1198 passed / 0 failed / 102 ignored**, one clean invocation, independently re-run
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] wasm32 check clean

`tier4_advanced_circuit_from_plates` timed out at 10008ms against its 10000ms `ntest` limit on a loaded first run, and passes in 0.75s in isolation. Load, not regression — but it's now flaked twice today at that boundary and is worth a longer limit.
