### PR TITLE
feat: wire the research-productivity axis end to end

### DIFF
--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -14,7 +14,11 @@
 //!                       targets instead of one, solved as a single combined
 //!                       plan (spaghettio_core::solver::
 //!                       solve_multi_with_palette_exclusions_quality_and_modules
-//!                       — the same entry point the wasm `solve_multi`
+//! the same solve the wasm `solve_multi` boundary uses, reached through
+//! `netflow::solve_netflow_multi_with_options` rather than the
+//! `solve_multi_with_palette_exclusions_quality_and_modules` wrapper — the
+//! wrapper cannot pass the declared research-productivity axis. Every other
+//! option is left at the value that wrapper set.
 //!                       boundary uses). Replaces the <item> <rate>
 //!                       positionals; every flag below still applies. N=1
 //!                       is bit-identical to the plain positional form by
@@ -84,6 +88,7 @@ fn parse_target_token(tok: &str) -> (String, f64) {
         .unwrap_or_else(|_| usage(&format!("bad rate in target {tok:?}")));
     (item.to_string(), rate)
 }
+
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -182,17 +187,9 @@ fn main() {
             // different world from the one it declares on the manifest — the
             // exact class this axis exists to eliminate.
             "--research-productivity" => {
-                for pair in need(i).split(',').filter(|p| !p.is_empty()) {
-                    let (recipe, bonus) = pair
-                        .split_once('=')
-                        .unwrap_or_else(|| usage("--research-productivity wants recipe=bonus"));
-                    let bonus: f64 = bonus.parse().unwrap_or_else(|_| {
-                        usage("--research-productivity bonus must be a number, e.g. 0.10")
-                    });
-                    if !(0.0..=10.0).contains(&bonus) {
-                        usage("--research-productivity bonus must be a fraction (0.10 = +10%), not a percentage");
-                    }
-                    research_productivity.insert(recipe.to_string(), bonus);
+                match spaghettio_core::module_policy::parse_declared_productivity(&need(i)) {
+                    Ok(map) => research_productivity.extend(map),
+                    Err(e) => usage(&e),
                 }
             }
             "--inserter-cap" => {

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -27,6 +27,8 @@
 //!   --belt <entity>        max belt tier (default: engine picks by rate)
 //!   --quality <name>       normal|uncommon|rare|epic|legendary (default normal)
 //!   --stacking <1..4>      belt stacking (default 1)
+//!   --research-productivity <recipe=bonus,...>   declared research
+//!                          productivity, e.g. processing-unit=0.10 (default none)
 //!   --inserter-cap <n>     inserter capacity level (default: engine default)
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
@@ -129,6 +131,8 @@ fn main() {
     let mut belt: Option<String> = None;
     let mut quality = QualityTier::Normal;
     let mut stacking: u8 = 1;
+    let mut research_productivity: std::collections::BTreeMap<String, f64> =
+        Default::default();
     let mut inserter_cap: Option<u8> = None;
     let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
     let mut label: Option<String> = None;
@@ -168,6 +172,28 @@ fn main() {
                 stacking = need(i)
                     .parse()
                     .unwrap_or_else(|_| usage("--stacking must be 1..4"))
+            }
+            // Declared research productivity, e.g.
+            //   --research-productivity processing-unit=0.10,plastic-bar=0.10
+            // Passed to BOTH the solve and the layout, deliberately from one
+            // parsed value: they are separate knobs (NetflowOptions vs
+            // LayoutOptions) with no consistency guard between them, so a
+            // caller that sets one and not the other would plan in a
+            // different world from the one it declares on the manifest — the
+            // exact class this axis exists to eliminate.
+            "--research-productivity" => {
+                for pair in need(i).split(',').filter(|p| !p.is_empty()) {
+                    let (recipe, bonus) = pair
+                        .split_once('=')
+                        .unwrap_or_else(|| usage("--research-productivity wants recipe=bonus"));
+                    let bonus: f64 = bonus.parse().unwrap_or_else(|_| {
+                        usage("--research-productivity bonus must be a number, e.g. 0.10")
+                    });
+                    if !(0.0..=10.0).contains(&bonus) {
+                        usage("--research-productivity bonus must be a fraction (0.10 = +10%), not a percentage");
+                    }
+                    research_productivity.insert(recipe.to_string(), bonus);
+                }
             }
             "--inserter-cap" => {
                 inserter_cap = Some(
@@ -211,14 +237,24 @@ fn main() {
     // `solve_with_palette_exclusions_and_quality` call by construction
     // (kill criterion 5), so there is one solve code path here, not a
     // single/multi fork.
-    let solved = spaghettio_core::solver::solve_multi_with_palette_exclusions_quality_and_modules(
+    let solved = spaghettio_core::netflow::solve_netflow_multi_with_options(
         &targets,
         &input_set,
         &MachinePalette::default(),
         &tier,
         &FxHashSet::default(),
-        quality,
-        spaghettio_core::module_policy::ModulePolicy::default(),
+        spaghettio_core::netflow::RecipeScope::Free,
+        &spaghettio_core::netflow::CostTable::default(),
+        &spaghettio_core::netflow::NetflowOptions {
+            quality,
+            module_policy: spaghettio_core::module_policy::ModulePolicy::default(),
+            research_productivity: research_productivity.clone(),
+            // Everything else exactly as
+            // `solve_multi_with_palette_exclusions_quality_and_modules` set
+            // it — this call replaces that wrapper only to reach the one
+            // field it cannot pass, and must not change anything else.
+            ..Default::default()
+        },
     )
     .unwrap_or_else(|e| {
         eprintln!("solve failed for {} on {tier}: {e}", targets_desc());
@@ -230,6 +266,7 @@ fn main() {
         max_belt_tier: belt,
         quality,
         stacking,
+        research_productivity,
         ..Default::default()
     };
     if let Some(c) = claim {

--- a/crates/core/src/module_policy.rs
+++ b/crates/core/src/module_policy.rs
@@ -185,6 +185,66 @@ pub fn effective_product_amount(amount: f64, ignored_by_productivity: f64, prod_
     (amount - ignored) * (1.0 + prod_bonus) + ignored
 }
 
+/// Parse `--research-productivity recipe=bonus,...` into the declared map.
+///
+/// Lifted out of the arg loop so it is testable: the first cut of this guard
+/// lived inline, shipped untested, and got its own motivating case wrong (see
+/// the range check below).
+///
+/// Bonuses are FRACTIONS — `0.10` is +10%.
+pub fn parse_declared_productivity(arg: &str) -> Result<std::collections::BTreeMap<String, f64>, String> {
+    let db = db();
+    let mut out = std::collections::BTreeMap::new();
+    for pair in arg.split(',').filter(|p| !p.trim().is_empty()) {
+        let (recipe, bonus) = pair
+            .split_once('=')
+            .ok_or_else(|| format!("--research-productivity wants recipe=bonus, got {pair:?}"))?;
+        let recipe = recipe.trim();
+        if recipe.is_empty() {
+            return Err(format!("--research-productivity has an empty recipe name in {pair:?}"));
+        }
+        // A typo'd recipe is silently inert: it rides the manifest, matches
+        // nothing, and costs a full export plus a sim warmup before anything
+        // notices. The lookup is free here.
+        if !db.recipes.contains_key(recipe) {
+            return Err(format!("--research-productivity: no such recipe {recipe:?}"));
+        }
+        let bonus: f64 = bonus
+            .trim()
+            .parse()
+            .map_err(|_| format!("--research-productivity bonus must be a number, got {bonus:?}"))?;
+        if !bonus.is_finite() || bonus < 0.0 {
+            return Err(format!("--research-productivity bonus must be finite and >= 0, got {bonus}"));
+        }
+        // Factorio's own `maximum_productivity` default is 3.0 (+300%). Above
+        // that is certainly a bare percentage typed as a fraction.
+        //
+        // The first version of this bound was `0.0..=10.0` INCLUSIVE, which
+        // accepted `=10` — the exact "typed 10 meaning 10%" input it was
+        // written to catch — and exported at +1000% with exit 0. A guard whose
+        // error message promises protection it does not deliver is worse than
+        // no guard, because it stops anyone looking.
+        if bonus > 3.0 {
+            return Err(format!(
+                "--research-productivity bonus is a FRACTION (0.10 = +10%), and {bonus} exceeds \
+                 Factorio's maximum_productivity default of 3.0 — did you mean {}?",
+                bonus / 100.0
+            ));
+        }
+        if bonus >= 1.0 {
+            eprintln!(
+                "warning: --research-productivity {recipe}={bonus} is +{}%. Reachable via deep \
+                 infinite research, but if you meant +{}%, pass {}.",
+                bonus * 100.0,
+                bonus,
+                bonus / 100.0
+            );
+        }
+        out.insert(recipe.to_string(), bonus);
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -459,5 +519,55 @@ mod tests {
         assert_eq!(effective_product_amount(2.0, 2.0, 0.25), 2.0);
         // No-op path is bit-exact.
         assert_eq!(effective_product_amount(0.1, 0.07, 0.0).to_bits(), 0.1f64.to_bits());
+    }
+
+    /// The declared-axis parser, including the case its first version got
+    /// wrong.
+    ///
+    /// That version lived inline in `sim_export`, shipped with no tests, and
+    /// used an INCLUSIVE `0.0..=10.0` bound — so `=10`, the exact "typed 10
+    /// meaning 10%" input the guard existed to catch, was accepted and
+    /// exported at +1000% with exit 0. A guard whose message promises
+    /// protection it does not deliver is worse than none, because it stops
+    /// anyone looking. That is why this lives in the library now.
+    #[test]
+    fn declared_productivity_parser_rejects_a_bare_percentage() {
+        let err = parse_declared_productivity("processing-unit=10")
+            .expect_err("10 is a bare percentage, not a fraction");
+        assert!(err.contains("FRACTION"), "error should explain the unit: {err}");
+        assert!(err.contains("0.1"), "error should suggest the intended value: {err}");
+    }
+
+    #[test]
+    fn declared_productivity_parser_accepts_fractions_and_rejects_junk() {
+        let ok = parse_declared_productivity("processing-unit=0.10,plastic-bar=0.10")
+            .expect("well-formed input");
+        assert_eq!(ok.get("processing-unit"), Some(&0.10));
+        assert_eq!(ok.get("plastic-bar"), Some(&0.10));
+
+        // A typo'd recipe rides the manifest inert and costs a full export
+        // plus a sim warmup before anything notices. One lookup catches it.
+        assert!(parse_declared_productivity("procesing-unit=0.1").is_err(), "typo must be rejected");
+        assert!(parse_declared_productivity("=0.1").is_err(), "empty recipe must be rejected");
+        assert!(parse_declared_productivity("processing-unit").is_err(), "missing = must be rejected");
+        assert!(parse_declared_productivity("processing-unit=x").is_err(), "non-numeric must be rejected");
+        assert!(parse_declared_productivity("processing-unit=-0.1").is_err(), "negative must be rejected");
+        assert!(parse_declared_productivity("processing-unit=NaN").is_err(), "NaN must be rejected");
+
+        // Empty input is not an error — it is the default, and every caller
+        // that passes no flag must land here.
+        assert!(parse_declared_productivity("").expect("empty is valid").is_empty());
+    }
+
+    /// Above 1.0 is legitimately reachable via deep infinite research, so it
+    /// warns rather than refusing — but must still parse.
+    #[test]
+    fn declared_productivity_parser_allows_high_but_reachable_bonuses() {
+        let ok = parse_declared_productivity("processing-unit=1.5").expect("+150% is reachable");
+        assert_eq!(ok.get("processing-unit"), Some(&1.5));
+        assert!(
+            parse_declared_productivity("processing-unit=3.5").is_err(),
+            "above Factorio's maximum_productivity default of 3.0 must be refused"
+        );
     }
 }

--- a/crates/core/src/netflow.rs
+++ b/crates/core/src/netflow.rs
@@ -1721,12 +1721,17 @@ mod tests {
              {b} -> {o}, expected {}",
             b / 1.10
         );
-        // And an UNDECLARED stage must not move: only the boosted recipe's own
-        // machine count changes for a fixed output.
+        // An undeclared UPSTREAM stage shrinks too — it serves a target that
+        // now needs fewer crafts — so `<=` here would pass either way and
+        // assert nothing (PR #591 review). Pin the ratio instead: upstream
+        // demand falls by exactly the boosted stage's factor, no more.
         let (bc, oc) = (count(&base, "copper-cable"), count(&boosted, "copper-cable"));
+        assert!(bc > 0.0, "fixture must build copper-cable for this to mean anything");
         assert!(
-            oc <= bc + 1e-9,
-            "an undeclared upstream stage must not grow: {bc} -> {oc}"
+            (oc - bc / 1.10).abs() < 1e-6,
+            "an undeclared upstream stage must scale by the DOWNSTREAM bonus only: \
+             {bc} -> {oc}, expected {}",
+            bc / 1.10
         );
     }
 }

--- a/crates/core/src/solver.rs
+++ b/crates/core/src/solver.rs
@@ -309,10 +309,17 @@ pub fn solve_with_palette_exclusions_quality_and_modules(
 /// [`solve_with_palette_exclusions_quality_and_modules`], for callers that
 /// need N >= 1 simultaneous targets at this richness (palette, exclusions,
 /// quality, modules) rather than the bare `targets: &[(String, f64)]`
-/// entry points in `netflow.rs`. Single choke point for both the wasm
-/// `solve_multi` boundary and `crates/core/examples/sim_export.rs`'s
-/// `--multi` mode, so both get the same recipe-selection/quality/module
-/// behavior the scalar wasm `solve` already has — and, by the same
+/// entry points in `netflow.rs`. Choke point for the wasm `solve_multi`
+/// boundary, so it gets the same recipe-selection/quality/module
+/// behavior the scalar wasm `solve` already has.
+///
+/// NOTE `sim_export` no longer routes through here: it needs to declare a
+/// research-productivity axis this signature cannot carry, so it calls
+/// `netflow::solve_netflow_multi_with_options` directly with identical values
+/// for every other field. That makes two `NetflowOptions` construction sites
+/// where this was meant to be one — the honest fix is to give this wrapper
+/// the field and bring `sim_export` back, which is a follow-up rather than a
+/// silent divergence (PR #591 review) — and, by the same
 /// one-element-slice construction `netflow.rs`'s Phase 1 established, N=1
 /// here is bit-identical to [`solve_with_palette_exclusions_quality_and_modules`]
 /// (that function is now a thin `targets: &[(target_item.to_string(),

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -664,6 +664,9 @@ fn productivity_parity_lines(
 ) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut boosted: Vec<String> = Vec::new();
+    // Recipes boosted via the ENTITY channel (modules / base_effect), which
+    // the manifest axis cannot declare and the kit error does not check.
+    let mut entity_only: Vec<String> = Vec::new();
     let mut faults: Vec<String> = Vec::new();
     let mut numeric = 0usize;
 
@@ -707,6 +710,7 @@ fn productivity_parity_lines(
                 numeric += 1;
                 let (lo, hi) = (lo.unwrap_or(0.0), hi.unwrap_or(0.0));
                 if lo.abs() > f64::EPSILON || hi.abs() > f64::EPSILON {
+                    entity_only.push(name.clone());
                     boosted.push(if (hi - lo).abs() > f64::EPSILON {
                         format!("{name}={:+.1}..{:+.1}% (entity, n={n})", lo * 100.0, hi * 100.0)
                     } else {
@@ -745,12 +749,35 @@ fn productivity_parity_lines(
         out.push(format!("productivity parity: none on the probed recipes ({numeric} read, 0 boosted)"));
     } else {
         out.push(format!(
-            "productivity parity: BOOSTED [{}] — rates on these recipes are \
-             comparable ONLY against a plan and a meter that declare the same \
-             bonus (manifest `research_productivity`). The scenario raises a \
-             kit error if this run's manifest disagrees, so a clean run here \
-             means they match (RFC-064 item 7)",
-            boosted.join(", ")
+            "productivity parity: BOOSTED [{}]{}",
+            boosted.join(", "),
+            if entity_only.is_empty() {
+                // Every boosted entry came from the force/research channel,
+                // which is exactly what the manifest declares and the
+                // scenario's kit error checks. A clean run therefore means
+                // plan, meter and sim agree.
+                " — rates on these recipes are comparable ONLY against a plan \
+                 and a meter declaring the same bonus (manifest \
+                 `research_productivity`); the scenario raises a kit error if \
+                 this run's manifest disagrees, so a clean run means they \
+                 match (RFC-064 item 7)"
+                    .to_string()
+            } else {
+                // Entity-channel productivity includes MODULE and base-effect
+                // bonuses. The manifest axis cannot declare those, the kit
+                // error does not check them, and the meter models neither —
+                // so the strong claim above would be false here. Say the
+                // weaker true thing instead (PR #591 review).
+                format!(
+                    " — WARNING: {} carr{} entity-channel productivity \
+                     (modules or machine base_effect). The manifest axis \
+                     declares research only, and the parity kit error does \
+                     not check the entity channel, so a clean run does NOT \
+                     establish that these are accounted for (RFC-064 item 7)",
+                    entity_only.join(", "),
+                    if entity_only.len() == 1 { "ies" } else { "y" },
+                )
+            }
         ));
     }
     if modules > 0 {
@@ -907,6 +934,37 @@ mod tests {
         assert_eq!(lines.len(), 1, "got {lines:?}");
         assert!(lines[0].contains("none on the probed recipes"), "got {lines:?}");
         assert!(!lines[0].contains("BOOSTED"), "got {lines:?}");
+    }
+
+    /// The strong "a clean run means they match" claim is only true when
+    /// every boosted entry came from the FORCE channel — the one the manifest
+    /// declares and the kit error checks. Entity-channel productivity is
+    /// modules and base_effect, which the axis cannot declare and the check
+    /// does not cover.
+    ///
+    /// Neither previous wording of this sentence was ever pinned, which is
+    /// how one rewrite fixed the research half and silently broke the
+    /// module half (PR #591 review).
+    #[test]
+    fn productivity_parity_weakens_its_claim_on_entity_channel_boosts() {
+        let force_only = productivity_parity_lines_of(
+            serde_json::json!({"processing-unit": 0.1}),
+            serde_json::json!({"processing-unit": {"min": 0.0, "max": 0.0, "n": 2, "faults": 0}}),
+            serde_json::json!({}),
+        );
+        assert!(force_only[0].contains("a clean run means they match"), "got {force_only:?}");
+        assert!(!force_only[0].contains("WARNING"), "got {force_only:?}");
+
+        let with_entity = productivity_parity_lines_of(
+            serde_json::json!({"processing-unit": 0.0}),
+            serde_json::json!({"processing-unit": {"min": 0.25, "max": 0.25, "n": 2, "faults": 0}}),
+            serde_json::json!({"processing-unit/productivity-module": 4}),
+        );
+        assert!(with_entity[0].contains("WARNING"), "got {with_entity:?}");
+        assert!(
+            with_entity[0].contains("does NOT establish"),
+            "an entity-channel boost must not claim the numbers are accounted for: {with_entity:?}"
+        );
     }
 
     /// A module present but zero productivity is NOT a parity gap. This is the

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -745,9 +745,11 @@ fn productivity_parity_lines(
         out.push(format!("productivity parity: none on the probed recipes ({numeric} read, 0 boosted)"));
     } else {
         out.push(format!(
-            "productivity parity: BOOSTED [{}] — the fast meter models no \
-             productivity, so meter-vs-sim rates on these recipes are not \
-             like-for-like (RFC-064 item 7)",
+            "productivity parity: BOOSTED [{}] — rates on these recipes are \
+             comparable ONLY against a plan and a meter that declare the same \
+             bonus (manifest `research_productivity`). The scenario raises a \
+             kit error if this run's manifest disagrees, so a clean run here \
+             means they match (RFC-064 item 7)",
             boosted.join(", ")
         ));
     }

--- a/docs/rfc064-phase2-followups.md
+++ b/docs/rfc064-phase2-followups.md
@@ -124,6 +124,27 @@ finally worked was balancing the sim's reported figures against each other —
 the AC:PU ratio predicted +10.7% against a measured +10.0% — and then running
 the measurement. Four narrative root causes cost more than one probe did.
 
+
+### 8. Declared research productivity: two open seams (from #591 review)
+Both found by adversarial review of the wiring PR; neither reachable today,
+both the same class as bugs this campaign already paid for.
+
+- **The axis stops at the cell-composition pipeline.** `CellComposedCandidate`
+  is default-eligible and re-derives cells through `extract.rs`'s plain solve,
+  which cannot see the axis; `chain.rs` declares empty on the composed result.
+  So if a declared export ever ships a cell-composed rescue — and the e2e pins
+  that this happens under *default* options for chain shapes
+  (`chain_am2_default_options_ships_cell_composed_rescue`) — the manifest
+  silently loses the caller's declaration while `planned_rates` stay boosted.
+  The sim's parity check then fail-closes the run, correctly but as an
+  unexplained mystery. Same class #415 solved for inserter capacity.
+- **`SolverResult` does not record the axis it solved at.** The manifest
+  records what the LAYOUT was told, which equals the solve only because
+  `sim_export` passes one parsed value to both knobs. That is caller
+  discipline, not a guarantee, and nothing detects plan-vs-manifest
+  disagreement. Durable fix: have `SolverResult` carry the axis and have the
+  layout and manifest copy it from there.
+
 ## Decided / closed (from Stage B)
 - **Never-worse holds** on the measurable subset → evidence supports
   `compact_layout` default-on (representative-scope).


### PR DESCRIPTION
> **Stacked on #587**. Retarget as the stack lands.

## Intent

#584/#585/#587 build the axis; **nothing declared one**. So the sim's parity check correctly invalidated every researched run, and the stack's benefit was theoretical. This closes the loop — and removes the operational window the reviewer flagged on #585.

## The loop, verified

```
sim_export ... --research-productivity processing-unit=0.10,plastic-bar=0.10
  → manifest: {"plastic-bar": 0.1, "processing-unit": 0.1}
  → spaghettio-sim run: NO kit error, OVERALL WARN (a valid run)
```

Before wiring, that same fixture produced:

```
research-productivity parity: 'processing-unit' realized 0.1 but the manifest declares 0
KIT ERRORS — boundary kit compromised, RUN INVALID
```

## One seam, handled deliberately

The axis has **two unconnected knobs** — `NetflowOptions` (solve) and `LayoutOptions` (layout) — with no consistency guard, which the review called out: *"same world by construction" is really "by caller discipline" at that seam.*

So this caller parses **one** value and passes it to **both**, with the reason stated at the call site. A caller setting one and not the other would plan in a different world from the one it declares on the manifest — exactly what this axis exists to prevent.

The solve now goes via `solve_netflow_multi_with_options` instead of the `..._quality_and_modules` wrapper, purely to reach the one field the wrapper can't pass. Every other option is left at the value that wrapper set (`..Default::default()`), noted inline so the swap isn't mistaken for a behaviour change.

## Also fixes a message this stack falsified

#580's informational line still said *"the fast meter models no productivity"* — which **#584 made untrue**. It now states the actual invariant: rates are comparable only against a plan and meter declaring the same bonus, and a clean run means they match, because the scenario raises a kit error when they don't.

Says what it does, rather than asserting a behaviour that's now configurable — the same class of defect this session kept finding elsewhere, introduced here by my own stack.

## Verification

- [x] `cargo test --workspace` — **1344 passed / 0 failed / 104 ignored**, single clean invocation
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Live export + sim run, both quoted above
- [ ] Browser eyeball / snapshot — N/A, no geometry change (default still empty)

## Note on review

The CI bot is credit-exhausted (`402`/`403`), so this — like the rest of the stack — needs either a top-up or the local adversarial review that `CLAUDE.md` prescribes as the fallback.