### PR TITLE
ci(second-opinion): cancel in-progress reviews only on synchronize (re-open of #589)

### DIFF
--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -19,13 +19,33 @@ on:
     # Until upstream grows one, re-review base-retargeted PRs session-side
     # (the stacked-PR retarget-to-main case is the one that occurs here).
 
-# One run per PR; a new push supersedes the old run's SHA, so cancelling is
-# safe. No `edited` trigger (unlike the parked claude-review workflow): this
-# reviewer files no description-scoped findings, so the event-class keying
-# saga (#521) does not apply here — a plain per-PR group is correct.
+# One concurrency group per PR; cancellation is CONDITIONAL on the event.
+# Only `synchronize` — the one trigger that means "a new head SHA exists" —
+# cancels the in-progress run: a superseded SHA's review is real money (this
+# action bills per review) and its check lands on a commit that can no longer
+# be merged, so cancelling there stays correct. Same-head re-events
+# (`reopened`, `ready_for_review`) must NOT cancel: an unconditional
+# cancel-in-progress let a close/reopen of #576 kill the in-progress run OF
+# THE SAME SHA ("Canceling since a higher priority waiting request for
+# second-opinion-576 exists", 2026-08-06), and a cancelled run leaves this
+# REQUIRED check with no successful conclusion — the PR is unmergeable until
+# someone overrides protection. Failure class 11 in docs/review-bot.md has
+# the forensics. Under the conditional, a same-head event queues behind the
+# running review (GitHub keeps one running + one pending per group) and is
+# near-free when its turn comes: the runner resolves the PR's head at
+# execution time and its per-SHA marker gate (`already_reviewed`, checked
+# before any model call) exits 0 green without spending.
+# NOT keyed on head.sha: that also fixes the same-SHA cancel, but it puts
+# each push in a fresh group, so a superseded run is never cancelled — the
+# exact spend the cancellation exists to stop. No `edited` trigger (unlike
+# the parked claude-review workflow): this reviewer files no
+# description-scoped findings, so the event-class keying saga (#521) does
+# not apply here — one group per PR remains correct.
 concurrency:
   group: second-opinion-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Evaluated on the NEWLY queued run: true only when that run carries a new
+  # head SHA worth yielding to.
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 jobs:
   second-opinion:

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -464,6 +464,52 @@ same-run attempts each failing the guard — that means the parking is
 deterministic for that PR, and the canary-gated `Agent` ban becomes the next
 lever.
 
+### Failure class 11: same-SHA event cancelled the required check (2026-08-06)
+
+The first second-opinion entry in this ledger, and the inverse of class 10:
+there the wrong run survived a cancellation race; here **nothing** survived,
+and the victim was a *required* check.
+
+On PR #576, at its final head `0d92f93a` (earlier SHAs had green reviews;
+this head had none yet), a close/reopen (times UTC):
+
+| run | created | outcome |
+|---|---|---|
+| `31124347719` | 17:51:39 | **cancelled** 17:54:47 — annotation: "Canceling since a higher priority waiting request for second-opinion-576 exists" |
+| `31124497214` attempt 1 | 17:54:41 | job cancelled 18:13:18 — "The job was not acquired by Runner of type hosted even after multiple attempts" |
+| `31124497214` attempt 2 (`gh run rerun`) | 18:31 | queued indefinitely |
+
+Two distinct causes composed. The first cancellation is the concurrency
+group: `second-opinion-<pr>` with an unconditional `cancel-in-progress: true`
+keys on the PR **number**, so a `reopened` event for the *same head SHA*
+cancelled the in-progress run — a cancellation that buys nothing (no newer
+SHA exists) and costs the head its only chance at a concluded check. The
+second and third are a platform runner-acquisition stall that day, not
+concurrency — but the group turned a transient stall into a dead end, because
+under it *any* subsequent same-PR event could keep killing recovery attempts.
+End state: `second-opinion` (required, `enforce_admins`) had no successful
+conclusion on the head and the PR was unmergeable without a protection
+override.
+
+**Fix:** `cancel-in-progress: ${{ github.event.action == 'synchronize' }}`.
+Cancellation was added for exactly one case — a new push supersedes the SHA
+under review, and reviewing a superseded SHA is billed spend — and
+`synchronize` is the only trigger in that case. Same-head events (`reopened`,
+`ready_for_review`) now queue behind the running review instead of killing
+it; when the queued duplicate runs, the runner's per-SHA marker gate
+(`already_reviewed`, checked before any model call, exit 0) makes it a green
+no-op. Keying the *group* on head SHA was considered and rejected: it fixes
+the same-SHA kill but isolates each push in its own group, so superseded
+runs would never be cancelled — reintroducing the spend the cancellation
+exists to stop.
+
+**Residual, accepted:** GitHub's own near-simultaneous-queue race (two runs
+entering one group at the same instant can cancel each other) still exists
+for bursts of pushes, and a run cancelled mid-flight by a genuine
+`synchronize` still leaves a `cancelled` conclusion on the *old* SHA — both
+fine, since the new head gets its own run. The recovery path is what the fix
+hardens: a `gh run rerun` can no longer be shot down by same-SHA event noise.
+
 ## Forensics playbook
 
 **Run signatures** (from the action's result JSON in the job log — grep the

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -477,7 +477,7 @@ this head had none yet), a close/reopen (times UTC):
 |---|---|---|
 | `31124347719` | 17:51:39 | **cancelled** 17:54:47 — annotation: "Canceling since a higher priority waiting request for second-opinion-576 exists" |
 | `31124497214` attempt 1 | 17:54:41 | job cancelled 18:13:18 — "The job was not acquired by Runner of type hosted even after multiple attempts" |
-| `31124497214` attempt 2 (`gh run rerun`) | 18:31 | queued indefinitely |
+| `31124497214` attempt 2 (`gh run rerun`) | 18:31:05 | job cancelled 20:03:00 — same runner-acquisition failure, after **92 min** queued |
 
 Two distinct causes composed. The first cancellation is the concurrency
 group: `second-opinion-<pr>` with an unconditional `cancel-in-progress: true`
@@ -485,8 +485,11 @@ keys on the PR **number**, so a `reopened` event for the *same head SHA*
 cancelled the in-progress run — a cancellation that buys nothing (no newer
 SHA exists) and costs the head its only chance at a concluded check. The
 second and third are a platform runner-acquisition stall that day, not
-concurrency — but the group turned a transient stall into a dead end, because
-under it *any* subsequent same-PR event could keep killing recovery attempts.
+concurrency — githubstatus.com carried Actions at **`major_outage`** through
+that evening (22:46 UTC check), so this is a confirmed platform incident
+rather than an inference from our own logs. But the group turned a transient
+stall into a dead end, because under it *any* subsequent same-PR event could
+keep killing recovery attempts.
 End state: `second-opinion` (required, `enforce_admins`) had no successful
 conclusion on the head and the PR was unmergeable without a protection
 override.


### PR DESCRIPTION
## Why this exists as a new PR

**#589 was closed without merging, and its content was lost.** Its base was `ci/loki-monitoring` (#586). When #586 was squash-merged and its branch deleted, GitHub auto-closed the child — and a closed PR whose base branch no longer exists can be neither reopened nor retargeted (`Cannot change the base branch of a closed pull request`).

Verified lost on `main` before re-opening: `cancel-in-progress: true` is still unconditional, and the class-11 ledger correction is absent.

Recovered by cherry-picking #589's own two commits onto current `main` — **not** by PRing the old branch, which still carries #586's commit as a parent. #586 was squash-merged, so that commit is not an ancestor of `main` and re-proposing the branch would re-apply an already-landed diff. Confirmed after the pick: the three `loki-*` inputs from #586 are intact and untouched.

## What it changes

`cancel-in-progress: ${{ github.event.action == 'synchronize' }}`.

Cancellation exists for exactly one case — a new push supersedes the SHA under review, and reviewing a superseded SHA is billed spend. `synchronize` is the only trigger in that case. Under the unconditional form, a same-head event (`reopened`, `ready_for_review`) kills a running review that nothing supersedes. That is failure class 11: on #576 a close/reopen cancelled the in-progress run at its final head, and combined with a runner-acquisition stall it left a **required** check with no conclusion and the PR unmergeable without a protection override.

Same-head events now queue behind the running review; when the duplicate runs, the per-SHA marker gate makes it a green no-op.

Plus a docs correction: the class-11 ledger row said run `31124497214` attempt 2 was "queued indefinitely". The job-level API reports it cancelled at 20:03:00 after 92 minutes queued — the same runner-acquisition failure as attempt 1, not a distinct state.

## Live confirmation from tonight

This bug's *benign* sibling was observed during the merge run: a delayed `reopened` event for #585 arrived ~5 min late and started a run against the **old** SHA, which a `synchronize` on the new head then cancelled. Newer-supersedes-older is correct and this change preserves it — only same-head cancellation is suppressed.

## Review status

Content is identical to #589, which had a session-side review. This is a workflow-file PR, so it runs its own modified workflow with `OPENROUTER_API_KEY` and `LOKI_TOKEN` in scope — the diff is two lines of trigger logic and a docs paragraph, no new steps, no `run:`, no new `uses:`, no new secret consumers.

## Verification

`workflow-guard` in ci.yml asserts the parked claude-review pieces are intact; docs half is inert.