### PR TITLE
fix(sim): served worlds starved themselves on convergence

### DIFF
--- a/crates/sim-harness/src/main.rs
+++ b/crates/sim-harness/src/main.rs
@@ -270,12 +270,16 @@ fn cmd_run(args: &[String]) -> Result<(), String> {
 /// - `--speed 1` by default: real time, so a human can watch items move.
 /// - A **fixed** port (34197, Factorio's default), because someone has to
 ///   type it into a client. `run` uses an ephemeral port for concurrency.
-/// - No tick ceiling: the scenario's end tick is pushed far out so the
-///   world does not finalize and stop while being inspected. That alone is
-///   NOT sufficient — `finalize` also fires on convergence — so serve also
-///   sets [`scenario::RunParams::keep_alive`], which keeps the boundary
-///   kit feeding afterwards. Both are required; the ceiling was there
-///   first and silently did half the job (2026-08-07).
+/// - No tick ceiling: the scenario's end tick is pushed far out, so the
+///   scenario keeps MEASURING (and appending its time-series) instead of
+///   finalizing at a ceiling minutes in. This does not by itself keep the
+///   world alive — `finalize` also fires on convergence, and the ceiling
+///   guard never covered that path (2026-08-07).
+/// - [`scenario::RunParams::keep_alive`]: what actually keeps an inspected
+///   world alive. It gates the boundary kit against finalize from EITHER
+///   caller, so it alone is sufficient for aliveness; the ceiling above is
+///   about how long measurement runs, not whether the factory keeps
+///   running.
 /// - The scratch run dir is left in place for the same reason.
 ///
 /// The client's version must match the server's install exactly.
@@ -324,10 +328,10 @@ fn cmd_serve(args: &[String]) -> Result<(), String> {
         Some(NO_CEILING),
     )
     .with_operator_qol()
-    // NO_CEILING alone does not keep an inspected world alive: `finalize`
-    // also fires on convergence, minutes in, and that stops the kit's
-    // feed/drain/power upkeep. Without this the operator inspects a
-    // starved, stopped factory (2026-08-07).
+    // This, not NO_CEILING above, is what keeps an inspected world alive:
+    // `finalize` also fires on CONVERGENCE (minutes in), and that stops
+    // the kit's feed/drain/power upkeep. Without it the operator inspects
+    // a starved, stopped factory (2026-08-07).
     .with_keep_alive();
     if let Some(w) = warmup {
         params = params.with_warmup(w);
@@ -347,7 +351,7 @@ fn cmd_serve(args: &[String]) -> Result<(), String> {
     // they watched instead of nothing — see docs/sim-harness.md "Reading
     // the time-series".
     println!(
-        "timeseries: {} (CSV, appended each checkpoint window)",
+        "timeseries: {} (CSV, appended each window until the run converges)",
         run_dir
             .join("script-output")
             .join("timeseries.csv")

--- a/crates/sim-harness/src/main.rs
+++ b/crates/sim-harness/src/main.rs
@@ -351,7 +351,9 @@ fn cmd_serve(args: &[String]) -> Result<(), String> {
     // they watched instead of nothing — see docs/sim-harness.md "Reading
     // the time-series".
     println!(
-        "timeseries: {} (CSV, appended each window until the run converges)",
+        "timeseries: {} (CSV, appended each window until the scenario \
+         finalizes — on convergence, or at the ceiling if it never \
+         converges; the factory keeps running either way)",
         run_dir
             .join("script-output")
             .join("timeseries.csv")

--- a/crates/sim-harness/src/main.rs
+++ b/crates/sim-harness/src/main.rs
@@ -271,7 +271,11 @@ fn cmd_run(args: &[String]) -> Result<(), String> {
 /// - A **fixed** port (34197, Factorio's default), because someone has to
 ///   type it into a client. `run` uses an ephemeral port for concurrency.
 /// - No tick ceiling: the scenario's end tick is pushed far out so the
-///   world does not finalize and stop while being inspected.
+///   world does not finalize and stop while being inspected. That alone is
+///   NOT sufficient — `finalize` also fires on convergence — so serve also
+///   sets [`scenario::RunParams::keep_alive`], which keeps the boundary
+///   kit feeding afterwards. Both are required; the ceiling was there
+///   first and silently did half the job (2026-08-07).
 /// - The scratch run dir is left in place for the same reason.
 ///
 /// The client's version must match the server's install exactly.
@@ -319,7 +323,12 @@ fn cmd_serve(args: &[String]) -> Result<(), String> {
         speed,
         Some(NO_CEILING),
     )
-    .with_operator_qol();
+    .with_operator_qol()
+    // NO_CEILING alone does not keep an inspected world alive: `finalize`
+    // also fires on convergence, minutes in, and that stops the kit's
+    // feed/drain/power upkeep. Without this the operator inspects a
+    // starved, stopped factory (2026-08-07).
+    .with_keep_alive();
     if let Some(w) = warmup {
         params = params.with_warmup(w);
     }

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1815,6 +1815,26 @@ mod tests {
              or KEEP_ALIVE lets it re-finalize at every window close"
         );
 
+        // The SEPARATION invariant, not just membership: no kit upkeep may
+        // appear below the measurement guard. Listing three statements
+        // above only pins the upkeep that exists today — a fourth
+        // mechanism added below the guard would re-introduce the
+        // starvation bug with this test still green (review finding, 3/3).
+        // Asserting the negative catches that case without needing to know
+        // what the mechanism is.
+        //
+        // NEW KIT UPKEEP GOES BETWEEN THE TWO GUARDS. If you are here
+        // because this assertion failed, that is why.
+        let below_measure_guard = &lua[measure_guard..];
+        for kit_marker in ["storage.eeis", "storage.feeds", "storage.drains"] {
+            assert!(
+                !below_measure_guard.contains(kit_marker),
+                "{kit_marker} appears below the measurement guard: kit upkeep \
+                 placed there is skipped once a served world converges, which \
+                 is exactly the bug this test exists to prevent"
+            );
+        }
+
         // A measurement run must still stop its kit at finalize.
         let measured = RunParams::defaults_for(&m, "t".into(), 32, None);
         assert!(!measured.keep_alive, "measurement runs must never keep-alive");

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1361,8 +1361,11 @@ local function finalize(s, converged)
   -- `script.on_nth_tick(60, nil)` makes the server's handler set differ
   -- from what a freshly-loaded client registers, and Factorio refuses
   -- the join ("mod event handlers are not identical ... level"). The
-  -- handler's own `storage.finalized` guard makes it a no-op after
-  -- this point, which is multiplayer-safe.
+  -- handler's own finalize guards keep it multiplayer-safe: its
+  -- MEASUREMENT half is a no-op after this point unconditionally, and
+  -- its kit-upkeep half is a no-op too EXCEPT under KEEP_ALIVE, where
+  -- `serve` deliberately keeps feeding the factory so an inspected
+  -- world stays alive.
 end
 
 -- Boundary-kit upkeep: power, feed top-up, drain empty. Everything that
@@ -1410,10 +1413,14 @@ script.on_nth_tick(60, function(ev)
   -- Not merging this into the guard at the top of the handler: that one
   -- lets `serve` keep the factory fed after finalize, and if it also let
   -- the measurement half run on, the convergence test would keep passing
-  -- on a still-running world and call `finalize` again every 60 ticks —
-  -- rewriting the report, re-appending the dead-rig audit's kit_errors,
-  -- and reprinting HARNESS_DONE forever. Observed live on the first cut of
-  -- this fix (2026-08-07); the Lua-text unit test could not see it.
+  -- on a still-running world and call `finalize` again at every WINDOW
+  -- CLOSE — rewriting the report, re-appending the dead-rig audit's
+  -- kit_errors, and reprinting HARNESS_DONE. Measured on the first cut of
+  -- this fix (2026-08-07): 257 finalizes in one 400s serve at speed 32,
+  -- i.e. window cadence (~1 per 3100 ticks), NOT the handler's own 60-tick
+  -- cadence — the convergence test lives inside the window-close branch,
+  -- not at the top of the handler. The Lua-text unit test could not see
+  -- any of this; only a live server could.
   if storage.finalized then return end
 
   local s = game.get_surface("lab")
@@ -1763,10 +1770,49 @@ mod tests {
         );
         // ...and the upkeep guard must come FIRST: the other order would
         // return before the kit is fed, restoring the original bug.
+        let upkeep_guard = lua
+            .find("if storage.finalized and not KEEP_ALIVE then return end")
+            .expect("upkeep guard present");
+        let measure_guard = lua
+            .find("if storage.finalized then return end")
+            .expect("measurement guard present");
         assert!(
-            lua.find("if storage.finalized and not KEEP_ALIVE then return end")
-                < lua.find("if storage.finalized then return end"),
+            upkeep_guard < measure_guard,
             "kit upkeep must run before the measurement half returns"
+        );
+
+        // Pin the STRUCTURE, not just the two strings: string presence
+        // cannot tell this handler from a text-equivalent one that guards
+        // the wrong statements (review finding on this PR). Each half's
+        // real work must sit on the correct side of the two guards —
+        // power/feed/drain between them, the convergence test after.
+        // Search WITHIN the handler, not the whole script: `finalize` and
+        // the kit audit iterate `storage.feeds` too, so a bare
+        // `lua.find(..)` matches one of those earlier copies and the
+        // assertion silently checks the wrong statement. (Caught by this
+        // very test on first write — the same not-unique-string trap the
+        // rest of this fix kept hitting.)
+        let handler = &lua[upkeep_guard..];
+        let measure_rel = measure_guard - upkeep_guard;
+        for kit_stmt in [
+            "e.energy = 1e13",            // power upkeep
+            "for item, banks in pairs(storage.feeds) do", // feed top-up
+            "for item, chests in pairs(storage.drains) do", // drain empty
+        ] {
+            let at = handler
+                .find(kit_stmt)
+                .unwrap_or_else(|| panic!("{kit_stmt} missing from the upkeep handler"));
+            assert!(
+                at < measure_rel,
+                "{kit_stmt} must run under KEEP_ALIVE (before the measurement \
+                 guard), else a served world starves after convergence"
+            );
+        }
+        let convergence = lua.find("finalize(s, true)").expect("convergence finalize");
+        assert!(
+            convergence > measure_guard,
+            "the convergence test must sit AFTER the unconditional guard, \
+             or KEEP_ALIVE lets it re-finalize at every window close"
         );
 
         // A measurement run must still stop its kit at finalize.

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -219,6 +219,37 @@ pub struct RunParams {
     /// long/grinding run can be watched and scored live (is it ramping toward
     /// plan, or flat-zero and dead?) without waiting for finalize.
     pub write_timeseries: bool,
+    /// `serve` only: keep the boundary kit ALIVE after the scenario
+    /// finalizes, so an inspected world keeps running instead of dying
+    /// under the operator.
+    ///
+    /// Why this exists (2026-08-07, found by in-client observation): the
+    /// kit's feed top-up, drain empty, and electric-interface recharge all
+    /// live in one `on_nth_tick(60)` handler whose first line is
+    /// `if storage.finalized then return end`. `finalize()` has TWO
+    /// callers — the `END_TICK` ceiling and, far earlier, the
+    /// **convergence** test. `serve` pushes `end_tick` out to ~a week of
+    /// game time specifically so the world "does not finalize and stop
+    /// while being inspected", but that only guards the ceiling path: a
+    /// served world still self-finalized the moment its rates stabilized,
+    /// typically minutes in. Past that point the feed chests were never
+    /// refilled, the drains never emptied, and the power interfaces never
+    /// recharged — the factory starved and stopped, and an operator who
+    /// joined later was looking at a corpse while believing they were
+    /// looking at the layout. Reported as "the input chests are empty and
+    /// I can't see much happening".
+    ///
+    /// Deliberately a separate flag from [`RunParams::operator_qol`]:
+    /// that one changes force bonuses and map reveal (never safe for a
+    /// measurement), whereas this only decides whether the kit keeps
+    /// feeding after the report is written. Keeping them distinct means a
+    /// reader never has to wonder why map-reveal controls chest refills.
+    ///
+    /// **Never set for measurement runs.** There, finalize-stops-the-kit
+    /// is correct: the checkpoints are taken before finalize, and letting
+    /// the kit run on would keep mutating the world after the numbers it
+    /// reports were sampled.
+    pub keep_alive: bool,
 }
 
 impl RunParams {
@@ -252,6 +283,7 @@ impl RunParams {
             scenario_name,
             operator_qol: false,
             write_timeseries: false,
+            keep_alive: false,
         }
     }
 
@@ -265,6 +297,13 @@ impl RunParams {
     /// (`run --timeseries`). Independent of `operator_qol`.
     pub fn with_timeseries(mut self) -> RunParams {
         self.write_timeseries = true;
+        self
+    }
+
+    /// Keep the boundary kit feeding after finalize (`serve`). See
+    /// [`RunParams::keep_alive`] for why an inspected world needs this.
+    pub fn with_keep_alive(mut self) -> RunParams {
+        self.keep_alive = true;
         self
     }
 
@@ -707,6 +746,7 @@ pub fn build_control_lua(manifest: &Manifest, bp: &str, params: &RunParams) -> S
         "local WINDOW_TICK_CAP = {}",
         window_tick_cap(params.window_ticks)
     );
+    let _ = writeln!(out, "local KEEP_ALIVE = {}", params.keep_alive);
     let _ = writeln!(out, "local STABILITY_TOL = {STABILITY_TOLERANCE}");
     let _ = writeln!(out, "local STABILITY_WINDOWS = {STABILITY_WINDOWS}");
     let _ = writeln!(
@@ -1325,8 +1365,18 @@ local function finalize(s, converged)
   -- this point, which is multiplayer-safe.
 end
 
+-- Boundary-kit upkeep: power, feed top-up, drain empty. Everything that
+-- keeps the factory alive is in here, so whether this runs after finalize
+-- decides whether an inspected world stays a factory or becomes a corpse.
+--
+-- Under `serve` (KEEP_ALIVE) it keeps running: `finalize` fires on
+-- CONVERGENCE as well as at END_TICK, and serve's whole point is that a
+-- human can look at a live factory long after it has stabilized. Under a
+-- measurement run it must stop, because the report's numbers were sampled
+-- at the checkpoints and the kit must not keep mutating the world past the
+-- moment it was measured.
 script.on_nth_tick(60, function(ev)
-  if storage.finalized then return end
+  if storage.finalized and not KEEP_ALIVE then return end
   for _, e in ipairs(storage.eeis) do if e.valid then e.energy = 1e13 end end
   for item, banks in pairs(storage.feeds) do
     for _, bank in ipairs(banks) do
@@ -1352,6 +1402,19 @@ script.on_nth_tick(60, function(ev)
     end
     storage.drained_total[item] = (storage.drained_total[item] or 0) + got
   end
+
+  -- END OF KIT UPKEEP. Everything past here is MEASUREMENT — sampling,
+  -- checkpoint windows, the convergence test, and `finalize` itself — and
+  -- it must stop at finalize even under KEEP_ALIVE.
+  --
+  -- Not merging this into the guard at the top of the handler: that one
+  -- lets `serve` keep the factory fed after finalize, and if it also let
+  -- the measurement half run on, the convergence test would keep passing
+  -- on a still-running world and call `finalize` again every 60 ticks —
+  -- rewriting the report, re-appending the dead-rig audit's kit_errors,
+  -- and reprinting HARNESS_DONE forever. Observed live on the first cut of
+  -- this fix (2026-08-07); the Lua-text unit test could not see it.
+  if storage.finalized then return end
 
   local s = game.get_surface("lab")
   local stats = game.forces.player.get_item_production_statistics(s)
@@ -1582,6 +1645,7 @@ mod tests {
             scenario_name: "t".into(),
             operator_qol: false,
             write_timeseries: false,
+            keep_alive: false,
         }
         .with_warmup(216_001);
         assert_eq!(p.warmup_ticks, 216_060);
@@ -1653,6 +1717,69 @@ mod tests {
         assert!(lua.contains(&format!("local STABILITY_WINDOWS = {STABILITY_WINDOWS}")));
         assert!(lua.contains("if n >= STABILITY_WINDOWS + 1 then"));
         assert!(lua.contains("(hi - lo) / lo <= STABILITY_TOL"));
+    }
+
+    /// An inspected world must keep being fed after it finalizes.
+    ///
+    /// The bug this pins (2026-08-07, found in-client): the kit's
+    /// feed/drain/power upkeep is one `on_nth_tick(60)` handler guarded by
+    /// `storage.finalized`, and `finalize` fires on CONVERGENCE as well as
+    /// at `END_TICK`. `serve` pushed `end_tick` out to ~a week to stop the
+    /// world dying mid-inspection, which guarded only the ceiling path —
+    /// so a served world still starved itself minutes in, and an operator
+    /// joining later saw empty feed chests and an idle factory.
+    ///
+    /// Asserted in BOTH directions deliberately: a keep-alive that also
+    /// leaked into measurement runs would let the kit keep mutating the
+    /// world after the checkpoints were sampled, which is a subtler and
+    /// worse bug than the one being fixed.
+    #[test]
+    fn serve_keeps_the_kit_alive_after_finalize_and_run_does_not() {
+        let m = fixture();
+
+        let served = RunParams::defaults_for(&m, "t".into(), 1, Some(36_000_000))
+            .with_operator_qol()
+            .with_keep_alive();
+        assert!(served.keep_alive);
+        let lua = build_control_lua(&m, "bp", &served);
+        assert!(lua.contains("local KEEP_ALIVE = true"));
+        assert!(
+            lua.contains("if storage.finalized and not KEEP_ALIVE then return end"),
+            "upkeep handler must consult KEEP_ALIVE, not `finalized` alone"
+        );
+        // The measurement half keeps an UNCONDITIONAL finalize guard: under
+        // KEEP_ALIVE the world runs on, so without it the convergence test
+        // re-fires every 60 ticks and calls `finalize` forever (observed
+        // live on this fix's first cut). Exactly one of each guard.
+        assert_eq!(
+            lua.matches("if storage.finalized and not KEEP_ALIVE then return end").count(),
+            1,
+            "kit-upkeep guard must appear exactly once"
+        );
+        assert_eq!(
+            lua.matches("if storage.finalized then return end").count(),
+            1,
+            "measurement half must keep exactly one unconditional finalize guard"
+        );
+        // ...and the upkeep guard must come FIRST: the other order would
+        // return before the kit is fed, restoring the original bug.
+        assert!(
+            lua.find("if storage.finalized and not KEEP_ALIVE then return end")
+                < lua.find("if storage.finalized then return end"),
+            "kit upkeep must run before the measurement half returns"
+        );
+
+        // A measurement run must still stop its kit at finalize.
+        let measured = RunParams::defaults_for(&m, "t".into(), 32, None);
+        assert!(!measured.keep_alive, "measurement runs must never keep-alive");
+        assert!(build_control_lua(&m, "bp", &measured).contains("local KEEP_ALIVE = false"));
+
+        // The ceiling is not, and never was, sufficient on its own — the
+        // convergence caller is what actually kills a served world.
+        assert!(
+            lua.contains("finalize(s, true)"),
+            "convergence finalize still present: keep-alive is the fix, not removing it"
+        );
     }
 
     /// The default wall-clock net must clear the run's own tick budget,

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -216,6 +216,32 @@ Then in a Factorio client: **Multiplayer → Connect to address**.
 Knobs: `--port N` (**34197**, Factorio's default — fixed, not ephemeral,
 because a human has to type it), `--speed N` (**1**), `--warmup N`.
 
+### The world stays alive after it converges (fixed 2026-08-07)
+
+`serve` keeps the boundary kit — feed top-up, drain emptying, and
+electric-interface recharge — running after the scenario finalizes
+(`RunParams::keep_alive`). **Before this fix it did not**, and the
+consequence was severe enough to be worth knowing when reading older
+notes: the kit's upkeep is one `on_nth_tick(60)` handler gated on
+`storage.finalized`, and `finalize` fires on **convergence** as well as at
+the tick ceiling. `serve` pushed the ceiling out to ~a week of game time
+to stop the world dying mid-inspection, which covered only one of the two
+callers — so a served world self-finalized as soon as its rates
+stabilised, typically minutes in, and then had no input, no drain and no
+power. Anyone who joined after that was looking at a **stopped factory**
+while believing they were looking at the layout. It was found exactly that
+way: "the input chests are empty and I can't see much happening".
+
+Two consequences for reading evidence:
+
+- **Flow observations made in a served world before this fix are
+  unreliable** if they were made more than a few minutes in — belt
+  saturation, which machines are running, where items are backing up.
+  **Structural** observations (machine counts, topology, what feeds what)
+  are unaffected.
+- The time-series CSV still stops at finalize; only the factory keeps
+  running. See ["Reading the time-series"](#reading-the-time-series).
+
 ### Connecting: the three things that will bite you
 
 1. **The client version must match the server install exactly.** The
@@ -341,8 +367,19 @@ tick,kind,unit,name,x,y,crafts_delta,status,item,produced_delta
 `kind` distinguishes the two row shapes; filter on it before further
 processing (e.g. `awk -F, '$2=="machine"'`). This is the machine-readable
 record a maintainer eyeballing a live `serve` session at speed 10
-otherwise has none of — the CSV keeps growing as long as the server runs,
-independent of whether/when the scenario ever finalizes.
+otherwise has none of.
+
+**The CSV stops at finalize; the world does not** (corrected 2026-08-07 —
+this section previously claimed the CSV "keeps growing as long as the
+server runs, independent of whether/when the scenario ever finalizes",
+which was never true of the convergence path). `finalize` fires on
+CONVERGENCE as well as at the tick ceiling, and it ends measurement — so
+the series freezes once rates stabilise, typically minutes in. What
+`serve` now guarantees is that the **factory keeps running** past that
+point (`RunParams::keep_alive`), so the world stays inspectable even
+though its time-series has stopped growing. If you need a longer series,
+raise `--warmup` so convergence is reached later, or take the measurement
+with `run --timeseries` instead.
 
 For the diagnostic reading of a flat-zero vs ramp-then-decay vs
 stable-below-plan series, see

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -377,9 +377,20 @@ CONVERGENCE as well as at the tick ceiling, and it ends measurement — so
 the series freezes once rates stabilise, typically minutes in. What
 `serve` now guarantees is that the **factory keeps running** past that
 point (`RunParams::keep_alive`), so the world stays inspectable even
-though its time-series has stopped growing. If you need a longer series,
-raise `--warmup` so convergence is reached later, or take the measurement
-with `run --timeseries` instead.
+though its time-series has stopped growing.
+
+For a longer series the lever is **`--warmup`** (measurement opens later,
+so windows keep closing for longer before the stability test can trip) —
+in either mode. Switching to `run --timeseries` does NOT buy length by
+itself: serve already runs under a ~36M-tick ceiling while `run`'s
+default ceiling is far smaller, so a bare `run` gives you *less* unless
+you also raise `--ticks`.
+
+Post-finalize staleness applies to every artifact, not just the CSV:
+`sim-state.json` and `harness-result.json` are both written *by*
+`finalize` and then frozen, while under `keep_alive` the served world
+carries on diverging from them. Treat all three as a snapshot of the
+moment the run converged, never as live state.
 
 For the diagnostic reading of a flat-zero vs ramp-then-decay vs
 stable-below-plan series, see


### PR DESCRIPTION
## Intent

An operator inspecting a served fixture reported *"the input chests are empty and I can't see much happening"*. They were right, and it wasn't the layout — **every served world has been killing itself minutes after start**, so any in-client inspection past that point was of a stopped factory.

## The bug

The boundary kit's upkeep — feed top-up, drain emptying, **and electric-interface recharge** — is a single `on_nth_tick(60)` handler whose first line is `if storage.finalized then return end`.

`finalize()` has **two** callers:
- the `END_TICK` ceiling (`scenario.rs`, bottom of the handler), and
- the **convergence** test, which fires as soon as rates stabilise — typically minutes in.

`serve` pushes `end_tick` out to ~a week of game time with the comment *"the world does not finalize and stop while being inspected"*. That guards the ceiling path only. The convergence path was never covered, so a served world finalized early and from then on had **no input, no drain, and no power**.

## The fix

A `keep_alive` flag, set only by `serve`, changing the upkeep guard to `if storage.finalized and not KEEP_ALIVE then return end`.

Deliberately **not** folded into the existing `operator_qol` flag: that one changes force bonuses and map reveal and must never touch a measurement run, and no reader should have to work out why map-reveal governs chest refills.

## The first cut was wrong, and green

Worth calling out for review purposes: the initial fix **passed all 77 unit tests and was broken**. The measurement half — sampling, checkpoint windows, the convergence test, and `finalize` itself — lives in that *same* handler, so relaxing the one guard let convergence re-fire every 60 ticks, calling `finalize()` forever, rewriting the report and re-appending the dead-rig audit's `kit_errors` each time. The tests asserted the generated Lua *contained the right string*, which it did; only a live server exposed the behaviour.

The guard is now split — upkeep under `KEEP_ALIVE`, measurement keeping an unconditional finalize guard — and the tests pin **exactly one of each and their order**, since reversing them silently restores the original bug.

## Verification actually run

- `cargo test -p spaghettio_sim_harness` — 77 passed, and `cargo clippy --all-targets` clean.
- **Live serve**, 400s at speed 32 (well past convergence), on a confirmed-free port: startup clean, `HARNESS_DONE` count **exactly 1** (was: repeating).

**Evidence boundary — please don't read more into this than it supports.** The live run proves startup and exactly-one-finalize. It does **not** prove chests stay stocked *after* finalize: `sim-state.json` is written *by* `finalize()`, so that census reads identically with or without this change. Post-finalize aliveness currently has no instrumentation. The confirming test is a human joining a served world after convergence — which is the next thing planned.

An earlier verification attempt returned `0 HARNESS_DONE` and was **discarded, not interpreted**: the log showed `Host address is already in use` — two of my own background jobs collided on a port and the server never ticked. The re-run checks startup explicitly so a dead server can't masquerade as a result.

## Consequences worth recording

This retro-invalidates **flow-based** observations made in served worlds past convergence, across the project's history. Structural observations (machine counts, topology) are unaffected. Measurement (`run`) numbers are unaffected — there, finalize-stops-the-kit is correct, since checkpoints are sampled before it.