### PR TITLE
fix(validate): restore fractional-duty scaling lost on the banded path

### DIFF
--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -2342,7 +2342,7 @@ fn compute_lane_rates_impl(
         // scales demand, or a fast machine at fractional count overstates
         // the lane rate (e.g. a 0.06-count foundry pressing transport-belt
         // at 16/s nominal seeds 16/s onto a lane that actually carries 1/s).
-        let utilization = physical_utilization(spec, band, &machine_ys_by_recipe, &per_row_count_recipes);
+        let utilization = physical_utilization(spec, fallback_spec, band, &machine_ys_by_recipe, &per_row_count_recipes);
         let rate = spec
             .outputs
             .iter()
@@ -2570,7 +2570,7 @@ fn compute_lane_rates_impl(
         // Same position-resolved attribution as the injection loop above —
         // see `super::resolve_row_spec`'s doc comment.
         let (spec, band) = super::resolve_row_spec_banded(layout, recipe, me.y, fallback_spec);
-        let utilization = physical_utilization(spec, band, &machine_ys_by_recipe, &per_row_count_recipes);
+        let utilization = physical_utilization(spec, fallback_spec, band, &machine_ys_by_recipe, &per_row_count_recipes);
         let required = spec
             .inputs
             .iter()
@@ -3285,14 +3285,33 @@ fn lane_transfer(
 /// 85.71/86 regressed to 1.0). Recipes shared by multiple specs
 /// (voider/self-loop siblings) are excluded upstream and fall back to
 /// `utilization_for`.
+/// FRACTIONAL-DUTY FLOOR (2026-08-07). `spec` here is the *band-resolved*
+/// spec from `effective_rows`, whose count is the count the ROW PLACED — so
+/// for a sub-one-machine plan it reads 1 while the solver planned 0.667, and
+/// `spec.count / n` collapses to 1/1 = 1.0, silently discarding exactly the
+/// scaling this function exists to apply. `plan_spec` is the solver's spec,
+/// and `utilization_for(plan_spec)` is `count / ceil(count)` — the true duty
+/// whenever the row places `ceil(count)` machines, which is the normal case.
+/// Taking the min restores it and is a no-op for integral counts.
+///
+/// Measured: `big-electric-pole@1` on am2 plans 0.667 machines, the row
+/// places 1, and the bus correctly delivers 8.0/s of iron-stick (= 0.667 ×
+/// 12.0). Without the floor the check demanded a fully saturated machine's
+/// 12.0/s and fired two warnings on a layout the sim measures at **110% of
+/// plan** — false positives that inverted candidate ranking the moment
+/// `input-rate-delivery` was allowed to steer selection (it preferred a
+/// layout measured at 0.51/s against a 1.00/s plan). See
+/// `docs/validator-trust.md` hole 2.
 fn physical_utilization(
     spec: &crate::models::MachineSpec,
+    plan_spec: &crate::models::MachineSpec,
     band: Option<(i32, i32)>,
     machine_ys_by_recipe: &FxHashMap<&str, Vec<i32>>,
     per_row_count_recipes: &FxHashSet<&str>,
 ) -> f64 {
+    let plan_duty = utilization_for(plan_spec);
     let Some(ys) = machine_ys_by_recipe.get(spec.recipe.as_str()) else {
-        return utilization_for(spec);
+        return utilization_for(spec).min(plan_duty);
     };
     let n = match band {
         Some((y0, y1)) if per_row_count_recipes.contains(spec.recipe.as_str()) => {
@@ -3301,9 +3320,9 @@ fn physical_utilization(
         _ => ys.len(),
     };
     if n == 0 {
-        return utilization_for(spec);
+        return utilization_for(spec).min(plan_duty);
     }
-    (spec.count / n as f64).min(1.0)
+    (spec.count / n as f64).min(1.0).min(plan_duty)
 }
 
 /// A tile's outflow after its own input-inserter pickups take their share
@@ -3638,7 +3657,7 @@ pub fn check_input_rate_delivery(
         // strict — up to 10× for a fractional machine (sulfuric-acid at 5/s
         // wants 0.1 machines running at 10% speed), 1/16 for chain-replicated
         // rows (see `physical_utilization`).
-        let utilization = physical_utilization(spec, band, &machine_ys_by_recipe, &per_row_count_recipes);
+        let utilization = physical_utilization(spec, fallback_spec, band, &machine_ys_by_recipe, &per_row_count_recipes);
         let required_rate = spec
             .inputs
             .iter()

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -1844,7 +1844,20 @@ fn tier4_advanced_circuit_partitioned() {
     // runs at 3.17x/4.67x their endpoint separation (13/11 excess tiles),
     // both well past the check's floors, not yet root-caused. Tolerated
     // explicitly rather than silently allowed.
-    assert_warnings_exactly(&result, &[("input-rate-delivery", 2), ("belt-detour", 2)]);
+    // 2026-08-07 fractional-duty floor (`physical_utilization`'s `plan_duty`
+    // min): 2 -> 3 input-rate-delivery. NOT a regression, and NOT a blanket
+    // re-bless — the two pre-existing warnings both got SMALLER deficits
+    // (0.3 -> 0.5 delivered at (15,23); demand 1.5 -> 1.2 at (15,32)) because
+    // honest upstream duty leaves more supply for the row tail. The third is
+    // newly surfaced: copper-cable plans 3.333 machines and the layout places
+    // 4, so its injection is now credited at 0.833 duty instead of a
+    // saturated 1.0, and an AC cable tap that was covered by the 20%
+    // over-credit no longer is (2.0/s delivered vs 3.0/s needed).
+    // HONESTY NOTE: that third warning is a candidate true positive of the
+    // #519 tail-starvation class, NOT a sim-verified one. It is pinned here
+    // so it stays visible; if a sim run shows this fixture at plan, it is a
+    // false positive and this line is the place to re-adjudicate.
+    assert_warnings_exactly(&result, &[("input-rate-delivery", 3), ("belt-detour", 2)]);
 }
 
 /// Regression test for the pipe-as-port-tile bug. URL:

--- a/docs/validator-trust.md
+++ b/docs/validator-trust.md
@@ -187,11 +187,26 @@ Severity `E/W` = both emitted, condition-dependent. "Sel" = counts in
 
    So the category's **negative direction is not merely unanchored, it is
    contradicted**: it warns twice on a layout that measures 110% of plan.
-   Its sim anchor is one-directional (PU positive). Lifting it blanket-wise
-   trades a measured ~1.5× win on PU for a measured ~2× loss on
-   big-electric-pole, and additionally collapses RFC-059's teeth test (both
-   claim orders then produce the identical layout). **Fix the
-   false-positive calibration first, then re-try the lift.**
+   Its sim anchor is one-directional (PU positive).
+
+   **Root-caused and fixed the same day (#602).** The false positives were
+   not a calibration judgement call but a plain defect:
+   `physical_utilization` receives the band-resolved spec from
+   `effective_rows`, whose `count` is the count the row PLACED, so for a
+   sub-one-machine plan it reads 1 where the plan says 0.667 and the duty
+   scaling collapses to 1.0. big-electric-pole plans 0.667 machines, the bus
+   delivers exactly the planned 8.0/s, and the check demanded a saturated
+   machine's 12.0/s. With the floor restored the 1.10/s layout scores 0 and
+   the 0.51/s one keeps its real `inserter-item-throughput` warning and
+   scores 1 — the ranking is correct, and lift-on-top drift falls from 6
+   fixtures to 2.
+
+   **Lift status: unblocked again, pending #602 and two drift
+   adjudications** (`tier2_electronic_circuit` 1→0, the intended effect; and
+   `belt_detour_migration_differential_fast`'s geometry oracle). Parked on
+   `fix/lift-input-rate-delivery-exemption`. The category's negative
+   direction remains one-directionally anchored — that has not changed, and
+   is still the reason to re-measure rather than assume.
 3. **The sim/meter side has no validator visibility.** `Manifest` carries no
    issue state, so parity sweeps can quote a condemned layout as a parity
    number — which is precisely how 68.2% was first reported with no mention


### PR DESCRIPTION
Replaces #602, which was orphaned when its base (#601) was squash-merged. Identical content, rebuilt on `main`.

## The bug

`physical_utilization` receives the **band-resolved** spec from `effective_rows`, whose `count` is the count the row **placed**, not the count the solver **planned**. For a sub-one-machine plan that reads `1` where the plan says `0.667`, so `spec.count / n` collapses to `1/1 = 1.0` — discarding exactly the scaling the function exists to apply.

Measured on `big-electric-pole@1`/am2: the plan is **0.667 machines**, the row places **1**, the bus delivers exactly the planned **8.0/s** of iron-stick (= 0.667 × 12.0), and the check demanded a fully saturated machine's **12.0/s**. Two `input-rate-delivery` warnings on a layout the sim measures at **110% of plan**.

## Why it matters beyond two spurious warnings

**The false positives inverted candidate ranking.** With the `input-rate-delivery` selection lift applied, the default shipped a layout **bit-identical** (same entity fingerprint) to the one RFC-059 measured at **0.51/s against a 1.00/s plan**, displacing the 1127-entity layout measured at **1.10/s**.

| layout | `input-rate-delivery` before | after | sim |
|---|---|---|---|
| 1127 | 2 (both false) | **0** | 1.10/s (110% of plan) |
| 1146 | 0 | 0 | 0.51/s (51%) |

After the fix the good layout scores 0 and the bad one keeps its **real** defect — one `inserter-item-throughput` warning (steel-plate inserters 2.40/s vs 5.00/s needed, a 2.08× shortfall that predicts the measured half-rate) — and scores 1. Verified: with the lift on top of this fix, corpus drift falls from **6 fixtures to 2** and `di_claim_order` passes.

## The fix

Take the min with `utilization_for(plan_spec)` — `count / ceil(count)`, the true duty whenever the row places `ceil(count)` machines. No-op for integral counts; generalizes correctly (2.5 placed as 3 → 0.833). Applied at all three call sites — `belt_flow.rs:2345`'s own comment already specified that formula as intended, so this **restores documented intent**.

## Corpus effect: one fixture moves

`tier4_advanced_circuit_partitioned` goes 2 → 3 `input-rate-delivery`, and it is **not** a blanket re-bless: both pre-existing warnings got **smaller** deficits (0.3 → 0.5 delivered; demand 1.5 → 1.2), and the third is newly surfaced by honest supply scaling (copper-cable plans 3.333, places 4, so injection is credited at 0.833 rather than a saturated 1.0). Pinned with an explicit note that it is a **candidate** true positive, not sim-verified, naming itself as the place to re-adjudicate.

## Verification

Full core suite green (0 failures, single clean invocation), clippy clean, before/after diffed on both affected fixtures directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPXzVRcKurGMWR3vqHE1Ur