### PR TITLE
feat(sim): print validator state beside every measured rate (stacked on #611)

### DIFF
--- a/crates/sim-harness/src/manifest.rs
+++ b/crates/sim-harness/src/manifest.rs
@@ -19,14 +19,17 @@
 //!   `dims`, `entities`, `stacking`, `inserter_capacity` are all emitted
 //!   verbatim by the `serde_json::json!` call in `export_with_manifest`.
 //! - The RFC's Design section says the manifest carries "validator
-//!   error/warning counts at export time" — the actual Phase 0 commit's
-//!   `export_with_manifest` does NOT include such fields. Resolved as: treat
-//!   them as optional/absent-tolerant (`validator_errors`/
-//!   `validator_warnings` are not modeled at all here; nothing in Phase 0/1
-//!   reads them). If a later Phase 0 revision adds them before merge, this
-//!   module only needs a new optional field, not a rewrite.
+//!   error/warning counts at export time". Phase 0 shipped without them and
+//!   this module resolved that as optional/absent-tolerant. **Delivered
+//!   2026-08-09** (`validator-trust.md` hole 3): `export_with_manifest` now
+//!   emits a `validator` object, modeled here as `Option<ValidatorSummary>`.
+//!   It is per-category rather than the flat `validator_errors`/
+//!   `validator_warnings` the RFC prose named, because a bare total cannot
+//!   tell 2 from 218 (`validator-reporting.md`). The field stays optional so
+//!   manifests written before it keep parsing — and `None` renders as `?`,
+//!   never as clean.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 /// Factorio's 4-way direction constants (the engine only ever emits one of
@@ -161,6 +164,142 @@ pub struct Manifest {
     /// a different world — which is exactly what RFC-064 Phase 2 item 7 was.
     #[serde(default)]
     pub research_productivity: std::collections::BTreeMap<String, f64>,
+    /// Validator state of the exact layout this manifest describes, as of
+    /// export. Closes hole 3 in `docs/validator-trust.md`.
+    ///
+    /// `Option`, and absent-tolerant, because manifests written before this
+    /// field existed must keep parsing — a pre-existing `.json` on disk is
+    /// how most sim fixtures are replayed. **`None` means "this manifest
+    /// predates the field", which is not the same as "clean"**; the report
+    /// renders it as `?`, never as an all-clear. Distinguishing those two is
+    /// the entire point — reading absence as clearance is the failure mode
+    /// `validator-reporting.md` catalogues.
+    #[serde(default)]
+    pub validator: Option<ValidatorSummary>,
+}
+
+/// Mirror of `spaghettio_core::validate::ValidatorSummary`.
+///
+/// Hand-mirrored rather than imported: this crate deliberately does not
+/// depend on `spaghettio_core` (RFC-050 constraint, "consumes the manifest
+/// schema only"), the same reason every other type in this module is a
+/// mirror.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ValidatorSummary {
+    #[serde(default)]
+    pub errors: usize,
+    #[serde(default)]
+    pub warnings: usize,
+    /// `category -> {errors, warnings}`. Per-category rather than totals
+    /// because a bare total cannot tell 2 from 218 — see
+    /// `docs/validator-reporting.md`.
+    #[serde(default)]
+    pub by_category: BTreeMap<String, CategoryCount>,
+    /// Pipeline-stamped `LayoutResult::warnings`, which the validator never
+    /// sees. Counted apart because reading only the validator has already
+    /// produced one false "0 errors 0 warnings" claim.
+    #[serde(default)]
+    pub layout_warnings: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CategoryCount {
+    #[serde(default)]
+    pub errors: usize,
+    #[serde(default)]
+    pub warnings: usize,
+}
+
+impl ValidatorSummary {
+    pub fn is_clean(&self) -> bool {
+        self.errors == 0 && self.warnings == 0 && self.layout_warnings == 0
+    }
+
+    /// Compact badge for report tables: `clean`, or e.g. `2E/5W/1L`.
+    pub fn badge(&self) -> String {
+        if self.is_clean() {
+            return "clean".to_string();
+        }
+        let mut parts = Vec::new();
+        if self.errors > 0 {
+            parts.push(format!("{}E", self.errors));
+        }
+        if self.warnings > 0 {
+            parts.push(format!("{}W", self.warnings));
+        }
+        if self.layout_warnings > 0 {
+            parts.push(format!("{}L", self.layout_warnings));
+        }
+        parts.join("/")
+    }
+
+    /// Categories with at least one issue, worst-first, for the report's
+    /// one-line explanation of *what* was flagged.
+    pub fn top_categories(&self, limit: usize) -> Vec<String> {
+        let mut v: Vec<(&String, &CategoryCount)> = self.by_category.iter().collect();
+        v.sort_by(|a, b| {
+            (b.1.errors, b.1.warnings)
+                .cmp(&(a.1.errors, a.1.warnings))
+                .then(a.0.cmp(b.0))
+        });
+        v.into_iter()
+            .take(limit)
+            .map(|(k, c)| {
+                let n = c.errors + c.warnings;
+                format!("{k}×{n}")
+            })
+            .collect()
+    }
+}
+
+/// How a measured rate should be read given the validator state of the
+/// layout it was measured on.
+///
+/// The distinction the 2026-08-07 PU@1/s incident lacked: a number measured
+/// on a layout the validator has already condemned is a fact about *that
+/// layout*, not evidence about the pipeline that produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MeasurementStanding {
+    /// Validator was silent. The number measures the pipeline — subject to
+    /// the standing caveat that validator silence is not proof of anything.
+    Unflagged,
+    /// The layout carried warnings. The number measures this layout.
+    Warned,
+    /// The layout carried errors. It should arguably not have been simmed.
+    Condemned,
+    /// The manifest predates the validator field — standing is unknown.
+    Unknown,
+}
+
+impl MeasurementStanding {
+    pub fn of(summary: Option<&ValidatorSummary>) -> MeasurementStanding {
+        match summary {
+            None => MeasurementStanding::Unknown,
+            Some(s) if s.errors > 0 => MeasurementStanding::Condemned,
+            Some(s) if !s.is_clean() => MeasurementStanding::Warned,
+            Some(_) => MeasurementStanding::Unflagged,
+        }
+    }
+
+    /// One-line caveat to print beside a rate, or `None` when unflagged.
+    pub fn caveat(self) -> Option<&'static str> {
+        match self {
+            MeasurementStanding::Unflagged => None,
+            MeasurementStanding::Warned => Some(
+                "measured on a layout carrying validator warnings — \
+                 this measures the layout, not the pipeline",
+            ),
+            MeasurementStanding::Condemned => Some(
+                "measured on a layout carrying validator ERRORS — \
+                 this measures the layout, not the pipeline",
+            ),
+            MeasurementStanding::Unknown => Some(
+                "manifest predates the validator field — validator state \
+                 unknown, not clean",
+            ),
+        }
+    }
 }
 
 impl Manifest {
@@ -245,5 +384,114 @@ mod tests {
     fn no_fluid_boundary_in_gear_fixture() {
         let m = Manifest::from_str(fixture_json()).expect("parse");
         assert!(!m.has_fluid_boundary());
+    }
+
+    /// The load-bearing distinction. A manifest written before the validator
+    /// field existed must NOT read as clean — that conflation is how a
+    /// condemned layout gets quoted as a parity number.
+    #[test]
+    fn absent_validator_is_unknown_not_clean() {
+        let m = Manifest::from_str(fixture_json()).expect("parse");
+        assert!(m.validator.is_none(), "gear fixture predates the field");
+        let standing = MeasurementStanding::of(m.validator.as_ref());
+        assert_eq!(standing, MeasurementStanding::Unknown);
+        assert_ne!(standing, MeasurementStanding::Unflagged);
+        assert!(
+            standing.caveat().is_some(),
+            "an unknown-state run must still print a caveat"
+        );
+    }
+
+    #[test]
+    fn standing_separates_clean_warned_and_condemned() {
+        let clean = ValidatorSummary::default();
+        assert_eq!(
+            MeasurementStanding::of(Some(&clean)),
+            MeasurementStanding::Unflagged
+        );
+        assert!(MeasurementStanding::of(Some(&clean)).caveat().is_none());
+
+        let warned = ValidatorSummary {
+            warnings: 3,
+            ..Default::default()
+        };
+        assert_eq!(
+            MeasurementStanding::of(Some(&warned)),
+            MeasurementStanding::Warned
+        );
+
+        let condemned = ValidatorSummary {
+            errors: 1,
+            warnings: 3,
+            ..Default::default()
+        };
+        assert_eq!(
+            MeasurementStanding::of(Some(&condemned)),
+            MeasurementStanding::Condemned
+        );
+
+        // A layout with only pipeline-stamped warnings is still not clean —
+        // reading the validator alone produced a false "0 errors 0 warnings"
+        // claim once already (#462).
+        let layout_only = ValidatorSummary {
+            layout_warnings: 2,
+            ..Default::default()
+        };
+        assert!(!layout_only.is_clean());
+        assert_eq!(
+            MeasurementStanding::of(Some(&layout_only)),
+            MeasurementStanding::Warned
+        );
+    }
+
+    #[test]
+    fn badge_and_categories_are_per_category_not_totals() {
+        let v = ValidatorSummary {
+            errors: 1,
+            warnings: 5,
+            layout_warnings: 2,
+            by_category: BTreeMap::from([
+                (
+                    "input-rate-delivery".to_string(),
+                    CategoryCount {
+                        errors: 0,
+                        warnings: 4,
+                    },
+                ),
+                (
+                    "entity-overlap".to_string(),
+                    CategoryCount {
+                        errors: 1,
+                        warnings: 1,
+                    },
+                ),
+            ]),
+        };
+        assert_eq!(v.badge(), "1E/5W/2L");
+        // Errors sort ahead of warnings, so the overlap error leads even
+        // though input-rate-delivery has more total issues. A reader needs
+        // to know 4 delivery warnings is not 1 — the whole reason this is
+        // per-category (`validator-reporting.md`).
+        let cats = v.top_categories(4);
+        assert_eq!(cats, vec!["entity-overlap×2", "input-rate-delivery×4"]);
+    }
+
+    #[test]
+    fn validator_object_parses_when_present() {
+        let json = r#"{
+            "label": "t", "bbox_min": [0,0], "dims": [4,4],
+            "validator": {
+              "errors": 2, "warnings": 1, "layout_warnings": 0,
+              "by_category": { "pipe-isolation": {"errors": 2, "warnings": 1} }
+            }
+        }"#;
+        let m = Manifest::from_str(json).expect("parse");
+        let v = m.validator.expect("validator present");
+        assert_eq!(v.errors, 2);
+        assert_eq!(v.by_category["pipe-isolation"].errors, 2);
+        assert_eq!(
+            MeasurementStanding::of(Some(&v)),
+            MeasurementStanding::Condemned
+        );
     }
 }

--- a/crates/sim-harness/src/manifest.rs
+++ b/crates/sim-harness/src/manifest.rs
@@ -235,6 +235,10 @@ impl ValidatorSummary {
 
     /// Categories with at least one issue, worst-first, for the report's
     /// one-line explanation of *what* was flagged.
+    ///
+    /// Can legitimately be empty even when the summary is not clean: a layout
+    /// carrying only pipeline-stamped `layout_warnings` has no validator
+    /// category to name. Callers must not print a separator unconditionally.
     pub fn top_categories(&self, limit: usize) -> Vec<String> {
         let mut v: Vec<(&String, &CategoryCount)> = self.by_category.iter().collect();
         v.sort_by(|a, b| {
@@ -286,9 +290,14 @@ impl MeasurementStanding {
     pub fn caveat(self) -> Option<&'static str> {
         match self {
             MeasurementStanding::Unflagged => None,
+            // Deliberately says "warnings", not "validator warnings": this
+            // state is also reached by a layout whose only entries are
+            // pipeline-stamped `layout_warnings`, which are explicitly NOT
+            // validator output (#462). Naming the wrong source would send a
+            // reader to the wrong place.
             MeasurementStanding::Warned => Some(
-                "measured on a layout carrying validator warnings — \
-                 this measures the layout, not the pipeline",
+                "measured on a layout carrying warnings (validator and/or \
+                 pipeline) — this measures the layout, not the pipeline",
             ),
             MeasurementStanding::Condemned => Some(
                 "measured on a layout carrying validator ERRORS — \

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -821,8 +821,16 @@ fn validator_line(report: &Report) -> String {
                 .to_string()
         }
         Some(v) => {
+            // `top_categories` is legitimately empty when the only entries are
+            // pipeline-stamped layout warnings — there is no validator
+            // category to name. Printing the separator unconditionally gave a
+            // dangling `"2L — "`.
             let cats = v.top_categories(4);
-            format!("{} — {}", v.badge(), cats.join(", "))
+            if cats.is_empty() {
+                v.badge()
+            } else {
+                format!("{} — {}", v.badge(), cats.join(", "))
+            }
         }
     }
 }
@@ -1450,6 +1458,33 @@ mod tests {
     /// This is the 2026-08-07 PU@1/s shape exactly: a layout carrying
     /// input-rate-delivery warnings that named the starving machines, whose
     /// measured rate was reported with no mention of them.
+    /// Regression for the dangling separator: a layout whose only entries
+    /// are pipeline-stamped warnings has no validator category to name.
+    #[test]
+    fn layout_warnings_only_renders_without_a_dangling_separator() {
+        let v = crate::manifest::ValidatorSummary {
+            errors: 0,
+            warnings: 0,
+            layout_warnings: 2,
+            by_category: Default::default(),
+        };
+        let r = report_with_validator(Some(v));
+        let line = validator_line(&r);
+        assert_eq!(line, "2L", "got: {line:?}");
+        assert!(!line.contains('—'), "no separator without categories: {line}");
+        assert_eq!(
+            r.validator_standing,
+            crate::manifest::MeasurementStanding::Warned
+        );
+        // ...and the banner must not blame the validator for a pipeline
+        // warning the validator never emitted (#462).
+        let caveat = r.validator_standing.caveat().expect("warned");
+        assert!(
+            !caveat.contains("validator warnings"),
+            "misattributes the source: {caveat}"
+        );
+    }
+
     #[test]
     fn errors_are_reported_as_condemned_not_merely_warned() {
         let v = crate::manifest::ValidatorSummary {

--- a/crates/sim-harness/src/report.rs
+++ b/crates/sim-harness/src/report.rs
@@ -194,6 +194,15 @@ pub struct Report {
     /// older reports and `baseline.rs`'s targeted-field reads are
     /// unaffected.
     pub timeseries: Vec<TimeseriesPoint>,
+    /// Validator state of the layout these rates were measured on, carried
+    /// through from the manifest (`validator-trust.md` hole 3). `None` means
+    /// the manifest predates the field — **not** that the layout was clean.
+    pub validator: Option<crate::manifest::ValidatorSummary>,
+    /// How the rates above should be read given that state. Recorded in the
+    /// JSON as well as printed, so downstream consumers (`bless`/`check`,
+    /// sweeps) can refuse to treat a condemned run as a pipeline result
+    /// without re-parsing prose.
+    pub validator_standing: crate::manifest::MeasurementStanding,
 }
 
 fn get_u64(v: &serde_json::Value, key: &str) -> u64 {
@@ -530,6 +539,8 @@ pub fn compute(manifest: &Manifest, result: &serde_json::Value) -> Report {
 
     Report {
         label: manifest.label.clone(),
+        validator: manifest.validator.clone(),
+        validator_standing: crate::manifest::MeasurementStanding::of(manifest.validator.as_ref()),
         items,
         import_rc: get_i64(result, "import_rc"),
         ghosts: get_u64(result, "ghosts"),
@@ -792,6 +803,30 @@ fn productivity_parity_lines(
     out
 }
 
+/// One-line validator summary for the report header.
+///
+/// Renders `?` for an absent summary rather than anything that could read as
+/// an all-clear: a manifest predating the field tells us nothing about the
+/// layout, and treating that silence as clearance is the exact failure
+/// `validator-reporting.md` catalogues.
+fn validator_line(report: &Report) -> String {
+    match &report.validator {
+        None => "? (manifest predates the validator field — state unknown, NOT clean)".to_string(),
+        Some(v) if v.is_clean() => {
+            // Deliberately not "PASS". Of ~40 checks only a handful carry
+            // refusal power and each is documented "never sim-anchored"
+            // (`validator-trust.md`), so silence here means the validator
+            // and the sim agree, not that either is right.
+            "clean (no issues reported — note validator silence is not proof of correctness)"
+                .to_string()
+        }
+        Some(v) => {
+            let cats = v.top_categories(4);
+            format!("{} — {}", v.badge(), cats.join(", "))
+        }
+    }
+}
+
 pub fn print_human(report: &Report) {
     println!("=== spaghettio-sim report: {} ===", report.label);
     println!(
@@ -819,6 +854,7 @@ pub fn print_human(report: &Report) {
         report.inserter_stack_size_bonus,
         report.bulk_inserter_capacity_bonus
     );
+    println!("validator: {}", validator_line(report));
     for line in productivity_parity_lines(
         &report.productivity_force,
         &report.productivity_entity,
@@ -850,6 +886,9 @@ pub fn print_human(report: &Report) {
         }
     }
     println!();
+    if let Some(caveat) = report.validator_standing.caveat() {
+        println!("!! {}", caveat.to_uppercase());
+    }
     println!(
         "{:<28} {:>10} {:>12} {:>10} {:>12} {:>10} {:>8}",
         "item", "planned/s", "produced/s", "d%", "delivered/s", "d%", "verdict"
@@ -1335,5 +1374,106 @@ mod tests {
         let result = serde_json::json!({"checkpoints": [], "samples": []});
         let report = compute(&m, &result);
         assert!(report.timeseries.is_empty());
+    }
+
+    fn report_with_validator(v: Option<crate::manifest::ValidatorSummary>) -> Report {
+        let mut m = fixture_manifest();
+        m.validator = v;
+        compute(&m, &serde_json::json!({"checkpoints": [], "samples": []}))
+    }
+
+    /// The whole point of hole 3: a rate must never be printed without the
+    /// validator state of the layout it was measured on. These assert the
+    /// rendered text, not just the struct — a field nobody reads is what
+    /// RFC-050 Phase 0 already shipped once.
+    #[test]
+    fn absent_validator_renders_as_unknown_never_as_clean() {
+        let r = report_with_validator(None);
+        let line = validator_line(&r);
+        assert!(line.contains('?'), "got: {line}");
+        assert!(
+            line.to_lowercase().contains("not clean"),
+            "absence must be spelled out as not-clean, got: {line}"
+        );
+        assert_eq!(
+            r.validator_standing,
+            crate::manifest::MeasurementStanding::Unknown
+        );
+        assert!(r.validator_standing.caveat().is_some());
+    }
+
+    #[test]
+    fn clean_validator_renders_without_claiming_correctness() {
+        let r = report_with_validator(Some(Default::default()));
+        let line = validator_line(&r);
+        assert!(line.starts_with("clean"), "got: {line}");
+        // Silence is not proof — of ~40 checks only a handful gate, and each
+        // is documented "never sim-anchored". The line must say so.
+        assert!(line.contains("not proof"), "got: {line}");
+        assert!(
+            r.validator_standing.caveat().is_none(),
+            "an unflagged run needs no banner"
+        );
+    }
+
+    #[test]
+    fn warned_validator_names_its_categories_and_flags_the_rates() {
+        let v = crate::manifest::ValidatorSummary {
+            errors: 0,
+            warnings: 3,
+            layout_warnings: 0,
+            by_category: std::collections::BTreeMap::from([(
+                "input-rate-delivery".to_string(),
+                crate::manifest::CategoryCount {
+                    errors: 0,
+                    warnings: 3,
+                },
+            )]),
+        };
+        let r = report_with_validator(Some(v));
+        let line = validator_line(&r);
+        // Per-category, not a bare total: a reader must be able to tell
+        // which check fired and how many times.
+        assert!(line.contains("input-rate-delivery"), "got: {line}");
+        assert!(line.contains("3W"), "got: {line}");
+        assert_eq!(
+            r.validator_standing,
+            crate::manifest::MeasurementStanding::Warned
+        );
+        let caveat = r.validator_standing.caveat().expect("warned needs a caveat");
+        assert!(
+            caveat.contains("measures the layout, not the pipeline"),
+            "got: {caveat}"
+        );
+    }
+
+    /// This is the 2026-08-07 PU@1/s shape exactly: a layout carrying
+    /// input-rate-delivery warnings that named the starving machines, whose
+    /// measured rate was reported with no mention of them.
+    #[test]
+    fn errors_are_reported_as_condemned_not_merely_warned() {
+        let v = crate::manifest::ValidatorSummary {
+            errors: 2,
+            warnings: 1,
+            layout_warnings: 0,
+            by_category: std::collections::BTreeMap::from([(
+                "entity-overlap".to_string(),
+                crate::manifest::CategoryCount {
+                    errors: 2,
+                    warnings: 1,
+                },
+            )]),
+        };
+        let r = report_with_validator(Some(v));
+        assert_eq!(
+            r.validator_standing,
+            crate::manifest::MeasurementStanding::Condemned
+        );
+        assert!(r
+            .validator_standing
+            .caveat()
+            .expect("condemned needs a caveat")
+            .contains("ERRORS"));
+        assert!(validator_line(&r).contains("2E/1W"));
     }
 }

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -309,6 +309,52 @@ informational — a two-sided tolerance would spuriously fail honest
 layouts. The run also dumps `sim-state.json` (belt contents, machine
 status), included in `--out`.
 
+### The `validator:` line — read this before the rates
+
+Every report header now carries the validator state of the exact layout
+that was measured (`validator-trust.md` hole 3, closed 2026-08-09):
+
+```
+validator: 3W — input-rate-delivery×3
+```
+
+and, when the layout was flagged, a banner immediately above the rate table:
+
+```
+!! MEASURED ON A LAYOUT CARRYING VALIDATOR WARNINGS — THIS MEASURES THE
+   LAYOUT, NOT THE PIPELINE
+```
+
+That distinction is the whole point. **A number measured on a layout the
+validator has already condemned is a fact about that layout, not evidence
+about the pipeline that produced it.** On 2026-08-07 a PU@1/s fixture was
+reported at 68.2% of plan while carrying three `input-rate-delivery`
+warnings naming the exact starving machines — the validator had localised
+the defect before the sim ran, and nothing printed it.
+
+Four states, recorded in the JSON as `validator_standing`:
+
+| State | Meaning |
+|---|---|
+| `unflagged` | Validator reported nothing |
+| `warned` | Warnings present — the rate describes this layout |
+| `condemned` | Errors present — arguably should not have been simmed |
+| `unknown` | Manifest predates the field — **not** the same as clean |
+
+Two things it does **not** mean:
+
+- **`unflagged` is not clearance.** Of ~40 checks only a handful carry
+  refusal power, and each is documented "never sim-anchored" in
+  `validator-trust.md`. A clean line beside an at-plan rate means the two
+  instruments agree, not that either is right.
+- **It is not a gate.** Nothing refuses to run a condemned layout. If you
+  want a parity number from a flagged fixture you can still have one — you
+  just can't get it without being told what you are measuring.
+
+Counts are per-category rather than totals because a total cannot tell 2
+from 218 (`validator-reporting.md`). `3W` with `input-rate-delivery×3`
+tells you which check fired and how often; `warnings: 3` would not.
+
 **Web overlay (RFC-050 Phase 4):** load the `--out` file via the sim
 report panel in the web app to get the verdict banner plus a `sim-state`
 entity overlay tinting machines/belts/inserters by their simulated state

--- a/docs/validator-trust.md
+++ b/docs/validator-trust.md
@@ -49,7 +49,7 @@ without comment.
 | C3 | transactional transforms (`bus/compaction.rs`) | a cut/candidate that has (or adds) Errors is rejected; the pre-transform layout survives. RFC-065 adds a `connectivity::error_certain_regression` reject-fast prefilter ahead of the full validate |
 | C4 | web UI | issues render as markers; export button works regardless |
 | C5 | blueprint export | **no gate** — export never consults validation |
-| C6 | sim / meter harness | **no gate, no visibility** — the manifest (`crates/sim-harness/src/manifest.rs::Manifest`) carries geometry, rates, boundaries, and the declared axes, but no issue state at all |
+| C6 | sim / meter harness | **no gate, but visibility since 2026-08-09** — the manifest carries a per-category `validator` block and the report prints it beside every rate, tagging the run `unflagged`/`warned`/`condemned`/`unknown` (hole 3). Still no *gate*: a condemned layout is flagged loudly, not refused |
 
 Second issue channel: `LayoutResult.warnings` — strings stamped by the layout
 pipeline itself (e.g. "No N→M balancer template"), never seen by `validate()`.
@@ -245,19 +245,30 @@ Severity `E/W` = both emitted, condition-dependent. "Sel" = counts in
    assume.
 
 
-3. **The sim/meter side has no validator visibility.** `Manifest` carries no
-   issue state, so parity sweeps can quote a condemned layout as a parity
-   number — which is precisely how 68.2% was first reported with no mention
-   of the three warnings that explained it. This is a **recorded RFC-050
-   Phase 0 deferral**, not an unnoticed gap: the RFC's Design section
-   promises `validator_errors`/`validator_warnings` in the manifest, and
-   `crates/sim-harness/src/manifest.rs`'s module doc documents that Phase 0
-   shipped without them (resolved as optional/absent-tolerant). **Next
-   action:** emit the fields the RFC already promised — per-category counts,
-   not just totals (`validator-reporting.md` rule: totals can't tell 2 from
-   218) — and make the sweep/report print them next to every rate, flagging
-   any "parity" number measured on a warned layout as measuring the layout,
-   not the pipeline.
+3. ~~**The sim/meter side has no validator visibility.**~~ **CLOSED
+   2026-08-09.** `Manifest` carried no issue state, so parity sweeps could
+   quote a condemned layout as a parity number — precisely how 68.2% was
+   first reported with no mention of the three warnings that explained it.
+   Delivered as the RFC-050 Design section originally promised, with one
+   change: **per-category counts, not two totals**, because totals can't
+   tell 2 from 218 (`validator-reporting.md`).
+   - `export_with_manifest` emits a `validator` object: `errors`,
+     `warnings`, `layout_warnings` (pipeline-stamped `LayoutResult::warnings`,
+     which `validate()` never sees — counted apart because reading only the
+     validator produced a false "0 errors 0 warnings" claim in #462), and
+     `by_category`.
+   - `spaghettio-sim` prints it in the report header and, when the layout was
+     flagged, a banner immediately above the rate table: *"measured on a
+     layout carrying validator warnings — this measures the layout, not the
+     pipeline."*
+   - A manifest predating the field renders `?`, never "clean".
+     `MeasurementStanding::Unknown` is a distinct state from `Unflagged`, and
+     it is pinned by a test — conflating absence with clearance is the
+     failure this whole page exists to stop.
+   - **Still not a gate.** Nothing refuses to sim or export a condemned
+     layout; C5 remains open. Making export refuse is a separate decision
+     with real consequences for the candidate search, and should be taken
+     deliberately rather than as a side effect of adding visibility.
 4. **`belt-flow-path` / `belt-flow-reachability` are Warnings under
    `LayoutStyle::Bus`** — the style every production call site passes
    (`LayoutStyle::default()` is Spaghetti, but nothing in production relies


### PR DESCRIPTION
## Intent

Closes the **consumer half of hole 3** in `docs/validator-trust.md` — and the hole itself. #611 emits a per-category `validator` block in the manifest; this reads it and puts it where a human reading a rate cannot miss it.

The report header gains:

```
validator: 3W — input-rate-delivery×3
```

and, when the layout was flagged, a banner immediately above the rate table:

```
!! MEASURED ON A LAYOUT CARRYING VALIDATOR WARNINGS — THIS MEASURES THE
   LAYOUT, NOT THE PIPELINE
```

That sentence is the point. On 2026-08-07 a PU@1/s fixture was reported at **68.2% of plan** while carrying three `input-rate-delivery` warnings naming the exact starving machines. The validator had localised the defect before the sim ran; every stage behaved as designed and none of them printed it.

## Scope

- **In:** `ValidatorSummary`/`CategoryCount` mirror types, `MeasurementStanding`, report header line + banner, `validator_standing` in the report JSON, and the doc close-outs in `validator-trust.md` and `sim-harness.md`.
- **Out:** **any gate.** A condemned layout is flagged loudly, not refused. Making the harness or export refuse is a real decision with consequences for the candidate search and should be taken deliberately, not as a side effect of adding visibility. C5 stays open in the trust table.
- **Size:** 467 added lines, over the 400 norm. It could not usefully split further — the split already happened at the crate boundary (#611), and halving again would separate the renderer from the type it renders, leaving one PR that reads a field and prints nothing. Roughly 55% of the diff is doc comments, doc updates, and tests; the executable change is ~120 lines.

## Independent of #611

Deliberately, and verified rather than assumed: `sim-harness` does not depend on `spaghettio_core`, and the mirror type tolerates an absent field. **This branch builds and passes 85/85 against unmodified core, with #611 not applied.** Landing order does not matter.

## `unknown` is not `clean`

Four states, serialized so sweeps and `bless`/`check` can act on them without parsing prose: `unflagged` / `warned` / `condemned` / `unknown`.

`unknown` is load-bearing and separate from `unflagged` by design. A manifest predating the field tells us nothing about the layout, and renders `?` — never "clean". Conflating absence with clearance is exactly the failure `validator-reporting.md` catalogues, so it is pinned by its own test rather than left to convention.

The `clean` rendering also declines to claim correctness inline: of ~40 checks only a handful gate, each documented "never sim-anchored".

## Verification

- [x] `cargo test -p spaghettio_sim_harness` — **85 passed, 0 failed**, one clean invocation, against an **unmodified** core
- [x] `cargo clippy --manifest-path crates/sim-harness/Cargo.toml --all-targets -- -D warnings` — clean
- [x] Tests assert the **rendered text**, not just the struct — a field nobody reads is what RFC-050 Phase 0 already shipped once. `absent_validator_renders_as_unknown_never_as_clean` and `clean_validator_renders_without_claiming_correctness` are the two that matter.
- [ ] Live sim run — not done. This is a reporting change with no effect on geometry or measurement; the rate path is untouched. Say the word if you want a fixture run anyway before merge.

## Deviations from intent

Size, argued above. Otherwise none.

## Models / contracts touched

RFC-050 manifest schema (consumer side, additive) and the report JSON (additive: `validator`, `validator_standing`). `validator-trust.md` C6 row and hole 3 updated in this PR; C5 (export has no validation gate) deliberately left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)