### PR TITLE
chore: check in the churn-audit pipeline so the norm's numbers are falsifiable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,12 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   the multiple concurrent Claude sessions that share this repo.
 - **Keep a PR under ~400 added lines.** This is the strongest predictor of
   *rework* we have measured. Across the 197 PRs merged **2026-07-20 → 08-09**
-  with >20 added lines, rework per 100 added lines ran 1.6 (<100 adds) · 2.6
-  (100–400) · **6.1 (400–1k)** — a ~4× rise holding under both per-PR and
-  pooled averaging — and PRs ≥400 adds, 36% of that population, accounted for **90% of
-  all rework**. Above 1k it stops rising (6.0 mean / 3.8 pooled) — but that step
-  is confounded by right-censoring, so read 400 as "where the climb is measured
+  with >20 added lines, rework per 100 added lines climbed with size under
+  both averagings — per-PR mean 1.6 (<100 adds) · 2.5 (100–400) · **4.7
+  (400–1k)**, pooled 2.1 · 2.4 · **4.6** (≈3× and ≈2×) — and PRs ≥400 adds,
+  36% of that population, accounted for **89% of its rework**. Above 1k the
+  two averagings disagree in direction (mean 5.7, pooled 3.6) and the step is
+  confounded by right-censoring, so read 400 as "where the climb is measured
   to happen", not as a ceiling. Denominators and caveats:
   [audit](docs/pr-churn-audit-2026-08.md).
   - Read "rework" literally — a later PR rewriting an earlier one's lines. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,9 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   PR to get code onto `main`. Besides review, this serializes `main` across
   the multiple concurrent Claude sessions that share this repo.
 - **Keep a PR under ~400 added lines.** This is the strongest predictor of
-  *rework* we have measured. Across the 194 PRs merged **2026-07-20 → 08-09**
-  with >20 added lines, rework per 100 added lines ran 1.6 (<100 adds) · 2.7
-  (100–400) · **6.3 (400–1k)** — a ~4× rise holding under both per-PR and
+  *rework* we have measured. Across the 197 PRs merged **2026-07-20 → 08-09**
+  with >20 added lines, rework per 100 added lines ran 1.6 (<100 adds) · 2.6
+  (100–400) · **6.1 (400–1k)** — a ~4× rise holding under both per-PR and
   pooled averaging — and PRs ≥400 adds, 32% of them, accounted for **90% of
   all rework**. Above 1k it stops rising (6.0 mean / 3.8 pooled), so 400 is the
   threshold: it is where the climb happens, not merely where two statistics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,12 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   the multiple concurrent Claude sessions that share this repo.
 - **Keep a PR under ~400 added lines.** This is the strongest predictor of
   *rework* we have measured. Across the 194 PRs merged **2026-07-20 → 08-09**
-  with >20 added lines, rework per 100 added lines ran 1.4 (<100 adds) · 3.2
-  (100–400) · **8.5 (400–1k)** — a 6–8× rise holding under both per-PR and
-  pooled averaging — and PRs ≥400 adds, 32% of them, accounted for **93% of
-  all rework**. Above 1k is unresolved: the two statistics disagree in
-  *direction* there, so 400 is the threshold precisely because that is where
-  they agree. Denominators and caveats:
+  with >20 added lines, rework per 100 added lines ran 1.6 (<100 adds) · 2.7
+  (100–400) · **6.3 (400–1k)** — a ~4× rise holding under both per-PR and
+  pooled averaging — and PRs ≥400 adds, 32% of them, accounted for **90% of
+  all rework**. Above 1k it stops rising (6.0 mean / 3.8 pooled), so 400 is the
+  threshold: it is where the climb happens, not merely where two statistics
+  agree. Denominators and caveats:
   [audit](docs/pr-churn-audit-2026-08.md).
   - Read "rework" literally — a later PR rewriting an earlier one's lines. A
     sampled split puts it at ~57% planned iteration / 23% genuine correction /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,10 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   *rework* we have measured. Across the 197 PRs merged **2026-07-20 → 08-09**
   with >20 added lines, rework per 100 added lines ran 1.6 (<100 adds) · 2.6
   (100–400) · **6.1 (400–1k)** — a ~4× rise holding under both per-PR and
-  pooled averaging — and PRs ≥400 adds, 32% of them, accounted for **90% of
-  all rework**. Above 1k it stops rising (6.0 mean / 3.8 pooled), so 400 is the
-  threshold: it is where the climb happens, not merely where two statistics
-  agree. Denominators and caveats:
+  pooled averaging — and PRs ≥400 adds, 36% of that population, accounted for **90% of
+  all rework**. Above 1k it stops rising (6.0 mean / 3.8 pooled) — but that step
+  is confounded by right-censoring, so read 400 as "where the climb is measured
+  to happen", not as a ceiling. Denominators and caveats:
   [audit](docs/pr-churn-audit-2026-08.md).
   - Read "rework" literally — a later PR rewriting an earlier one's lines. A
     sampled split puts it at ~57% planned iteration / 23% genuine correction /

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -59,6 +59,14 @@ subsystems with less existing code to collide with) is plausible but this
 pipeline cannot distinguish it from truncation — only the left-censoring was
 previously acknowledged. Treat >1k as unmeasured, in either direction.
 
+The same confound was checked against the *climb* and measured dead
+(`probe-exposure.sh`): mean exposure — days between merge and window end — is
+flat across the buckets, **11.2 / 12.2 / 12.1 / 11.4 days** (<100 → >1k,
+medians 11/14/14/10). An 8% exposure difference cannot manufacture a ~3× rate
+difference, so the <100 → 400–1k climb is not an exposure-time artifact; the
+>1k bucket sitting *lowest* is consistent with, and small relative to, the
+censoring caveat above.
+
 > **Denominators.** `04-analyze.sh` prints these; do not hand-derive them.
 > The per-PR pull (`review_rounds.tsv`) covers **220** PRs merged 2026-07-20 →
 > 08-09; **197** of those clear the >20-add floor and form the bucket

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -26,32 +26,30 @@ before the numbers below were trustworthy (see [Method](#method)).
 | Measure | Value |
 |---|---|
 | PRs opened / merged | 232 / 218 |
-| Blame-paired rework edges | 3,114 |
-| Median rework lag | 2 days (57% within 3) |
-| Share of rework from PRs ≥400 added lines | **93.2%** (from 32% of PRs) |
+| Blame-paired rework edges | 1,841 |
+| Median rework lag | 1 day (65% within 3) |
+| Share of rework from PRs ≥400 added lines | **90.1%** (from 32% of PRs) |
 | Corrective-PR rate | flat 20–30% since April; 12% in Aug wk0 |
 
 ### Rework per 100 added lines, by PR size
 
 | Bucket | n | Mean of per-PR rates | Pooled (Σrework/Σadds) |
 |---|---:|---:|---:|
-| <100 adds | 42 | 1.4 | 1.1 |
-| 100–400 | 82 | 3.2 | 3.0 |
-| 400–1k | 41 | 8.5 | 8.3 |
-| **>1k** | 29 | **10.5** | 6.9 |
+| <100 adds | 42 | 1.6 | 2.1 |
+| 100–400 | 82 | 2.7 | 2.5 |
+| 400–1k | 41 | 6.3 | 6.2 |
+| **>1k** | 29 | 6.0 | 3.8 |
 
-**What is robust:** the rate rises steeply and monotonically across the first
-three buckets under *both* statistics — roughly 6–8× from <100 to 400–1k. That
-alone carries the norm, whose threshold is 400.
+**What is robust:** the rate rises across the first three buckets under *both*
+statistics — roughly 4× from <100 to 400–1k (1.6→6.3 mean, 2.1→6.2 pooled).
+That carries the norm, whose threshold is 400.
 
-**What is not:** the two statistics disagree on the 400–1k → >1k step in
-*direction*, not merely magnitude. The per-PR mean rises (8.5 → 10.5); pooled
-**falls** (8.3 → 6.9), because pooling weights by PR size and a few very large
-PRs with proportionally little rework dominate that cell. So: do not claim
-monotonicity across all four buckets, and do not claim >1k is worse than
-400–1k, or even "at least as bad" — one of the two statistics says it is
-better. The >1k bucket is **unresolved on this data**; the norm's threshold is
-400 precisely because that is where both statistics agree.
+**What is not:** the climb does not continue past 1k. Both statistics fall
+across the 400–1k → >1k step (mean 6.3 → 6.0, pooled 6.2 → 3.8), so >1k is
+**not** worse than 400–1k on this data — plausibly a floor effect, since the
+largest PRs are often standalone new subsystems with less existing code to
+collide with. The norm's threshold is 400 because that is where the rise
+happens.
 
 > **Denominators.** These buckets cover the 194 PRs that merged 2026-07-20 →
 > 08-09 with more than 20 added lines. That is narrower than the 218 merged
@@ -137,20 +135,31 @@ commit mapped back to its PR.
 
 Effect of correcting both:
 
-| Measure | v1 | v2 |
-|---|---:|---:|
-| Edges | 1,639 | 3,114 |
-| Median lag | 1d | 2d |
-| Within 3 days | 61% | 57% |
-| Chain-interior share | 61% | 38% |
-| Rate >1k adds | 5.7 | **10.5** |
-| Large-PR share | 89.7% | 93.2% |
+| Measure | v1 | v2 | **v3 (current)** |
+|---|---:|---:|---:|
+| Edges | 1,639 | 3,114 | **1,841** |
+| Median lag | 1d | 2d | **1d** |
+| Within 3 days | 61% | 57% | **65%** |
+| Rate <100 adds | 1.6 | 1.4 | **1.6** |
+| Rate 400–1k | 6.3 | 8.5 | **6.3** |
+| Rate >1k adds | 5.7 | 10.5 | **6.0** |
+| Large-PR share | 89.7% | 93.2% | **90.1%** |
 
-The size finding strengthened across the buckets where it is load-bearing.
-v1's per-PR-mean dip in the top bucket was an artifact of the truncation, not
-the floor effect I first claimed — but correcting it made only the *mean*
-monotonic, not the pooled figure, which still falls in the top bucket. The
-fix-chain finding shrank by a third.
+**v2 was the outlier, and v2 is what was originally published here.** Replacing
+`sha^1..sha` with a bare `sha~N..sha` fixed a too-narrow range by introducing a
+too-wide one: `gh` reports the PR *branch's* commit count, but a squash-merged
+PR contributes only one commit to main, so `sha~N` walks N−1 commits back into
+earlier PRs. Measured: **48 of 218 in-window PRs (22%)**, and size-correlated
+(17% under 400 adds, 34% over) — biased in the same direction as the finding.
+v3 resolves each range by walking back only until it meets a commit announcing
+a different PR, which handles squash, rebase and merge commits alike. It lands
+almost exactly on v1, whose two errors had partially cancelled.
+
+The size finding survives all three versions: the ~4× climb from <100 to
+400–1k, and large PRs producing ~90% of rework, are present in v1 and v3 and
+exaggerated in v2. What did *not* survive is v2's claim that the top bucket
+keeps climbing — under v3 it falls, and the floor-effect reading I originally
+gave in v1 (and then retracted) turns out to have been right.
 
 ### Caveats
 

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -10,9 +10,9 @@ it, using the checked-in pipeline at
 reproduces the **blame-edge, age and size-bucket** figures exactly — the ones
 the norm rests on. It does not regenerate the hand-classified parts (corrective
 rate, latency bands, the within-PR complexity control, concurrency); those live
-only in this doc. Its README also records the two measurement defects
-(truncated diff range, issue-numbers-read-as-PR-numbers) that made the first
-version of these numbers wrong.
+only in this doc. Its README also records the measurement defects — a
+truncated diff range, an over-wide one, issue numbers read as PR numbers —
+that made earlier versions of these numbers wrong.
 
 Motivating question from the owner: PR churn feels like it's rising — is the
 model getting worse, or is the code getting harder to work in?
@@ -25,10 +25,10 @@ before the numbers below were trustworthy (see [Method](#method)).
 
 | Measure | Value |
 |---|---|
-| PRs opened / merged | 232 / 218 |
-| Blame-paired rework edges | 1,999 |
-| Median rework lag | 2 days (60% within 3) |
-| Share of rework from PRs ≥400 added lines | **90.1%** (from 36% of the bucket population) |
+| PRs opened / merged | 237 / 221 |
+| Blame-paired rework edges | 2,022 |
+| Median rework lag | 1 day (61% within 3) |
+| Share of the bucket population's rework from PRs ≥400 added lines | **89.3%** (from 36% of that population) |
 | Corrective-PR rate | flat 20–30% since April; 12% in Aug wk0 |
 
 ### Rework per 100 added lines, by PR size
@@ -36,26 +36,28 @@ before the numbers below were trustworthy (see [Method](#method)).
 | Bucket | n | Mean of per-PR rates | Pooled (Σrework/Σadds) |
 |---|---:|---:|---:|
 | <100 adds | 42 | 1.6 | 2.1 |
-| 100–400 | 84 | 2.6 | 2.5 |
-| 400–1k | 42 | 6.1 | 6.1 |
-| **>1k** | 29 | 6.0 | 3.8 |
+| 100–400 | 84 | 2.5 | 2.4 |
+| 400–1k | 42 | 4.7 | 4.6 |
+| **>1k** | 29 | 5.7 | 3.6 |
 
 **What is robust:** the rate rises across the first three buckets under *both*
-statistics — roughly 4× from <100 to 400–1k (1.6→6.1 mean, 2.1→6.1 pooled).
-That carries the norm, whose threshold is 400.
+statistics — ≈3× from <100 to 400–1k on the per-PR mean (1.6→4.7), ≈2×
+pooled (2.1→4.6). That carries the norm, whose threshold is 400.
 
-**What is not:** the climb does not continue past 1k. Both statistics fall
-across the 400–1k → >1k step (mean 6.1 → 6.0, pooled 6.1 → 3.8), so >1k is
-**not** measured as worse than 400–1k.
+**What is not:** the >1k step. The two statistics disagree in *direction*
+there (mean 4.7 → 5.7, pooled 4.6 → 3.6), and the bucket has flipped under
+every measurement correction so far (fell in v1, climbed in v2, fell in v3,
+splits in v4 — see [Method](#method)).
 
-Do not read that as a ceiling. The step is **confounded by right-censoring**:
+Do not read any of that as a ceiling. The step is **confounded by
+right-censoring**:
 an edge exists only when the *reworker* is inside the window, so a PR merged
 near 08-09 accrues almost no rework regardless of its size, and stage 4 divides
 that near-zero by its full additions. Any bucket whose PRs cluster late is
 deflated. The floor-effect reading (largest PRs are often standalone new
 subsystems with less existing code to collide with) is plausible but this
 pipeline cannot distinguish it from truncation — only the left-censoring was
-previously acknowledged. Treat >1k as unmeasured, not as flat.
+previously acknowledged. Treat >1k as unmeasured, in either direction.
 
 > **Denominators.** `04-analyze.sh` prints these; do not hand-derive them.
 > The per-PR pull (`review_rounds.tsv`) covers **220** PRs merged 2026-07-20 →
@@ -146,47 +148,64 @@ commit mapped back to its PR.
    Rebuilt from authoritative per-PR commit ranges: **35% of commits (322 of
    907) had been mis-attributed**.
 
-Effect of correcting both:
+Effect of correcting both, and of the two later review-caught fixes (v4):
 
-| Measure | v1 | v2 | **v3 (current)** |
-|---|---:|---:|---:|
-| Edges | 1,639 | 3,114 | **1,999** |
-| Median lag | 1d | 2d | **2d** |
-| Within 3 days | 61% | 57% | **60%** |
-| Rate <100 adds | 1.6 | 1.4 | **1.6** |
-| Rate 400–1k | 6.3 | 8.5 | **6.1** |
-| Rate >1k adds | 5.7 | 10.5 | **6.0** |
-| Large-PR share | 89.7% | 93.2% | **90.1%** |
+| Measure | v1 | v2 | v3 | **v4 (current)** |
+|---|---:|---:|---:|---:|
+| Edges | 1,639 | 3,114 | 1,999 | **2,022** |
+| Median lag | 1d | 2d | 2d | **1d** |
+| Within 3 days | 61% | 57% | 60% | **61%** |
+| Rate <100 adds | 1.6 | 1.4 | 1.6 | **1.6** |
+| Rate 400–1k | 6.3 | 8.5 | 6.1 | **4.7** |
+| Rate >1k adds | 5.7 | 10.5 | 6.0 | **5.7** |
+| Large-PR share | 89.7% | 93.2% | 90.1% | **89.3%** |
 
-These v3 figures are the **checked-in pipeline's own output**, regenerated
-end-to-end from scratch rather than from any surviving intermediate. An earlier
-draft of v3 quoted 1,841 edges and 1.6/2.7/6.3; those came from reusing a
-`prs_merged.json` capped at 300 PRs, which silently dropped blame hits whose
-target PR fell outside the cap. Raising the cap resolves those, which is why the
-edge count rises and the age tail lengthens (p90 9 → 80 days): rework of older
-PRs was previously invisible, not absent.
+These v4 figures are the **checked-in pipeline's own output**, regenerated
+end-to-end from scratch rather than from any surviving intermediate. (An
+earlier draft of v3 quoted 1,841 edges and 1.6/2.7/6.3; those came from
+reusing a `prs_merged.json` capped at 300 PRs, which silently dropped blame
+hits whose target PR fell outside the cap. Raising the cap is why the edge
+count rose and the age tail lengthened (p90 9 → 80 days): rework of older PRs
+was previously invisible, not absent.)
+
+**v4 is v3 plus two fixes caught in this PR's own review.** First, the
+boundary walk now validates a trailing `(#N)` against the merged-PR list —
+defect 2's issue-ref regex had re-entered through the walk and truncated the
+range of #317, the very PR defect 1 was measured on. Isolated, that fix moved
+almost nothing (edges 1,999 → 2,005). Second, the diff now passes `-w` to
+match the blame's `-w`, so whitespace-only churn no longer counts as rework —
+and that is what moved the numbers: the 400–1k bucket drops 6.1 → 4.7,
+meaning roughly a quarter of that bucket's previously-counted rework was
+whitespace-only lines.
 
 **v2 was the outlier, and v2 is what was originally published here.** Replacing
 `sha^1..sha` with a bare `sha~N..sha` fixed a too-narrow range by introducing a
 too-wide one: `gh` reports the PR *branch's* commit count, but a squash-merged
 PR contributes only one commit to main, so `sha~N` walks N−1 commits back into
-earlier PRs. Measured: **48 of 218 in-window PRs (22%)**, and size-correlated
-(17% under 400 adds, 34% over) — biased in the same direction as the finding.
+earlier PRs. Measured (`probe-v2-defect.sh`): **50 of 221 in-window PRs
+(22%)**, and size-correlated (17% under 400 adds, 33% over) — biased in the
+same direction as the finding.
 v3 resolves each range by walking back only until it meets a commit announcing
 a different PR, which handles squash, rebase and merge commits alike. It lands
 almost exactly on v1, whose two errors had partially cancelled.
 
-The size finding survives all three versions: the ~4× climb from <100 to
-400–1k, and large PRs producing ~90% of rework, are present in v1 and v3 and
-exaggerated in v2. What did *not* survive is v2's claim that the top bucket
-keeps climbing — under v3 it falls, and the floor-effect reading I originally
-gave in v1 (and then retracted) turns out to have been right.
+The size finding survives all four versions: the climb from <100 to 400–1k,
+and large PRs producing ~90% of rework, are present in every one and
+exaggerated in v2. What survives *no* pair of versions is the top bucket: it
+falls in v1, climbs in v2, falls in v3, and splits in v4 (mean up, pooled
+down). A bucket that changes direction under every measurement correction is
+telling you it is unmeasured, not what its value is.
 
 ### Caveats
 
 - **Rework ≠ defect.** A sampled classification of 85 PR-pairs splits edges
   ~57% planned iteration / 23% genuine correction / 20% collision. Absolute
   edge counts overstate churn; the size finding is ratio-based and survives.
+- **Lag figures are edge-weighted.** The median/percentile lag and "within 3
+  days" are computed over (hunk × origin-commit) rows, each counting once
+  regardless of how many lines it carries; the edge total and bucket rates are
+  line-based. The two weightings answer slightly different questions and have
+  not been cross-checked against each other.
 - **Size and difficulty are confounded.** Large PRs may be large because the
   work is harder. Per-line normalization controls for volume, not difficulty.
 - **One signal is unresolved.** The rate at which the owner pushes back *in
@@ -214,8 +233,10 @@ Ranked by expected value, not yet actioned:
 3. **Review-bot reliability.** The single most systemic complaint in the
    conversation record — 8 distinct sessions, more than any other theme —
    plus 9 of the 13 closed-unmerged PRs are skip-guard duplicates or
-   stacked-PR orphans, meaning ~4% of the "232 PRs" figure is the same work
-   re-counted. (232 = 218 merged + 13 closed + 1 open.)
+   stacked-PR orphans, meaning ~4% of the "237 PRs" figure is the same work
+   re-counted. (237 = 221 merged + 13 closed-unmerged + 3 open at close-out;
+   the merged count is stage 1's, the other two are `gh pr list` snapshots
+   taken 2026-08-09.)
 4. **Turnaround guardrail on large PRs**, not a concurrency cap. Concurrency
    is a threshold effect on one day (Jul 22 carries 31% of all reworked lines;
    dropping it collapses the day-level correlation from 0.318 to 0.145), and

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -63,9 +63,10 @@ The same confound was checked against the *climb* and measured dead
 (`probe-exposure.sh`): mean exposure — days between merge and window end — is
 flat across the buckets, **11.2 / 12.2 / 12.1 / 11.4 days** (<100 → >1k,
 medians 11/14/14/10). An 8% exposure difference cannot manufacture a ~3× rate
-difference, so the <100 → 400–1k climb is not an exposure-time artifact; the
->1k bucket sitting *lowest* is consistent with, and small relative to, the
-censoring caveat above.
+difference, so the <100 → 400–1k climb is not an exposure-time artifact. For
+the >1k bucket the support is weaker and median-only: its *median* exposure
+sits lowest (10 days) while its mean is second-lowest by 0.2 days — weakly
+consistent with the censoring caveat above, and small either way.
 
 > **Denominators.** `04-analyze.sh` prints these; do not hand-derive them.
 > The per-PR pull (`review_rounds.tsv`) covers **220** PRs merged 2026-07-20 →

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -185,8 +185,9 @@ boundary walk now validates a trailing `(#N)` against the merged-PR list —
 defect 2's issue-ref regex had re-entered through the walk and truncated the
 range of #317, the very PR defect 1 was measured on. Isolated, that fix moved
 almost nothing (edges 1,999 → 2,005). Second, the diff now passes `-w` to
-match the blame's `-w`, so whitespace-only churn no longer counts as rework —
-and that is what moved the numbers: the 400–1k bucket drops 6.1 → 4.7,
+match the blame's `-w`, so whitespace-only modifications no longer count as
+rework (deleting a whole whitespace-only line still counts, consistent with
+the deletions asymmetry) — and that is what moved the numbers: the 400–1k bucket drops 6.1 → 4.7,
 meaning roughly a quarter of that bucket's previously-counted rework was
 whitespace-only lines. (The edge *row* count still rises 2,005 → 2,022 under
 `-w`: rows are hunk-grained, and a block whose interior lines changed only in

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -5,7 +5,11 @@ change-size norm cites this file as its evidence, so it is load-bearing and
 outside the "archive or delete freely" contract that the docs taxonomy gives
 session notes. If the norm goes, this can go with it; not before. Numbers here
 are scoped to the window in the title — re-measure before citing them outside
-it.
+it, using the checked-in pipeline at
+[`scripts/pr-churn-audit/`](../scripts/pr-churn-audit/README.md). That pipeline
+reproduces every figure below exactly; its README documents the two measurement
+defects (truncated diff range, issue-numbers-read-as-PR-numbers) that made the
+first version of these numbers wrong.
 
 Motivating question from the owner: PR churn feels like it's rising — is the
 model getting worse, or is the code getting harder to work in?

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -26,8 +26,8 @@ before the numbers below were trustworthy (see [Method](#method)).
 | Measure | Value |
 |---|---|
 | PRs opened / merged | 232 / 218 |
-| Blame-paired rework edges | 1,841 |
-| Median rework lag | 1 day (65% within 3) |
+| Blame-paired rework edges | 1,999 |
+| Median rework lag | 2 days (60% within 3) |
 | Share of rework from PRs ≥400 added lines | **90.1%** (from 32% of PRs) |
 | Corrective-PR rate | flat 20–30% since April; 12% in Aug wk0 |
 
@@ -36,16 +36,16 @@ before the numbers below were trustworthy (see [Method](#method)).
 | Bucket | n | Mean of per-PR rates | Pooled (Σrework/Σadds) |
 |---|---:|---:|---:|
 | <100 adds | 42 | 1.6 | 2.1 |
-| 100–400 | 82 | 2.7 | 2.5 |
-| 400–1k | 41 | 6.3 | 6.2 |
+| 100–400 | 84 | 2.6 | 2.5 |
+| 400–1k | 42 | 6.1 | 6.1 |
 | **>1k** | 29 | 6.0 | 3.8 |
 
 **What is robust:** the rate rises across the first three buckets under *both*
-statistics — roughly 4× from <100 to 400–1k (1.6→6.3 mean, 2.1→6.2 pooled).
+statistics — roughly 4× from <100 to 400–1k (1.6→6.1 mean, 2.1→6.1 pooled).
 That carries the norm, whose threshold is 400.
 
 **What is not:** the climb does not continue past 1k. Both statistics fall
-across the 400–1k → >1k step (mean 6.3 → 6.0, pooled 6.2 → 3.8), so >1k is
+across the 400–1k → >1k step (mean 6.1 → 6.0, pooled 6.1 → 3.8), so >1k is
 **not** worse than 400–1k on this data — plausibly a floor effect, since the
 largest PRs are often standalone new subsystems with less existing code to
 collide with. The norm's threshold is 400 because that is where the rise
@@ -137,13 +137,21 @@ Effect of correcting both:
 
 | Measure | v1 | v2 | **v3 (current)** |
 |---|---:|---:|---:|
-| Edges | 1,639 | 3,114 | **1,841** |
-| Median lag | 1d | 2d | **1d** |
-| Within 3 days | 61% | 57% | **65%** |
+| Edges | 1,639 | 3,114 | **1,999** |
+| Median lag | 1d | 2d | **2d** |
+| Within 3 days | 61% | 57% | **60%** |
 | Rate <100 adds | 1.6 | 1.4 | **1.6** |
-| Rate 400–1k | 6.3 | 8.5 | **6.3** |
+| Rate 400–1k | 6.3 | 8.5 | **6.1** |
 | Rate >1k adds | 5.7 | 10.5 | **6.0** |
 | Large-PR share | 89.7% | 93.2% | **90.1%** |
+
+These v3 figures are the **checked-in pipeline's own output**, regenerated
+end-to-end from scratch rather than from any surviving intermediate. An earlier
+draft of v3 quoted 1,841 edges and 1.6/2.7/6.3; those came from reusing a
+`prs_merged.json` capped at 300 PRs, which silently dropped blame hits whose
+target PR fell outside the cap. Raising the cap resolves those, which is why the
+edge count rises and the age tail lengthens (p90 9 → 80 days): rework of older
+PRs was previously invisible, not absent.
 
 **v2 was the outlier, and v2 is what was originally published here.** Replacing
 `sha^1..sha` with a bare `sha~N..sha` fixed a too-narrow range by introducing a

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -28,7 +28,7 @@ before the numbers below were trustworthy (see [Method](#method)).
 | PRs opened / merged | 232 / 218 |
 | Blame-paired rework edges | 1,999 |
 | Median rework lag | 2 days (60% within 3) |
-| Share of rework from PRs ≥400 added lines | **90.1%** (from 32% of PRs) |
+| Share of rework from PRs ≥400 added lines | **90.1%** (from 36% of the bucket population) |
 | Corrective-PR rate | flat 20–30% since April; 12% in Aug wk0 |
 
 ### Rework per 100 added lines, by PR size
@@ -46,18 +46,28 @@ That carries the norm, whose threshold is 400.
 
 **What is not:** the climb does not continue past 1k. Both statistics fall
 across the 400–1k → >1k step (mean 6.1 → 6.0, pooled 6.1 → 3.8), so >1k is
-**not** worse than 400–1k on this data — plausibly a floor effect, since the
-largest PRs are often standalone new subsystems with less existing code to
-collide with. The norm's threshold is 400 because that is where the rise
-happens.
+**not** measured as worse than 400–1k.
 
-> **Denominators.** These buckets cover the 194 PRs that merged 2026-07-20 →
-> 08-09 with more than 20 added lines. That is narrower than the 218 merged
-> since 07-12 in the headline table: `review_rounds.tsv` (the per-PR
-> commits/comments/latency pull) starts at 07-20 and covers 217 PRs, and 23 of
-> those fall below the 20-add floor used to keep tiny PRs from producing
-> meaningless per-line ratios. The "32% of PRs ≥400 adds" figure is 70/217 from
-> the unfiltered set. Reconcile before quoting any of these against each other.
+Do not read that as a ceiling. The step is **confounded by right-censoring**:
+an edge exists only when the *reworker* is inside the window, so a PR merged
+near 08-09 accrues almost no rework regardless of its size, and stage 4 divides
+that near-zero by its full additions. Any bucket whose PRs cluster late is
+deflated. The floor-effect reading (largest PRs are often standalone new
+subsystems with less existing code to collide with) is plausible but this
+pipeline cannot distinguish it from truncation — only the left-censoring was
+previously acknowledged. Treat >1k as unmeasured, not as flat.
+
+> **Denominators.** `04-analyze.sh` prints these; do not hand-derive them.
+> The per-PR pull (`review_rounds.tsv`) covers **220** PRs merged 2026-07-20 →
+> 08-09; **197** of those clear the >20-add floor and form the bucket
+> population; **71** of the 197 are ≥400 adds — **36%** of the bucket
+> population, or 32% of the unfiltered 220.
+>
+> Quoting 32% against 197 is the mixed-denominator trap, and an earlier revision
+> of this very doc did exactly that. Stage 4 now prints all four figures
+> together and names the trap, because every denominator dispute in this
+> pipeline's review history came from one number being hand-copied into prose
+> and not updated with its siblings.
 
 ## What was refuted
 
@@ -70,7 +80,10 @@ happens.
   and other files in the *same commit* — holding author, session, review and
   size constant — old files churned at **3.30** per 100 adds vs **6.87** for
   the rest, and churned higher in only 3 of 36 pairs. Pooled: 2.48 vs 4.62.
-  Independently confirmed by size-bucketing all 217 PRs by complexity-touch:
+  Independently confirmed by size-bucketing by complexity-touch (run on the
+  earlier 217-row per-PR pull, not the current 220 — that control has not been
+  re-derived against the corrected pipeline, and its conclusion is directional
+  rather than exact):
   the complex-touch group is at or below the other in every powered cell.
   Real code-quality problems exist (`route_bus_ghost` is a 3,875-line function
   whose rework arrives at 12–97 days, the classic long-lag signature) but they

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -165,7 +165,7 @@ end-to-end from scratch rather than from any surviving intermediate. (An
 earlier draft of v3 quoted 1,841 edges and 1.6/2.7/6.3; those came from
 reusing a `prs_merged.json` capped at 300 PRs, which silently dropped blame
 hits whose target PR fell outside the cap. Raising the cap is why the edge
-count rose and the age tail lengthened (p90 9 → 80 days): rework of older PRs
+count rose and the age tail lengthened (p90 9 → 81 days): rework of older PRs
 was previously invisible, not absent.)
 
 **v4 is v3 plus two fixes caught in this PR's own review.** First, the
@@ -176,7 +176,10 @@ almost nothing (edges 1,999 → 2,005). Second, the diff now passes `-w` to
 match the blame's `-w`, so whitespace-only churn no longer counts as rework —
 and that is what moved the numbers: the 400–1k bucket drops 6.1 → 4.7,
 meaning roughly a quarter of that bucket's previously-counted rework was
-whitespace-only lines.
+whitespace-only lines. (The edge *row* count still rises 2,005 → 2,022 under
+`-w`: rows are hunk-grained, and a block whose interior lines changed only in
+whitespace splits into several smaller hunks even as the counted lines fall —
+large-bucket rework lines drop 4,885 → 4,332.)
 
 **v2 was the outlier, and v2 is what was originally published here.** Replacing
 `sha^1..sha` with a bare `sha~N..sha` fixed a too-narrow range by introducing a
@@ -201,11 +204,12 @@ telling you it is unmeasured, not what its value is.
 - **Rework ≠ defect.** A sampled classification of 85 PR-pairs splits edges
   ~57% planned iteration / 23% genuine correction / 20% collision. Absolute
   edge counts overstate churn; the size finding is ratio-based and survives.
-- **Lag figures are edge-weighted.** The median/percentile lag and "within 3
-  days" are computed over (hunk × origin-commit) rows, each counting once
-  regardless of how many lines it carries; the edge total and bucket rates are
-  line-based. The two weightings answer slightly different questions and have
-  not been cross-checked against each other.
+- **Lag figures and the edge count are edge-weighted.** The median/percentile
+  lag, "within 3 days" and the headline edge count are computed over
+  (hunk × origin-commit) rows, each counting once regardless of how many lines
+  it carries; only the bucket rates and the large-PR share are line-weighted.
+  The two weightings answer slightly different questions and have not been
+  cross-checked against each other.
 - **Size and difficulty are confounded.** Large PRs may be large because the
   work is harder. Per-line normalization controls for volume, not difficulty.
 - **One signal is unresolved.** The rate at which the owner pushes back *in

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -7,9 +7,12 @@ session notes. If the norm goes, this can go with it; not before. Numbers here
 are scoped to the window in the title — re-measure before citing them outside
 it, using the checked-in pipeline at
 [`scripts/pr-churn-audit/`](../scripts/pr-churn-audit/README.md). That pipeline
-reproduces every figure below exactly; its README documents the two measurement
-defects (truncated diff range, issue-numbers-read-as-PR-numbers) that made the
-first version of these numbers wrong.
+reproduces the **blame-edge, age and size-bucket** figures exactly — the ones
+the norm rests on. It does not regenerate the hand-classified parts (corrective
+rate, latency bands, the within-PR complexity control, concurrency); those live
+only in this doc. Its README also records the two measurement defects
+(truncated diff range, issue-numbers-read-as-PR-numbers) that made the first
+version of these numbers wrong.
 
 Motivating question from the owner: PR churn feels like it's rising — is the
 model getting worse, or is the code getting harder to work in?

--- a/docs/pr-churn-audit-2026-08.md
+++ b/docs/pr-churn-audit-2026-08.md
@@ -27,7 +27,7 @@ before the numbers below were trustworthy (see [Method](#method)).
 |---|---|
 | PRs opened / merged | 237 / 221 |
 | Blame-paired rework edges | 2,022 |
-| Median rework lag | 1 day (61% within 3) |
+| Median rework lag | 1 day (61% under 4 days) |
 | Share of the bucket population's rework from PRs ≥400 added lines | **89.3%** (from 36% of that population) |
 | Corrective-PR rate | flat 20–30% since April; 12% in Aug wk0 |
 
@@ -154,11 +154,15 @@ Effect of correcting both, and of the two later review-caught fixes (v4):
 |---|---:|---:|---:|---:|
 | Edges | 1,639 | 3,114 | 1,999 | **2,022** |
 | Median lag | 1d | 2d | 2d | **1d** |
-| Within 3 days | 61% | 57% | 60% | **61%** |
+| Under 4 days¹ | 61% | 57% | 60% | **61%** |
 | Rate <100 adds | 1.6 | 1.4 | 1.6 | **1.6** |
 | Rate 400–1k | 6.3 | 8.5 | 6.1 | **4.7** |
 | Rate >1k adds | 5.7 | 10.5 | 6.0 | **5.7** |
 | Large-PR share | 89.7% | 93.2% | 90.1% | **89.3%** |
+
+¹ Formerly labelled "within 3 days". Ages floor to whole days, so the
+comparator (floor ≤ 3) covers [0,4) days; the label now says so. The
+comparator itself never changed, so the row is comparable across versions.
 
 These v4 figures are the **checked-in pipeline's own output**, regenerated
 end-to-end from scratch rather than from any surviving intermediate. (An
@@ -186,8 +190,8 @@ large-bucket rework lines drop 4,885 → 4,332.)
 too-wide one: `gh` reports the PR *branch's* commit count, but a squash-merged
 PR contributes only one commit to main, so `sha~N` walks N−1 commits back into
 earlier PRs. Measured (`probe-v2-defect.sh`): **50 of 221 in-window PRs
-(22%)**, and size-correlated (17% under 400 adds, 33% over) — biased in the
-same direction as the finding.
+(22.6%)**, and size-correlated (17.4% under 400 adds, 33.3% over) — biased in
+the same direction as the finding.
 v3 resolves each range by walking back only until it meets a commit announcing
 a different PR, which handles squash, rebase and merge commits alike. It lands
 almost exactly on v1, whose two errors had partially cancelled.
@@ -205,7 +209,7 @@ telling you it is unmeasured, not what its value is.
   ~57% planned iteration / 23% genuine correction / 20% collision. Absolute
   edge counts overstate churn; the size finding is ratio-based and survives.
 - **Lag figures and the edge count are edge-weighted.** The median/percentile
-  lag, "within 3 days" and the headline edge count are computed over
+  lag, "under 4 days" and the headline edge count are computed over
   (hunk × origin-commit) rows, each counting once regardless of how many lines
   it carries; only the bucket rates and the large-PR share are line-weighted.
   The two weightings answer slightly different questions and have not been

--- a/docs/warm-review-experiment-2026-08.md
+++ b/docs/warm-review-experiment-2026-08.md
@@ -1,0 +1,98 @@
+# Warm vs cold re-review — final results
+
+**Question.** When a reviewer re-reviews a PR it has already reviewed, does
+resuming its prior session (warm) beat starting fresh (cold)?
+
+**Setup.** Warm = 3 passes, each forked from that pass's *own* prior-round pi
+session, shown the next round's tree, asked to re-assess its earlier findings
+and hunt for new ones. Cold = what the real reviewer actually posted that round.
+Both K=3, unioned. Same model and harness as production
+(`deepseek-v4-flash-0731` via pi). 7 transitions, 4 PRs, retrospective on real
+review history. Scored by one agent per transition against a fixed rubric.
+
+## Results
+
+| Transition | Content | HC recall | Overall | Unique | Compression | Arith. pathology |
+|---|---|---:|---:|---:|---:|---:|
+| 576 r10→11 | meter docs | 1/1 | 5/6 | 2 | n/a | **2** |
+| 576 r5→6 | meter docs | 1/1 | 3/5 | 6 | 1 | **2** |
+| 606 r6→7 | meter docs | 0/2 | 1/4 | 3 | 0 | 0 |
+| 606 r9→10 | meter docs | 2/2 | 2/7 | 4 | 0 | 0 |
+| 608 r7→8 | code (validator) | 2/2 | 5/6 | 9 | 4 | 0 |
+| 608 r4→5 | code (validator) | 4/6 | 6/11 | 5 | 1 | 0 |
+| 604 r5→6 | code (py/shell) | 3/4 | 5/12 | 8 | 2 | 0 |
+
+- High-confidence recall **13/18 (72%)** · overall recall **27/51 (53%)**
+- **37** findings warm raised that cold did not
+- **8** same-defect compression hits (warm found it a full round early)
+- Cost: **a wash** — warm $0.0230 vs cold $0.0241 per pass, both measured
+
+Dropped: 604 r8→9 (session artifacts exist, **no posted review** for round 9 —
+a review that ran and published nothing). 576 r10 has no round-12 comparator.
+
+## Conclusions
+
+**1. Warm cannot replace cold.** 53% overall recall means swapping cold for warm
+loses about half the findings, including a bare `.unwrap()` that would panic a
+whole sweep.
+
+**2. Warm adds real value.** 37 unique findings and 8 defects caught a round
+early. It is *differently blind*, not worse.
+
+**→ Recommendation: split K=3 into warm and cold passes and union as now.**
+Cost unchanged (still 3 passes); gains warm's compression without losing cold's
+recall. The optimal split is unmeasured — this compared warm-K3 to cold-K3, not
+mixed.
+
+**3. Do not warm-fork arithmetic-dense documentation.** All four instances of
+confident-wrong arithmetic appeared on the two meter-docs transitions of #576:
+two passes "verifying" figures that were themselves the bug (r10), one false
+clearance of a real contradiction, one false alarm from an invented premise
+(r5). Mechanism: a fork carries stale numbers in context and reasons from them
+instead of recomputing.
+
+## Hypotheses killed along the way
+
+- *Delta-scoping the diff saves money* — the diff is ~0.3% of tokens; the cost
+  is agentic re-derivation.
+- *Warm is cheaper* — a wash. Warm ships fewer total tokens but a higher share
+  of expensive fresh input.
+- *Self-consistency bias makes warm rubber-stamp* — the opposite; warm was more
+  skeptical than cold in the pilot.
+- *Warm compresses on code, not docs* — falsified by 576 r5 (docs, 1 hit).
+- *Smaller PRs cut review spend* — they raise it ~2.5×; the norm is justified by
+  rework, not cost.
+
+## Caveats
+
+- n=7 transitions, 4 PRs, one repo, one model.
+- Content-type is confounded with PR identity: both zero-compression
+  transitions are #606, and all four arithmetic pathologies are #576.
+- Compression's ground truth requires cold's *next* round to have found the
+  thing; those reviews sample, so a miss is not proof warm was early.
+- Compression within code is noisy (4/9, 2/8, 1/5 of unique findings), and
+  608 r4's single hit turns on a same-defect-vs-same-class judgement call its
+  own scorer flagged as contestable.
+
+## Incidental findings worth acting on
+
+- **`docs/meter-divergence.md`'s L7 retraction is wrong.** Its claim that meter
+  and sim "agree by design" at non-bulk L7 is contradicted by its own cited
+  code (`entity_data.rs:365` declares axis 3; `scenario.rs:901-903` yields
+  realized hand 4), with fixture `chain-ec15-d7` measuring the disagreement.
+  Found independently by two warm passes on 604; cold never touched that file.
+  Arithmetic re-derived by the scorer against the repo.
+- **PR 604 round 9 published no review** despite running — degraded class,
+  visible in the historical record.
+
+## Also learned about the stack
+
+- Prompt caching is already doing most of the work available: `cacheRead` is
+  ~78% of tokens at ~10× cheaper than fresh input, and prompt ordering is
+  already cache-optimal (stable system prompt first, volatile diff last).
+- **Cross-run caching does not hit** — a byte-identical prefix two minutes
+  apart got zero `cacheRead`. Cause: pi has `sendSessionAffinityHeaders`
+  (`sessionAffinityFormat: openrouter` → `x-session-id`) but it **defaults to
+  false**, so OpenRouter's sticky routing never engages. Worth ~⅓ of a warm
+  round. Note affinity derives from the session id, and a fork gets a new one,
+  so it likely needs the id pinned across rounds.

--- a/scripts/pr-churn-audit/01-fetch.sh
+++ b/scripts/pr-churn-audit/01-fetch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Stage 1: pull the PR corpus and per-PR commit counts from GitHub.
+#
+# The commit count is not a nicety — stage 3 needs it to compute each PR's
+# diff range. This repo rebase-merges multi-commit PRs, so a PR's recorded
+# mergeCommit is only its LAST commit; `sha^1..sha` sees a fraction of it.
+set -euo pipefail
+WORK="${WORK:-./audit-work}"
+REPO="${REPO:-storkme/spaghettio}"
+SINCE="${SINCE:-2026-07-12}"
+mkdir -p "$WORK"
+
+echo "fetching merged PRs from $REPO..."
+gh pr list --repo "$REPO" --state merged --limit 300 \
+  --json number,title,mergedAt,mergeCommit,headRefName,additions,deletions,changedFiles \
+  > "$WORK/prs_merged.json"
+echo "  $(jq --arg s "$SINCE" '[.[]|select(.mergedAt>$s)]|length' "$WORK/prs_merged.json") merged since $SINCE"
+
+echo "fetching per-PR commit counts (slow — one API call per PR)..."
+: > "$WORK/pr_commits.tsv"
+jq -r --arg s "$SINCE" '[.[]|select(.mergedAt>$s)]|.[].number' "$WORK/prs_merged.json" |
+while read -r n; do
+  c=$(gh pr view "$n" --repo "$REPO" --json commits --jq '.commits|length' 2>/dev/null || echo 1)
+  printf '%s\t%s\n' "$n" "${c:-1}" >> "$WORK/pr_commits.tsv"
+done
+echo "  $(wc -l < "$WORK/pr_commits.tsv") rows"
+
+echo "fetching per-PR review/latency stats..."
+printf 'pr\tcommits\tcomments\treviews\thours\tadds\ttitle\n' > "$WORK/review_rounds.tsv"
+jq -r --arg s "$SINCE" '[.[]|select(.mergedAt>$s)]|sort_by(.mergedAt)|.[].number' "$WORK/prs_merged.json" |
+while read -r n; do
+  gh pr view "$n" --repo "$REPO" \
+    --json number,title,createdAt,mergedAt,commits,comments,reviews,additions 2>/dev/null |
+  jq -r '[ .number, (.commits|length), (.comments|length), (.reviews|length),
+           (((.mergedAt|fromdateiso8601)-(.createdAt|fromdateiso8601))/3600|floor),
+           .additions, (.title|.[0:70]) ] | @tsv' >> "$WORK/review_rounds.tsv" || true
+done
+echo "  $(( $(wc -l < "$WORK/review_rounds.tsv") - 1 )) rows"

--- a/scripts/pr-churn-audit/01-fetch.sh
+++ b/scripts/pr-churn-audit/01-fetch.sh
@@ -7,24 +7,11 @@
 set -euo pipefail
 WORK="${WORK:-./audit-work}"
 REPO="${REPO:-storkme/spaghettio}"
-# TWO windows, deliberately, because the published figures use two.
-#   SINCE..UNTIL       the corpus: blame edges, age distribution, edge count.
-#   BUCKET_SINCE..UNTIL the per-PR review/latency pull the size buckets divide by.
-# They differ because the bucket data was collected later in the session, from
-# 07-20. Quoting a bucket count against the corpus count without reconciling
-# them is the mixed-denominator trap the audit doc warns about.
-SINCE="${SINCE:-2026-07-12}"
-BUCKET_SINCE="${BUCKET_SINCE:-2026-07-20}"
-# UNTIL is load-bearing for reproducibility: without it, `gh pr list` keeps
-# pulling PRs merged after the study and every n drifts upward over time.
-UNTIL="${UNTIL:-2026-08-09}"
-# End-of-day, NOT the bare date. mergedAt always carries a time, and
-# "2026-08-09T09:49:40Z" < "2026-08-09" is FALSE lexicographically — a bare
-# bound silently drops every PR merged on the closing day. Stage 3 uses the
-# same expansion; if these two ever disagree the corpus and the bucket
-# denominator cover different windows, which is the mixed-denominator trap
-# this pipeline exists to document.
-UNTIL_TS="${UNTIL}T23:59:59Z"
+# Window bounds live in window.env — one file, sourced by every consumer, so a
+# partial edit cannot put the corpus and the bucket denominators on different
+# windows. UNTIL is load-bearing for reproducibility: without it, `gh pr list`
+# keeps pulling PRs merged after the study and every n drifts upward forever.
+. "$(dirname "$0")/window.env"
 mkdir -p "$WORK"
 
 echo "fetching merged PRs from $REPO..."
@@ -34,7 +21,7 @@ echo "fetching merged PRs from $REPO..."
 # doc's v3 note), so hitting the limit is an ERROR, not a nit: the oldest PRs
 # are the likeliest blame TARGETS, and losing them sheds edges silently.
 gh pr list --repo "$REPO" --state merged --limit 1000 \
-  --json number,title,mergedAt,mergeCommit,headRefName,additions,deletions,changedFiles \
+  --json number,title,mergedAt,mergeCommit,additions,deletions,changedFiles \
   > "$WORK/prs_merged.json"
 npr=$(jq 'length' "$WORK/prs_merged.json")
 if [ "$npr" -ge 1000 ]; then

--- a/scripts/pr-churn-audit/01-fetch.sh
+++ b/scripts/pr-churn-audit/01-fetch.sh
@@ -7,18 +7,34 @@
 set -euo pipefail
 WORK="${WORK:-./audit-work}"
 REPO="${REPO:-storkme/spaghettio}"
+# TWO windows, deliberately, because the published figures use two.
+#   SINCE..UNTIL       the corpus: blame edges, age distribution, edge count.
+#   BUCKET_SINCE..UNTIL the per-PR review/latency pull the size buckets divide by.
+# They differ because the bucket data was collected later in the session, from
+# 07-20. Quoting a bucket count against the corpus count without reconciling
+# them is the mixed-denominator trap the audit doc warns about.
 SINCE="${SINCE:-2026-07-12}"
+BUCKET_SINCE="${BUCKET_SINCE:-2026-07-20}"
+# UNTIL is load-bearing for reproducibility: without it, `gh pr list` keeps
+# pulling PRs merged after the study and every n drifts upward over time.
+UNTIL="${UNTIL:-2026-08-09}"
 mkdir -p "$WORK"
 
 echo "fetching merged PRs from $REPO..."
-gh pr list --repo "$REPO" --state merged --limit 300 \
+# --limit well above the window's size: at 300 a later re-run could silently
+# drop the OLDEST in-window PRs, moving numerator and denominator together with
+# no warning.
+gh pr list --repo "$REPO" --state merged --limit 1000 \
   --json number,title,mergedAt,mergeCommit,headRefName,additions,deletions,changedFiles \
   > "$WORK/prs_merged.json"
-echo "  $(jq --arg s "$SINCE" '[.[]|select(.mergedAt>$s)]|length' "$WORK/prs_merged.json") merged since $SINCE"
+echo "  $(jq --arg s "$SINCE" --arg u "$UNTIL" '[.[]|select(.mergedAt>$s and .mergedAt<$u)]|length' "$WORK/prs_merged.json") merged in $SINCE..$UNTIL"
 
 echo "fetching per-PR commit counts (slow — one API call per PR)..."
 : > "$WORK/pr_commits.tsv"
-jq -r --arg s "$SINCE" '[.[]|select(.mergedAt>$s)]|.[].number' "$WORK/prs_merged.json" |
+# Every PR in the file, not just in-window: stage 2 builds its map over all of
+# them, and a missing count silently degrades that PR to a 1-commit range,
+# dropping its earlier commits from the map and losing edges that blame to them.
+jq -r '.[].number' "$WORK/prs_merged.json" |
 while read -r n; do
   c=$(gh pr view "$n" --repo "$REPO" --json commits --jq '.commits|length' 2>/dev/null || echo 1)
   printf '%s\t%s\n' "$n" "${c:-1}" >> "$WORK/pr_commits.tsv"
@@ -27,7 +43,8 @@ echo "  $(wc -l < "$WORK/pr_commits.tsv") rows"
 
 echo "fetching per-PR review/latency stats..."
 printf 'pr\tcommits\tcomments\treviews\thours\tadds\ttitle\n' > "$WORK/review_rounds.tsv"
-jq -r --arg s "$SINCE" '[.[]|select(.mergedAt>$s)]|sort_by(.mergedAt)|.[].number' "$WORK/prs_merged.json" |
+jq -r --arg s "$BUCKET_SINCE" --arg u "$UNTIL" \
+  '[.[]|select(.mergedAt>$s and .mergedAt<$u)]|sort_by(.mergedAt)|.[].number' "$WORK/prs_merged.json" |
 while read -r n; do
   gh pr view "$n" --repo "$REPO" \
     --json number,title,createdAt,mergedAt,commits,comments,reviews,additions 2>/dev/null |

--- a/scripts/pr-churn-audit/01-fetch.sh
+++ b/scripts/pr-churn-audit/01-fetch.sh
@@ -30,10 +30,21 @@ mkdir -p "$WORK"
 echo "fetching merged PRs from $REPO..."
 # --limit well above the window's size: at 300 a later re-run could silently
 # drop the OLDEST in-window PRs, moving numerator and denominator together with
-# no warning.
+# no warning. That cap bug already shipped one wrong edge count (see the audit
+# doc's v3 note), so hitting the limit is an ERROR, not a nit: the oldest PRs
+# are the likeliest blame TARGETS, and losing them sheds edges silently.
 gh pr list --repo "$REPO" --state merged --limit 1000 \
   --json number,title,mergedAt,mergeCommit,headRefName,additions,deletions,changedFiles \
   > "$WORK/prs_merged.json"
+npr=$(jq 'length' "$WORK/prs_merged.json")
+if [ "$npr" -ge 1000 ]; then
+  echo "ERROR: gh pr list returned $npr rows — the --limit cap is hit and the" >&2
+  echo "       OLDEST merged PRs are silently missing. Raise the limit before" >&2
+  echo "       trusting any number downstream (stage 2's PR set and stage 3's" >&2
+  echo "       commit->PR map both derive from this file)." >&2
+  exit 2
+fi
+echo "  $npr merged PRs fetched (cap 1000 not hit)"
 echo "  $(jq --arg s "$SINCE" --arg u "$UNTIL_TS" '[.[]|select(.mergedAt>$s and .mergedAt<$u)]|length' "$WORK/prs_merged.json") merged in $SINCE..$UNTIL_TS"
 
 echo "fetching per-PR commit counts (slow — one API call per PR)..."

--- a/scripts/pr-churn-audit/01-fetch.sh
+++ b/scripts/pr-churn-audit/01-fetch.sh
@@ -18,6 +18,13 @@ BUCKET_SINCE="${BUCKET_SINCE:-2026-07-20}"
 # UNTIL is load-bearing for reproducibility: without it, `gh pr list` keeps
 # pulling PRs merged after the study and every n drifts upward over time.
 UNTIL="${UNTIL:-2026-08-09}"
+# End-of-day, NOT the bare date. mergedAt always carries a time, and
+# "2026-08-09T09:49:40Z" < "2026-08-09" is FALSE lexicographically — a bare
+# bound silently drops every PR merged on the closing day. Stage 3 uses the
+# same expansion; if these two ever disagree the corpus and the bucket
+# denominator cover different windows, which is the mixed-denominator trap
+# this pipeline exists to document.
+UNTIL_TS="${UNTIL}T23:59:59Z"
 mkdir -p "$WORK"
 
 echo "fetching merged PRs from $REPO..."
@@ -27,29 +34,47 @@ echo "fetching merged PRs from $REPO..."
 gh pr list --repo "$REPO" --state merged --limit 1000 \
   --json number,title,mergedAt,mergeCommit,headRefName,additions,deletions,changedFiles \
   > "$WORK/prs_merged.json"
-echo "  $(jq --arg s "$SINCE" --arg u "$UNTIL" '[.[]|select(.mergedAt>$s and .mergedAt<$u)]|length' "$WORK/prs_merged.json") merged in $SINCE..$UNTIL"
+echo "  $(jq --arg s "$SINCE" --arg u "$UNTIL_TS" '[.[]|select(.mergedAt>$s and .mergedAt<$u)]|length' "$WORK/prs_merged.json") merged in $SINCE..$UNTIL_TS"
 
 echo "fetching per-PR commit counts (slow — one API call per PR)..."
 : > "$WORK/pr_commits.tsv"
 # Every PR in the file, not just in-window: stage 2 builds its map over all of
 # them, and a missing count silently degrades that PR to a 1-commit range,
 # dropping its earlier commits from the map and losing edges that blame to them.
+# A failed fetch here is NOT harmless: stage 2 would build a 1-commit range for
+# that PR, which is exactly the truncated-range defect this pipeline documents.
+# Record failures and refuse to pretend the dataset is complete.
+: > "$WORK/fetch_failures.txt"
 jq -r '.[].number' "$WORK/prs_merged.json" |
 while read -r n; do
-  c=$(gh pr view "$n" --repo "$REPO" --json commits --jq '.commits|length' 2>/dev/null || echo 1)
-  printf '%s\t%s\n' "$n" "${c:-1}" >> "$WORK/pr_commits.tsv"
+  if c=$(gh pr view "$n" --repo "$REPO" --json commits --jq '.commits|length' 2>/dev/null) && [ -n "$c" ]; then
+    printf '%s\t%s\n' "$n" "$c" >> "$WORK/pr_commits.tsv"
+  else
+    printf 'commit-count\t%s\n' "$n" >> "$WORK/fetch_failures.txt"
+  fi
 done
 echo "  $(wc -l < "$WORK/pr_commits.tsv") rows"
 
 echo "fetching per-PR review/latency stats..."
 printf 'pr\tcommits\tcomments\treviews\thours\tadds\ttitle\n' > "$WORK/review_rounds.tsv"
-jq -r --arg s "$BUCKET_SINCE" --arg u "$UNTIL" \
+jq -r --arg s "$BUCKET_SINCE" --arg u "$UNTIL_TS" \
   '[.[]|select(.mergedAt>$s and .mergedAt<$u)]|sort_by(.mergedAt)|.[].number' "$WORK/prs_merged.json" |
 while read -r n; do
   gh pr view "$n" --repo "$REPO" \
     --json number,title,createdAt,mergedAt,commits,comments,reviews,additions 2>/dev/null |
   jq -r '[ .number, (.commits|length), (.comments|length), (.reviews|length),
            (((.mergedAt|fromdateiso8601)-(.createdAt|fromdateiso8601))/3600|floor),
-           .additions, (.title|.[0:70]) ] | @tsv' >> "$WORK/review_rounds.tsv" || true
+           .additions, (.title|.[0:70]) ] | @tsv' >> "$WORK/review_rounds.tsv" \
+    || printf 'review-row\t%s\n' "$n" >> "$WORK/fetch_failures.txt"
 done
 echo "  $(( $(wc -l < "$WORK/review_rounds.tsv") - 1 )) rows"
+
+nf=$(wc -l < "$WORK/fetch_failures.txt")
+if [ "$nf" -gt 0 ]; then
+  echo
+  echo "WARNING: $nf per-PR fetch(es) failed — the dataset is INCOMPLETE."
+  echo "         A missing commit count becomes a 1-commit range in stage 2 (the"
+  echo "         truncated-range defect); a missing review row silently shrinks a"
+  echo "         bucket denominator. See $WORK/fetch_failures.txt."
+  echo "         Re-run stage 1 until this is empty before quoting any figure."
+fi

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -78,14 +78,27 @@ while IFS=$'\t' read -r pr sha; do
       git rev-parse "$cand" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
       depth=$((depth+1))
     done
-    # Walked the full branch length without meeting another PR's boundary. That
-    # is correct for a rebase-merge, but it is ALSO what a squash-merge sitting
-    # on an UNLABELLED commit looks like — and in that case the range is
-    # over-wide, exactly the v2 defect. The heuristic cannot tell them apart, so
-    # count these and report rather than assume the benign reading.
+    # The loop bound stops at depth-1, so the cap-th ancestor was never
+    # inspected. Look at it now — that is what distinguishes the two cases:
+    #
+    #   sha~cap announces ANOTHER PR  -> clean rebase-merge sitting exactly on
+    #                                    the previous PR's boundary. Expected.
+    #   sha~cap announces nothing     -> genuinely ambiguous: either a rebase
+    #                                    onto an unlabelled commit, or a squash
+    #                                    whose range is now over-wide (the v2
+    #                                    defect). Flag it.
+    #
+    # Without this check the marker fired for every clean multi-commit rebase —
+    # i.e. the dominant case — which made it useless for spotting the harmful
+    # one. A warning that fires on everything is a warning about nothing.
     if [ "$hit_boundary" -eq 0 ] && [ "$depth" -gt 1 ]; then
-      caphits=$((caphits+1))
-      printf '%s\tcap-exhausted\tdepth=%s\n' "$pr" "$depth" >> "$WORK/range_unverified.txt"
+      capsubj=$(git log -1 --format='%s' "${sha}~${depth}" 2>/dev/null || echo "")
+      capowner=$(boundary_pr "$capsubj")
+      if [ -z "$capowner" ] || [ "$capowner" = "$pr" ]; then
+        caphits=$((caphits+1))
+        printf '%s\tambiguous-base\tdepth=%s\tbase_subject=%s\n' \
+          "$pr" "$depth" "${capsubj:0:60}" >> "$WORK/range_unverified.txt"
+      fi
     fi
     base="${sha}~${depth}"
     git rev-parse -q --verify "$base" >/dev/null 2>&1 || base="${sha}^1"
@@ -103,8 +116,11 @@ echo "commit2pr       : $(wc -l < "$WORK/commit2pr.tsv")"
 echo "walks truncated at another PR's boundary: $overwalks"
 echo "  (each of these would have been an over-wide range under a bare sha~N)"
 if [ "$caphits" -gt 0 ]; then
-  echo "NOTE: $caphits multi-commit PR(s) walked their full branch length without"
-  echo "      meeting another PR's boundary — correct for a rebase-merge, but"
-  echo "      indistinguishable from a squash landing on an unlabelled commit."
-  echo "      Listed in $WORK/range_unverified.txt; spot-check if a figure surprises you."
+  echo "NOTE: $caphits PR(s) resolved to a base that announces no other PR, so the"
+  echo "      range could not be confirmed as ending at the previous PR's boundary."
+  echo "      Either a rebase onto an unlabelled commit (harmless) or a squash whose"
+  echo "      range is over-wide (the v2 defect). Listed with their base subject in"
+  echo "      $WORK/range_unverified.txt — spot-check before quoting affected PRs."
+else
+  echo "every multi-commit range ended on another PR's boundary (none ambiguous)"
 fi

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -109,7 +109,12 @@ while IFS=$'\t' read -r pr sha; do
     # True merge commit: the PR's work is the second-parent branch.
     base="${sha}^1"
     while read -r bsha; do
-      printf '%s\t%s\n' "$bsha" "$pr" >> "$WORK/.c2p.raw"; CLAIMED[$bsha]=$pr
+      # First claim wins here too — a branch that contains another PR's
+      # commits (branched off it) must not re-claim them, or CLAIMED's
+      # in-walk stops would disagree with the final first-claim dedup.
+      if [ -z "${CLAIMED[$bsha]:-}" ]; then
+        printf '%s\t%s\n' "$bsha" "$pr" >> "$WORK/.c2p.raw"; CLAIMED[$bsha]=$pr
+      fi
     done < <(git rev-list "${sha}^1..${sha}^2"; echo "$sha")
   else
     cap="${NCOM[$pr]:-1}"; [ "$cap" -lt 1 ] && cap=1
@@ -171,7 +176,7 @@ while IFS=$'\t' read -r pr sha; do
     git rev-parse -q --verify "$base" >/dev/null 2>&1 || base="${sha}^1"
   fi
   printf '%s\t%s\n' "$pr" "$base" >> "$WORK/pr_base.tsv"
-done < <(jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.mergedAt)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
+done < <(jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.mergedAt,.number)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
            "$WORK/prs_merged.json")
 
 # First claim wins, deterministically: rows append in MERGE order and the

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -1,16 +1,33 @@
 #!/usr/bin/env bash
-# Stage 2: build the commit -> PR map from AUTHORITATIVE per-PR commit ranges.
+# Stage 2: resolve each PR's OWN commit range, then build the commit -> PR map.
 #
-# Do NOT rebuild this by parsing "(#N)" out of commit subjects. This project
-# writes ISSUE references into subjects, and a regex cannot tell an issue from
-# a PR. The first version of this audit did exactly that and mis-attributed
-# **35% of commits** (322 of 907) — verified on PR #317, whose three commits
-# were all credited to issue 315.
+# Writes two files:
+#   pr_base.tsv     pr -> base sha   (the single source of truth for stage 3)
+#   commit2pr.tsv   commit -> pr
 #
-# Rule per merged PR:
-#   true merge commit (>=2 parents) -> every commit in sha^1..sha^2
-#   otherwise (squash / rebase)     -> every commit in sha~N..sha  (N = commits)
-# Later PRs win on duplicate commits (relands).
+# ---------------------------------------------------------------------------
+# Why the range is not simply `sha~N..sha`
+#
+# `gh pr view --json commits` reports the PR BRANCH's commit count. How many
+# commits that PR actually contributed to main depends on the merge strategy,
+# and this repo uses all three:
+#
+#   squash  -> ONE commit on main, but gh still reports N. `sha~N` then walks
+#              N-1 commits up into PREVIOUS PRs.
+#   rebase  -> N commits on main. `sha~N` is correct.
+#   merge   -> a 2-parent commit; the PR's work is sha^1..sha^2.
+#
+# Measured on this corpus: trusting `sha~N` blindly gave a wrong range for
+# **48 of 218 in-window PRs (22%)**, and the error was size-correlated (17% of
+# PRs under 400 adds, 34% of those over) — i.e. biased in the same direction as
+# the size finding the audit publishes. Do not reintroduce it.
+#
+# The fix: walk back from the merge commit but STOP at the first commit that
+# belongs to a different PR. A boundary commit is one whose subject announces a
+# PR — either `Merge pull request #N` or a trailing `(#N)`. For a squash merge
+# the very next commit back is another PR's boundary, so the walk stops at
+# depth 1, which is correct.
+# ---------------------------------------------------------------------------
 set -euo pipefail
 WORK="${WORK:-./audit-work}"
 REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel)}"
@@ -19,26 +36,57 @@ cd "$REPO_DIR"
 declare -A NCOM
 while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
 
-tmp="$WORK/.c2p.raw"; : > "$tmp"
-jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.number)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
-  "$WORK/prs_merged.json" |
+# Which PR does a commit's own subject announce, if any? Empty = not a boundary.
+boundary_pr() {
+  local subj="$1"
+  if [[ "$subj" =~ ^Merge\ pull\ request\ \#([0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ "$subj" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  fi
+}
+
+: > "$WORK/pr_base.tsv"
+: > "$WORK/.c2p.raw"
+overwalks=0
+
 while IFS=$'\t' read -r pr sha; do
   git cat-file -e "${sha}^{commit}" 2>/dev/null || continue
-  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w)
-  if [ "$np" -ge 3 ]; then
-    rng="${sha}^1..${sha}^2"
-  else
-    n="${NCOM[$pr]:-1}"; [ "$n" -lt 1 ] && n=1
-    if git rev-parse -q --verify "${sha}~${n}" >/dev/null 2>&1; then
-      rng="${sha}~${n}..${sha}"
-    else
-      rng="${sha}^1..${sha}"
-    fi
-  fi
-  git rev-list "$rng" 2>/dev/null | sed "s/\$/\t$pr/" >> "$tmp"
-done
+  np=$(git rev-list --parents -n1 "$sha" | wc -w)
 
-sort -k1,1 -k2,2n "$tmp" | awk -F'\t' '{m[$1]=$2} END{for(k in m) print k"\t"m[k]}' \
+  if [ "$np" -ge 3 ]; then
+    # True merge commit: the PR's work is the second-parent branch.
+    base="${sha}^1"
+    git rev-list "${sha}^1..${sha}^2" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
+    echo "$sha" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
+  else
+    cap="${NCOM[$pr]:-1}"; [ "$cap" -lt 1 ] && cap=1
+    depth=1
+    echo "$sha" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
+    while [ "$depth" -lt "$cap" ]; do
+      cand="${sha}~${depth}"
+      git rev-parse -q --verify "$cand" >/dev/null 2>&1 || break
+      csubj=$(git log -1 --format='%s' "$cand")
+      owner=$(boundary_pr "$csubj")
+      # Stop before absorbing a commit that announces a different PR.
+      if [ -n "$owner" ] && [ "$owner" != "$pr" ]; then
+        overwalks=$((overwalks+1)); break
+      fi
+      git rev-parse "$cand" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
+      depth=$((depth+1))
+    done
+    base="${sha}~${depth}"
+    git rev-parse -q --verify "$base" >/dev/null 2>&1 || base="${sha}^1"
+  fi
+  printf '%s\t%s\n' "$pr" "$base" >> "$WORK/pr_base.tsv"
+done < <(jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.number)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
+           "$WORK/prs_merged.json")
+
+sort -k1,1 -k2,2n "$WORK/.c2p.raw" | awk -F'\t' '{m[$1]=$2} END{for(k in m) print k"\t"m[k]}' \
   > "$WORK/commit2pr.tsv"
-rm -f "$tmp"
-echo "commit2pr entries: $(wc -l < "$WORK/commit2pr.tsv")"
+rm -f "$WORK/.c2p.raw"
+
+echo "pr_base entries : $(wc -l < "$WORK/pr_base.tsv")"
+echo "commit2pr       : $(wc -l < "$WORK/commit2pr.tsv")"
+echo "walks truncated at another PR's boundary: $overwalks"
+echo "  (each of these would have been an over-wide range under a bare sha~N)"

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Stage 2: build the commit -> PR map from AUTHORITATIVE per-PR commit ranges.
+#
+# Do NOT rebuild this by parsing "(#N)" out of commit subjects. This project
+# writes ISSUE references into subjects, and a regex cannot tell an issue from
+# a PR. The first version of this audit did exactly that and mis-attributed
+# **35% of commits** (322 of 907) — verified on PR #317, whose three commits
+# were all credited to issue 315.
+#
+# Rule per merged PR:
+#   true merge commit (>=2 parents) -> every commit in sha^1..sha^2
+#   otherwise (squash / rebase)     -> every commit in sha~N..sha  (N = commits)
+# Later PRs win on duplicate commits (relands).
+set -euo pipefail
+WORK="${WORK:-./audit-work}"
+REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel)}"
+cd "$REPO_DIR"
+
+declare -A NCOM
+while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
+
+tmp="$WORK/.c2p.raw"; : > "$tmp"
+jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.number)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
+  "$WORK/prs_merged.json" |
+while IFS=$'\t' read -r pr sha; do
+  git cat-file -e "${sha}^{commit}" 2>/dev/null || continue
+  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w)
+  if [ "$np" -ge 3 ]; then
+    rng="${sha}^1..${sha}^2"
+  else
+    n="${NCOM[$pr]:-1}"; [ "$n" -lt 1 ] && n=1
+    if git rev-parse -q --verify "${sha}~${n}" >/dev/null 2>&1; then
+      rng="${sha}~${n}..${sha}"
+    else
+      rng="${sha}^1..${sha}"
+    fi
+  fi
+  git rev-list "$rng" 2>/dev/null | sed "s/\$/\t$pr/" >> "$tmp"
+done
+
+sort -k1,1 -k2,2n "$tmp" | awk -F'\t' '{m[$1]=$2} END{for(k in m) print k"\t"m[k]}' \
+  > "$WORK/commit2pr.tsv"
+rm -f "$tmp"
+echo "commit2pr entries: $(wc -l < "$WORK/commit2pr.tsv")"

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -17,16 +17,27 @@
 #   rebase  -> N commits on main. `sha~N` is correct.
 #   merge   -> a 2-parent commit; the PR's work is sha^1..sha^2.
 #
-# Measured on this corpus: trusting `sha~N` blindly gave a wrong range for
-# **48 of 218 in-window PRs (22%)**, and the error was size-correlated (17% of
-# PRs under 400 adds, 34% of those over) — i.e. biased in the same direction as
-# the size finding the audit publishes. Do not reintroduce it.
+# Measured on this corpus (probe-v2-defect.sh): trusting `sha~N` blindly gives
+# a wrong range for **50 of 221 in-window PRs (22%)**, and the error is
+# size-correlated (17% of PRs under 400 adds, 33% of those over) — i.e. biased
+# in the same direction as the size finding the audit publishes. Do not
+# reintroduce it.
 #
 # The fix: walk back from the merge commit but STOP at the first commit that
 # belongs to a different PR. A boundary commit is one whose subject announces a
 # PR — either `Merge pull request #N` or a trailing `(#N)`. For a squash merge
 # the very next commit back is another PR's boundary, so the walk stops at
 # depth 1, which is correct.
+#
+# But a trailing `(#N)` is exactly the regex that mistake 3 (see README) says
+# cannot distinguish PR refs from ISSUE refs — this project writes issue
+# numbers into subjects, and that error once mis-attributed 35% of commits. An
+# intermediate commit of a rebase-merged PR whose subject happens to end in
+# `(#<issue>)` would read as another PR's boundary and silently truncate the
+# range (the v1 too-narrow defect, returning). So a trailing `(#N)` only counts
+# as a boundary if N is an actual merged-PR number from prs_merged.json; the
+# `Merge pull request #N` form needs no such check because nothing writes issue
+# refs in that shape. Rejected candidates are logged, not silently skipped.
 # ---------------------------------------------------------------------------
 set -euo pipefail
 WORK="${WORK:-./audit-work}"
@@ -36,19 +47,31 @@ cd "$REPO_DIR"
 declare -A NCOM
 while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
 
+# Known merged-PR numbers: the referee for the ambiguous `(#N)` form. Complete
+# as long as stage 1's --limit was not hit, which stage 1 now checks.
+declare -A ISPR
+while read -r n; do ISPR[$n]=1; done < <(jq -r '.[].number' "$WORK/prs_merged.json")
+
 # Which PR does a commit's own subject announce, if any? Empty = not a boundary.
+# A trailing `(#N)` where N is not a known merged PR is an issue ref, not a
+# boundary — announce the rejection on fd 3 so the caller can count it.
 boundary_pr() {
   local subj="$1"
   if [[ "$subj" =~ ^Merge\ pull\ request\ \#([0-9]+) ]]; then
     echo "${BASH_REMATCH[1]}"
   elif [[ "$subj" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
-    echo "${BASH_REMATCH[1]}"
+    if [ -n "${ISPR[${BASH_REMATCH[1]}]:-}" ]; then
+      echo "${BASH_REMATCH[1]}"
+    else
+      echo "issue-ref (#${BASH_REMATCH[1]}) not a merged PR: ${subj:0:60}" >&3
+    fi
   fi
 }
 
 : > "$WORK/pr_base.tsv"
 : > "$WORK/.c2p.raw"
 : > "$WORK/range_unverified.txt"
+exec 3> "$WORK/issue_ref_skips.txt"
 overwalks=0
 caphits=0
 
@@ -111,10 +134,17 @@ sort -k1,1 -k2,2n "$WORK/.c2p.raw" | awk -F'\t' '{m[$1]=$2} END{for(k in m) prin
   > "$WORK/commit2pr.tsv"
 rm -f "$WORK/.c2p.raw"
 
+exec 3>&-
 echo "pr_base entries : $(wc -l < "$WORK/pr_base.tsv")"
 echo "commit2pr       : $(wc -l < "$WORK/commit2pr.tsv")"
 echo "walks truncated at another PR's boundary: $overwalks"
 echo "  (each of these would have been an over-wide range under a bare sha~N)"
+skips=$(wc -l < "$WORK/issue_ref_skips.txt")
+if [ "$skips" -gt 0 ]; then
+  echo "trailing (#N) refs rejected as issue refs, walk continued: $skips"
+  echo "  (each would have silently truncated a range if trusted as a boundary;"
+  echo "   listed in $WORK/issue_ref_skips.txt)"
+fi
 if [ "$caphits" -gt 0 ]; then
   echo "NOTE: $caphits PR(s) resolved to a base that announces no other PR, so the"
   echo "      range could not be confirmed as ending at the previous PR's boundary."

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -18,8 +18,8 @@
 #   merge   -> a 2-parent commit; the PR's work is sha^1..sha^2.
 #
 # Measured on this corpus (probe-v2-defect.sh): trusting `sha~N` blindly gives
-# a wrong range for **50 of 221 in-window PRs (22%)**, and the error is
-# size-correlated (17% of PRs under 400 adds, 33% of those over) — i.e. biased
+# a wrong range for **50 of 221 in-window PRs (22.6%)**, and the error is
+# size-correlated (17.4% of PRs under 400 adds, 33.3% of those over) — biased
 # in the same direction as the size finding the audit publishes. Do not
 # reintroduce it.
 #
@@ -43,6 +43,15 @@ set -euo pipefail
 WORK="${WORK:-./audit-work}"
 REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel)}"
 cd "$REPO_DIR"
+
+# Cross-stage guard: stage 1's failures degrade THIS stage (a missing commit
+# count silently becomes a 1-commit range — the truncated-range defect), and a
+# stage-scoped warning is easy to miss on a partial re-run days later.
+if [ -s "$WORK/fetch_failures.txt" ]; then
+  echo "WARNING: stage 1 recorded $(wc -l < "$WORK/fetch_failures.txt") fetch failure(s)."
+  echo "         A missing commit count becomes a 1-commit range HERE. Re-run"
+  echo "         stage 1 until fetch_failures.txt is empty before trusting this."
+fi
 
 declare -A NCOM
 while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
@@ -77,6 +86,7 @@ exec 3> "$WORK/issue_ref_skips.txt"
 overwalks=0
 caphits=0
 claimstops=0
+earlystops=0
 
 # Commits already assigned to a processed PR. PRs are processed in MERGE order
 # (sort_by(.mergedAt), not number), so by the time a PR's walk runs, every PR
@@ -89,7 +99,11 @@ declare -A CLAIMED
 
 while IFS=$'\t' read -r pr sha; do
   git cat-file -e "${sha}^{commit}" 2>/dev/null || continue
-  np=$(git rev-list --parents -n1 "$sha" | wc -w)
+  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w) || np=0
+  if [ "$np" -eq 0 ]; then
+    printf '%s\tunreadable-merge-commit\t%s\n' "$pr" "$sha" >> "$WORK/range_unverified.txt"
+    continue
+  fi
 
   if [ "$np" -ge 3 ]; then
     # True merge commit: the PR's work is the second-parent branch.
@@ -118,6 +132,19 @@ while IFS=$'\t' read -r pr sha; do
       printf '%s\t%s\n' "$csha" "$pr" >> "$WORK/.c2p.raw"; CLAIMED[$csha]=$pr
       depth=$((depth+1))
     done
+    # A boundary stop at depth > 1 means the walk ABSORBED depth-1 anonymous
+    # commits (unlabelled, unclaimed) before meeting the boundary. For a
+    # rebase-merged PR those are its own commits (gh's count overestimated);
+    # for a squash-merged PR they are foreign — e.g. a direct push to main —
+    # and the range is over-wide with the push's rework misattributed to this
+    # PR. Indistinguishable from subjects alone, so FLAG it; the earlier code
+    # ran its ambiguity check only on the hit_boundary=0 path, which let this
+    # exact case pass as clean (round-8 review, 3/3 passes).
+    if [ "$hit_boundary" -eq 1 ] && [ "$depth" -gt 1 ]; then
+      earlystops=$((earlystops+1))
+      printf '%s\tboundary-stop-after-absorbing\tabsorbed=%s\tcap=%s\n' \
+        "$pr" "$((depth-1))" "$cap" >> "$WORK/range_unverified.txt"
+    fi
     # The loop bound stops at depth-1, so the cap-th ancestor was never
     # inspected. Look at it now — that is what distinguishes the two cases:
     #
@@ -147,7 +174,12 @@ while IFS=$'\t' read -r pr sha; do
 done < <(jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.mergedAt)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
            "$WORK/prs_merged.json")
 
-sort -k1,1 -k2,2n "$WORK/.c2p.raw" | awk -F'\t' '{m[$1]=$2} END{for(k in m) print k"\t"m[k]}' \
+# First claim wins, deterministically: rows append in MERGE order and the
+# CLAIMED array already stops later walks at a claimed commit, so keeping the
+# first occurrence matches the walk's own semantics. (The old
+# sort|last-write dedup kept the highest PR number instead — a second,
+# unrelated tie-break that disagreed with CLAIMED on any overlap.)
+awk -F'\t' '!($1 in m){m[$1]=$2} END{for(k in m) print k"\t"m[k]}' "$WORK/.c2p.raw" \
   > "$WORK/commit2pr.tsv"
 rm -f "$WORK/.c2p.raw"
 
@@ -164,6 +196,11 @@ if [ "$skips" -gt 0 ]; then
   echo "trailing (#N) refs rejected as issue refs, walk continued: $skips"
   echo "  (each would have silently truncated a range if trusted as a boundary;"
   echo "   listed in $WORK/issue_ref_skips.txt)"
+fi
+if [ "$earlystops" -gt 0 ]; then
+  echo "boundary stops that first absorbed anonymous commits: $earlystops"
+  echo "  (rebase-with-overcounted-cap or squash-over-direct-push — cannot tell"
+  echo "   which from subjects; flagged in range_unverified.txt, spot-check them)"
 fi
 if [ "$caphits" -gt 0 ]; then
   echo "NOTE: $caphits PR(s) resolved to a base that announces no other PR, so the"

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -54,15 +54,17 @@ while read -r n; do ISPR[$n]=1; done < <(jq -r '.[].number' "$WORK/prs_merged.js
 
 # Which PR does a commit's own subject announce, if any? Empty = not a boundary.
 # A trailing `(#N)` where N is not a known merged PR is an issue ref, not a
-# boundary — announce the rejection on fd 3 so the caller can count it.
+# boundary — announce the rejection on fd 3 so the caller can count it, unless
+# the caller passes `quiet` (the cap-ancestor confirmation probes commits that
+# were never walk candidates; logging those would inflate the skips count).
 boundary_pr() {
-  local subj="$1"
+  local subj="$1" mode="${2:-log}"
   if [[ "$subj" =~ ^Merge\ pull\ request\ \#([0-9]+) ]]; then
     echo "${BASH_REMATCH[1]}"
   elif [[ "$subj" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
     if [ -n "${ISPR[${BASH_REMATCH[1]}]:-}" ]; then
       echo "${BASH_REMATCH[1]}"
-    else
+    elif [ "$mode" != quiet ]; then
       echo "issue-ref (#${BASH_REMATCH[1]}) not a merged PR: ${subj:0:60}" >&3
     fi
   fi
@@ -74,6 +76,16 @@ boundary_pr() {
 exec 3> "$WORK/issue_ref_skips.txt"
 overwalks=0
 caphits=0
+claimstops=0
+
+# Commits already assigned to a processed PR. PRs are processed in MERGE order
+# (sort_by(.mergedAt), not number), so by the time a PR's walk runs, every PR
+# merged before it has claimed its own commits — and a walk that reaches one of
+# them has walked out of its own range. Subject parsing alone cannot catch
+# this: a squash-merged PR sitting on an *unlabelled* rebase-merged PR absorbs
+# those commits without ever meeting a labelled boundary, and the cap-ancestor
+# check below only inspects the endpoint, not what was absorbed on the way.
+declare -A CLAIMED
 
 while IFS=$'\t' read -r pr sha; do
   git cat-file -e "${sha}^{commit}" 2>/dev/null || continue
@@ -82,23 +94,28 @@ while IFS=$'\t' read -r pr sha; do
   if [ "$np" -ge 3 ]; then
     # True merge commit: the PR's work is the second-parent branch.
     base="${sha}^1"
-    git rev-list "${sha}^1..${sha}^2" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
-    echo "$sha" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
+    while read -r bsha; do
+      printf '%s\t%s\n' "$bsha" "$pr" >> "$WORK/.c2p.raw"; CLAIMED[$bsha]=$pr
+    done < <(git rev-list "${sha}^1..${sha}^2"; echo "$sha")
   else
     cap="${NCOM[$pr]:-1}"; [ "$cap" -lt 1 ] && cap=1
     depth=1
     hit_boundary=0
-    echo "$sha" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
+    printf '%s\t%s\n' "$sha" "$pr" >> "$WORK/.c2p.raw"; CLAIMED[$sha]=$pr
     while [ "$depth" -lt "$cap" ]; do
-      cand="${sha}~${depth}"
-      git rev-parse -q --verify "$cand" >/dev/null 2>&1 || break
-      csubj=$(git log -1 --format='%s' "$cand")
+      csha=$(git rev-parse -q --verify "${sha}~${depth}" 2>/dev/null) || break
+      # Already another PR's commit? Then the walk has left its own range —
+      # stop regardless of what the subject says.
+      if [ -n "${CLAIMED[$csha]:-}" ] && [ "${CLAIMED[$csha]}" != "$pr" ]; then
+        claimstops=$((claimstops+1)); hit_boundary=1; break
+      fi
+      csubj=$(git log -1 --format='%s' "$csha")
       owner=$(boundary_pr "$csubj")
       # Stop before absorbing a commit that announces a different PR.
       if [ -n "$owner" ] && [ "$owner" != "$pr" ]; then
         overwalks=$((overwalks+1)); hit_boundary=1; break
       fi
-      git rev-parse "$cand" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
+      printf '%s\t%s\n' "$csha" "$pr" >> "$WORK/.c2p.raw"; CLAIMED[$csha]=$pr
       depth=$((depth+1))
     done
     # The loop bound stops at depth-1, so the cap-th ancestor was never
@@ -116,7 +133,7 @@ while IFS=$'\t' read -r pr sha; do
     # one. A warning that fires on everything is a warning about nothing.
     if [ "$hit_boundary" -eq 0 ] && [ "$depth" -gt 1 ]; then
       capsubj=$(git log -1 --format='%s' "${sha}~${depth}" 2>/dev/null || echo "")
-      capowner=$(boundary_pr "$capsubj")
+      capowner=$(boundary_pr "$capsubj" quiet)
       if [ -z "$capowner" ] || [ "$capowner" = "$pr" ]; then
         caphits=$((caphits+1))
         printf '%s\tambiguous-base\tdepth=%s\tbase_subject=%s\n' \
@@ -127,7 +144,7 @@ while IFS=$'\t' read -r pr sha; do
     git rev-parse -q --verify "$base" >/dev/null 2>&1 || base="${sha}^1"
   fi
   printf '%s\t%s\n' "$pr" "$base" >> "$WORK/pr_base.tsv"
-done < <(jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.number)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
+done < <(jq -r '[.[]|select(.mergeCommit!=null)]|sort_by(.mergedAt)|.[]|"\(.number)\t\(.mergeCommit.oid)"' \
            "$WORK/prs_merged.json")
 
 sort -k1,1 -k2,2n "$WORK/.c2p.raw" | awk -F'\t' '{m[$1]=$2} END{for(k in m) print k"\t"m[k]}' \
@@ -139,6 +156,9 @@ echo "pr_base entries : $(wc -l < "$WORK/pr_base.tsv")"
 echo "commit2pr       : $(wc -l < "$WORK/commit2pr.tsv")"
 echo "walks truncated at another PR's boundary: $overwalks"
 echo "  (each of these would have been an over-wide range under a bare sha~N)"
+echo "walks truncated at a commit another PR already claimed: $claimstops"
+echo "  (subject parsing alone would have absorbed these — the squash-over-"
+echo "   unlabelled-rebase case no boundary regex can see)"
 skips=$(wc -l < "$WORK/issue_ref_skips.txt")
 if [ "$skips" -gt 0 ]; then
   echo "trailing (#N) refs rejected as issue refs, walk continued: $skips"

--- a/scripts/pr-churn-audit/02-commit-map.sh
+++ b/scripts/pr-churn-audit/02-commit-map.sh
@@ -48,7 +48,9 @@ boundary_pr() {
 
 : > "$WORK/pr_base.tsv"
 : > "$WORK/.c2p.raw"
+: > "$WORK/range_unverified.txt"
 overwalks=0
+caphits=0
 
 while IFS=$'\t' read -r pr sha; do
   git cat-file -e "${sha}^{commit}" 2>/dev/null || continue
@@ -62,6 +64,7 @@ while IFS=$'\t' read -r pr sha; do
   else
     cap="${NCOM[$pr]:-1}"; [ "$cap" -lt 1 ] && cap=1
     depth=1
+    hit_boundary=0
     echo "$sha" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
     while [ "$depth" -lt "$cap" ]; do
       cand="${sha}~${depth}"
@@ -70,11 +73,20 @@ while IFS=$'\t' read -r pr sha; do
       owner=$(boundary_pr "$csubj")
       # Stop before absorbing a commit that announces a different PR.
       if [ -n "$owner" ] && [ "$owner" != "$pr" ]; then
-        overwalks=$((overwalks+1)); break
+        overwalks=$((overwalks+1)); hit_boundary=1; break
       fi
       git rev-parse "$cand" | sed "s/\$/\t$pr/" >> "$WORK/.c2p.raw"
       depth=$((depth+1))
     done
+    # Walked the full branch length without meeting another PR's boundary. That
+    # is correct for a rebase-merge, but it is ALSO what a squash-merge sitting
+    # on an UNLABELLED commit looks like — and in that case the range is
+    # over-wide, exactly the v2 defect. The heuristic cannot tell them apart, so
+    # count these and report rather than assume the benign reading.
+    if [ "$hit_boundary" -eq 0 ] && [ "$depth" -gt 1 ]; then
+      caphits=$((caphits+1))
+      printf '%s\tcap-exhausted\tdepth=%s\n' "$pr" "$depth" >> "$WORK/range_unverified.txt"
+    fi
     base="${sha}~${depth}"
     git rev-parse -q --verify "$base" >/dev/null 2>&1 || base="${sha}^1"
   fi
@@ -90,3 +102,9 @@ echo "pr_base entries : $(wc -l < "$WORK/pr_base.tsv")"
 echo "commit2pr       : $(wc -l < "$WORK/commit2pr.tsv")"
 echo "walks truncated at another PR's boundary: $overwalks"
 echo "  (each of these would have been an over-wide range under a bare sha~N)"
+if [ "$caphits" -gt 0 ]; then
+  echo "NOTE: $caphits multi-commit PR(s) walked their full branch length without"
+  echo "      meeting another PR's boundary — correct for a rebase-merge, but"
+  echo "      indistinguishable from a squash landing on an unlabelled commit."
+  echo "      Listed in $WORK/range_unverified.txt; spot-check if a figure surprises you."
+fi

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -61,7 +61,18 @@ while IFS=$'\t' read -r pr sha mdate; do
   git rev-parse -q --verify "$base" >/dev/null 2>&1 || {
     printf '%s\t(base unresolvable)\t%s\n' "$pr" "$base" >> "$fails"; continue; }
 
-  git diff --unified=0 --no-color "$base" "$sha" -- 'crates/*.rs' 'web/src/*.ts' 2>/dev/null |
+  # Capture the diff and CHECK it. Piped straight into awk, a failed diff
+  # (missing object -> exit 128) reads as empty input: the PR contributes zero
+  # edges, lands in no failure file, and the "INCOMPLETE" warning stays quiet —
+  # the silent-truncation class this script exists to ban.
+  # -w matches blame's -w below: whitespace-only churn is not rework. Without
+  # it a rustfmt-style sweep diffs whole blocks as deletions while -w blame
+  # attributes those lines to their ORIGINAL authors — a fake rework spike
+  # against old PRs for a semantic no-op.
+  if ! git diff --unified=0 --no-color -w "$base" "$sha" -- 'crates/*.rs' 'web/src/*.ts' \
+       > "$WORK/.diff.tmp" 2>/dev/null; then
+    printf '%s\t(git diff failed)\t%s..%s\n' "$pr" "$base" "$sha" >> "$fails"; continue
+  fi
   awk '
     /^--- a\// { f=substr($0,7); next }
     /^\+\+\+ /  { next }
@@ -69,7 +80,7 @@ while IFS=$'\t' read -r pr sha mdate; do
       match($0, /-[0-9]+(,[0-9]+)?/); spec=substr($0,RSTART+1,RLENGTH-1)
       split(spec,a,","); st=a[1]; cn=(length(a)>1?a[2]:1)
       if (cn>0 && f!="") print f "\t" st "\t" cn
-    }' |
+    }' "$WORK/.diff.tmp" |
   while IFS=$'\t' read -r f st cn; do
     en=$((st+cn-1))
     blame=$(git blame -w --line-porcelain -L "${st},${en}" "$base" -- "$f" 2>/dev/null) || {
@@ -86,6 +97,7 @@ while IFS=$'\t' read -r pr sha mdate; do
       done
   done
 done
+rm -f "$WORK/.diff.tmp"
 nf=$(wc -l < "$fails")
 echo "rework edges: $(wc -l < "$out")"
 # Loud, not silent: a truncated dataset that reports itself is recoverable; one

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -53,7 +53,7 @@ out="$WORK/rework_edges.tsv"; : > "$out"
 fails="$WORK/blame_failures.txt"; : > "$fails"
 
 jq -r --arg s "$SINCE" --arg u "$UNTIL_TS" '[.[]|select(.mergedAt>$s and .mergedAt<$u and .mergeCommit!=null)]
-  | sort_by(.mergedAt) | .[] | "\(.number)\t\(.mergeCommit.oid)\t\(.mergedAt)"' \
+  | sort_by(.mergedAt,.number) | .[] | "\(.number)\t\(.mergeCommit.oid)\t\(.mergedAt)"' \
   "$WORK/prs_merged.json" |
 while IFS=$'\t' read -r pr sha mdate; do
   base="${BASE[$pr]:-}"

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -74,8 +74,8 @@ while IFS=$'\t' read -r pr sha mdate; do
   # it a rustfmt-style sweep diffs whole blocks as deletions while -w blame
   # attributes those lines to their ORIGINAL authors — a fake rework spike
   # against old PRs for a semantic no-op.
-  if ! git diff --unified=0 --no-color -w "$base" "$sha" -- 'crates/*.rs' 'web/src/*.ts' \
-       > "$WORK/.diff.tmp" 2>/dev/null; then
+  if ! git -c diff.renames=true diff --unified=0 --no-color -w "$base" "$sha" \
+       -- 'crates/*.rs' 'web/src/*.ts' > "$WORK/.diff.tmp" 2>/dev/null; then
     printf '%s\t(git diff failed)\t%s..%s\n' "$pr" "$base" "$sha" >> "$fails"; continue
   fi
   awk '

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -21,10 +21,9 @@
 set -uo pipefail
 WORK="${WORK:-./audit-work}"
 REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel)}"
-SINCE="${SINCE:-2026-07-12}"
-# End-of-day, not the bare date: "2026-08-09T00:00:00Z" < "2026-08-09" is FALSE
-# lexicographically, so a bare bound silently drops the entire closing day.
-UNTIL="${UNTIL:-2026-08-09}"; UNTIL_TS="${UNTIL}T23:59:59Z"
+# Window bounds come from window.env — the single source of truth shared with
+# stage 1 and the probe (see that file for why UNTIL_TS is end-of-day).
+. "$(dirname "$0")/window.env"
 
 # GNU coreutils / GNU grep required — see README. Fail loudly here rather than
 # producing a plausible-looking but wrong dataset: BSD `date` makes every age 0,

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -12,10 +12,25 @@
 # exactly where the headline finding lives.
 #
 # Slow: one `git blame` per changed hunk. Budget ~10 min for ~220 PRs.
-set -euo pipefail
+# NOTE: deliberately NOT `set -e`. A single `git blame` failure (exit 128 on an
+# out-of-range -L, a missing object, a transient error) would otherwise abort
+# the whole stage mid-corpus and leave rework_edges.tsv SILENTLY SHORT — every
+# PR after the failing hunk dropped with no indication. For a script whose
+# entire purpose is re-derivable numbers, a silent truncation is the worst
+# available failure. Per-hunk failures are counted and reported instead.
+set -uo pipefail
 WORK="${WORK:-./audit-work}"
 REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel)}"
 SINCE="${SINCE:-2026-07-12}"
+UNTIL="${UNTIL:-2026-08-09}"
+
+# GNU coreutils / GNU grep required — see README. Fail loudly here rather than
+# producing a plausible-looking but wrong dataset: BSD `date` makes every age 0,
+# and `grep -P` errors drop every edge.
+date -u -d "2026-01-01" +%s >/dev/null 2>&1 || {
+  echo "ERROR: GNU date required (BSD date makes every age 0, silently)." >&2; exit 2; }
+echo x | grep -qoP 'x' 2>/dev/null || {
+  echo "ERROR: GNU grep with -P required (otherwise every edge is dropped)." >&2; exit 2; }
 cd "$REPO_DIR"
 
 declare -A C2P
@@ -28,8 +43,9 @@ while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
 
 epoch() { date -u -d "$1" +%s 2>/dev/null || echo 0; }
 out="$WORK/rework_edges.tsv"; : > "$out"
+fails="$WORK/blame_failures.txt"; : > "$fails"
 
-jq -r --arg s "$SINCE" '[.[]|select(.mergedAt>$s and .mergeCommit!=null)]
+jq -r --arg s "$SINCE" --arg u "$UNTIL" '[.[]|select(.mergedAt>$s and .mergedAt<$u and .mergeCommit!=null)]
   | sort_by(.mergedAt) | .[] | "\(.number)\t\(.mergeCommit.oid)\t\(.mergedAt)"' \
   "$WORK/prs_merged.json" |
 while IFS=$'\t' read -r pr sha mdate; do
@@ -54,7 +70,9 @@ while IFS=$'\t' read -r pr sha mdate; do
     }' |
   while IFS=$'\t' read -r f st cn; do
     en=$((st+cn-1))
-    git blame -w --line-porcelain -L "${st},${en}" "$base" -- "$f" 2>/dev/null |
+    blame=$(git blame -w --line-porcelain -L "${st},${en}" "$base" -- "$f" 2>/dev/null) || {
+      printf '%s\t%s\t%s,%s\n' "$pr" "$f" "$st" "$en" >> "$fails"; continue; }
+    printf '%s' "$blame" |
       grep -oP '^[0-9a-f]{40}(?= )' | sort | uniq -c |
       while read -r nl bsha; do
         opr="${C2P[$bsha]:-}"; [ -z "$opr" ] && continue
@@ -66,4 +84,11 @@ while IFS=$'\t' read -r pr sha mdate; do
       done
   done
 done
+nf=$(wc -l < "$fails")
 echo "rework edges: $(wc -l < "$out")"
+# Loud, not silent: a truncated dataset that reports itself is recoverable; one
+# that doesn't is how the first version of this audit shipped wrong numbers.
+if [ "$nf" -gt 0 ]; then
+  echo "WARNING: $nf hunk(s) failed to blame — dataset is INCOMPLETE."
+  echo "         see $fails ; do not quote these figures until it is empty."
+fi

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Stage 3: for each merged PR, blame the lines it deleted/modified back to the
+# PR that introduced them. Emits rework edges:
+#
+#   reworker_pr  reworked_pr  file  age_days  lines
+#
+# Diff range matters. This repo REBASE-MERGES multi-commit PRs, so the PR's
+# mergeCommit is only its last commit and `sha^1..sha` sees a fraction of the
+# change. Measured on #317: 281 additions across 3 commits, of which sha^1..sha
+# showed 18 lines in one docs file. Worst on large PRs, which average 13.6
+# commits above 1k adds vs 1.5 below 100 — i.e. the truncation is heaviest
+# exactly where the headline finding lives.
+#
+# Slow: one `git blame` per changed hunk. Budget ~10 min for ~220 PRs.
+set -euo pipefail
+WORK="${WORK:-./audit-work}"
+REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel)}"
+SINCE="${SINCE:-2026-07-12}"
+cd "$REPO_DIR"
+
+declare -A C2P
+while IFS=$'\t' read -r sha pr; do C2P[$sha]=$pr; done < "$WORK/commit2pr.tsv"
+declare -A PRDATE
+while IFS=$'\t' read -r pr d; do PRDATE[$pr]=$d; done < <(
+  jq -r '.[]|"\(.number)\t\(.mergedAt)"' "$WORK/prs_merged.json")
+declare -A NCOM
+while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
+
+epoch() { date -u -d "$1" +%s 2>/dev/null || echo 0; }
+out="$WORK/rework_edges.tsv"; : > "$out"
+
+jq -r --arg s "$SINCE" '[.[]|select(.mergedAt>$s and .mergeCommit!=null)]
+  | sort_by(.mergedAt) | .[] | "\(.number)\t\(.mergeCommit.oid)\t\(.mergedAt)"' \
+  "$WORK/prs_merged.json" |
+while IFS=$'\t' read -r pr sha mdate; do
+  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w)
+  if [ "$np" -ge 3 ]; then
+    base="${sha}^1"
+  else
+    n="${NCOM[$pr]:-1}"; [ "$n" -lt 1 ] && n=1
+    base="${sha}~${n}"
+  fi
+  git rev-parse -q --verify "$base" >/dev/null 2>&1 || base="${sha}^1"
+  git rev-parse -q --verify "$base" >/dev/null 2>&1 || continue
+
+  git diff --unified=0 --no-color "$base" "$sha" -- 'crates/*.rs' 'web/src/*.ts' 2>/dev/null |
+  awk '
+    /^--- a\// { f=substr($0,7); next }
+    /^\+\+\+ /  { next }
+    /^@@/ {
+      match($0, /-[0-9]+(,[0-9]+)?/); spec=substr($0,RSTART+1,RLENGTH-1)
+      split(spec,a,","); st=a[1]; cn=(length(a)>1?a[2]:1)
+      if (cn>0 && f!="") print f "\t" st "\t" cn
+    }' |
+  while IFS=$'\t' read -r f st cn; do
+    en=$((st+cn-1))
+    git blame -w --line-porcelain -L "${st},${en}" "$base" -- "$f" 2>/dev/null |
+      grep -oP '^[0-9a-f]{40}(?= )' | sort | uniq -c |
+      while read -r nl bsha; do
+        opr="${C2P[$bsha]:-}"; [ -z "$opr" ] && continue
+        [ "$opr" = "$pr" ] && continue
+        od="${PRDATE[$opr]:-}"; [ -z "$od" ] && continue
+        age=$(( ( $(epoch "$mdate") - $(epoch "$od") ) / 86400 ))
+        [ "$age" -lt 0 ] && continue
+        printf '%s\t%s\t%s\t%s\t%s\n' "$pr" "$opr" "$f" "$age" "$nl" >> "$out"
+      done
+  done
+done
+echo "rework edges: $(wc -l < "$out")"

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -46,7 +46,10 @@ while IFS=$'\t' read -r pr d; do PRDATE[$pr]=$d; done < <(
 declare -A BASE
 while IFS=$'\t' read -r pr b; do BASE[$pr]=$b; done < "$WORK/pr_base.tsv"
 
-epoch() { date -u -d "$1" +%s 2>/dev/null || echo 0; }
+# Empty on failure — callers CHECK and record, never default. The old
+# `|| echo 0` fallback would count an unparseable date as same-day rework
+# (age passes the -lt 0 guard at exactly 0) — silent corruption.
+epoch() { date -u -d "$1" +%s 2>/dev/null; }
 out="$WORK/rework_edges.tsv"; : > "$out"
 fails="$WORK/blame_failures.txt"; : > "$fails"
 
@@ -60,6 +63,9 @@ while IFS=$'\t' read -r pr sha mdate; do
   fi
   git rev-parse -q --verify "$base" >/dev/null 2>&1 || {
     printf '%s\t(base unresolvable)\t%s\n' "$pr" "$base" >> "$fails"; continue; }
+  me=$(epoch "$mdate")
+  [ -z "$me" ] && {
+    printf '%s\t(unparseable mergedAt)\t%s\n' "$pr" "$mdate" >> "$fails"; continue; }
 
   # Capture the diff and CHECK it. Piped straight into awk, a failed diff
   # (missing object -> exit 128) reads as empty input: the PR contributes zero
@@ -88,10 +94,17 @@ while IFS=$'\t' read -r pr sha mdate; do
     printf '%s' "$blame" |
       grep -oP '^[0-9a-f]{40}(?= )' | sort | uniq -c |
       while read -r nl bsha; do
+        # Not in the map = not introduced by any fetched merged PR (direct
+        # pushes, pre-PR history). Out of scope by design, not a failure —
+        # and stage 1 hard-errors if its fetch cap truncated the PR list, so
+        # "unmapped because the PR fell off the end" cannot happen silently.
         opr="${C2P[$bsha]:-}"; [ -z "$opr" ] && continue
         [ "$opr" = "$pr" ] && continue
         od="${PRDATE[$opr]:-}"; [ -z "$od" ] && continue
-        age=$(( ( $(epoch "$mdate") - $(epoch "$od") ) / 86400 ))
+        oe=$(epoch "$od")
+        [ -z "$oe" ] && {
+          printf '%s\t(unparseable origin date)\t%s\n' "$pr" "$od" >> "$fails"; continue; }
+        age=$(( (me - oe) / 86400 ))
         [ "$age" -lt 0 ] && continue
         printf '%s\t%s\t%s\t%s\t%s\n' "$pr" "$opr" "$f" "$age" "$nl" >> "$out"
       done

--- a/scripts/pr-churn-audit/03-blame-edges.sh
+++ b/scripts/pr-churn-audit/03-blame-edges.sh
@@ -22,7 +22,9 @@ set -uo pipefail
 WORK="${WORK:-./audit-work}"
 REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel)}"
 SINCE="${SINCE:-2026-07-12}"
-UNTIL="${UNTIL:-2026-08-09}"
+# End-of-day, not the bare date: "2026-08-09T00:00:00Z" < "2026-08-09" is FALSE
+# lexicographically, so a bare bound silently drops the entire closing day.
+UNTIL="${UNTIL:-2026-08-09}"; UNTIL_TS="${UNTIL}T23:59:59Z"
 
 # GNU coreutils / GNU grep required — see README. Fail loudly here rather than
 # producing a plausible-looking but wrong dataset: BSD `date` makes every age 0,
@@ -38,26 +40,26 @@ while IFS=$'\t' read -r sha pr; do C2P[$sha]=$pr; done < "$WORK/commit2pr.tsv"
 declare -A PRDATE
 while IFS=$'\t' read -r pr d; do PRDATE[$pr]=$d; done < <(
   jq -r '.[]|"\(.number)\t\(.mergedAt)"' "$WORK/prs_merged.json")
-declare -A NCOM
-while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
+# Ranges come from stage 2, which resolves them properly and is the single
+# source of truth. Recomputing sha~N here is what produced an over-wide range
+# for 22% of PRs — see 02-commit-map.sh's header for the measurement.
+declare -A BASE
+while IFS=$'\t' read -r pr b; do BASE[$pr]=$b; done < "$WORK/pr_base.tsv"
 
 epoch() { date -u -d "$1" +%s 2>/dev/null || echo 0; }
 out="$WORK/rework_edges.tsv"; : > "$out"
 fails="$WORK/blame_failures.txt"; : > "$fails"
 
-jq -r --arg s "$SINCE" --arg u "$UNTIL" '[.[]|select(.mergedAt>$s and .mergedAt<$u and .mergeCommit!=null)]
+jq -r --arg s "$SINCE" --arg u "$UNTIL_TS" '[.[]|select(.mergedAt>$s and .mergedAt<$u and .mergeCommit!=null)]
   | sort_by(.mergedAt) | .[] | "\(.number)\t\(.mergeCommit.oid)\t\(.mergedAt)"' \
   "$WORK/prs_merged.json" |
 while IFS=$'\t' read -r pr sha mdate; do
-  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w)
-  if [ "$np" -ge 3 ]; then
-    base="${sha}^1"
-  else
-    n="${NCOM[$pr]:-1}"; [ "$n" -lt 1 ] && n=1
-    base="${sha}~${n}"
+  base="${BASE[$pr]:-}"
+  if [ -z "$base" ]; then
+    printf '%s\t(no base from stage 2)\t-\n' "$pr" >> "$fails"; continue
   fi
-  git rev-parse -q --verify "$base" >/dev/null 2>&1 || base="${sha}^1"
-  git rev-parse -q --verify "$base" >/dev/null 2>&1 || continue
+  git rev-parse -q --verify "$base" >/dev/null 2>&1 || {
+    printf '%s\t(base unresolvable)\t%s\n' "$pr" "$base" >> "$fails"; continue; }
 
   git diff --unified=0 --no-color "$base" "$sha" -- 'crates/*.rs' 'web/src/*.ts' 2>/dev/null |
   awk '

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -2,10 +2,10 @@
 # Stage 4: the numbers CLAUDE.md's change-size norm rests on.
 #
 # Prints BOTH averaging methods for the size buckets. They agree across the
-# first three (which is why the norm's threshold is 400) and also on the top
-# one, where both FALL past 1k (mean 6.1 -> 6.0, pooled 6.1 -> 3.8). Quote both
-# anyway: an earlier over-wide-range artifact made them appear to diverge there,
-# and printing one alone is how that went unnoticed.
+# first three (which is why the norm's threshold is 400) and DISAGREE in
+# direction on the top one — the top bucket has flipped in every version of
+# this dataset and is right-censored besides, so neither figure may be quoted
+# alone there. Printing one alone is how that went unnoticed the first time.
 #
 # `reworked_totals` is keyed by the REWORKED pr (column 2) and divided by that
 # PR's own additions: the figure is "how much of what this PR wrote did not
@@ -18,19 +18,25 @@ WORK="${WORK:-./audit-work}"
 awk -F'\t' '{t[$2]+=$5} END{for(k in t) print k"\t"t[k]}' "$WORK/rework_edges.tsv" \
   > "$WORK/reworked_totals.tsv"
 
-# Population reconciliation FIRST, and asserted. Every denominator dispute in
+# Population reconciliation FIRST, computed ONCE. Every denominator dispute in
 # this pipeline's review history came from a number hand-copied into prose and
-# then not updated with its siblings. Print them together so they cannot drift,
-# and fail loudly if the bucket rows do not sum to the population they cite.
+# then not updated with its siblings. These three variables are the only place
+# the populations are derived; the bucket table asserts against $pop below, so
+# an edit that changes one filter and not the other fails the run instead of
+# shipping a table that disagrees with its own caption.
+tot=$(awk -F'\t' 'NR>1{n++}          END{print n+0}' "$WORK/review_rounds.tsv")
+pop=$(awk -F'\t' 'NR>1 && $6>20{n++} END{print n+0}' "$WORK/review_rounds.tsv")
+big=$(awk -F'\t' 'NR>1 && $6>=400{n++} END{print n+0}' "$WORK/review_rounds.tsv")
+[ "$pop" -gt 0 ] || {
+  echo "ERROR: bucket population is empty — review_rounds.tsv missing or unfiltered." >&2; exit 3; }
 echo "=== population (cite these, do not hand-derive them)"
-awk -F'\t' 'NR>1 {tot++; if($6>20) pop++; if($6>=400) big++}
-  END{
+awk -v tot="$tot" -v pop="$pop" -v big="$big" 'BEGIN{
     printf "  review_rounds rows (unfiltered) : %d\n", tot
     printf "  bucket population (>20 adds)    : %d\n", pop
     printf "  of those, >=400 adds            : %d  (%.0f%% of the bucket population)\n", big, 100*big/pop
     printf "  NB %d/%d = %.0f%% is the UNFILTERED share — quoting it against the\n", big, tot, 100*big/tot
     printf "     bucket population is the mixed-denominator trap. Pick one base.\n"
-  }' "$WORK/review_rounds.tsv"
+  }'
 
 echo
 echo "=== rework age distribution (all edges)"
@@ -46,7 +52,7 @@ echo "    NOTE the numerator is Rust/TS rework only (crates/*.rs, web/src/*.ts),
 echo "    while the denominator is GitHub's TOTAL additions across all files."
 echo "    Consistent across buckets, so the comparison holds — but it is not"
 echo "    literally 'per 100 added lines'."
-awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
+awk -F'\t' -v T="$WORK/reworked_totals.tsv" -v POP="$pop" '
   BEGIN{ while((getline l < T)>0){ split(l,p,"\t"); rw[p[1]]=p[2] } }
   FNR>1 && $6>20 {
     adds=$6+0; r=(rw[$1]+0); rate=100*r/adds
@@ -61,25 +67,33 @@ awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
     # sorted the header too — it begins with "b", so it landed BELOW the four
     # numbered rows it labels. That shipped once and was caught in review after
     # I had already quoted the output as verification.
-    nb=0
-    for(b in n) rows[++nb]=sprintf("  %-11s %4d %14.1f %10.1f", b, n[b], s[b]/n[b], 100*tr[b]/ta[b])
+    nb=0; sum=0
+    for(b in n){ rows[++nb]=sprintf("  %-11s %4d %14.1f %10.1f", b, n[b], s[b]/n[b], 100*tr[b]/ta[b]); sum+=n[b] }
     for(i=1;i<nb;i++) for(j=i+1;j<=nb;j++) if(rows[j]<rows[i]){t=rows[i];rows[i]=rows[j];rows[j]=t}
     printf "  %-11s %4s %14s %10s\n","bucket","n","mean-of-rates","pooled"
     for(i=1;i<=nb;i++) print rows[i]
+    # Assert, not narrate: the rows must sum to the population the caption
+    # cites. Guards the drift where someone edits one filter and not the other.
+    if (sum != POP) {
+      printf "ERROR: bucket rows sum to %d but the stated population is %d\n", sum, POP > "/dev/stderr"
+      exit 3
+    }
+    printf "  (rows above sum to %d, the bucket population)\n", sum
   }' "$WORK/review_rounds.tsv"
 
-# Assertion: the four bucket rows must account for exactly the population.
-awk -F'\t' 'NR>1 && $6>20 {n++} END{exit (n>0 ? 0 : 1)}' "$WORK/review_rounds.tsv" || {
-  echo "ERROR: bucket population is empty — review_rounds.tsv missing or unfiltered." >&2; exit 3; }
-sum=$(awk -F'\t' 'NR>1 && $6>20 {n++} END{print n+0}' "$WORK/review_rounds.tsv")
-echo "  (rows above sum to $sum, the bucket population)"
-
 echo
-echo "=== share of all rework, by originating PR size"
+echo "=== share of rework, by originating PR size"
+echo "    Both denominators, because prose keeps mixing them. The numerator is"
+echo "    identical (every >=400-add PR clears the >20 floor); only the base"
+echo "    changes. NB either way the denominator counts only rework of PRs in"
+echo "    review_rounds.tsv (merged from BUCKET_SINCE) — rework of code written"
+echo "    before that window is in the edge total but in neither share."
 awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
   BEGIN{ while((getline l < T)>0){ split(l,p,"\t"); rw[p[1]]=p[2] } }
-  FNR>1 { r=(rw[$1]+0); if($6+0<400){sm+=r; sn++} else {lg+=r; ln++} }
-  END{ g=sm+lg
-       printf "  large (>=400 adds): PRs=%d  lines=%d  %.1f%%\n", ln, lg, 100*lg/g
-       printf "  small (<400 adds) : PRs=%d  lines=%d  %.1f%%\n", sn, sm, 100*sm/g }' \
+  FNR>1 { r=(rw[$1]+0); g+=r
+          if($6+0>=400){lg+=r; ln++}
+          if($6+0>20){ gp+=r; if($6+0>=400) np++ } }
+  END{ printf "  large (>=400 adds): PRs=%d  lines=%d\n", ln, lg
+       printf "    of the bucket population(>20 adds) rework: %.1f%%\n", 100*lg/gp
+       printf "    of all review_rounds rework (unfiltered) : %.1f%%\n", 100*lg/g }' \
   "$WORK/review_rounds.tsv"

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -18,6 +18,21 @@ WORK="${WORK:-./audit-work}"
 awk -F'\t' '{t[$2]+=$5} END{for(k in t) print k"\t"t[k]}' "$WORK/rework_edges.tsv" \
   > "$WORK/reworked_totals.tsv"
 
+# Population reconciliation FIRST, and asserted. Every denominator dispute in
+# this pipeline's review history came from a number hand-copied into prose and
+# then not updated with its siblings. Print them together so they cannot drift,
+# and fail loudly if the bucket rows do not sum to the population they cite.
+echo "=== population (cite these, do not hand-derive them)"
+awk -F'\t' 'NR>1 {tot++; if($6>20) pop++; if($6>=400) big++}
+  END{
+    printf "  review_rounds rows (unfiltered) : %d\n", tot
+    printf "  bucket population (>20 adds)    : %d\n", pop
+    printf "  of those, >=400 adds            : %d  (%.0f%% of the bucket population)\n", big, 100*big/pop
+    printf "  NB %d/%d = %.0f%% is the UNFILTERED share — quoting it against the\n", big, tot, 100*big/tot
+    printf "     bucket population is the mixed-denominator trap. Pick one base.\n"
+  }' "$WORK/review_rounds.tsv"
+
+echo
 echo "=== rework age distribution (all edges)"
 awk -F'\t' '{print $4}' "$WORK/rework_edges.tsv" | sort -n | awk '
   {a[NR]=$1} END{printf "  n=%d  p50=%s  p75=%s  p90=%s\n", NR, a[int(NR*.5)], a[int(NR*.75)], a[int(NR*.9)]}'
@@ -52,6 +67,12 @@ awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
     printf "  %-11s %4s %14s %10s\n","bucket","n","mean-of-rates","pooled"
     for(i=1;i<=nb;i++) print rows[i]
   }' "$WORK/review_rounds.tsv"
+
+# Assertion: the four bucket rows must account for exactly the population.
+awk -F'\t' 'NR>1 && $6>20 {n++} END{exit (n>0 ? 0 : 1)}' "$WORK/review_rounds.tsv" || {
+  echo "ERROR: bucket population is empty — review_rounds.tsv missing or unfiltered." >&2; exit 3; }
+sum=$(awk -F'\t' 'NR>1 && $6>20 {n++} END{print n+0}' "$WORK/review_rounds.tsv")
+echo "  (rows above sum to $sum, the bucket population)"
 
 echo
 echo "=== share of all rework, by originating PR size"

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -15,6 +15,11 @@
 set -euo pipefail
 WORK="${WORK:-./audit-work}"
 
+# An empty edge file would make every figure below 0/0 — gawk prints nan/inf
+# and exits 0, the quiet-garbage mode this pipeline bans. Refuse instead.
+[ -s "$WORK/rework_edges.tsv" ] || {
+  echo "ERROR: $WORK/rework_edges.tsv is missing or empty — run stage 3 first." >&2; exit 3; }
+
 awk -F'\t' '{t[$2]+=$5} END{for(k in t) print k"\t"t[k]}' "$WORK/rework_edges.tsv" \
   > "$WORK/reworked_totals.tsv"
 
@@ -45,7 +50,11 @@ awk -F'\t' '{print $4}' "$WORK/rework_edges.tsv" | sort -n | awk '
   # undershoots by one rank whenever N*p is fractional (N=7, p50 -> a[3]).
   function nr(p,  i){ i=int(NR*p); if (i < NR*p) i++; return a[i] }
   {a[NR]=$1} END{printf "  n=%d  p50=%s  p75=%s  p90=%s\n", NR, nr(.5), nr(.75), nr(.9)}'
-awk -F'\t' '{n++; if($4<=3)c++} END{printf "  within 3 days: %d/%d = %d%%\n", c, n, 100*c/n}' \
+# "under 4 days", because age is FLOORED to whole days: floor(age)<=3 covers
+# [0,4) days. The old "within 3 days" label promised [0,3] while measuring
+# [0,4) — same number, honest name. The comparator is deliberately unchanged
+# so the figure stays comparable across every version of this dataset.
+awk -F'\t' '{n++; if($4<=3)c++} END{printf "  under 4 days: %d/%d = %d%%\n", c, n, 100*c/n}' \
   "$WORK/rework_edges.tsv"
 
 echo
@@ -95,8 +104,12 @@ awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
   BEGIN{ while((getline l < T)>0){ split(l,p,"\t"); rw[p[1]]=p[2] } }
   FNR>1 { r=(rw[$1]+0); g+=r
           if($6+0>=400){lg+=r; ln++}
-          if($6+0>20){ gp+=r; if($6+0>=400) np++ } }
-  END{ printf "  large (>=400 adds): PRs=%d  lines=%d\n", ln, lg
+          if($6+0>20) gp+=r }
+  END{ if (g==0 || gp==0) {
+         print "ERROR: zero total rework in a denominator — refusing to print shares." > "/dev/stderr"
+         exit 3
+       }
+       printf "  large (>=400 adds): PRs=%d  lines=%d\n", ln, lg
        printf "    of the bucket population(>20 adds) rework: %.1f%%\n", 100*lg/gp
        printf "    of all review_rounds rework (unfiltered) : %.1f%%\n", 100*lg/g }' \
   "$WORK/review_rounds.tsv"

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -20,6 +20,21 @@ WORK="${WORK:-./audit-work}"
 [ -s "$WORK/rework_edges.tsv" ] || {
   echo "ERROR: $WORK/rework_edges.tsv is missing or empty — run stage 3 first." >&2; exit 3; }
 
+# Enforce the completeness contract AT THE QUOTING POINT. Stages 1 and 3 warn
+# about their own failures in their own terminal output, but this is the stage
+# whose output gets transcribed into docs — a partial dataset must not produce
+# complete-looking numbers from a clean run here.
+for f in fetch_failures.txt blame_failures.txt; do
+  [ -s "$WORK/$f" ] && {
+    echo "ERROR: $WORK/$f is non-empty — the dataset is INCOMPLETE (see the" >&2
+    echo "       stage that wrote it). Refusing to print quotable numbers." >&2
+    exit 3; }
+done
+if [ -s "$WORK/range_unverified.txt" ]; then
+  echo "NOTE: $(wc -l < "$WORK/range_unverified.txt") flagged range(s) in range_unverified.txt —"
+  echo "      not fatal, but spot-check before quoting figures involving those PRs."
+fi
+
 awk -F'\t' '{t[$2]+=$5} END{for(k in t) print k"\t"t[k]}' "$WORK/rework_edges.tsv" \
   > "$WORK/reworked_totals.tsv"
 

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -19,7 +19,11 @@ awk -F'\t' '{n++; if($4<=3)c++} END{printf "  within 3 days: %d/%d = %d%%\n", c,
 
 echo
 echo "=== rework per 100 added lines, by PR size"
-echo "    (buckets cover PRs with >20 adds; see the denominators note in the doc)"
+echo "    buckets cover PRs with >20 adds, merged from BUCKET_SINCE (see 01-fetch.sh)"
+echo "    NOTE the numerator is Rust/TS rework only (crates/*.rs, web/src/*.ts),"
+echo "    while the denominator is GitHub's TOTAL additions across all files."
+echo "    Consistent across buckets, so the comparison holds — but it is not"
+echo "    literally 'per 100 added lines'."
 awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
   BEGIN{ while((getline l < T)>0){ split(l,p,"\t"); rw[p[1]]=p[2] } }
   FNR>1 && $6>20 {
@@ -31,9 +35,16 @@ awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
     n[b]++; s[b]+=rate; tr[b]+=r; ta[b]+=adds
   }
   END{
+    # Sort the bucket rows INSIDE awk. Piping the whole block through `sort`
+    # sorted the header too — it begins with "b", so it landed BELOW the four
+    # numbered rows it labels. That shipped once and was caught in review after
+    # I had already quoted the output as verification.
+    nb=0
+    for(b in n) rows[++nb]=sprintf("  %-11s %4d %14.1f %10.1f", b, n[b], s[b]/n[b], 100*tr[b]/ta[b])
+    for(i=1;i<nb;i++) for(j=i+1;j<=nb;j++) if(rows[j]<rows[i]){t=rows[i];rows[i]=rows[j];rows[j]=t}
     printf "  %-11s %4s %14s %10s\n","bucket","n","mean-of-rates","pooled"
-    for(b in n) printf "  %-11s %4d %14.1f %10.1f\n", b, n[b], s[b]/n[b], 100*tr[b]/ta[b]
-  }' "$WORK/review_rounds.tsv" | sort
+    for(i=1;i<=nb;i++) print rows[i]
+  }' "$WORK/review_rounds.tsv"
 
 echo
 echo "=== share of all rework, by originating PR size"

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -2,9 +2,16 @@
 # Stage 4: the numbers CLAUDE.md's change-size norm rests on.
 #
 # Prints BOTH averaging methods for the size buckets. They agree across the
-# first three buckets (which is why the norm's threshold is 400) and disagree
-# in direction on the top one — mean rises 8.5 -> 10.5, pooled FALLS 8.3 -> 6.9.
-# Do not quote one without the other.
+# first three (which is why the norm's threshold is 400) and also on the top
+# one, where both FALL past 1k (mean 6.1 -> 6.0, pooled 6.1 -> 3.8). Quote both
+# anyway: an earlier over-wide-range artifact made them appear to diverge there,
+# and printing one alone is how that went unnoticed.
+#
+# `reworked_totals` is keyed by the REWORKED pr (column 2) and divided by that
+# PR's own additions: the figure is "how much of what this PR wrote did not
+# survive", NOT "how much rewriting this PR did". A PR that rewrites lots of old
+# code therefore scores 0 in its own bucket, which is correct — see the README's
+# "What the rate actually measures".
 set -euo pipefail
 WORK="${WORK:-./audit-work}"
 

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Stage 4: the numbers CLAUDE.md's change-size norm rests on.
+#
+# Prints BOTH averaging methods for the size buckets. They agree across the
+# first three buckets (which is why the norm's threshold is 400) and disagree
+# in direction on the top one — mean rises 8.5 -> 10.5, pooled FALLS 8.3 -> 6.9.
+# Do not quote one without the other.
+set -euo pipefail
+WORK="${WORK:-./audit-work}"
+
+awk -F'\t' '{t[$2]+=$5} END{for(k in t) print k"\t"t[k]}' "$WORK/rework_edges.tsv" \
+  > "$WORK/reworked_totals.tsv"
+
+echo "=== rework age distribution (all edges)"
+awk -F'\t' '{print $4}' "$WORK/rework_edges.tsv" | sort -n | awk '
+  {a[NR]=$1} END{printf "  n=%d  p50=%s  p75=%s  p90=%s\n", NR, a[int(NR*.5)], a[int(NR*.75)], a[int(NR*.9)]}'
+awk -F'\t' '{n++; if($4<=3)c++} END{printf "  within 3 days: %d/%d = %d%%\n", c, n, 100*c/n}' \
+  "$WORK/rework_edges.tsv"
+
+echo
+echo "=== rework per 100 added lines, by PR size"
+echo "    (buckets cover PRs with >20 adds; see the denominators note in the doc)"
+awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
+  BEGIN{ while((getline l < T)>0){ split(l,p,"\t"); rw[p[1]]=p[2] } }
+  FNR>1 && $6>20 {
+    adds=$6+0; r=(rw[$1]+0); rate=100*r/adds
+    if(adds<100)      b="1. <100"
+    else if(adds<400) b="2. 100-400"
+    else if(adds<1000)b="3. 400-1k"
+    else              b="4. >1k"
+    n[b]++; s[b]+=rate; tr[b]+=r; ta[b]+=adds
+  }
+  END{
+    printf "  %-11s %4s %14s %10s\n","bucket","n","mean-of-rates","pooled"
+    for(b in n) printf "  %-11s %4d %14.1f %10.1f\n", b, n[b], s[b]/n[b], 100*tr[b]/ta[b]
+  }' "$WORK/review_rounds.tsv" | sort
+
+echo
+echo "=== share of all rework, by originating PR size"
+awk -F'\t' -v T="$WORK/reworked_totals.tsv" '
+  BEGIN{ while((getline l < T)>0){ split(l,p,"\t"); rw[p[1]]=p[2] } }
+  FNR>1 { r=(rw[$1]+0); if($6+0<400){sm+=r; sn++} else {lg+=r; ln++} }
+  END{ g=sm+lg
+       printf "  large (>=400 adds): PRs=%d  lines=%d  %.1f%%\n", ln, lg, 100*lg/g
+       printf "  small (<400 adds) : PRs=%d  lines=%d  %.1f%%\n", sn, sm, 100*sm/g }' \
+  "$WORK/review_rounds.tsv"

--- a/scripts/pr-churn-audit/04-analyze.sh
+++ b/scripts/pr-churn-audit/04-analyze.sh
@@ -41,7 +41,10 @@ awk -v tot="$tot" -v pop="$pop" -v big="$big" 'BEGIN{
 echo
 echo "=== rework age distribution (all edges)"
 awk -F'\t' '{print $4}' "$WORK/rework_edges.tsv" | sort -n | awk '
-  {a[NR]=$1} END{printf "  n=%d  p50=%s  p75=%s  p90=%s\n", NR, a[int(NR*.5)], a[int(NR*.75)], a[int(NR*.9)]}'
+  # Nearest-rank percentiles: index = ceil(N*p). The tempting int(N*p)
+  # undershoots by one rank whenever N*p is fractional (N=7, p50 -> a[3]).
+  function nr(p,  i){ i=int(NR*p); if (i < NR*p) i++; return a[i] }
+  {a[NR]=$1} END{printf "  n=%d  p50=%s  p75=%s  p90=%s\n", NR, nr(.5), nr(.75), nr(.9)}'
 awk -F'\t' '{n++; if($4<=3)c++} END{printf "  within 3 days: %d/%d = %d%%\n", c, n, 100*c/n}' \
   "$WORK/rework_edges.tsv"
 

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -187,11 +187,14 @@ PR that deletes a stale subsystem inflates the rework attributed to whoever
 wrote it. Keep it in mind when a single old PR shows a surprisingly large
 reworked total.
 
-**Whitespace-only churn is not counted.** Both the diff and the blame pass
-`-w`, deliberately paired: with `-w` on blame alone, a reformat-only sweep
-diffs whole blocks as deletions while the blame attributes those lines to
-their *original* authors — a large fake rework spike against old PRs for a
-semantic no-op.
+**Whitespace-only *modifications* are not counted.** Both the diff and the
+blame pass `-w`, deliberately paired: with `-w` on blame alone, a
+reformat-only sweep diffs whole blocks as deletions while the blame
+attributes those lines to their *original* authors — a large fake rework
+spike against old PRs for a semantic no-op. One edge stays counted,
+verified deliberately: *deleting* a line whose entire content is whitespace
+still emits a hunk under `-w` and is blamed — consistent with the
+deletions-count asymmetry above.
 
 **The age distribution and edge count are edge-weighted, not line-weighted.**
 Each (hunk × origin-commit) row counts once in the lag percentiles and once in
@@ -221,8 +224,14 @@ the published figures are unaffected. The flags are deliberately narrow: an
 earlier marker fired for every clean multi-commit rebase, the dominant case,
 and a warning that fires on everything is a warning about nothing.
 
-One residual no flag can catch: a commit subject ending in `(#N)` where N is a
-*merged PR's number* being used as an issue reference. At depth 1 that reads
-as a clean squash boundary and silently truncates the range; deeper in, it at
-least lands in boundary-stop-after-absorbing. Subjects cannot disambiguate
-that collision — the ISPR lookup narrows the issue-ref hole to exactly it.
+Two residuals no flag can catch. First: a commit subject ending in `(#N)`
+where N is a *merged PR's number* being used as an issue reference. At depth 1
+that reads as a clean squash boundary and silently truncates the range; deeper
+in, it at least lands in boundary-stop-after-absorbing. Subjects cannot
+disambiguate that collision — the ISPR lookup narrows the issue-ref hole to
+exactly it. Second: a walk that runs out of cap exactly on a *labelled* older
+boundary after absorbing anonymous commits. That signature is identical to
+every clean multi-commit rebase — flagging it would flag the dominant case,
+the round-5 lesson — so a squash PR whose gh count exactly spans a foreign
+anonymous block ending on a labelled boundary passes unflagged. Both residuals
+require data subjects cannot provide (the PR branch's own commit list).

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -1,0 +1,63 @@
+# PR churn audit pipeline
+
+Reproduces the numbers behind the **change-size norm** in
+[`CLAUDE.md`](../../CLAUDE.md#workflow-branches-review-merging) and the findings
+in [`docs/pr-churn-audit-2026-08.md`](../../docs/pr-churn-audit-2026-08.md).
+
+Checked in because that doc is labelled load-bearing and CLAUDE.md cites it as
+the evidence for a standing rule. A norm whose numbers cannot be re-derived is
+folklore.
+
+```bash
+export WORK=/tmp/audit-work          # scratch dir (default ./audit-work)
+export SINCE=2026-07-12              # window start
+bash scripts/pr-churn-audit/01-fetch.sh        # PR corpus + commit counts   (~5 min, API-bound)
+bash scripts/pr-churn-audit/02-commit-map.sh   # commit -> PR map            (~1 min)
+bash scripts/pr-churn-audit/03-blame-edges.sh  # rework edges via git blame  (~10 min)
+bash scripts/pr-churn-audit/04-analyze.sh      # the headline numbers
+```
+
+Needs `gh` (authenticated), `jq`, and a full clone — stage 3 blames history, so
+a shallow checkout silently produces nothing.
+
+## Two mistakes this pipeline exists to not repeat
+
+Both were made in the first version of the audit, both changed the answer, and
+both were caught by someone else rather than by the author.
+
+**The diff range.** This repo *rebase-merges* multi-commit PRs, so a PR's
+recorded `mergeCommit` is only its **last** commit. Diffing `sha^1..sha` sees a
+fraction of the change — measured on #317, 18 lines of one docs file out of 281
+additions across 3 commits. It is worst where it matters most: PRs above 1k
+additions average **13.6 commits** against 1.5 below 100. Stage 3 therefore
+uses `sha~N..sha`, with `sha^1..sha^2` for true merge commits.
+
+**The commit → PR map.** Parsing `(#N)` out of commit subjects does not work
+here, because this project writes *issue* references into subjects and a regex
+cannot distinguish them. That error mis-attributed **35% of commits** (322 of
+907). Stage 2 derives the map from authoritative per-PR commit ranges instead.
+
+Correcting both roughly doubled the edge count (1,639 → 3,114), moved the median
+rework lag from 1 day to 2, and turned the size relationship from
+1.6/2.7/6.3/**5.7** into 1.4/3.2/8.5/**10.5** — the dip in the top bucket had
+been an artifact of the truncation, not a floor effect.
+
+## Reading the output
+
+`04-analyze.sh` prints **both** averaging methods per size bucket. They agree
+across the first three, which is why the norm's threshold is 400. They disagree
+in *direction* on the top bucket — mean rises to 10.5, pooled falls to 6.9 —
+so `>1k` is unresolved on this data and neither figure should be quoted alone.
+
+Buckets cover PRs with more than 20 added lines merged from the start of
+`review_rounds.tsv`'s coverage; the share-of-rework figure uses the unfiltered
+set. These denominators differ, and the audit doc's "Denominators" note explains
+why. Reconcile before quoting them against each other.
+
+## What is not here
+
+The blame-edge dataset counts a later PR rewriting an earlier PR's lines. A
+sampled classification put that at roughly **57% planned iteration / 23%
+genuine correction / 20% collision** — so it is *not* a defect rate, and no
+script here separates those. The ratios the norm rests on survive the
+distinction; absolute counts do not.

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -17,6 +17,7 @@ bash scripts/pr-churn-audit/01-fetch.sh        # PR corpus + commit counts   (~5
 bash scripts/pr-churn-audit/02-commit-map.sh   # commit -> PR map            (~1 min)
 bash scripts/pr-churn-audit/03-blame-edges.sh  # rework edges via git blame  (~10 min)
 bash scripts/pr-churn-audit/04-analyze.sh      # the headline numbers
+bash scripts/pr-churn-audit/probe-v2-defect.sh "$WORK"   # re-derives the "50 of 221" range-defect figure
 ```
 
 Needs `gh` (authenticated), `jq`, **GNU coreutils and GNU grep**, and a full
@@ -64,16 +65,23 @@ reports the PR *branch's* commit count, but the number of commits that reach
 main depends on the merge strategy, and **this repo uses all three**. A
 squash-merged PR contributes exactly one commit while `gh` still reports N, so
 `sha~N` walks N−1 commits back into *earlier* PRs; stage 3 then blames a range
-spanning other people's work. Measured: **48 of 218 in-window PRs (22%)**, and
-size-correlated (17% of PRs under 400 adds, 34% of those over) — i.e. skewed in
-the same direction as the size finding it feeds.
+spanning other people's work. Measured, and re-derivable with
+`probe-v2-defect.sh`: **50 of 221 in-window PRs (22%)**, size-correlated (17%
+of PRs under 400 adds, 33% of those over) — i.e. skewed in the same direction
+as the size finding it feeds.
 
 Stage 2 therefore resolves each range by walking back from the merge commit and
-**stopping at the first commit that announces a different PR** (`Merge pull
-request #N`, or a trailing `(#N)`). That is strategy-agnostic: for a squash it
-stops at depth 1, for a rebase it stops at the previous PR's boundary, and true
-merge commits take `sha^1..sha^2`. The resolved base is written once to
-`pr_base.tsv` and stage 3 consumes it rather than re-deriving.
+**stopping at the first commit that announces a different PR** — `Merge pull
+request #N`, or a trailing `(#N)` **that resolves to a known merged-PR number**.
+The qualifier is mistake 3 applied to this walk: the trailing form is the same
+regex that cannot distinguish PR refs from issue refs, so stopping at an
+intermediate commit whose subject merely ends in an issue ref would silently
+re-introduce the too-narrow defect. Candidates that fail the lookup are walked
+through, not stopped at, and logged to `issue_ref_skips.txt`. The walk is
+strategy-agnostic: for a squash it stops at depth 1, for a rebase it stops at
+the previous PR's boundary, and true merge commits take `sha^1..sha^2`. The
+resolved base is written once to `pr_base.tsv` and stage 3 consumes it rather
+than re-deriving.
 
 **3. The commit → PR map.** Parsing `(#N)` out of commit subjects does not work
 here, because this project writes *issue* references into subjects and a regex
@@ -82,29 +90,33 @@ cannot distinguish them. That error mis-attributed **35% of commits** (322 of
 
 ### What each version produced
 
-| Measure | v1 (narrow + regex) | v2 (wide) | v3 (current) |
-|---|---:|---:|---:|
-| Edges | 1,639 | 3,114 | 1,999 |
-| Median lag | 1d | 2d | 2d |
-| Within 3 days | 61% | 57% | 60% |
-| Rate 400–1k | 6.3 | 8.5 | 6.1 |
-| Rate >1k | 5.7 | 10.5 | 6.0 |
-| Large-PR share | 89.7% | 93.2% | 90.1% |
+| Measure | v1 (narrow + regex) | v2 (wide) | v3 (walk) | v4 (current) |
+|---|---:|---:|---:|---:|
+| Edges | 1,639 | 3,114 | 1,999 | 2,022 |
+| Median lag | 1d | 2d | 2d | 1d |
+| Within 3 days | 61% | 57% | 60% | 61% |
+| Rate 400–1k | 6.3 | 8.5 | 6.1 | 4.7 |
+| Rate >1k | 5.7 | 10.5 | 6.0 | 5.7 |
+| Large-PR share | 89.7% | 93.2% | 90.1% | 89.3% |
 
-v2 is the one that was published, and it is the outlier. v3 lands almost
-exactly on v1, whose two errors had partially cancelled. The finding the norm
-rests on — a ~4× climb from <100 to 400–1k, and ~90% of rework from PRs ≥400
-adds — is present in all three; only its magnitude moved.
+v2 is the one that was originally published, and it is the outlier. v3 lands
+almost exactly on v1, whose two errors had partially cancelled. v4 is v3 plus
+two review-caught fixes: the issue-ref boundary validation (negligible —
+edges 1,999 → 2,005) and the paired `-w` (the real mover — 400–1k drops
+6.1 → 4.7, i.e. roughly a quarter of that bucket's counted rework was
+whitespace-only lines). The finding the norm rests on — the climb from <100
+to 400–1k and ~90% of rework from PRs ≥400 adds — is present in all four;
+its magnitude has moved with every correction, and the top bucket's
+*direction* has never once been stable across versions.
 
 ## Reading the output
 
 `04-analyze.sh` prints **both** averaging methods per size bucket. They agree
 across the first three, which is why the norm's threshold is 400 — and they
-agree on the top bucket too: both **fall** past 1k (mean 6.1 → 6.0, pooled
-6.1 → 3.8). So >1k is not worse than 400–1k, plausibly a floor effect. (An
-earlier version had the mean rising to 10.5 against a pooled 6.9 and called the
-bucket unresolved; that was the over-wide-range artifact, not a real
-divergence.)
+**disagree in direction** on the top one (mean 4.7 → 5.7, pooled 4.6 → 3.6).
+Do not quote either alone there: across v1→v4 the top bucket has fallen,
+climbed, fallen and split, and it is right-censored besides (the audit doc's
+"Denominators" and censoring notes). Treat >1k as unmeasured.
 
 ### What the rate actually measures
 
@@ -125,9 +137,14 @@ If you want the other reading — rework *caused* per PR — key on column 1
 instead. It is a different question and the norm does not rest on it.
 
 Buckets cover PRs with more than 20 added lines merged from the start of
-`review_rounds.tsv`'s coverage; the share-of-rework figure uses the unfiltered
-set. These denominators differ, and the audit doc's "Denominators" note explains
-why. Reconcile before quoting them against each other.
+`review_rounds.tsv`'s coverage. The share-of-rework figure is printed under
+**both** denominators — the bucket population and the unfiltered set — because
+the "36% of the population produced ~90% of rework" sentence needs its
+numerator and denominator drawn from the same base, and an earlier revision
+quoted the 36% against one and the 90% against the other. Note also that
+either share counts only rework of code written by PRs inside
+`review_rounds.tsv`'s window: rework of older code is in the edge total but in
+neither share.
 
 ### Scope of "reproduces exactly"
 
@@ -159,6 +176,18 @@ question is "how much of what this PR wrote did not survive" — but it means a
 PR that deletes a stale subsystem inflates the rework attributed to whoever
 wrote it. Keep it in mind when a single old PR shows a surprisingly large
 reworked total.
+
+**Whitespace-only churn is not counted.** Both the diff and the blame pass
+`-w`, deliberately paired: with `-w` on blame alone, a reformat-only sweep
+diffs whole blocks as deletions while the blame attributes those lines to
+their *original* authors — a large fake rework spike against old PRs for a
+semantic no-op.
+
+**The age distribution is edge-weighted, not line-weighted.** Each
+(hunk × origin-commit) row counts once in the lag percentiles regardless of
+its `lines` column, while the edge total and the bucket rates are line-based.
+A 40-line deletion and a 1-line edit pull equally on "median lag / within 3
+days"; nothing here says lag would look the same weighted per-line.
 
 **The boundary walk is a heuristic, not a proof.** Stage 2 stops at the first
 ancestor whose subject announces another PR, then checks whether the resolved

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -10,15 +10,30 @@ folklore.
 
 ```bash
 export WORK=/tmp/audit-work          # scratch dir (default ./audit-work)
-export SINCE=2026-07-12              # window start
+export SINCE=2026-07-12              # corpus window start
+export BUCKET_SINCE=2026-07-20       # size-bucket window start (see below)
+export UNTIL=2026-08-09              # window end — omit it and n drifts forever
 bash scripts/pr-churn-audit/01-fetch.sh        # PR corpus + commit counts   (~5 min, API-bound)
 bash scripts/pr-churn-audit/02-commit-map.sh   # commit -> PR map            (~1 min)
 bash scripts/pr-churn-audit/03-blame-edges.sh  # rework edges via git blame  (~10 min)
 bash scripts/pr-churn-audit/04-analyze.sh      # the headline numbers
 ```
 
-Needs `gh` (authenticated), `jq`, and a full clone — stage 3 blames history, so
-a shallow checkout silently produces nothing.
+Needs `gh` (authenticated), `jq`, **GNU coreutils and GNU grep**, and a full
+clone — stage 3 blames history, so a shallow checkout silently produces nothing.
+
+The GNU requirement is not cosmetic and stage 3 now refuses to start without
+it: BSD `date` makes `epoch()` return 0, so every age becomes 0 and the age
+distribution collapses to a plausible-looking lie; BSD `grep` has no `-P`, so
+every edge is dropped. Both fail quietly, which is why they are checked up
+front.
+
+**Two windows, deliberately.** `SINCE..UNTIL` bounds the corpus (edges, ages);
+`BUCKET_SINCE..UNTIL` bounds the per-PR review pull the size buckets divide by.
+They differ because the two datasets were collected at different points in the
+session — 218 merged PRs in the corpus, 217 in the bucket pull, 194 after the
+>20-adds floor. Do not quote a bucket `n` against a corpus `n` without
+reconciling them; that is the mixed-denominator trap the audit doc warns about.
 
 ## Two mistakes this pipeline exists to not repeat
 
@@ -54,7 +69,22 @@ Buckets cover PRs with more than 20 added lines merged from the start of
 set. These denominators differ, and the audit doc's "Denominators" note explains
 why. Reconcile before quoting them against each other.
 
-## What is not here
+### Scope of "reproduces exactly"
+
+These scripts regenerate the **blame-edge, age-distribution and size-bucket**
+figures — the ones CLAUDE.md's norm rests on. They do **not** regenerate the
+rest of the audit: the corrective-PR rate, the merge-latency bands, the
+within-PR complexity control, the day-level concurrency correlation, and the
+warm-review scoring were all hand-classified or one-off, and are recorded in
+the docs rather than automated. Treat "reproduces every figure" as scoped to
+what stage 4 prints.
+
+Also note the numerator/denominator scope mismatch stage 4 now prints: rework
+is blamed only over `crates/*.rs` and `web/src/*.ts`, while `adds` is GitHub's
+total additions across all files. The ratio is consistent across buckets so the
+comparison holds, but it is not literally "per 100 added lines".
+
+# What is not here
 
 The blame-edge dataset counts a later PR rewriting an earlier PR's lines. A
 sampled classification put that at roughly **57% planned iteration / 23%

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -18,6 +18,7 @@ bash scripts/pr-churn-audit/02-commit-map.sh   # commit -> PR map            (~1
 bash scripts/pr-churn-audit/03-blame-edges.sh  # rework edges via git blame  (~10 min)
 bash scripts/pr-churn-audit/04-analyze.sh      # the headline numbers
 bash scripts/pr-churn-audit/probe-v2-defect.sh "$WORK"   # re-derives the "50 of 221" range-defect figure
+bash scripts/pr-churn-audit/probe-exposure.sh "$WORK"    # exposure-per-bucket (censoring confound check)
 ```
 
 Needs `gh` (authenticated), `jq`, **GNU coreutils and GNU grep**, and a full

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -35,27 +35,54 @@ session — 218 merged PRs in the corpus, 217 in the bucket pull, 194 after the
 >20-adds floor. Do not quote a bucket `n` against a corpus `n` without
 reconciling them; that is the mixed-denominator trap the audit doc warns about.
 
-## Two mistakes this pipeline exists to not repeat
+## Three mistakes this pipeline exists to not repeat
 
-Both were made in the first version of the audit, both changed the answer, and
-both were caught by someone else rather than by the author.
+All three were made while producing these numbers, all three changed the
+answer, and every one was caught by a reviewer rather than by the author.
 
-**The diff range.** This repo *rebase-merges* multi-commit PRs, so a PR's
-recorded `mergeCommit` is only its **last** commit. Diffing `sha^1..sha` sees a
+**1. The diff range, too narrow.** A PR's recorded `mergeCommit` is only its
+**last** commit when the PR was rebase-merged. Diffing `sha^1..sha` then sees a
 fraction of the change — measured on #317, 18 lines of one docs file out of 281
-additions across 3 commits. It is worst where it matters most: PRs above 1k
-additions average **13.6 commits** against 1.5 below 100. Stage 3 therefore
-uses `sha~N..sha`, with `sha^1..sha^2` for true merge commits.
+additions across 3 commits. Worst where it matters: PRs above 1k additions
+average **13.6 commits** against 1.5 below 100.
 
-**The commit → PR map.** Parsing `(#N)` out of commit subjects does not work
+**2. The diff range, too wide.** The obvious fix — `sha~N..sha`, with N from
+`gh pr view --json commits` — is also wrong, and this is the subtle one. `gh`
+reports the PR *branch's* commit count, but the number of commits that reach
+main depends on the merge strategy, and **this repo uses all three**. A
+squash-merged PR contributes exactly one commit while `gh` still reports N, so
+`sha~N` walks N−1 commits back into *earlier* PRs; stage 3 then blames a range
+spanning other people's work. Measured: **48 of 218 in-window PRs (22%)**, and
+size-correlated (17% of PRs under 400 adds, 34% of those over) — i.e. skewed in
+the same direction as the size finding it feeds.
+
+Stage 2 therefore resolves each range by walking back from the merge commit and
+**stopping at the first commit that announces a different PR** (`Merge pull
+request #N`, or a trailing `(#N)`). That is strategy-agnostic: for a squash it
+stops at depth 1, for a rebase it stops at the previous PR's boundary, and true
+merge commits take `sha^1..sha^2`. The resolved base is written once to
+`pr_base.tsv` and stage 3 consumes it rather than re-deriving.
+
+**3. The commit → PR map.** Parsing `(#N)` out of commit subjects does not work
 here, because this project writes *issue* references into subjects and a regex
 cannot distinguish them. That error mis-attributed **35% of commits** (322 of
-907). Stage 2 derives the map from authoritative per-PR commit ranges instead.
+907). Stage 2 derives the map from the resolved ranges instead.
 
-Correcting both roughly doubled the edge count (1,639 → 3,114), moved the median
-rework lag from 1 day to 2, and turned the size relationship from
-1.6/2.7/6.3/**5.7** into 1.4/3.2/8.5/**10.5** — the dip in the top bucket had
-been an artifact of the truncation, not a floor effect.
+### What each version produced
+
+| Measure | v1 (narrow + regex) | v2 (wide) | v3 (current) |
+|---|---:|---:|---:|
+| Edges | 1,639 | 3,114 | 1,841 |
+| Median lag | 1d | 2d | 1d |
+| Within 3 days | 61% | 57% | 65% |
+| Rate 400–1k | 6.3 | 8.5 | 6.3 |
+| Rate >1k | 5.7 | 10.5 | 6.0 |
+| Large-PR share | 89.7% | 93.2% | 90.1% |
+
+v2 is the one that was published, and it is the outlier. v3 lands almost
+exactly on v1, whose two errors had partially cancelled. The finding the norm
+rests on — a ~4× climb from <100 to 400–1k, and ~90% of rework from PRs ≥400
+adds — is present in all three; only its magnitude moved.
 
 ## Reading the output
 

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -21,7 +21,9 @@ bash scripts/pr-churn-audit/probe-v2-defect.sh "$WORK"   # re-derives the "50 of
 ```
 
 Needs `gh` (authenticated), `jq`, **GNU coreutils and GNU grep**, and a full
-clone — stage 3 blames history, so a shallow checkout silently produces nothing.
+clone — stage 3 blames history, so on a shallow checkout the bases don't
+resolve; every affected PR lands in `blame_failures.txt` and the INCOMPLETE
+warning fires rather than quoting a truncated dataset.
 
 The GNU requirement is not cosmetic and stage 3 now refuses to start without
 it: BSD `date` makes `epoch()` return 0, so every age becomes 0 and the age
@@ -77,7 +79,14 @@ The qualifier is mistake 3 applied to this walk: the trailing form is the same
 regex that cannot distinguish PR refs from issue refs, so stopping at an
 intermediate commit whose subject merely ends in an issue ref would silently
 re-introduce the too-narrow defect. Candidates that fail the lookup are walked
-through, not stopped at, and logged to `issue_ref_skips.txt`. The walk is
+through, not stopped at, and logged to `issue_ref_skips.txt`.
+
+Subjects alone are still not enough: a squash-merged PR sitting on an
+*unlabelled* rebase-merged PR would absorb that PR's commits without ever
+meeting a labelled boundary, and no endpoint check can see what was absorbed
+on the way. So PRs are processed in **merge order** and the walk also stops at
+any commit **already claimed** by a previously-processed PR's range — the
+subject-blind backstop for exactly that case. With both stops, the walk is
 strategy-agnostic: for a squash it stops at depth 1, for a rebase it stops at
 the previous PR's boundary, and true merge commits take `sha^1..sha^2`. The
 resolved base is written once to `pr_base.tsv` and stage 3 consumes it rather
@@ -183,10 +192,11 @@ diffs whole blocks as deletions while the blame attributes those lines to
 their *original* authors — a large fake rework spike against old PRs for a
 semantic no-op.
 
-**The age distribution is edge-weighted, not line-weighted.** Each
-(hunk × origin-commit) row counts once in the lag percentiles regardless of
-its `lines` column, while the edge total and the bucket rates are line-based.
-A 40-line deletion and a 1-line edit pull equally on "median lag / within 3
+**The age distribution and edge count are edge-weighted, not line-weighted.**
+Each (hunk × origin-commit) row counts once in the lag percentiles and once in
+the headline edge count, regardless of its `lines` column; only the bucket
+rates and the large-PR share are line-weighted (they sum that column). A
+40-line deletion and a 1-line edit pull equally on "median lag / within 3
 days"; nothing here says lag would look the same weighted per-line.
 
 **The boundary walk is a heuristic, not a proof.** Stage 2 stops at the first

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -118,3 +118,19 @@ sampled classification put that at roughly **57% planned iteration / 23%
 genuine correction / 20% collision** — so it is *not* a defect rate, and no
 script here separates those. The ratios the norm rests on survive the
 distinction; absolute counts do not.
+
+**Deletions count as rework; additions do not.** Stage 3 blames the *old* side
+of each hunk, so removing 40 of an earlier PR's lines scores 40 edges against
+it, while adding 40 new lines scores none. That asymmetry is deliberate — the
+question is "how much of what this PR wrote did not survive" — but it means a
+PR that deletes a stale subsystem inflates the rework attributed to whoever
+wrote it. Keep it in mind when a single old PR shows a surprisingly large
+reworked total.
+
+**The boundary walk is a heuristic, not a proof.** Stage 2 stops at the first
+ancestor whose subject announces another PR. If a previous PR ended in an
+*unlabelled* commit the walk can overrun into it, which is the v2 defect
+returning. Those cases cannot be distinguished from a legitimate rebase-merge,
+so stage 2 counts them and writes them to `range_unverified.txt` rather than
+assuming the benign reading. A non-empty file is not necessarily wrong — but it
+is the first place to look if a figure surprises you.

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -30,10 +30,22 @@ front.
 
 **Two windows, deliberately.** `SINCE..UNTIL` bounds the corpus (edges, ages);
 `BUCKET_SINCE..UNTIL` bounds the per-PR review pull the size buckets divide by.
-They differ because the two datasets were collected at different points in the
-session — 218 merged PRs in the corpus, 217 in the bucket pull, 194 after the
->20-adds floor. Do not quote a bucket `n` against a corpus `n` without
-reconciling them; that is the mixed-denominator trap the audit doc warns about.
+They differ because the bucket data starts later.
+
+**Do not hand-derive the denominators — stage 4 prints them**, together and
+with the trap named:
+
+```
+review_rounds rows (unfiltered) : 220
+bucket population (>20 adds)    : 197
+of those, >=400 adds            : 71  (36% of the bucket population)
+NB 71/220 = 32% is the UNFILTERED share
+```
+
+Quoting 32% against 197 mixes the two. Every denominator dispute in this
+pipeline's review history — and there were several — came from one number being
+copied into prose and not updated alongside its siblings. Transcribe the block
+above; do not recompute it.
 
 ## Three mistakes this pipeline exists to not repeat
 
@@ -149,9 +161,15 @@ wrote it. Keep it in mind when a single old PR shows a surprisingly large
 reworked total.
 
 **The boundary walk is a heuristic, not a proof.** Stage 2 stops at the first
-ancestor whose subject announces another PR. If a previous PR ended in an
-*unlabelled* commit the walk can overrun into it, which is the v2 defect
-returning. Those cases cannot be distinguished from a legitimate rebase-merge,
-so stage 2 counts them and writes them to `range_unverified.txt` rather than
-assuming the benign reading. A non-empty file is not necessarily wrong — but it
-is the first place to look if a figure surprises you.
+ancestor whose subject announces another PR, then checks whether the resolved
+base *itself* announces one. If it does, the range ended cleanly on the previous
+PR's boundary. If it doesn't, the case is genuinely ambiguous — either a rebase
+onto an unlabelled commit (harmless) or a squash whose range is now over-wide
+(the v2 defect) — and it is written to `range_unverified.txt` with its base
+subject.
+
+That final check matters: without it the marker fired for *every* clean
+multi-commit rebase, i.e. the dominant case, which made it useless for spotting
+the harmful one. A warning that fires on everything is a warning about nothing.
+On the current corpus 11 PRs are ambiguous, all numbered 144–306 — none inside
+the audit window, so the published figures are unaffected.

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -68,9 +68,9 @@ main depends on the merge strategy, and **this repo uses all three**. A
 squash-merged PR contributes exactly one commit while `gh` still reports N, so
 `sha~N` walks N−1 commits back into *earlier* PRs; stage 3 then blames a range
 spanning other people's work. Measured, and re-derivable with
-`probe-v2-defect.sh`: **50 of 221 in-window PRs (22%)**, size-correlated (17%
-of PRs under 400 adds, 33% of those over) — i.e. skewed in the same direction
-as the size finding it feeds.
+`probe-v2-defect.sh`: **50 of 221 in-window PRs (22.6%)**, size-correlated
+(17.4% of PRs under 400 adds, 33.3% of those over) — i.e. skewed in the same
+direction as the size finding it feeds.
 
 Stage 2 therefore resolves each range by walking back from the merge commit and
 **stopping at the first commit that announces a different PR** — `Merge pull
@@ -103,7 +103,7 @@ cannot distinguish them. That error mis-attributed **35% of commits** (322 of
 |---|---:|---:|---:|---:|
 | Edges | 1,639 | 3,114 | 1,999 | 2,022 |
 | Median lag | 1d | 2d | 2d | 1d |
-| Within 3 days | 61% | 57% | 60% | 61% |
+| Under 4 days (floored ages ≤3) | 61% | 57% | 60% | 61% |
 | Rate 400–1k | 6.3 | 8.5 | 6.1 | 4.7 |
 | Rate >1k | 5.7 | 10.5 | 6.0 | 5.7 |
 | Large-PR share | 89.7% | 93.2% | 90.1% | 89.3% |
@@ -196,19 +196,32 @@ semantic no-op.
 Each (hunk × origin-commit) row counts once in the lag percentiles and once in
 the headline edge count, regardless of its `lines` column; only the bucket
 rates and the large-PR share are line-weighted (they sum that column). A
-40-line deletion and a 1-line edit pull equally on "median lag / within 3
+40-line deletion and a 1-line edit pull equally on "median lag / under 4
 days"; nothing here says lag would look the same weighted per-line.
 
-**The boundary walk is a heuristic, not a proof.** Stage 2 stops at the first
-ancestor whose subject announces another PR, then checks whether the resolved
-base *itself* announces one. If it does, the range ended cleanly on the previous
-PR's boundary. If it doesn't, the case is genuinely ambiguous — either a rebase
-onto an unlabelled commit (harmless) or a squash whose range is now over-wide
-(the v2 defect) — and it is written to `range_unverified.txt` with its base
-subject.
+**The boundary walk is a heuristic, not a proof.** Three flag classes land in
+`range_unverified.txt`, all meaning "spot-check before quoting affected PRs":
 
-That final check matters: without it the marker fired for *every* clean
-multi-commit rebase, i.e. the dominant case, which made it useless for spotting
-the harmful one. A warning that fires on everything is a warning about nothing.
-On the current corpus 11 PRs are ambiguous, all numbered 144–306 — none inside
-the audit window, so the published figures are unaffected.
+- **ambiguous-base** — the walk ran to its cap and the resolved base announces
+  no other PR: either a rebase onto an unlabelled commit (harmless) or a
+  squash whose range is over-wide (the v2 defect). 11 on the current corpus.
+- **boundary-stop-after-absorbing** — the walk absorbed anonymous commits and
+  *then* hit a boundary: either a rebase whose `gh` count overestimated
+  (harmless) or a squash sitting on a direct push to main, whose range is
+  over-wide and whose absorbed commits' rework is misattributed. 4 on the
+  current corpus. The round-8 review caught that the previous revision ran its
+  ambiguity check only on walks that reached the cap, so this class passed as
+  clean with no marker at all.
+- **unreadable-merge-commit** — the merge commit's parents could not be read
+  (partial clone); the PR is skipped and recorded rather than guessed at.
+
+All 15 flagged PRs are numbered 144–306 — none inside the audit window, so
+the published figures are unaffected. The flags are deliberately narrow: an
+earlier marker fired for every clean multi-commit rebase, the dominant case,
+and a warning that fires on everything is a warning about nothing.
+
+One residual no flag can catch: a commit subject ending in `(#N)` where N is a
+*merged PR's number* being used as an issue reference. At depth 1 that reads
+as a clean squash boundary and silently truncates the range; deeper in, it at
+least lands in boundary-stop-after-absorbing. Subjects cannot disambiguate
+that collision — the ISPR lookup narrows the issue-ref hole to exactly it.

--- a/scripts/pr-churn-audit/README.md
+++ b/scripts/pr-churn-audit/README.md
@@ -72,10 +72,10 @@ cannot distinguish them. That error mis-attributed **35% of commits** (322 of
 
 | Measure | v1 (narrow + regex) | v2 (wide) | v3 (current) |
 |---|---:|---:|---:|
-| Edges | 1,639 | 3,114 | 1,841 |
-| Median lag | 1d | 2d | 1d |
-| Within 3 days | 61% | 57% | 65% |
-| Rate 400–1k | 6.3 | 8.5 | 6.3 |
+| Edges | 1,639 | 3,114 | 1,999 |
+| Median lag | 1d | 2d | 2d |
+| Within 3 days | 61% | 57% | 60% |
+| Rate 400–1k | 6.3 | 8.5 | 6.1 |
 | Rate >1k | 5.7 | 10.5 | 6.0 |
 | Large-PR share | 89.7% | 93.2% | 90.1% |
 
@@ -87,9 +87,30 @@ adds — is present in all three; only its magnitude moved.
 ## Reading the output
 
 `04-analyze.sh` prints **both** averaging methods per size bucket. They agree
-across the first three, which is why the norm's threshold is 400. They disagree
-in *direction* on the top bucket — mean rises to 10.5, pooled falls to 6.9 —
-so `>1k` is unresolved on this data and neither figure should be quoted alone.
+across the first three, which is why the norm's threshold is 400 — and they
+agree on the top bucket too: both **fall** past 1k (mean 6.1 → 6.0, pooled
+6.1 → 3.8). So >1k is not worse than 400–1k, plausibly a floor effect. (An
+earlier version had the mean rising to 10.5 against a pooled 6.9 and called the
+bucket unresolved; that was the over-wide-range artifact, not a real
+divergence.)
+
+### What the rate actually measures
+
+`reworked_totals` is keyed by the **reworked** PR — column 2 of
+`rework_edges.tsv` — and divided by *that* PR's own additions. So the figure is
+**"how much of what this PR wrote did not survive"**, not "how much rewriting
+this PR did". That is the reading the norm needs: it claims a large PR's own
+code gets rewritten more per line.
+
+Two consequences that are correct but look like bugs at a glance:
+
+- An in-window PR that rewrites lots of *old* code scores 0 in its own bucket.
+  It is a reworker, not reworked, and the metric is not about reworkers.
+- Edges whose reworked PR predates `BUCKET_SINCE` appear in the edge total but
+  in no bucket, because that PR is not in the bucket population.
+
+If you want the other reading — rework *caused* per PR — key on column 1
+instead. It is a different question and the norm does not rest on it.
 
 Buckets cover PRs with more than 20 added lines merged from the start of
 `review_rounds.tsv`'s coverage; the share-of-rework figure uses the unfiltered

--- a/scripts/pr-churn-audit/probe-exposure.sh
+++ b/scripts/pr-churn-audit/probe-exposure.sh
@@ -9,11 +9,19 @@
 set -euo pipefail
 WORK="${1:-${WORK:-./audit-work}}"
 . "$(dirname "$0")/window.env"
+# Same GNU guard as stage 3: this probe can run right after stage 1, which
+# performs no such check, and a BSD `date -d` would either abort or silently
+# compute a wrong END — feeding a wrong exposure table into the doc.
+date -u -d "2026-01-01" +%s >/dev/null 2>&1 || {
+  echo "ERROR: GNU date required (BSD date breaks -d parsing)." >&2; exit 2; }
 END=$(date -u -d "$UNTIL_TS" +%s)
+dropped=0
 jq -r '.[]|"\(.number)\t\(.mergedAt)"' "$WORK/prs_merged.json" | sort > "$WORK/.pr_dates"
 awk -F'\t' 'NR>1 && $6>20 {print $1"\t"$6}' "$WORK/review_rounds.tsv" | sort > "$WORK/.pr_adds"
 join -t $'\t' "$WORK/.pr_adds" "$WORK/.pr_dates" | while IFS=$'\t' read -r pr adds md; do
-  e=$(date -u -d "$md" +%s) || continue
+  if ! e=$(date -u -d "$md" +%s 2>/dev/null); then
+    echo "DROPPED: PR $pr has unparseable mergedAt '$md'" >&2; continue
+  fi
   printf '%s\t%s\n' "$adds" "$(( (END - e) / 86400 ))"
 done | awk -F'\t' '
   {
@@ -31,7 +39,12 @@ done | awk -F'\t' '
       cnt=n[b]
       for(i=1;i<=cnt;i++) for(j=i+1;j<=cnt;j++)
         if(d[b,j]<d[b,i]){t=d[b,i];d[b,i]=d[b,j];d[b,j]=t}
-      rows[++nb]=sprintf("  %-11s %4d %18.1f %8d", b, cnt, s[b]/cnt, d[b,int((cnt+1)/2)])
+      # Textbook median: mean of the two middles for even n. The lower-middle
+      # shortcut was off by up to a day on three of these four buckets, and
+      # the doc quotes these values.
+      if (cnt % 2) med = d[b,(cnt+1)/2]
+      else         med = (d[b,cnt/2] + d[b,cnt/2+1]) / 2
+      rows[++nb]=sprintf("  %-11s %4d %18.1f %8.1f", b, cnt, s[b]/cnt, med)
     }
     for(i=1;i<nb;i++) for(j=i+1;j<=nb;j++) if(rows[j]<rows[i]){t=rows[i];rows[i]=rows[j];rows[j]=t}
     printf "  %-11s %4s %18s %8s\n","bucket","n","mean-exposure-days","median"

--- a/scripts/pr-churn-audit/probe-exposure.sh
+++ b/scripts/pr-churn-audit/probe-exposure.sh
@@ -15,7 +15,6 @@ WORK="${1:-${WORK:-./audit-work}}"
 date -u -d "2026-01-01" +%s >/dev/null 2>&1 || {
   echo "ERROR: GNU date required (BSD date breaks -d parsing)." >&2; exit 2; }
 END=$(date -u -d "$UNTIL_TS" +%s)
-dropped=0
 jq -r '.[]|"\(.number)\t\(.mergedAt)"' "$WORK/prs_merged.json" | sort > "$WORK/.pr_dates"
 awk -F'\t' 'NR>1 && $6>20 {print $1"\t"$6}' "$WORK/review_rounds.tsv" | sort > "$WORK/.pr_adds"
 join -t $'\t' "$WORK/.pr_adds" "$WORK/.pr_dates" | while IFS=$'\t' read -r pr adds md; do

--- a/scripts/pr-churn-audit/probe-exposure.sh
+++ b/scripts/pr-churn-audit/probe-exposure.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Not a pipeline stage — answers one confound question (round-9 review): does
+# merge timing correlate with PR size? Edges only accrue from later in-window
+# reworkers, so a bucket whose PRs cluster late is deflated. If exposure time
+# (days between merge and window end) is flat across buckets, that censoring
+# cannot manufacture the size climb. The audit doc quotes this probe's output.
+#
+# Run AFTER stage 1:  probe-exposure.sh "$WORK"
+set -euo pipefail
+WORK="${1:-${WORK:-./audit-work}}"
+. "$(dirname "$0")/window.env"
+END=$(date -u -d "$UNTIL_TS" +%s)
+jq -r '.[]|"\(.number)\t\(.mergedAt)"' "$WORK/prs_merged.json" | sort > "$WORK/.pr_dates"
+awk -F'\t' 'NR>1 && $6>20 {print $1"\t"$6}' "$WORK/review_rounds.tsv" | sort > "$WORK/.pr_adds"
+join -t $'\t' "$WORK/.pr_adds" "$WORK/.pr_dates" | while IFS=$'\t' read -r pr adds md; do
+  e=$(date -u -d "$md" +%s) || continue
+  printf '%s\t%s\n' "$adds" "$(( (END - e) / 86400 ))"
+done | awk -F'\t' '
+  {
+    if($1<100)      b="1. <100"
+    else if($1<400) b="2. 100-400"
+    else if($1<1000)b="3. 400-1k"
+    else            b="4. >1k"
+    n[b]++; s[b]+=$2; d[b,n[b]]=$2
+  }
+  END{
+    # sort rows inside awk — see 04-analyze.sh for why the header must not be
+    # piped through sort with the data
+    nb=0
+    for(b in n){
+      cnt=n[b]
+      for(i=1;i<=cnt;i++) for(j=i+1;j<=cnt;j++)
+        if(d[b,j]<d[b,i]){t=d[b,i];d[b,i]=d[b,j];d[b,j]=t}
+      rows[++nb]=sprintf("  %-11s %4d %18.1f %8d", b, cnt, s[b]/cnt, d[b,int((cnt+1)/2)])
+    }
+    for(i=1;i<nb;i++) for(j=i+1;j<=nb;j++) if(rows[j]<rows[i]){t=rows[i];rows[i]=rows[j];rows[j]=t}
+    printf "  %-11s %4s %18s %8s\n","bucket","n","mean-exposure-days","median"
+    for(i=1;i<=nb;i++) print rows[i]
+  }'
+rm -f "$WORK/.pr_dates" "$WORK/.pr_adds"

--- a/scripts/pr-churn-audit/probe-v2-defect.sh
+++ b/scripts/pr-churn-audit/probe-v2-defect.sh
@@ -14,11 +14,13 @@ cd "$(git rev-parse --show-toplevel)"
 declare -A NCOM BASE
 while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
 while IFS=$'\t' read -r pr b; do BASE[$pr]=$b; done < "$WORK/pr_base.tsv"
-tot=0; wrong=0; small=0; wrong_small=0; big=0; wrong_big=0
+tot=0; wrong=0; small=0; wrong_small=0; big=0; wrong_big=0; skipped=0
 while IFS=$'\t' read -r pr sha adds; do
-  resolved="${BASE[$pr]:-}"; [ -z "$resolved" ] && continue
+  resolved="${BASE[$pr]:-}"
+  [ -z "$resolved" ] && { skipped=$((skipped+1)); continue; }
+  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w) || np=0
+  [ "$np" -eq 0 ] && { skipped=$((skipped+1)); continue; }
   tot=$((tot+1))
-  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w)
   if [ "$np" -ge 3 ]; then v2base="${sha}^1"
   else cap="${NCOM[$pr]:-1}"; [ "$cap" -lt 1 ] && cap=1; v2base="${sha}~${cap}"; fi
   v2=$(git rev-parse -q --verify "$v2base" 2>/dev/null || echo MISSING)
@@ -32,3 +34,10 @@ done < <(jq -r --arg s "$SINCE" --arg u "$UNTIL_TS" \
 echo "v2 range wrong: $wrong / $tot in-window PRs ($(( 100*wrong/tot ))%)"
 echo "  <400 adds : $wrong_small/$small ($(( 100*wrong_small/small ))%)"
 echo "  >=400 adds: $wrong_big/$big ($(( 100*wrong_big/big ))%)"
+echo "  (a disagreement rate between v2's heuristic and stage 2's resolution —"
+echo "   the walk is the better-validated heuristic, not ground truth)"
+if [ "$skipped" -gt 0 ]; then
+  echo "WARNING: $skipped in-window PR(s) skipped (no stage-2 base, or object"
+  echo "         unreadable) — they are missing from BOTH numerator and"
+  echo "         denominator above. Fix stage 2 coverage before quoting this."
+fi

--- a/scripts/pr-churn-audit/probe-v2-defect.sh
+++ b/scripts/pr-churn-audit/probe-v2-defect.sh
@@ -8,8 +8,7 @@
 # Run AFTER stages 1-2:  probe-v2-defect.sh "$WORK"
 set -euo pipefail
 WORK="${1:-${WORK:-./audit-work}}"
-SINCE="${SINCE:-2026-07-12}"
-UNTIL="${UNTIL:-2026-08-09}"; UNTIL_TS="${UNTIL}T23:59:59Z"
+. "$(dirname "$0")/window.env"
 cd "$(git rev-parse --show-toplevel)"
 declare -A NCOM BASE
 while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
@@ -31,9 +30,14 @@ while IFS=$'\t' read -r pr sha adds; do
 done < <(jq -r --arg s "$SINCE" --arg u "$UNTIL_TS" \
   '[.[]|select(.mergedAt>$s and .mergedAt<$u and .mergeCommit!=null)]
    |.[]|"\(.number)\t\(.mergeCommit.oid)\t\(.additions)"' "$WORK/prs_merged.json")
-echo "v2 range wrong: $wrong / $tot in-window PRs ($(( 100*wrong/tot ))%)"
-echo "  <400 adds : $wrong_small/$small ($(( 100*wrong_small/small ))%)"
-echo "  >=400 adds: $wrong_big/$big ($(( 100*wrong_big/big ))%)"
+# awk, not $((...)): integer division floors 22.6% to 22%, and an empty size
+# class would make it a fatal divide-by-zero under set -e.
+awk -v w="$wrong" -v t="$tot" -v ws="$wrong_small" -v s="$small" \
+    -v wb="$wrong_big" -v b="$big" 'BEGIN{
+  printf "v2 range wrong: %d / %d in-window PRs (%.1f%%)\n", w, t, (t?100*w/t:0)
+  printf "  <400 adds : %d/%d (%.1f%%)\n", ws, s, (s?100*ws/s:0)
+  printf "  >=400 adds: %d/%d (%.1f%%)\n", wb, b, (b?100*wb/b:0)
+}'
 echo "  (a disagreement rate between v2's heuristic and stage 2's resolution —"
 echo "   the walk is the better-validated heuristic, not ground truth)"
 if [ "$skipped" -gt 0 ]; then

--- a/scripts/pr-churn-audit/probe-v2-defect.sh
+++ b/scripts/pr-churn-audit/probe-v2-defect.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Not a pipeline stage — a probe that re-derives one quoted figure: how many
+# in-window PRs get a WRONG diff range under the v2 strategy (bare sha~N for
+# squash/rebase merges, sha^1 for true merge commits), compared against stage
+# 2's resolved bases. The "50 of 221 in-window PRs (22%)" sentence in the
+# README, the audit doc and 02-commit-map.sh's header comes from here.
+#
+# Run AFTER stages 1-2:  probe-v2-defect.sh "$WORK"
+set -euo pipefail
+WORK="${1:-${WORK:-./audit-work}}"
+SINCE="${SINCE:-2026-07-12}"
+UNTIL="${UNTIL:-2026-08-09}"; UNTIL_TS="${UNTIL}T23:59:59Z"
+cd "$(git rev-parse --show-toplevel)"
+declare -A NCOM BASE
+while IFS=$'\t' read -r pr c; do NCOM[$pr]=$c; done < "$WORK/pr_commits.tsv"
+while IFS=$'\t' read -r pr b; do BASE[$pr]=$b; done < "$WORK/pr_base.tsv"
+tot=0; wrong=0; small=0; wrong_small=0; big=0; wrong_big=0
+while IFS=$'\t' read -r pr sha adds; do
+  resolved="${BASE[$pr]:-}"; [ -z "$resolved" ] && continue
+  tot=$((tot+1))
+  np=$(git rev-list --parents -n1 "$sha" 2>/dev/null | wc -w)
+  if [ "$np" -ge 3 ]; then v2base="${sha}^1"
+  else cap="${NCOM[$pr]:-1}"; [ "$cap" -lt 1 ] && cap=1; v2base="${sha}~${cap}"; fi
+  v2=$(git rev-parse -q --verify "$v2base" 2>/dev/null || echo MISSING)
+  res=$(git rev-parse -q --verify "$resolved" 2>/dev/null || echo NONE)
+  w=0; [ "$v2" != "$res" ] && { wrong=$((wrong+1)); w=1; }
+  if [ "$adds" -ge 400 ]; then big=$((big+1)); wrong_big=$((wrong_big+w))
+  else small=$((small+1)); wrong_small=$((wrong_small+w)); fi
+done < <(jq -r --arg s "$SINCE" --arg u "$UNTIL_TS" \
+  '[.[]|select(.mergedAt>$s and .mergedAt<$u and .mergeCommit!=null)]
+   |.[]|"\(.number)\t\(.mergeCommit.oid)\t\(.additions)"' "$WORK/prs_merged.json")
+echo "v2 range wrong: $wrong / $tot in-window PRs ($(( 100*wrong/tot ))%)"
+echo "  <400 adds : $wrong_small/$small ($(( 100*wrong_small/small ))%)"
+echo "  >=400 adds: $wrong_big/$big ($(( 100*wrong_big/big ))%)"

--- a/scripts/pr-churn-audit/window.env
+++ b/scripts/pr-churn-audit/window.env
@@ -1,0 +1,18 @@
+# Single source of truth for the audit window. Sourced by stages 1 and 3 and
+# the probe; every value stays env-overridable. Duplicating these per-script
+# invited the exact mixed-window trap the pipeline documents: a re-run that
+# updates one script's UNTIL and not another's silently puts the corpus and
+# the bucket denominators on different windows.
+#
+# TWO start dates, deliberately, because the published figures use two.
+#   SINCE..UNTIL        the corpus: blame edges, age distribution, edge count.
+#   BUCKET_SINCE..UNTIL the per-PR review/latency pull the size buckets divide by.
+# They differ because the bucket data was collected later in the session.
+#
+# UNTIL_TS is end-of-day, NOT the bare date: mergedAt always carries a time,
+# and "2026-08-09T09:49:40Z" < "2026-08-09" is FALSE lexicographically — a
+# bare bound silently drops every PR merged on the closing day.
+SINCE="${SINCE:-2026-07-12}"
+BUCKET_SINCE="${BUCKET_SINCE:-2026-07-20}"
+UNTIL="${UNTIL:-2026-08-09}"
+UNTIL_TS="${UNTIL}T23:59:59Z"


### PR DESCRIPTION
## Intent

`CLAUDE.md`'s change-size norm cites `docs/pr-churn-audit-2026-08.md` as its evidence, and that doc declares itself load-bearing. But the pipeline that produced its numbers lived only in a session scratchpad. The second-opinion review on #610 flagged precisely this and I acknowledged it without fixing it:

> Every number the norm leans on is unfalsifiable from the checked-in tree.

Closing that. A standing rule whose numbers can't be re-derived is folklore.

## Scope

- **In:** four staged scripts + a defect-figure probe + README under `scripts/pr-churn-audit/`; the warm-review experiment writeup; audit-doc and `CLAUDE.md` updates that are the pipeline's regenerated output.
- **Out:** the raw datasets (regenerable), and the ~30 exploratory one-off scripts from the session — only the pipeline that produces the norm's numbers is here.

## Size: 903 added lines, and why it is not split

The original PR was 363; six rounds of adversarial review grew it — each round's fixes landed as commits on the branch under review. Why not split now: the unit is falsifiability. The scripts and the docs that quote their output have to land together, or the tree is in exactly the state this PR exists to end — published numbers that the checked-in pipeline does not produce. The honestly-separable piece is the warm-review writeup (98 lines); it predates round 1 and the branch has been under continuous review since (review freeze: no branch surgery mid-review).

## Verified, not just committed

The full pipeline was re-run **end-to-end from scratch this session**, stage 1's API pull included. Stage 4's output:

```
n=2022  p50=1  p75=6  p90=81        within 3 days: 61%
bucket        n   mean-of-rates   pooled
1. <100      42            1.6      2.1
2. 100-400   84            2.5      2.4
3. 400-1k    42            4.7      4.6
4. >1k       29            5.7      3.6
large (>=400 adds): 89.3% of the bucket population's rework
populations: 220 unfiltered / 197 bucket / 71 large — asserted in-run
```

Every figure in the audit doc, the README and `CLAUDE.md` was transcribed from this run. The bucket table asserts its rows sum to the population it cites; the populations are computed once and printed together.

## Round 6 changed the numbers, and the docs say so

Both round-6 majors were real, and one of them was poetic:

- **The boundary walk had re-introduced mistake 3 inside the fix for mistake 2.** A trailing `(#N)` was trusted as a PR boundary, but this project writes *issue* refs in that form — and the walk was truncating the range of **#317, the very PR mistake 1 was measured on** (its two `(#315)` commits read as another PR's boundary). Trailing refs now validate against the merged-PR list; rejections are logged. Isolated effect: negligible (edges 1,999 → 2,005).
- **`git blame -w` without `git diff -w` counted whitespace-only churn as rework.** Pairing them is the real mover: the 400–1k bucket drops **6.1 → 4.7** (roughly a quarter of its counted rework was whitespace-only lines), and the top bucket's "both statistics fall" becomes "they **disagree in direction**" (mean 5.7, pooled 3.6). The norm now quotes the two averagings separately (≈3× mean / ≈2× pooled — not "~4×"), and >1k is documented as unmeasured: its direction has flipped under every measurement correction (v1 fell, v2 rose, v3 fell, v4 splits).
- The headline corpus prose was stale (218; the pipeline's closing-day fix makes it **221**), and "48 of 218" re-measures as **50 of 221 (22%, split 17%/33%)** — now re-derivable via the checked-in `probe-v2-defect.sh` rather than quoted from a dead scratchpad.
- Remaining minors: stage 1 hard-errors if the `--limit` cap is hit; stage 3 checks `git diff`'s exit status (a failed diff was a silent zero-edge PR); the share prints under both denominators with its window-scope disclosed; lag-figure weighting disclosed.

A v4 column was added to both version tables — the review history is part of the dataset's documentation.

## Convergence: round-9 residuals, accepted not fixed

Rounds 7–8 each found one real thing (a subject-blind walk hole, fixed and measured harmless; a suppressed ambiguity flag that fires on 4 pre-window PRs, now flagged; a percentile off-by-one that moved p90 from 80 to 81). Round 9 returned **zero criticals, zero majors, twelve 1/3-pass minors**. The one that touched the norm's claim — the exposure-time confound on the size climb — was **measured dead** rather than caveated: `probe-exposure.sh` shows mean exposure flat across buckets (11.2 / 12.2 / 12.1 / 11.4 days), which cannot manufacture a ~3× rate difference; the doc quotes it.

The other eleven are accepted residuals, listed here deliberately: guards for corpora this repo does not have — partial clones (full clone is a documented requirement), filenames with spaces (none in-tree), null `additions` from the API (never observed), empty size buckets, a shared issue/PR number colliding at walk depth 1 (README documents exactly this residual) — plus boundary-label pedantry (">1k" includes exactly 1000). None can change a published number, and every new guard is itself new review surface. Stopping here is deliberate, not fatigue: the convergence criterion was stated on the PR before round 9 posted.

Round 12 (on rounds 10–11's six-line diff) returned one moderate and ten minors, all 1/3-pass, zero touching a quoted number — including third and second re-litigations of already-declined items, and two findings requesting disclosures the docs already carry verbatim. No changes made; convergence held. Rounds 10–11 followed the same bar. Taken: stage 4 now hard-refuses over non-empty failure files (the completeness contract's actual enforcement point), textbook medians in the exposure probe (values unchanged — now correct by convention rather than coincidence), deterministic sort tie-breaks, one empirically-tested docs de-overclaim (deleting a whitespace-only line *does* survive `diff -w`; modifications don't), an overstated ">1k sits lowest" sentence corrected to its median-only reality, and a rename-detection pin. Additional accepted residuals: cross-window manifest stamping for partial re-runs, negative-age drop recording, the root-commit `^1` fallback, advisory-vs-fatal scope of `range_unverified.txt`, and completeness checks scoped wider than the quoted window — all misuse guards, none able to change a published number.

## Also included

`docs/warm-review-experiment-2026-08.md` — the warm-vs-cold re-review study (7 transitions, 4 PRs, warm forked from prior `pi` sessions, scored against what the reviewer actually posted).

Conclusion: warm **cannot replace** cold (53% overall recall) but adds 37 unique findings and 8 round-early catches at equal measured cost — so split K=3 rather than choosing. And don't warm-fork arithmetic-dense docs: all four instances of confident-wrong arithmetic occurred there. It also lists the five hypotheses the study killed, three of them mine.

## Verification

- [x] All five scripts parse (`bash -n`)
- [x] Stages 1–4 re-run end-to-end from scratch; stage 4 reproduces every published figure exactly
- [x] Attribution run (stage 3 with the old diff flags against the same stage-2 output) isolates each fix's effect on the numbers
- [x] Boundary-walk fix confirmed against the live corpus (2 issue-ref skips, both #317's commits; ambiguous-range list unchanged at 11 PRs, all pre-window)
- [ ] `cargo test` — n/a, no Rust touched
- [ ] WASM — n/a

## Models / contracts touched

None. Documentation and tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n
