### PR TITLE
feat(celldb): RFC-067 P1 — the store: schema, loader, seed tool, top-5 engine seeds

### DIFF
--- a/crates/core/data/celldb.json
+++ b/crates/core/data/celldb.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": []
+}

--- a/crates/core/data/celldb.json
+++ b/crates/core/data/celldb.json
@@ -1,4 +1,14800 @@
 {
   "version": 1,
-  "entries": []
+  "entries": [
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "copper-plate",
+        "machine": "electric-furnace",
+        "count": 48
+      },
+      "entities": [
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 21,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 22,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 23,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 24,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 25,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 26,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 27,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 28,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 29,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 30,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 31,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 32,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 33,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 34,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 35,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 36,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 37,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 38,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 39,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 40,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 41,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 42,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 43,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 44,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 45,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 46,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 47,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 48,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 49,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 50,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 51,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 52,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 53,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 54,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 55,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 56,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 57,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 58,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 59,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 60,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 61,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 62,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 63,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 64,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 65,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 66,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 67,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 68,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 69,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 70,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 71,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 72,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 73,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 74,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 75,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 76,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 77,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 78,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 79,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 80,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 81,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 82,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 83,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 84,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 85,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 86,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 87,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 88,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 89,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 90,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 91,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 92,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 93,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 94,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 95,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 96,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 97,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 98,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 99,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 100,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 101,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 102,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 103,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 104,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 105,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 106,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 107,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 108,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 109,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 110,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 111,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 112,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 113,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 114,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 115,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 116,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 117,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 118,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 119,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 120,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 121,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 122,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 123,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 124,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 125,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 126,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 127,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 128,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 129,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 130,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 131,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 132,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 133,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 134,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 135,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 136,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 137,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 138,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 139,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 140,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 141,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 142,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:belt-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 22,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 25,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 31,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 34,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 37,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 40,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 43,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 46,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 49,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 52,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 55,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 58,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 61,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 64,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 67,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 70,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 73,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 76,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 79,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 82,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 85,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 88,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 91,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 94,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 97,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 100,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 103,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 106,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 109,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 112,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 115,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 118,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 121,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 124,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 127,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 130,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 133,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 136,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 139,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 142,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore",
+          "segment_id": "row:copper-plate:inserter-in:copper-ore",
+          "rate": 30.0
+        },
+        {
+          "name": "electric-furnace",
+          "x": 0,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 3,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 6,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 9,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 12,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 15,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 18,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 21,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 24,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 27,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 30,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 33,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 36,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 39,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 42,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 45,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 48,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 51,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 54,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 57,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 60,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 63,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 66,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 69,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 72,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 75,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 78,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 81,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 84,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 87,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 90,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 93,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 96,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 99,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 102,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 105,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 108,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 111,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 114,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 117,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 120,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 123,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 126,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 129,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 132,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 135,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 138,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 141,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "segment_id": "row:copper-plate:machine"
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 22,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 25,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 31,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 34,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 37,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 40,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 43,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 46,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 49,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 52,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 55,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 58,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 61,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 64,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 67,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 69,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 5,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 72,
+          "y": 5,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 73,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 76,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 79,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 82,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 85,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 88,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 91,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 94,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 97,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 100,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 103,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 106,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 109,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 112,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 115,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 118,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 121,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 124,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 127,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 130,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 133,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 136,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 139,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "inserter",
+          "x": 142,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 0,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 29,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 30,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 31,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 32,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 33,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 34,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 35,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 36,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 37,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 38,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 39,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 40,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 41,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 42,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 43,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 44,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 45,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 49,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 50,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 51,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 52,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 53,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 54,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 55,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 56,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 57,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 58,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 59,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 60,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 61,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 62,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 63,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 64,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 65,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 66,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 67,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 68,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 69,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 72,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 73,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 74,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 75,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 76,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 77,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 78,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 79,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 80,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 81,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 82,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 83,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 84,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 85,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 86,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 87,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 88,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 89,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 90,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 91,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 92,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 93,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 94,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 95,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 96,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 97,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 98,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 99,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 100,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 101,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 102,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 103,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 104,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 105,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 106,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 107,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 108,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 109,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 110,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 111,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 112,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 113,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 114,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 115,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 116,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 117,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 118,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 119,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 120,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 121,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 122,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 123,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 124,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 125,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 126,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 127,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 128,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 129,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 130,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 131,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 132,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 133,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 134,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 135,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 136,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 137,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 138,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 139,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 140,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 141,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 142,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-plate:belt-out",
+          "rate": 30.0
+        }
+      ],
+      "ports": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "kind": "belt-in",
+          "item": "copper-ore"
+        },
+        {
+          "dx": 0,
+          "dy": 6,
+          "kind": "belt-out",
+          "item": "copper-plate"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 144,
+        "bbox_h": 7,
+        "interior_tiles": 817,
+        "entity_count": 433
+      },
+      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "sim_anchor": "unanchored"
+    },
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "iron-plate",
+        "machine": "electric-furnace",
+        "count": 32
+      },
+      "entities": [
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 21,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 22,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 23,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 24,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 25,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 26,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 27,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 28,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 29,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 30,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 31,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 32,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 33,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 34,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 35,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 36,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 37,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 38,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 39,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 40,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 41,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 42,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 43,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 44,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 45,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 46,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 47,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 48,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 49,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 50,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 51,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 52,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 53,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 54,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 55,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 56,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 57,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 58,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 59,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 60,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 61,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 62,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 63,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 64,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 65,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 66,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 67,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 68,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 69,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 70,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 71,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 72,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 73,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 74,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 75,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 76,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 77,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 78,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 79,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 80,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 81,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 82,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 83,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 84,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 85,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 86,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 87,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 88,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 89,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 90,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 91,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 92,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 93,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 94,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:belt-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 22,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 25,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 31,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 34,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 37,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 40,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 43,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 46,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 49,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 52,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 55,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 58,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 61,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 64,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 67,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 70,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 73,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 76,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 79,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 82,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 85,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 88,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 91,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 94,
+          "y": 1,
+          "direction": "South",
+          "carries": "iron-ore",
+          "segment_id": "row:iron-plate:inserter-in:iron-ore",
+          "rate": 20.0
+        },
+        {
+          "name": "electric-furnace",
+          "x": 0,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 3,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 6,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 9,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 12,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 15,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 18,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 21,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 24,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 27,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 30,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 33,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 36,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 39,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 42,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 45,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 48,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 51,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 54,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 57,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 60,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 63,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 66,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 69,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 72,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 75,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 78,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 81,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 84,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 87,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 90,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 93,
+          "y": 2,
+          "direction": "North",
+          "recipe": "iron-plate",
+          "segment_id": "row:iron-plate:machine"
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 22,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 25,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 31,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 34,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 37,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 40,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 43,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 45,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 5,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 5,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 49,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 52,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 55,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 58,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 61,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 64,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 67,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 70,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 73,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 76,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 79,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 82,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 85,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 88,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 91,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "inserter",
+          "x": 94,
+          "y": 5,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:inserter-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 0,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 29,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 30,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 31,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 32,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 33,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 34,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 35,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 36,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 37,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 38,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 39,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 40,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 41,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 42,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 43,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 44,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 45,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 6,
+          "direction": "North",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 49,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 50,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 51,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 52,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 53,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 54,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 55,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 56,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 57,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 58,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 59,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 60,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 61,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 62,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 63,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 64,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 65,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 66,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 67,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 68,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 69,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 72,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 73,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 74,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 75,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 76,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 77,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 78,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 79,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 80,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 81,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 82,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 83,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 84,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 85,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 86,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 87,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 88,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 89,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 90,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 91,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 92,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 93,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 94,
+          "y": 6,
+          "direction": "West",
+          "carries": "iron-plate",
+          "segment_id": "row:iron-plate:belt-out",
+          "rate": 20.0
+        }
+      ],
+      "ports": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "kind": "belt-in",
+          "item": "iron-ore"
+        },
+        {
+          "dx": 0,
+          "dy": 6,
+          "kind": "belt-out",
+          "item": "iron-plate"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 96,
+        "bbox_h": 7,
+        "interior_tiles": 545,
+        "entity_count": 289
+      },
+      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "sim_anchor": "unanchored"
+    },
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "copper-cable",
+        "machine": "assembling-machine-2",
+        "count": 20
+      },
+      "entities": [
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 21,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 22,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 23,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 24,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 25,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 26,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 27,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 28,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 22,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 25,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 0,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 3,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 6,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 9,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 12,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 15,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 18,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 21,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 24,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 27,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 4,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 7,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 12,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 5,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 5,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 16,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 19,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 22,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 25,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 28,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 0,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 21,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 22,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 23,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 24,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 25,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 26,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 27,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 28,
+          "y": 7,
+          "direction": "East",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:belt-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 22,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 25,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-plate",
+          "segment_id": "row:copper-cable:inserter-in:copper-plate",
+          "rate": 15.0
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 0,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 3,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 6,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 9,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 12,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 15,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 18,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 21,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 24,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 27,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-cable",
+          "segment_id": "row:copper-cable:machine"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 4,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 7,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 12,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 12,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 12,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 16,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 19,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 22,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 25,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-inserter",
+          "x": 28,
+          "y": 12,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:inserter-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 0,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 13,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 13,
+          "direction": "West",
+          "carries": "copper-cable",
+          "segment_id": "row:copper-cable:belt-out",
+          "rate": 30.0
+        }
+      ],
+      "ports": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "kind": "belt-in",
+          "item": "copper-plate"
+        },
+        {
+          "dx": 0,
+          "dy": 7,
+          "kind": "belt-in",
+          "item": "copper-plate"
+        },
+        {
+          "dx": 0,
+          "dy": 6,
+          "kind": "belt-out",
+          "item": "copper-cable"
+        },
+        {
+          "dx": 0,
+          "dy": 13,
+          "kind": "belt-out",
+          "item": "copper-cable"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 30,
+        "bbox_h": 14,
+        "interior_tiles": 342,
+        "entity_count": 182
+      },
+      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "sim_anchor": "unanchored"
+    },
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "electronic-circuit",
+        "machine": "assembling-machine-2",
+        "count": 14
+      },
+      "entities": [
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 0,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 1,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 0,
+          "y": 2,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 2,
+          "y": 2,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 2,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 5,
+          "y": 2,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 2,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 2,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 9,
+          "y": 2,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 11,
+          "y": 2,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 2,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 14,
+          "y": 2,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 2,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 2,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 18,
+          "y": 2,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 20,
+          "y": 2,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 0,
+          "y": 3,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 3,
+          "y": 3,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 6,
+          "y": 3,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 9,
+          "y": 3,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 12,
+          "y": 3,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 15,
+          "y": 3,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 18,
+          "y": 3,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 9,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 10,
+          "y": 6,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 11,
+          "y": 6,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 12,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 6,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 0,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 1,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 2,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 3,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 4,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 5,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 6,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 7,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 8,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 9,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 10,
+          "y": 7,
+          "direction": "North",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 11,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 12,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 13,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 14,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 15,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 16,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 17,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 18,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 19,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 20,
+          "y": 7,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 8,
+          "direction": "East",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 9,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 0,
+          "y": 10,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 2,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 10,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 5,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 10,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 9,
+          "y": 10,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 11,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 10,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 14,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 10,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 18,
+          "y": 10,
+          "direction": "South",
+          "carries": "iron-plate",
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
+          "rate": 10.5
+        },
+        {
+          "name": "fast-inserter",
+          "x": 20,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-cable",
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
+          "rate": 31.5
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 0,
+          "y": 11,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 3,
+          "y": 11,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 6,
+          "y": 11,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 9,
+          "y": 11,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 12,
+          "y": 11,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 15,
+          "y": 11,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 18,
+          "y": 11,
+          "direction": "North",
+          "recipe": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:machine"
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 9,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 10,
+          "y": 14,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 11,
+          "y": 14,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 12,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 14,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:inserter-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 0,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 1,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 2,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 3,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 4,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 5,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 6,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 7,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 8,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 9,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 10,
+          "y": 15,
+          "direction": "North",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 11,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 12,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 13,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 14,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 15,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 16,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 17,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 18,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 19,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        },
+        {
+          "name": "transport-belt",
+          "x": 20,
+          "y": 15,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:electronic-circuit:belt-out",
+          "rate": 10.5
+        }
+      ],
+      "ports": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "kind": "belt-in",
+          "item": "iron-plate"
+        },
+        {
+          "dx": 0,
+          "dy": 8,
+          "kind": "belt-in",
+          "item": "iron-plate"
+        },
+        {
+          "dx": 0,
+          "dy": 1,
+          "kind": "belt-in",
+          "item": "copper-cable"
+        },
+        {
+          "dx": 0,
+          "dy": 9,
+          "kind": "belt-in",
+          "item": "copper-cable"
+        },
+        {
+          "dx": 20,
+          "dy": 7,
+          "kind": "belt-out",
+          "item": "electronic-circuit"
+        },
+        {
+          "dx": 20,
+          "dy": 15,
+          "kind": "belt-out",
+          "item": "electronic-circuit"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 21,
+        "bbox_h": 16,
+        "interior_tiles": 296,
+        "entity_count": 184
+      },
+      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "sim_anchor": "unanchored"
+    },
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "advanced-circuit",
+        "machine": "assembling-machine-2",
+        "count": 32
+      },
+      "entities": [
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 21,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 22,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 23,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 24,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 25,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 26,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 27,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 28,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 29,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 30,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 31,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 32,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 33,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 34,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 35,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 36,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 37,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 38,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 39,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 40,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 41,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 42,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 43,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 44,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 45,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 46,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 47,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 48,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 49,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 50,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 51,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 52,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 53,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 54,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 55,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 56,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 57,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 58,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 59,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 60,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 61,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 62,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 63,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 64,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 65,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 66,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 67,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 68,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 69,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 70,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 71,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 72,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 73,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 74,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 75,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 76,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 77,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 78,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 79,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 80,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 81,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 82,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 83,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 84,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 85,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 86,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 87,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 88,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 89,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 90,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 91,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 92,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 93,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 94,
+          "y": 0,
+          "direction": "East",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 21,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 22,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 23,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 24,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 25,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 26,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 27,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 28,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 29,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 30,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 31,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 32,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 33,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 34,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 35,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 36,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 37,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 38,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 39,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 40,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 41,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 42,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 43,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 44,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 45,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 46,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 47,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 48,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 49,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 50,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 51,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 52,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 53,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 54,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 55,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 56,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 57,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 58,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 59,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 60,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 61,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 62,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 63,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 64,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 65,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 66,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 67,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 68,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 69,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 70,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 71,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 72,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 73,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 74,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 75,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 76,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 77,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 78,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 79,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 80,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 81,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 82,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 83,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 84,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 85,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 86,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 87,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 88,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 89,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 90,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 91,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 92,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 93,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 94,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 95,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 96,
+          "y": 1,
+          "direction": "East",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 0,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 2,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 5,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 8,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 9,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 11,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 14,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 17,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 18,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 20,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 21,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 23,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 24,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 26,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 27,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 29,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 30,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 32,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 33,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 35,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 36,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 38,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 39,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 41,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 42,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 44,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 45,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 47,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 49,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 51,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 52,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 54,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 55,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 57,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 58,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 60,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 61,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 63,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 64,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 66,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 67,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 69,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 70,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 72,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 73,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 75,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 76,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 78,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 79,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 81,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 82,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 84,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 85,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 87,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 88,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 90,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 91,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 93,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 94,
+          "y": 2,
+          "direction": "South",
+          "carries": "electronic-circuit",
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
+          "rate": 8.0
+        },
+        {
+          "name": "inserter",
+          "x": 96,
+          "y": 2,
+          "direction": "South",
+          "carries": "plastic-bar",
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
+          "rate": 8.0
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 0,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 3,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 6,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 9,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 12,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 15,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 18,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 21,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 24,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 27,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 30,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 33,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 36,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 39,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 42,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 45,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 49,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 52,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 55,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 58,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 61,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 64,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 67,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 70,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 73,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 76,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 79,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 82,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 85,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 88,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 91,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "assembling-machine-2",
+          "x": 94,
+          "y": 3,
+          "direction": "North",
+          "recipe": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:machine"
+        },
+        {
+          "name": "inserter",
+          "x": 1,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 2,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 4,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 5,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 8,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 11,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 13,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 14,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 17,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 20,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 22,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 23,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 25,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 26,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 29,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 31,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 32,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 34,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 35,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 37,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 38,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 40,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 41,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 43,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 44,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 45,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 46,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 47,
+          "y": 6,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 48,
+          "y": 6,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 49,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "inserter",
+          "x": 50,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 51,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 53,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 54,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 56,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 57,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 59,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 60,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 62,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 63,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 65,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 66,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 68,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 69,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 71,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 72,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 74,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 75,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 77,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 78,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 80,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 81,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 83,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 84,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 86,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 87,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 89,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 90,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 92,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 93,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "inserter",
+          "x": 95,
+          "y": 6,
+          "direction": "South",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:inserter-out",
+          "rate": 4.0
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 96,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 0,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 1,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 2,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 3,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 4,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 5,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 6,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 7,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 8,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 9,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 10,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 11,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 12,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 13,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 14,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 15,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 16,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 17,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 18,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 19,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 20,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 21,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 22,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 23,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 24,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 25,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 26,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 27,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 28,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 29,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 30,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 31,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 32,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 33,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 34,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 35,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 36,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 37,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 38,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 39,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 40,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 41,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 42,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 43,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 44,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 45,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 46,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 47,
+          "y": 7,
+          "direction": "North",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 48,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 49,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 50,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 51,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 52,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 53,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 54,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 55,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 56,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 57,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 58,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 59,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 60,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 61,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 62,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 63,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 64,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 65,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 66,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 67,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 68,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 69,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 70,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 71,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 72,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 73,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 74,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 75,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 76,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 77,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 78,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 79,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 80,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 81,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 82,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 83,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 84,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 85,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 86,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 87,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 88,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 89,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 90,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 91,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 92,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 93,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 94,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 95,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "transport-belt",
+          "x": 96,
+          "y": 7,
+          "direction": "East",
+          "carries": "advanced-circuit",
+          "segment_id": "row:advanced-circuit:belt-out",
+          "rate": 4.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 19,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 20,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 21,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 22,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 23,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 24,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 25,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 26,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 27,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 28,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 29,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 30,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 31,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 32,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 33,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 34,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 35,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 36,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 37,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 38,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 39,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 40,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 41,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 42,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 43,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 44,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 45,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 46,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 47,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 48,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 49,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 50,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 51,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 52,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 53,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 54,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 55,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 56,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 57,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 58,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 59,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 60,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 61,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 62,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 63,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 64,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 65,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 66,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 67,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 68,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 69,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 70,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 71,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 72,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 73,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 74,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 75,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 76,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 77,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 78,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 79,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 80,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 81,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 82,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 83,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 84,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 85,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 86,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 87,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 88,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 89,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 90,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 91,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 92,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 93,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 94,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 95,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 96,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-cable",
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
+          "rate": 16.0
+        }
+      ],
+      "ports": [
+        {
+          "dx": 0,
+          "dy": 0,
+          "kind": "belt-in",
+          "item": "electronic-circuit"
+        },
+        {
+          "dx": 0,
+          "dy": 1,
+          "kind": "belt-in",
+          "item": "plastic-bar"
+        },
+        {
+          "dx": 96,
+          "dy": 7,
+          "kind": "belt-out",
+          "item": "advanced-circuit"
+        },
+        {
+          "dx": 0,
+          "dy": 8,
+          "kind": "belt-in",
+          "item": "copper-cable"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 97,
+        "bbox_h": 9,
+        "interior_tiles": 805,
+        "entity_count": 549
+      },
+      "provenance": "engine@worktree fixture=advanced-circuit@4",
+      "sim_anchor": "unanchored"
+    }
+  ]
 }

--- a/crates/core/data/celldb.json
+++ b/crates/core/data/celldb.json
@@ -3494,7 +3494,7 @@
         "interior_tiles": 817,
         "entity_count": 433
       },
-      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
+      "provenance": "engine@d2a93e71 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -5838,7 +5838,7 @@
         "interior_tiles": 545,
         "entity_count": 289
       },
-      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
+      "provenance": "engine@d2a93e71 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -7338,7 +7338,7 @@
         "interior_tiles": 342,
         "entity_count": 182
       },
-      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
+      "provenance": "engine@d2a93e71 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -8866,7 +8866,7 @@
         "interior_tiles": 296,
         "entity_count": 184
       },
-      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
+      "provenance": "engine@d2a93e71 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -13302,7 +13302,7 @@
         "interior_tiles": 805,
         "entity_count": 549
       },
-      "provenance": "engine@3ec12291 fixture=advanced-circuit@4",
+      "provenance": "engine@d2a93e71 fixture=advanced-circuit@4",
       "sim_anchor": "unanchored"
     }
   ]

--- a/crates/core/data/celldb.json
+++ b/crates/core/data/celldb.json
@@ -15,8 +15,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -24,8 +23,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -33,8 +31,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -42,8 +39,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -51,8 +47,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -60,8 +55,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -69,8 +63,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -78,8 +71,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -87,8 +79,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -96,8 +87,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -105,8 +95,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -114,8 +103,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -123,8 +111,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -132,8 +119,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -141,8 +127,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -150,8 +135,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -159,8 +143,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -168,8 +151,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -177,8 +159,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -186,8 +167,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -195,8 +175,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -204,8 +183,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -213,8 +191,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -222,8 +199,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -231,8 +207,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -240,8 +215,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -249,8 +223,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -258,8 +231,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -267,8 +239,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -276,8 +247,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -285,8 +255,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -294,8 +263,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -303,8 +271,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -312,8 +279,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -321,8 +287,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -330,8 +295,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -339,8 +303,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -348,8 +311,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -357,8 +319,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -366,8 +327,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -375,8 +335,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -384,8 +343,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -393,8 +351,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -402,8 +359,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -411,8 +367,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -420,8 +375,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -429,8 +383,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -438,8 +391,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -447,8 +399,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -456,8 +407,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -465,8 +415,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -474,8 +423,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -483,8 +431,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -492,8 +439,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -501,8 +447,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -510,8 +455,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -519,8 +463,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -528,8 +471,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -537,8 +479,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -546,8 +487,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -555,8 +495,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -564,8 +503,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -573,8 +511,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -582,8 +519,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -591,8 +527,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -600,8 +535,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -609,8 +543,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -618,8 +551,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -627,8 +559,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -636,8 +567,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -645,8 +575,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -654,8 +583,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -663,8 +591,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -672,8 +599,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -681,8 +607,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -690,8 +615,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -699,8 +623,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -708,8 +631,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -717,8 +639,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -726,8 +647,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -735,8 +655,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -744,8 +663,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -753,8 +671,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -762,8 +679,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -771,8 +687,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -780,8 +695,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -789,8 +703,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -798,8 +711,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -807,8 +719,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -816,8 +727,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -825,8 +735,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -834,8 +743,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -843,8 +751,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -852,8 +759,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -861,8 +767,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -870,8 +775,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -879,8 +783,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -888,8 +791,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -897,8 +799,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -906,8 +807,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -915,8 +815,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -924,8 +823,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -933,8 +831,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -942,8 +839,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -951,8 +847,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -960,8 +855,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -969,8 +863,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -978,8 +871,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -987,8 +879,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -996,8 +887,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1005,8 +895,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1014,8 +903,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1023,8 +911,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1032,8 +919,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1041,8 +927,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1050,8 +935,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1059,8 +943,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1068,8 +951,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1077,8 +959,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1086,8 +967,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1095,8 +975,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1104,8 +983,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1113,8 +991,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1122,8 +999,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1131,8 +1007,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1140,8 +1015,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1149,8 +1023,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1158,8 +1031,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1167,8 +1039,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1176,8 +1047,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1185,8 +1055,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1194,8 +1063,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1203,8 +1071,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1212,8 +1079,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1221,8 +1087,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1230,8 +1095,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1239,8 +1103,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1248,8 +1111,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1257,8 +1119,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1266,8 +1127,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1275,8 +1135,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1284,8 +1143,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "express-transport-belt",
@@ -1293,8 +1151,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:belt-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1302,8 +1159,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1311,8 +1167,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1320,8 +1175,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1329,8 +1183,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1338,8 +1191,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1347,8 +1199,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1356,8 +1207,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1365,8 +1215,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1374,8 +1223,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1383,8 +1231,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1392,8 +1239,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1401,8 +1247,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1410,8 +1255,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1419,8 +1263,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1428,8 +1271,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1437,8 +1279,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1446,8 +1287,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1455,8 +1295,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1464,8 +1303,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1473,8 +1311,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1482,8 +1319,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1491,8 +1327,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1500,8 +1335,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1509,8 +1343,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1518,8 +1351,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1527,8 +1359,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1536,8 +1367,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1545,8 +1375,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1554,8 +1383,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1563,8 +1391,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1572,8 +1399,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1581,8 +1407,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1590,8 +1415,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1599,8 +1423,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1608,8 +1431,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1617,8 +1439,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1626,8 +1447,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1635,8 +1455,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1644,8 +1463,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1653,8 +1471,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1662,8 +1479,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1671,8 +1487,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1680,8 +1495,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1689,8 +1503,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1698,8 +1511,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1707,8 +1519,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1716,8 +1527,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "inserter",
@@ -1725,8 +1535,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-ore",
-          "segment_id": "row:copper-plate:inserter-in:copper-ore",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-in:copper-ore"
         },
         {
           "name": "electric-furnace",
@@ -2118,8 +1927,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2127,8 +1935,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2136,8 +1943,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2145,8 +1951,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2154,8 +1959,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2163,8 +1967,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2172,8 +1975,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2181,8 +1983,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2190,8 +1991,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2199,8 +1999,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2208,8 +2007,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2217,8 +2015,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2226,8 +2023,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2235,8 +2031,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2244,8 +2039,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2253,8 +2047,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2262,8 +2055,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2271,8 +2063,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2280,8 +2071,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2289,8 +2079,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2298,8 +2087,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2307,8 +2095,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2316,8 +2103,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2325,8 +2111,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2334,8 +2119,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2343,8 +2127,7 @@
           "y": 5,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2352,8 +2135,7 @@
           "y": 5,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "inserter",
@@ -2361,8 +2143,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2370,8 +2151,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2379,8 +2159,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2388,8 +2167,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2397,8 +2175,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2406,8 +2183,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2415,8 +2191,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2424,8 +2199,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2433,8 +2207,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2442,8 +2215,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2451,8 +2223,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2460,8 +2231,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2469,8 +2239,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2478,8 +2247,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2487,8 +2255,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2496,8 +2263,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2505,8 +2271,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2514,8 +2279,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2523,8 +2287,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2532,8 +2295,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2541,8 +2303,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2550,8 +2311,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2559,8 +2319,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -2568,8 +2327,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2577,8 +2335,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2586,8 +2343,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2595,8 +2351,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2604,8 +2359,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2613,8 +2367,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2622,8 +2375,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2631,8 +2383,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2640,8 +2391,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2649,8 +2399,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2658,8 +2407,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2667,8 +2415,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2676,8 +2423,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2685,8 +2431,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2694,8 +2439,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2703,8 +2447,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2712,8 +2455,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2721,8 +2463,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2730,8 +2471,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2739,8 +2479,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2748,8 +2487,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2757,8 +2495,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2766,8 +2503,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2775,8 +2511,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2784,8 +2519,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2793,8 +2527,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2802,8 +2535,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2811,8 +2543,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2820,8 +2551,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2829,8 +2559,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2838,8 +2567,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2847,8 +2575,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2856,8 +2583,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2865,8 +2591,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2874,8 +2599,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2883,8 +2607,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2892,8 +2615,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2901,8 +2623,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2910,8 +2631,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2919,8 +2639,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2928,8 +2647,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2937,8 +2655,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2946,8 +2663,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2955,8 +2671,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2964,8 +2679,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2973,8 +2687,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2982,8 +2695,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -2991,8 +2703,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3000,8 +2711,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3009,8 +2719,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3018,8 +2727,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3027,8 +2735,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3036,8 +2743,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3045,8 +2751,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3054,8 +2759,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3063,8 +2767,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3072,8 +2775,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3081,8 +2783,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3090,8 +2791,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3099,8 +2799,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3108,8 +2807,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3117,8 +2815,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3126,8 +2823,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3135,8 +2831,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3144,8 +2839,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3153,8 +2847,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3162,8 +2855,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3171,8 +2863,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3180,8 +2871,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3189,8 +2879,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3198,8 +2887,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3207,8 +2895,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3216,8 +2903,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3225,8 +2911,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3234,8 +2919,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3243,8 +2927,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3252,8 +2935,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3261,8 +2943,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3270,8 +2951,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3279,8 +2959,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3288,8 +2967,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3297,8 +2975,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3306,8 +2983,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3315,8 +2991,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3324,8 +2999,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3333,8 +3007,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3342,8 +3015,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3351,8 +3023,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3360,8 +3031,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3369,8 +3039,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3378,8 +3047,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3387,8 +3055,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3396,8 +3063,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3405,8 +3071,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3414,8 +3079,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3423,8 +3087,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3432,8 +3095,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3441,8 +3103,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3450,8 +3111,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3459,8 +3119,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3468,8 +3127,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3477,8 +3135,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3486,8 +3143,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3495,8 +3151,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3504,8 +3159,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3513,8 +3167,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3522,8 +3175,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3531,8 +3183,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3540,8 +3191,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3549,8 +3199,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3558,8 +3207,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3567,8 +3215,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3576,8 +3223,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3585,8 +3231,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3594,8 +3239,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3603,8 +3247,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3612,8 +3255,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3621,8 +3263,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3630,8 +3271,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3639,8 +3279,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3648,8 +3287,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3657,8 +3295,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3666,8 +3303,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3675,8 +3311,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3684,8 +3319,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3693,8 +3327,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3702,8 +3335,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3711,8 +3343,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3720,8 +3351,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3729,8 +3359,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3738,8 +3367,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3747,8 +3375,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3756,8 +3383,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3765,8 +3391,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3774,8 +3399,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3783,8 +3407,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3792,8 +3415,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3801,8 +3423,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3810,8 +3431,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3819,8 +3439,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3828,8 +3447,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3837,8 +3455,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3846,8 +3463,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -3855,8 +3471,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-plate",
-          "segment_id": "row:copper-plate:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-plate:belt-out"
         }
       ],
       "ports": [
@@ -3896,8 +3511,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3905,8 +3519,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3914,8 +3527,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3923,8 +3535,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3932,8 +3543,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3941,8 +3551,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3950,8 +3559,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3959,8 +3567,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3968,8 +3575,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3977,8 +3583,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3986,8 +3591,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -3995,8 +3599,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4004,8 +3607,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4013,8 +3615,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4022,8 +3623,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4031,8 +3631,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4040,8 +3639,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4049,8 +3647,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4058,8 +3655,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4067,8 +3663,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4076,8 +3671,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4085,8 +3679,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4094,8 +3687,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4103,8 +3695,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4112,8 +3703,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4121,8 +3711,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4130,8 +3719,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4139,8 +3727,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4148,8 +3735,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4157,8 +3743,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4166,8 +3751,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4175,8 +3759,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4184,8 +3767,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4193,8 +3775,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4202,8 +3783,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4211,8 +3791,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4220,8 +3799,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4229,8 +3807,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4238,8 +3815,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4247,8 +3823,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4256,8 +3831,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4265,8 +3839,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4274,8 +3847,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4283,8 +3855,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4292,8 +3863,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4301,8 +3871,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4310,8 +3879,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4319,8 +3887,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4328,8 +3895,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4337,8 +3903,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4346,8 +3911,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4355,8 +3919,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4364,8 +3927,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4373,8 +3935,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4382,8 +3943,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4391,8 +3951,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4400,8 +3959,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4409,8 +3967,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4418,8 +3975,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4427,8 +3983,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4436,8 +3991,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4445,8 +3999,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4454,8 +4007,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4463,8 +4015,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4472,8 +4023,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4481,8 +4031,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4490,8 +4039,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4499,8 +4047,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4508,8 +4055,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4517,8 +4063,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4526,8 +4071,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4535,8 +4079,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4544,8 +4087,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4553,8 +4095,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4562,8 +4103,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4571,8 +4111,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4580,8 +4119,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4589,8 +4127,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4598,8 +4135,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4607,8 +4143,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4616,8 +4151,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4625,8 +4159,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4634,8 +4167,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4643,8 +4175,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4652,8 +4183,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4661,8 +4191,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4670,8 +4199,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4679,8 +4207,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4688,8 +4215,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4697,8 +4223,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4706,8 +4231,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4715,8 +4239,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4724,8 +4247,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4733,8 +4255,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "express-transport-belt",
@@ -4742,8 +4263,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:belt-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4751,8 +4271,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4760,8 +4279,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4769,8 +4287,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4778,8 +4295,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4787,8 +4303,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4796,8 +4311,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4805,8 +4319,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4814,8 +4327,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4823,8 +4335,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4832,8 +4343,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4841,8 +4351,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4850,8 +4359,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4859,8 +4367,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4868,8 +4375,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4877,8 +4383,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4886,8 +4391,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4895,8 +4399,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4904,8 +4407,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4913,8 +4415,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4922,8 +4423,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4931,8 +4431,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4940,8 +4439,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4949,8 +4447,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4958,8 +4455,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4967,8 +4463,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4976,8 +4471,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4985,8 +4479,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -4994,8 +4487,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -5003,8 +4495,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -5012,8 +4503,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -5021,8 +4511,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "inserter",
@@ -5030,8 +4519,7 @@
           "y": 1,
           "direction": "South",
           "carries": "iron-ore",
-          "segment_id": "row:iron-plate:inserter-in:iron-ore",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-in:iron-ore"
         },
         {
           "name": "electric-furnace",
@@ -5295,8 +4783,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5304,8 +4791,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5313,8 +4799,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5322,8 +4807,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5331,8 +4815,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5340,8 +4823,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5349,8 +4831,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5358,8 +4839,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5367,8 +4847,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5376,8 +4855,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5385,8 +4863,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5394,8 +4871,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5403,8 +4879,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5412,8 +4887,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5421,8 +4895,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5430,8 +4903,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5439,8 +4911,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5448,8 +4919,7 @@
           "y": 5,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5457,8 +4927,7 @@
           "y": 5,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "inserter",
@@ -5466,8 +4935,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5475,8 +4943,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5484,8 +4951,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5493,8 +4959,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5502,8 +4967,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5511,8 +4975,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5520,8 +4983,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5529,8 +4991,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5538,8 +4999,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5547,8 +5007,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5556,8 +5015,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5565,8 +5023,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5574,8 +5031,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5583,8 +5039,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5592,8 +5047,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "inserter",
@@ -5601,8 +5055,7 @@
           "y": 5,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:inserter-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5610,8 +5063,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5619,8 +5071,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5628,8 +5079,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5637,8 +5087,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5646,8 +5095,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5655,8 +5103,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5664,8 +5111,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5673,8 +5119,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5682,8 +5127,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5691,8 +5135,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5700,8 +5143,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5709,8 +5151,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5718,8 +5159,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5727,8 +5167,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5736,8 +5175,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5745,8 +5183,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5754,8 +5191,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5763,8 +5199,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5772,8 +5207,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5781,8 +5215,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5790,8 +5223,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5799,8 +5231,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5808,8 +5239,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5817,8 +5247,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5826,8 +5255,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5835,8 +5263,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5844,8 +5271,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5853,8 +5279,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5862,8 +5287,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5871,8 +5295,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5880,8 +5303,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5889,8 +5311,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5898,8 +5319,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5907,8 +5327,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5916,8 +5335,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5925,8 +5343,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5934,8 +5351,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5943,8 +5359,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5952,8 +5367,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5961,8 +5375,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5970,8 +5383,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5979,8 +5391,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5988,8 +5399,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -5997,8 +5407,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6006,8 +5415,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6015,8 +5423,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6024,8 +5431,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6033,8 +5439,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6042,8 +5447,7 @@
           "y": 6,
           "direction": "North",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6051,8 +5455,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6060,8 +5463,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6069,8 +5471,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6078,8 +5479,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6087,8 +5487,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6096,8 +5495,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6105,8 +5503,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6114,8 +5511,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6123,8 +5519,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6132,8 +5527,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6141,8 +5535,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6150,8 +5543,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6159,8 +5551,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6168,8 +5559,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6177,8 +5567,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6186,8 +5575,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6195,8 +5583,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6204,8 +5591,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6213,8 +5599,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6222,8 +5607,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6231,8 +5615,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6240,8 +5623,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6249,8 +5631,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6258,8 +5639,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6267,8 +5647,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6276,8 +5655,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6285,8 +5663,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6294,8 +5671,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6303,8 +5679,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6312,8 +5687,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6321,8 +5695,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6330,8 +5703,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6339,8 +5711,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6348,8 +5719,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6357,8 +5727,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6366,8 +5735,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6375,8 +5743,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6384,8 +5751,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6393,8 +5759,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6402,8 +5767,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6411,8 +5775,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6420,8 +5783,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6429,8 +5791,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6438,8 +5799,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6447,8 +5807,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6456,8 +5815,7 @@
           "y": 6,
           "direction": "West",
           "carries": "iron-plate",
-          "segment_id": "row:iron-plate:belt-out",
-          "rate": 20.0
+          "segment_id": "row:iron-plate:belt-out"
         }
       ],
       "ports": [
@@ -6497,8 +5855,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6506,8 +5863,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6515,8 +5871,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6524,8 +5879,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6533,8 +5887,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6542,8 +5895,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6551,8 +5903,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6560,8 +5911,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6569,8 +5919,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6578,8 +5927,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6587,8 +5935,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6596,8 +5943,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6605,8 +5951,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6614,8 +5959,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6623,8 +5967,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6632,8 +5975,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6641,8 +5983,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6650,8 +5991,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6659,8 +5999,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6668,8 +6007,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6677,8 +6015,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6686,8 +6023,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6695,8 +6031,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6704,8 +6039,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6713,8 +6047,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6722,8 +6055,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6731,8 +6063,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6740,8 +6071,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -6749,8 +6079,7 @@
           "y": 0,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6758,8 +6087,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6767,8 +6095,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6776,8 +6103,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6785,8 +6111,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6794,8 +6119,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6803,8 +6127,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6812,8 +6135,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6821,8 +6143,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6830,8 +6151,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -6839,8 +6159,7 @@
           "y": 1,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "assembling-machine-2",
@@ -6928,8 +6247,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -6937,8 +6255,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -6946,8 +6263,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -6955,8 +6271,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -6964,8 +6279,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6973,8 +6287,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6982,8 +6295,7 @@
           "y": 5,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -6991,8 +6303,7 @@
           "y": 5,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-inserter",
@@ -7000,8 +6311,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7009,8 +6319,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7018,8 +6327,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7027,8 +6335,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7036,8 +6343,7 @@
           "y": 5,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7045,8 +6351,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7054,8 +6359,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7063,8 +6367,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7072,8 +6375,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7081,8 +6383,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7090,8 +6391,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7099,8 +6399,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7108,8 +6407,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7117,8 +6415,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7126,8 +6423,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7135,8 +6431,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7144,8 +6439,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7153,8 +6447,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7162,8 +6455,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7171,8 +6463,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7180,8 +6471,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7189,8 +6479,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7198,8 +6487,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7207,8 +6495,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7216,8 +6503,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7225,8 +6511,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7234,8 +6519,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7243,8 +6527,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7252,8 +6535,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7261,8 +6543,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7270,8 +6551,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7279,8 +6559,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7288,8 +6567,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7297,8 +6575,7 @@
           "y": 6,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "express-transport-belt",
@@ -7306,8 +6583,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7315,8 +6591,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7324,8 +6599,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7333,8 +6607,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7342,8 +6615,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7351,8 +6623,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7360,8 +6631,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7369,8 +6639,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7378,8 +6647,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7387,8 +6655,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7396,8 +6663,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7405,8 +6671,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7414,8 +6679,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7423,8 +6687,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7432,8 +6695,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7441,8 +6703,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7450,8 +6711,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7459,8 +6719,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7468,8 +6727,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7477,8 +6735,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7486,8 +6743,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7495,8 +6751,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7504,8 +6759,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7513,8 +6767,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7522,8 +6775,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7531,8 +6783,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7540,8 +6791,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7549,8 +6799,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "express-transport-belt",
@@ -7558,8 +6807,7 @@
           "y": 7,
           "direction": "East",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:belt-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:belt-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7567,8 +6815,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7576,8 +6823,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7585,8 +6831,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7594,8 +6839,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7603,8 +6847,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7612,8 +6855,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7621,8 +6863,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7630,8 +6871,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7639,8 +6879,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "inserter",
@@ -7648,8 +6887,7 @@
           "y": 8,
           "direction": "South",
           "carries": "copper-plate",
-          "segment_id": "row:copper-cable:inserter-in:copper-plate",
-          "rate": 15.0
+          "segment_id": "row:copper-cable:inserter-in:copper-plate"
         },
         {
           "name": "assembling-machine-2",
@@ -7737,8 +6975,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7746,8 +6983,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7755,8 +6991,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7764,8 +6999,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7773,8 +7007,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7782,8 +7015,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7791,8 +7023,7 @@
           "y": 12,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7800,8 +7031,7 @@
           "y": 12,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-inserter",
@@ -7809,8 +7039,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7818,8 +7047,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7827,8 +7055,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7836,8 +7063,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-inserter",
@@ -7845,8 +7071,7 @@
           "y": 12,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:inserter-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:inserter-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7854,8 +7079,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7863,8 +7087,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7872,8 +7095,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7881,8 +7103,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7890,8 +7111,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7899,8 +7119,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7908,8 +7127,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7917,8 +7135,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7926,8 +7143,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7935,8 +7151,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7944,8 +7159,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7953,8 +7167,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7962,8 +7175,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7971,8 +7183,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7980,8 +7191,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7989,8 +7199,7 @@
           "y": 13,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -7998,8 +7207,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8007,8 +7215,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8016,8 +7223,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8025,8 +7231,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8034,8 +7239,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8043,8 +7247,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8052,8 +7255,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8061,8 +7263,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8070,8 +7271,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8079,8 +7279,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8088,8 +7287,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8097,8 +7295,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         },
         {
           "name": "fast-transport-belt",
@@ -8106,8 +7303,7 @@
           "y": 13,
           "direction": "West",
           "carries": "copper-cable",
-          "segment_id": "row:copper-cable:belt-out",
-          "rate": 30.0
+          "segment_id": "row:copper-cable:belt-out"
         }
       ],
       "ports": [
@@ -8159,8 +7355,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8168,8 +7363,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8177,8 +7371,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8186,8 +7379,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8195,8 +7387,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8204,8 +7395,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8213,8 +7403,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8222,8 +7411,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8231,8 +7419,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8240,8 +7427,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8249,8 +7435,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8258,8 +7443,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8267,8 +7451,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8276,8 +7459,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8285,8 +7467,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8294,8 +7475,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8303,8 +7483,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8312,8 +7491,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8321,8 +7499,7 @@
           "y": 0,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8330,8 +7507,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8339,8 +7515,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8348,8 +7523,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8357,8 +7531,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8366,8 +7539,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8375,8 +7547,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8384,8 +7555,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8393,8 +7563,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8402,8 +7571,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8411,8 +7579,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8420,8 +7587,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8429,8 +7595,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8438,8 +7603,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8447,8 +7611,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8456,8 +7619,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8465,8 +7627,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8474,8 +7635,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8483,8 +7643,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8492,8 +7651,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8501,8 +7659,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -8510,8 +7667,7 @@
           "y": 1,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -8519,8 +7675,7 @@
           "y": 2,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -8528,8 +7683,7 @@
           "y": 2,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -8537,8 +7691,7 @@
           "y": 2,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -8546,8 +7699,7 @@
           "y": 2,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -8555,8 +7707,7 @@
           "y": 2,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -8564,8 +7715,7 @@
           "y": 2,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -8573,8 +7723,7 @@
           "y": 2,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -8582,8 +7731,7 @@
           "y": 2,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -8591,8 +7739,7 @@
           "y": 2,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -8600,8 +7747,7 @@
           "y": 2,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -8609,8 +7755,7 @@
           "y": 2,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -8618,8 +7763,7 @@
           "y": 2,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -8627,8 +7771,7 @@
           "y": 2,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -8636,8 +7779,7 @@
           "y": 2,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "assembling-machine-2",
@@ -8701,8 +7843,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -8710,8 +7851,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -8719,8 +7859,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -8728,8 +7867,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "transport-belt",
@@ -8737,8 +7875,7 @@
           "y": 6,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8746,8 +7883,7 @@
           "y": 6,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8755,8 +7891,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "inserter",
@@ -8764,8 +7899,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -8773,8 +7907,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -8782,8 +7915,7 @@
           "y": 6,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "transport-belt",
@@ -8791,8 +7923,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8800,8 +7931,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8809,8 +7939,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8818,8 +7947,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8827,8 +7955,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8836,8 +7963,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8845,8 +7971,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8854,8 +7979,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8863,8 +7987,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8872,8 +7995,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8881,8 +8003,7 @@
           "y": 7,
           "direction": "North",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8890,8 +8011,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8899,8 +8019,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8908,8 +8027,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8917,8 +8035,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8926,8 +8043,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8935,8 +8051,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8944,8 +8059,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8953,8 +8067,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8962,8 +8075,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -8971,8 +8083,7 @@
           "y": 7,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "express-transport-belt",
@@ -8980,8 +8091,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8989,8 +8099,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -8998,8 +8107,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9007,8 +8115,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9016,8 +8123,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9025,8 +8131,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9034,8 +8139,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9043,8 +8147,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9052,8 +8155,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9061,8 +8163,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9070,8 +8171,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9079,8 +8179,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9088,8 +8187,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9097,8 +8195,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9106,8 +8203,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9115,8 +8211,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9124,8 +8219,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9133,8 +8227,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9142,8 +8235,7 @@
           "y": 8,
           "direction": "East",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:belt-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-in:iron-plate"
         },
         {
           "name": "express-transport-belt",
@@ -9151,8 +8243,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9160,8 +8251,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9169,8 +8259,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9178,8 +8267,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9187,8 +8275,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9196,8 +8283,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9205,8 +8291,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9214,8 +8299,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9223,8 +8307,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9232,8 +8315,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9241,8 +8323,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9250,8 +8331,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9259,8 +8339,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9268,8 +8347,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9277,8 +8355,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9286,8 +8363,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9295,8 +8371,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9304,8 +8379,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9313,8 +8387,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9322,8 +8395,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -9331,8 +8403,7 @@
           "y": 9,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:belt-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:belt-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -9340,8 +8411,7 @@
           "y": 10,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -9349,8 +8419,7 @@
           "y": 10,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -9358,8 +8427,7 @@
           "y": 10,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -9367,8 +8435,7 @@
           "y": 10,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -9376,8 +8443,7 @@
           "y": 10,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -9385,8 +8451,7 @@
           "y": 10,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -9394,8 +8459,7 @@
           "y": 10,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -9403,8 +8467,7 @@
           "y": 10,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -9412,8 +8475,7 @@
           "y": 10,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -9421,8 +8483,7 @@
           "y": 10,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -9430,8 +8491,7 @@
           "y": 10,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -9439,8 +8499,7 @@
           "y": 10,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -9448,8 +8507,7 @@
           "y": 10,
           "direction": "South",
           "carries": "iron-plate",
-          "segment_id": "row:electronic-circuit:inserter-in:iron-plate",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-in:iron-plate"
         },
         {
           "name": "fast-inserter",
@@ -9457,8 +8515,7 @@
           "y": 10,
           "direction": "South",
           "carries": "copper-cable",
-          "segment_id": "row:electronic-circuit:inserter-in:copper-cable",
-          "rate": 31.5
+          "segment_id": "row:electronic-circuit:inserter-in:copper-cable"
         },
         {
           "name": "assembling-machine-2",
@@ -9522,8 +8579,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -9531,8 +8587,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -9540,8 +8595,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -9549,8 +8603,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "transport-belt",
@@ -9558,8 +8611,7 @@
           "y": 14,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9567,8 +8619,7 @@
           "y": 14,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9576,8 +8627,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "inserter",
@@ -9585,8 +8635,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -9594,8 +8643,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "inserter",
@@ -9603,8 +8651,7 @@
           "y": 14,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:inserter-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:inserter-out"
         },
         {
           "name": "transport-belt",
@@ -9612,8 +8659,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9621,8 +8667,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9630,8 +8675,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9639,8 +8683,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9648,8 +8691,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9657,8 +8699,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9666,8 +8707,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9675,8 +8715,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9684,8 +8723,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9693,8 +8731,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9702,8 +8739,7 @@
           "y": 15,
           "direction": "North",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9711,8 +8747,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9720,8 +8755,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9729,8 +8763,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9738,8 +8771,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9747,8 +8779,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9756,8 +8787,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9765,8 +8795,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9774,8 +8803,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9783,8 +8811,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -9792,8 +8819,7 @@
           "y": 15,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:electronic-circuit:belt-out",
-          "rate": 10.5
+          "segment_id": "row:electronic-circuit:belt-out"
         }
       ],
       "ports": [
@@ -9857,8 +8883,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9866,8 +8891,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9875,8 +8899,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9884,8 +8907,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9893,8 +8915,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9902,8 +8923,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9911,8 +8931,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9920,8 +8939,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9929,8 +8947,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9938,8 +8955,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9947,8 +8963,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9956,8 +8971,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9965,8 +8979,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9974,8 +8987,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9983,8 +8995,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -9992,8 +9003,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10001,8 +9011,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10010,8 +9019,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10019,8 +9027,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10028,8 +9035,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10037,8 +9043,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10046,8 +9051,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10055,8 +9059,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10064,8 +9067,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10073,8 +9075,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10082,8 +9083,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10091,8 +9091,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10100,8 +9099,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10109,8 +9107,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10118,8 +9115,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10127,8 +9123,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10136,8 +9131,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10145,8 +9139,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10154,8 +9147,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10163,8 +9155,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10172,8 +9163,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10181,8 +9171,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10190,8 +9179,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10199,8 +9187,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10208,8 +9195,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10217,8 +9203,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10226,8 +9211,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10235,8 +9219,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10244,8 +9227,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10253,8 +9235,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10262,8 +9243,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10271,8 +9251,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10280,8 +9259,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10289,8 +9267,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10298,8 +9275,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10307,8 +9283,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10316,8 +9291,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10325,8 +9299,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10334,8 +9307,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10343,8 +9315,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10352,8 +9323,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10361,8 +9331,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10370,8 +9339,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10379,8 +9347,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10388,8 +9355,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10397,8 +9363,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10406,8 +9371,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10415,8 +9379,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10424,8 +9387,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10433,8 +9395,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10442,8 +9403,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10451,8 +9411,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10460,8 +9419,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10469,8 +9427,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10478,8 +9435,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10487,8 +9443,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10496,8 +9451,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10505,8 +9459,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10514,8 +9467,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10523,8 +9475,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10532,8 +9483,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10541,8 +9491,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10550,8 +9499,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10559,8 +9507,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10568,8 +9515,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10577,8 +9523,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10586,8 +9531,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10595,8 +9539,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10604,8 +9547,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10613,8 +9555,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10622,8 +9563,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10631,8 +9571,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10640,8 +9579,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10649,8 +9587,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10658,8 +9595,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10667,8 +9603,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10676,8 +9611,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10685,8 +9619,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10694,8 +9627,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10703,8 +9635,7 @@
           "y": 0,
           "direction": "East",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:electronic-circuit"
         },
         {
           "name": "express-transport-belt",
@@ -10712,8 +9643,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10721,8 +9651,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10730,8 +9659,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10739,8 +9667,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10748,8 +9675,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10757,8 +9683,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10766,8 +9691,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10775,8 +9699,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10784,8 +9707,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10793,8 +9715,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10802,8 +9723,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10811,8 +9731,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10820,8 +9739,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10829,8 +9747,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10838,8 +9755,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10847,8 +9763,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10856,8 +9771,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10865,8 +9779,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10874,8 +9787,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10883,8 +9795,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10892,8 +9803,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10901,8 +9811,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10910,8 +9819,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10919,8 +9827,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10928,8 +9835,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10937,8 +9843,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10946,8 +9851,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10955,8 +9859,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10964,8 +9867,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10973,8 +9875,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10982,8 +9883,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -10991,8 +9891,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11000,8 +9899,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11009,8 +9907,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11018,8 +9915,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11027,8 +9923,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11036,8 +9931,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11045,8 +9939,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11054,8 +9947,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11063,8 +9955,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11072,8 +9963,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11081,8 +9971,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11090,8 +9979,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11099,8 +9987,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11108,8 +9995,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11117,8 +10003,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11126,8 +10011,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11135,8 +10019,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11144,8 +10027,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11153,8 +10035,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11162,8 +10043,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11171,8 +10051,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11180,8 +10059,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11189,8 +10067,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11198,8 +10075,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11207,8 +10083,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11216,8 +10091,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11225,8 +10099,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11234,8 +10107,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11243,8 +10115,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11252,8 +10123,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11261,8 +10131,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11270,8 +10139,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11279,8 +10147,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11288,8 +10155,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11297,8 +10163,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11306,8 +10171,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11315,8 +10179,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11324,8 +10187,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11333,8 +10195,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11342,8 +10203,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11351,8 +10211,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11360,8 +10219,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11369,8 +10227,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11378,8 +10235,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11387,8 +10243,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11396,8 +10251,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11405,8 +10259,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11414,8 +10267,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11423,8 +10275,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11432,8 +10283,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11441,8 +10291,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11450,8 +10299,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11459,8 +10307,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11468,8 +10315,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11477,8 +10323,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11486,8 +10331,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11495,8 +10339,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11504,8 +10347,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11513,8 +10355,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11522,8 +10363,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11531,8 +10371,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11540,8 +10379,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11549,8 +10387,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11558,8 +10395,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11567,8 +10403,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "express-transport-belt",
@@ -11576,8 +10411,7 @@
           "y": 1,
           "direction": "East",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:belt-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:belt-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11585,8 +10419,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11594,8 +10427,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11603,8 +10435,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11612,8 +10443,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11621,8 +10451,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11630,8 +10459,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11639,8 +10467,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11648,8 +10475,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11657,8 +10483,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11666,8 +10491,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11675,8 +10499,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11684,8 +10507,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11693,8 +10515,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11702,8 +10523,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11711,8 +10531,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11720,8 +10539,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11729,8 +10547,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11738,8 +10555,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11747,8 +10563,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11756,8 +10571,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11765,8 +10579,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11774,8 +10587,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11783,8 +10595,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11792,8 +10603,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11801,8 +10611,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11810,8 +10619,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11819,8 +10627,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11828,8 +10635,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11837,8 +10643,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11846,8 +10651,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11855,8 +10659,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11864,8 +10667,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11873,8 +10675,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11882,8 +10683,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11891,8 +10691,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11900,8 +10699,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11909,8 +10707,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11918,8 +10715,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11927,8 +10723,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11936,8 +10731,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11945,8 +10739,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11954,8 +10747,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11963,8 +10755,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11972,8 +10763,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11981,8 +10771,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -11990,8 +10779,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -11999,8 +10787,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12008,8 +10795,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12017,8 +10803,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12026,8 +10811,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12035,8 +10819,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12044,8 +10827,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12053,8 +10835,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12062,8 +10843,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12071,8 +10851,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12080,8 +10859,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12089,8 +10867,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12098,8 +10875,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12107,8 +10883,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12116,8 +10891,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12125,8 +10899,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12134,8 +10907,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "long-handed-inserter",
@@ -12143,8 +10915,7 @@
           "y": 2,
           "direction": "South",
           "carries": "electronic-circuit",
-          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:electronic-circuit"
         },
         {
           "name": "inserter",
@@ -12152,8 +10923,7 @@
           "y": 2,
           "direction": "South",
           "carries": "plastic-bar",
-          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar",
-          "rate": 8.0
+          "segment_id": "row:advanced-circuit:inserter-in:plastic-bar"
         },
         {
           "name": "assembling-machine-2",
@@ -12417,8 +11187,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12426,8 +11195,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12435,8 +11203,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12444,8 +11211,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12453,8 +11219,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12462,8 +11227,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12471,8 +11235,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12480,8 +11243,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12489,8 +11251,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12498,8 +11259,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12507,8 +11267,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12516,8 +11275,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12525,8 +11283,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12534,8 +11291,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12543,8 +11299,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12552,8 +11307,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12561,8 +11315,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12570,8 +11323,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12579,8 +11331,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12588,8 +11339,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12597,8 +11347,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12606,8 +11355,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12615,8 +11363,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12624,8 +11371,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12633,8 +11379,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12642,8 +11387,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12651,8 +11395,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12660,8 +11403,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12669,8 +11411,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12678,8 +11419,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "long-handed-inserter",
@@ -12687,8 +11427,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12696,8 +11435,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "transport-belt",
@@ -12705,8 +11443,7 @@
           "y": 6,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -12714,8 +11451,7 @@
           "y": 6,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -12723,8 +11459,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "inserter",
@@ -12732,8 +11467,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12741,8 +11475,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12750,8 +11483,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12759,8 +11491,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12768,8 +11499,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12777,8 +11507,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12786,8 +11515,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12795,8 +11523,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12804,8 +11531,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12813,8 +11539,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12822,8 +11547,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12831,8 +11555,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12840,8 +11563,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12849,8 +11571,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12858,8 +11579,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12867,8 +11587,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12876,8 +11595,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12885,8 +11603,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12894,8 +11611,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12903,8 +11619,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12912,8 +11627,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12921,8 +11635,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12930,8 +11643,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12939,8 +11651,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12948,8 +11659,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12957,8 +11667,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12966,8 +11675,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12975,8 +11683,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -12984,8 +11691,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -12993,8 +11699,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "inserter",
@@ -13002,8 +11707,7 @@
           "y": 6,
           "direction": "South",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:inserter-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:inserter-out"
         },
         {
           "name": "long-handed-inserter",
@@ -13011,8 +11715,7 @@
           "y": 6,
           "direction": "North",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:inserter-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:inserter-in:copper-cable"
         },
         {
           "name": "transport-belt",
@@ -13020,8 +11723,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13029,8 +11731,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13038,8 +11739,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13047,8 +11747,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13056,8 +11755,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13065,8 +11763,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13074,8 +11771,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13083,8 +11779,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13092,8 +11787,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13101,8 +11795,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13110,8 +11803,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13119,8 +11811,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13128,8 +11819,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13137,8 +11827,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13146,8 +11835,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13155,8 +11843,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13164,8 +11851,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13173,8 +11859,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13182,8 +11867,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13191,8 +11875,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13200,8 +11883,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13209,8 +11891,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13218,8 +11899,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13227,8 +11907,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13236,8 +11915,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13245,8 +11923,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13254,8 +11931,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13263,8 +11939,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13272,8 +11947,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13281,8 +11955,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13290,8 +11963,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13299,8 +11971,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13308,8 +11979,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13317,8 +11987,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13326,8 +11995,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13335,8 +12003,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13344,8 +12011,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13353,8 +12019,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13362,8 +12027,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13371,8 +12035,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13380,8 +12043,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13389,8 +12051,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13398,8 +12059,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13407,8 +12067,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13416,8 +12075,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13425,8 +12083,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13434,8 +12091,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13443,8 +12099,7 @@
           "y": 7,
           "direction": "North",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13452,8 +12107,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13461,8 +12115,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13470,8 +12123,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13479,8 +12131,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13488,8 +12139,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13497,8 +12147,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13506,8 +12155,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13515,8 +12163,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13524,8 +12171,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13533,8 +12179,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13542,8 +12187,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13551,8 +12195,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13560,8 +12203,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13569,8 +12211,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13578,8 +12219,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13587,8 +12227,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13596,8 +12235,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13605,8 +12243,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13614,8 +12251,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13623,8 +12259,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13632,8 +12267,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13641,8 +12275,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13650,8 +12283,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13659,8 +12291,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13668,8 +12299,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13677,8 +12307,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13686,8 +12315,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13695,8 +12323,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13704,8 +12331,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13713,8 +12339,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13722,8 +12347,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13731,8 +12355,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13740,8 +12363,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13749,8 +12371,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13758,8 +12379,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13767,8 +12387,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13776,8 +12395,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13785,8 +12403,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13794,8 +12411,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13803,8 +12419,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13812,8 +12427,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13821,8 +12435,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13830,8 +12443,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13839,8 +12451,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13848,8 +12459,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13857,8 +12467,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13866,8 +12475,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13875,8 +12483,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "transport-belt",
@@ -13884,8 +12491,7 @@
           "y": 7,
           "direction": "East",
           "carries": "advanced-circuit",
-          "segment_id": "row:advanced-circuit:belt-out",
-          "rate": 4.0
+          "segment_id": "row:advanced-circuit:belt-out"
         },
         {
           "name": "express-transport-belt",
@@ -13893,8 +12499,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13902,8 +12507,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13911,8 +12515,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13920,8 +12523,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13929,8 +12531,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13938,8 +12539,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13947,8 +12547,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13956,8 +12555,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13965,8 +12563,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13974,8 +12571,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13983,8 +12579,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -13992,8 +12587,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14001,8 +12595,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14010,8 +12603,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14019,8 +12611,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14028,8 +12619,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14037,8 +12627,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14046,8 +12635,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14055,8 +12643,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14064,8 +12651,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14073,8 +12659,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14082,8 +12667,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14091,8 +12675,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14100,8 +12683,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14109,8 +12691,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14118,8 +12699,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14127,8 +12707,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14136,8 +12715,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14145,8 +12723,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14154,8 +12731,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14163,8 +12739,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14172,8 +12747,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14181,8 +12755,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14190,8 +12763,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14199,8 +12771,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14208,8 +12779,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14217,8 +12787,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14226,8 +12795,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14235,8 +12803,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14244,8 +12811,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14253,8 +12819,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14262,8 +12827,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14271,8 +12835,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14280,8 +12843,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14289,8 +12851,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14298,8 +12859,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14307,8 +12867,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14316,8 +12875,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14325,8 +12883,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14334,8 +12891,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14343,8 +12899,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14352,8 +12907,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14361,8 +12915,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14370,8 +12923,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14379,8 +12931,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14388,8 +12939,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14397,8 +12947,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14406,8 +12955,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14415,8 +12963,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14424,8 +12971,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14433,8 +12979,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14442,8 +12987,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14451,8 +12995,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14460,8 +13003,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14469,8 +13011,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14478,8 +13019,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14487,8 +13027,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14496,8 +13035,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14505,8 +13043,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14514,8 +13051,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14523,8 +13059,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14532,8 +13067,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14541,8 +13075,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14550,8 +13083,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14559,8 +13091,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14568,8 +13099,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14577,8 +13107,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14586,8 +13115,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14595,8 +13123,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14604,8 +13131,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14613,8 +13139,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14622,8 +13147,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14631,8 +13155,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14640,8 +13163,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14649,8 +13171,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14658,8 +13179,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14667,8 +13187,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14676,8 +13195,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14685,8 +13203,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14694,8 +13211,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14703,8 +13219,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14712,8 +13227,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14721,8 +13235,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14730,8 +13243,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14739,8 +13251,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14748,8 +13259,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         },
         {
           "name": "express-transport-belt",
@@ -14757,8 +13267,7 @@
           "y": 8,
           "direction": "East",
           "carries": "copper-cable",
-          "segment_id": "row:advanced-circuit:belt-in:copper-cable",
-          "rate": 16.0
+          "segment_id": "row:advanced-circuit:belt-in:copper-cable"
         }
       ],
       "ports": [

--- a/crates/core/data/celldb.json
+++ b/crates/core/data/celldb.json
@@ -3494,7 +3494,7 @@
         "interior_tiles": 817,
         "entity_count": 433
       },
-      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -5838,7 +5838,7 @@
         "interior_tiles": 545,
         "entity_count": 289
       },
-      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -7338,7 +7338,7 @@
         "interior_tiles": 342,
         "entity_count": 182
       },
-      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -8866,7 +8866,7 @@
         "interior_tiles": 296,
         "entity_count": 184
       },
-      "provenance": "engine@worktree fixture=electronic-circuit@20",
+      "provenance": "engine@3ec12291 fixture=electronic-circuit@20",
       "sim_anchor": "unanchored"
     },
     {
@@ -13302,7 +13302,7 @@
         "interior_tiles": 805,
         "entity_count": 549
       },
-      "provenance": "engine@worktree fixture=advanced-circuit@4",
+      "provenance": "engine@3ec12291 fixture=advanced-circuit@4",
       "sim_anchor": "unanchored"
     }
   ]

--- a/crates/core/examples/celldb_seed.rs
+++ b/crates/core/examples/celldb_seed.rs
@@ -1,16 +1,13 @@
 //! Seed tool for the cell-interface DB (RFC-067 P1). Regenerates
 //! `crates/core/data/celldb.json` from ENGINE OUTPUT — metrics are recorded
-//! by this tool, never typed by hand, and provenance names the fixture and
-//! SHA so drift is attributable.
+//! by the extraction, never typed by hand, and provenance names the fixture
+//! and SHA so drift is attributable.
 //!
-//! Extraction: build a source fixture's full layout, then for each target
-//! recipe take its machines plus every entity whose segment id starts
-//! `row:{recipe}:` — the same attribution rule the Phase-0 cost probe used.
-//! Fragments normalize to origin. Ports are DERIVED, not declared: a
-//! belt-in run's port is the tile no fragment tile feeds; a belt-out run's
-//! port is the tile whose successor lies outside the fragment. Ambiguity
-//! (0 or >1 candidates) prints a loud PORT-WARN — K67-1's escape-hatch
-//! count is exactly the number of those lines.
+//! The extraction itself lives in `spaghettio_core::celldb::extract_unit`
+//! (so the drift regression test can re-extract from a fresh layout and
+//! diff against the store); this tool is a thin driver that picks the
+//! source fixtures and writes the JSON. Every extraction warning prints as
+//! SEED-WARN — each one is an escape hatch under RFC-067 K67-1.
 //!
 //! Top-5 motifs (Phase-0 census) via two fixtures:
 //!   electronic-circuit@20 from ore  -> copper-plate, iron-plate,
@@ -18,160 +15,8 @@
 //!   advanced-circuit@4 from plates  -> advanced-circuit
 use rustc_hash::FxHashSet;
 use spaghettio_core::bus::layout::{self, LayoutOptions};
-use spaghettio_core::celldb::{CellDb, CellEntry, Metrics, Motif, Port, PortKind};
-use spaghettio_core::common::{dir_to_vec, entity_size, is_machine_entity};
-use spaghettio_core::models::PlacedEntity;
+use spaghettio_core::celldb::{extract_unit, CellDb, CellEntry, Motif};
 use spaghettio_core::solver;
-
-fn extract(
-    entities: &[PlacedEntity],
-    recipe: &str,
-    machine: &str,
-    provenance: &str,
-) -> Option<CellEntry> {
-    let frag: Vec<PlacedEntity> = entities
-        .iter()
-        .filter(|e| {
-            e.recipe.as_deref() == Some(recipe) && is_machine_entity(&e.name)
-                || e
-                    .segment_id
-                    .as_deref()
-                    .is_some_and(|s| s.starts_with(&format!("row:{recipe}:")))
-        })
-        .cloned()
-        .collect();
-    if frag.is_empty() {
-        println!("EXTRACT-WARN: no entities for {recipe}");
-        return None;
-    }
-    // Normalize to origin.
-    let min_x = frag.iter().map(|e| e.x).min().unwrap();
-    let min_y = frag.iter().map(|e| e.y).min().unwrap();
-    let mut frag: Vec<PlacedEntity> = frag
-        .into_iter()
-        .map(|mut e| {
-            e.x -= min_x;
-            e.y -= min_y;
-            e
-        })
-        .collect();
-    frag.sort_by_key(|e| (e.y, e.x, e.name.clone()));
-
-    let count = frag
-        .iter()
-        .filter(|e| e.recipe.as_deref() == Some(recipe) && is_machine_entity(&e.name))
-        .count() as u32;
-
-    // Occupied tile set for successor/feeder tests.
-    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
-    let mut tiles = 0u32;
-    let (mut max_x, mut max_y) = (0, 0);
-    for e in &frag {
-        let (w, h) = entity_size(&e.name);
-        for dx in 0..w as i32 {
-            for dy in 0..h as i32 {
-                occupied.insert((e.x + dx, e.y + dy));
-                max_x = max_x.max(e.x + dx);
-                max_y = max_y.max(e.y + dy);
-                tiles += 1;
-            }
-        }
-    }
-
-    // Derive ports from the belt-in / belt-out / fluid-in segment runs.
-    let mut ports: Vec<Port> = Vec::new();
-    let mut seg_items: Vec<(String, String)> = Vec::new(); // (seg kind, item)
-    for e in &frag {
-        if let Some(s) = e.segment_id.as_deref() {
-            let parts: Vec<&str> = s.split(':').collect();
-            if parts.len() >= 4 && (parts[2] == "belt-in" || parts[2] == "fluid-in") {
-                let key = (parts[2].to_string(), parts[3].to_string());
-                if !seg_items.contains(&key) {
-                    seg_items.push(key);
-                }
-            } else if parts.len() >= 3 && parts[2] == "belt-out" {
-                let item = parts.get(3).unwrap_or(&recipe).to_string();
-                let key = ("belt-out".to_string(), item);
-                if !seg_items.contains(&key) {
-                    seg_items.push(key);
-                }
-            }
-        }
-    }
-    for (kind, item) in &seg_items {
-        let run: Vec<&PlacedEntity> = frag
-            .iter()
-            .filter(|e| {
-                e.segment_id.as_deref().is_some_and(|s| {
-                    let p: Vec<&str> = s.split(':').collect();
-                    p.get(2).is_some_and(|k| k == kind)
-                        && (p.get(3).is_some_and(|i| i == item) || (kind == "belt-out" && p.len() == 3))
-                })
-            })
-            .collect();
-        let candidates: Vec<(i32, i32)> = match kind.as_str() {
-            "belt-in" => run
-                .iter()
-                .filter(|t| {
-                    !run.iter().any(|f| {
-                        let (dx, dy) = dir_to_vec(f.direction);
-                        (f.x + dx, f.y + dy) == (t.x, t.y)
-                    })
-                })
-                .map(|t| (t.x, t.y))
-                .collect(),
-            "belt-out" => run
-                .iter()
-                .filter(|t| {
-                    let (dx, dy) = dir_to_vec(t.direction);
-                    !occupied.contains(&(t.x + dx, t.y + dy))
-                })
-                .map(|t| (t.x, t.y))
-                .collect(),
-            _ => run
-                .iter()
-                .filter(|t| t.x == 0 || t.x == max_x || t.y == 0 || t.y == max_y)
-                .map(|t| (t.x, t.y))
-                .collect(),
-        };
-        // Multiple candidates are not ambiguity — a split row has one entry
-        // per half, and each is a genuine boundary port that composition
-        // must feed. Emit them all; only ZERO candidates is a defect worth
-        // a warning (and an escape hatch under K67-1).
-        if candidates.is_empty() {
-            println!("PORT-WARN {recipe}: {kind}:{item} has no candidate tiles");
-            continue;
-        }
-        let pk = match kind.as_str() {
-            "belt-in" => PortKind::BeltIn,
-            "belt-out" => PortKind::BeltOut,
-            _ => PortKind::PipeIn,
-        };
-        let mut sorted = candidates.clone();
-        sorted.sort();
-        for (dx, dy) in sorted {
-            ports.push(Port { dx, dy, kind: pk, item: item.clone() });
-        }
-    }
-
-    Some(CellEntry {
-        motif: Motif::Unit {
-            recipe: recipe.to_string(),
-            machine: machine.to_string(),
-            count,
-        },
-        metrics: Metrics {
-            bbox_w: max_x + 1,
-            bbox_h: max_y + 1,
-            interior_tiles: tiles,
-            entity_count: frag.len() as u32,
-        },
-        entities: frag,
-        ports,
-        provenance: provenance.to_string(),
-        sim_anchor: "unanchored".to_string(),
-    })
-}
 
 fn main() {
     let sha = std::env::var("SEED_SHA").unwrap_or_else(|_| "worktree".into());
@@ -199,6 +44,7 @@ fn main() {
         ),
     ];
 
+    let mut total_warnings = 0usize;
     for (item, rate, machine, inputs, targets) in sources {
         let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve(item, rate, &input_set, machine).expect("seed fixture must solve");
@@ -206,7 +52,12 @@ fn main() {
             .expect("seed fixture must lay out");
         let prov = format!("engine@{sha} fixture={item}@{rate}");
         for (recipe, target_machine) in targets {
-            if let Some(e) = extract(&l.entities, recipe, target_machine, &prov) {
+            let (entry, warnings) = extract_unit(&l.entities, recipe, target_machine, &prov);
+            for w in &warnings {
+                println!("SEED-WARN {recipe}: {w}");
+            }
+            total_warnings += warnings.len();
+            if let Some(e) = entry {
                 println!(
                     "seeded {recipe:<24} count={:<3} bbox={}x{} tiles={} ports={}",
                     match &e.motif {
@@ -226,5 +77,8 @@ fn main() {
     let db = CellDb { version: 1, entries };
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/data/celldb.json");
     std::fs::write(path, serde_json::to_string_pretty(&db).unwrap()).unwrap();
-    println!("wrote {} entries to {path}", db.entries.len());
+    println!(
+        "wrote {} entries to {path}  (escape hatches: {total_warnings} — K67-1 trips above 1)",
+        db.entries.len()
+    );
 }

--- a/crates/core/examples/celldb_seed.rs
+++ b/crates/core/examples/celldb_seed.rs
@@ -1,0 +1,228 @@
+//! Seed tool for the cell-interface DB (RFC-067 P1). Regenerates
+//! `crates/core/data/celldb.json` from ENGINE OUTPUT — metrics are recorded
+//! by this tool, never typed by hand, and provenance names the fixture and
+//! SHA so drift is attributable.
+//!
+//! Extraction: build a source fixture's full layout, then for each target
+//! recipe take its machines plus every entity whose segment id starts
+//! `row:{recipe}:` — the same attribution rule the Phase-0 cost probe used.
+//! Fragments normalize to origin. Ports are DERIVED, not declared: a
+//! belt-in run's port is the tile no fragment tile feeds; a belt-out run's
+//! port is the tile whose successor lies outside the fragment. Ambiguity
+//! (0 or >1 candidates) prints a loud PORT-WARN — K67-1's escape-hatch
+//! count is exactly the number of those lines.
+//!
+//! Top-5 motifs (Phase-0 census) via two fixtures:
+//!   electronic-circuit@20 from ore  -> copper-plate, iron-plate,
+//!                                      copper-cable, electronic-circuit
+//!   advanced-circuit@4 from plates  -> advanced-circuit
+use rustc_hash::FxHashSet;
+use spaghettio_core::bus::layout::{self, LayoutOptions};
+use spaghettio_core::celldb::{CellDb, CellEntry, Metrics, Motif, Port, PortKind};
+use spaghettio_core::common::{dir_to_vec, entity_size, is_machine_entity};
+use spaghettio_core::models::PlacedEntity;
+use spaghettio_core::solver;
+
+fn extract(
+    entities: &[PlacedEntity],
+    recipe: &str,
+    machine: &str,
+    provenance: &str,
+) -> Option<CellEntry> {
+    let frag: Vec<PlacedEntity> = entities
+        .iter()
+        .filter(|e| {
+            e.recipe.as_deref() == Some(recipe) && is_machine_entity(&e.name)
+                || e
+                    .segment_id
+                    .as_deref()
+                    .is_some_and(|s| s.starts_with(&format!("row:{recipe}:")))
+        })
+        .cloned()
+        .collect();
+    if frag.is_empty() {
+        println!("EXTRACT-WARN: no entities for {recipe}");
+        return None;
+    }
+    // Normalize to origin.
+    let min_x = frag.iter().map(|e| e.x).min().unwrap();
+    let min_y = frag.iter().map(|e| e.y).min().unwrap();
+    let mut frag: Vec<PlacedEntity> = frag
+        .into_iter()
+        .map(|mut e| {
+            e.x -= min_x;
+            e.y -= min_y;
+            e
+        })
+        .collect();
+    frag.sort_by_key(|e| (e.y, e.x, e.name.clone()));
+
+    let count = frag
+        .iter()
+        .filter(|e| e.recipe.as_deref() == Some(recipe) && is_machine_entity(&e.name))
+        .count() as u32;
+
+    // Occupied tile set for successor/feeder tests.
+    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+    let mut tiles = 0u32;
+    let (mut max_x, mut max_y) = (0, 0);
+    for e in &frag {
+        let (w, h) = entity_size(&e.name);
+        for dx in 0..w as i32 {
+            for dy in 0..h as i32 {
+                occupied.insert((e.x + dx, e.y + dy));
+                max_x = max_x.max(e.x + dx);
+                max_y = max_y.max(e.y + dy);
+                tiles += 1;
+            }
+        }
+    }
+
+    // Derive ports from the belt-in / belt-out / fluid-in segment runs.
+    let mut ports: Vec<Port> = Vec::new();
+    let mut seg_items: Vec<(String, String)> = Vec::new(); // (seg kind, item)
+    for e in &frag {
+        if let Some(s) = e.segment_id.as_deref() {
+            let parts: Vec<&str> = s.split(':').collect();
+            if parts.len() >= 4 && (parts[2] == "belt-in" || parts[2] == "fluid-in") {
+                let key = (parts[2].to_string(), parts[3].to_string());
+                if !seg_items.contains(&key) {
+                    seg_items.push(key);
+                }
+            } else if parts.len() >= 3 && parts[2] == "belt-out" {
+                let item = parts.get(3).unwrap_or(&recipe).to_string();
+                let key = ("belt-out".to_string(), item);
+                if !seg_items.contains(&key) {
+                    seg_items.push(key);
+                }
+            }
+        }
+    }
+    for (kind, item) in &seg_items {
+        let run: Vec<&PlacedEntity> = frag
+            .iter()
+            .filter(|e| {
+                e.segment_id.as_deref().is_some_and(|s| {
+                    let p: Vec<&str> = s.split(':').collect();
+                    p.get(2).is_some_and(|k| k == kind)
+                        && (p.get(3).is_some_and(|i| i == item) || (kind == "belt-out" && p.len() == 3))
+                })
+            })
+            .collect();
+        let candidates: Vec<(i32, i32)> = match kind.as_str() {
+            "belt-in" => run
+                .iter()
+                .filter(|t| {
+                    !run.iter().any(|f| {
+                        let (dx, dy) = dir_to_vec(f.direction);
+                        (f.x + dx, f.y + dy) == (t.x, t.y)
+                    })
+                })
+                .map(|t| (t.x, t.y))
+                .collect(),
+            "belt-out" => run
+                .iter()
+                .filter(|t| {
+                    let (dx, dy) = dir_to_vec(t.direction);
+                    !occupied.contains(&(t.x + dx, t.y + dy))
+                })
+                .map(|t| (t.x, t.y))
+                .collect(),
+            _ => run
+                .iter()
+                .filter(|t| t.x == 0 || t.x == max_x || t.y == 0 || t.y == max_y)
+                .map(|t| (t.x, t.y))
+                .collect(),
+        };
+        if candidates.len() != 1 {
+            println!(
+                "PORT-WARN {recipe}: {kind}:{item} has {} candidate tiles {:?} — picking min",
+                candidates.len(),
+                candidates
+            );
+        }
+        let Some(&(dx, dy)) = candidates.iter().min() else {
+            continue;
+        };
+        let pk = match kind.as_str() {
+            "belt-in" => PortKind::BeltIn,
+            "belt-out" => PortKind::BeltOut,
+            _ => PortKind::PipeIn,
+        };
+        ports.push(Port { dx, dy, kind: pk, item: item.clone() });
+    }
+
+    Some(CellEntry {
+        motif: Motif::Unit {
+            recipe: recipe.to_string(),
+            machine: machine.to_string(),
+            count,
+        },
+        metrics: Metrics {
+            bbox_w: max_x + 1,
+            bbox_h: max_y + 1,
+            interior_tiles: tiles,
+            entity_count: frag.len() as u32,
+        },
+        entities: frag,
+        ports,
+        provenance: provenance.to_string(),
+        sim_anchor: "unanchored".to_string(),
+    })
+}
+
+fn main() {
+    let sha = std::env::var("SEED_SHA").unwrap_or_else(|_| "worktree".into());
+    let mut entries: Vec<CellEntry> = Vec::new();
+
+    let sources: Vec<(&str, f64, &str, Vec<&str>, Vec<(&str, &str)>)> = vec![
+        (
+            "electronic-circuit",
+            20.0,
+            "assembling-machine-2",
+            vec!["iron-ore", "copper-ore"],
+            vec![
+                ("copper-plate", "electric-furnace"),
+                ("iron-plate", "electric-furnace"),
+                ("copper-cable", "assembling-machine-2"),
+                ("electronic-circuit", "assembling-machine-2"),
+            ],
+        ),
+        (
+            "advanced-circuit",
+            4.0,
+            "assembling-machine-2",
+            vec!["iron-plate", "copper-plate", "plastic-bar"],
+            vec![("advanced-circuit", "assembling-machine-2")],
+        ),
+    ];
+
+    for (item, rate, machine, inputs, targets) in sources {
+        let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = solver::solve(item, rate, &input_set, machine).expect("seed fixture must solve");
+        let l = layout::build_bus_layout(&sr, LayoutOptions::default())
+            .expect("seed fixture must lay out");
+        let prov = format!("engine@{sha} fixture={item}@{rate}");
+        for (recipe, target_machine) in targets {
+            if let Some(e) = extract(&l.entities, recipe, target_machine, &prov) {
+                println!(
+                    "seeded {recipe:<24} count={:<3} bbox={}x{} tiles={} ports={}",
+                    match &e.motif {
+                        Motif::Unit { count, .. } => *count,
+                        _ => 0,
+                    },
+                    e.metrics.bbox_w,
+                    e.metrics.bbox_h,
+                    e.metrics.interior_tiles,
+                    e.ports.len()
+                );
+                entries.push(e);
+            }
+        }
+    }
+
+    let db = CellDb { version: 1, entries };
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/data/celldb.json");
+    std::fs::write(path, serde_json::to_string_pretty(&db).unwrap()).unwrap();
+    println!("wrote {} entries to {path}", db.entries.len());
+}

--- a/crates/core/examples/celldb_seed.rs
+++ b/crates/core/examples/celldb_seed.rs
@@ -134,22 +134,24 @@ fn extract(
                 .map(|t| (t.x, t.y))
                 .collect(),
         };
-        if candidates.len() != 1 {
-            println!(
-                "PORT-WARN {recipe}: {kind}:{item} has {} candidate tiles {:?} — picking min",
-                candidates.len(),
-                candidates
-            );
-        }
-        let Some(&(dx, dy)) = candidates.iter().min() else {
+        // Multiple candidates are not ambiguity — a split row has one entry
+        // per half, and each is a genuine boundary port that composition
+        // must feed. Emit them all; only ZERO candidates is a defect worth
+        // a warning (and an escape hatch under K67-1).
+        if candidates.is_empty() {
+            println!("PORT-WARN {recipe}: {kind}:{item} has no candidate tiles");
             continue;
-        };
+        }
         let pk = match kind.as_str() {
             "belt-in" => PortKind::BeltIn,
             "belt-out" => PortKind::BeltOut,
             _ => PortKind::PipeIn,
         };
-        ports.push(Port { dx, dy, kind: pk, item: item.clone() });
+        let mut sorted = candidates.clone();
+        sorted.sort();
+        for (dx, dy) in sorted {
+            ports.push(Port { dx, dy, kind: pk, item: item.clone() });
+        }
     }
 
     Some(CellEntry {

--- a/crates/core/examples/celldb_seed.rs
+++ b/crates/core/examples/celldb_seed.rs
@@ -19,33 +19,29 @@ use spaghettio_core::celldb::{extract_unit, CellDb, CellEntry, Motif};
 use spaghettio_core::solver;
 
 fn main() {
-    let sha = std::env::var("SEED_SHA").unwrap_or_else(|_| "worktree".into());
+    // Provenance SHA: explicit SEED_SHA, else the actual HEAD — committing
+    // "engine@worktree" identified no real commit, defeating the very
+    // attributability provenance exists for (round-2 review, 3/3). A dirty
+    // tree is marked as such.
+    let sha = std::env::var("SEED_SHA").unwrap_or_else(|_| {
+        let head = std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_else(|| "unknown".into());
+        let dirty = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .output()
+            .ok()
+            .is_some_and(|o| !o.stdout.is_empty());
+        if dirty { format!("{head}-dirty") } else { head }
+    });
     let mut entries: Vec<CellEntry> = Vec::new();
 
-    let sources: Vec<(&str, f64, &str, Vec<&str>, Vec<(&str, &str)>)> = vec![
-        (
-            "electronic-circuit",
-            20.0,
-            "assembling-machine-2",
-            vec!["iron-ore", "copper-ore"],
-            vec![
-                ("copper-plate", "electric-furnace"),
-                ("iron-plate", "electric-furnace"),
-                ("copper-cable", "assembling-machine-2"),
-                ("electronic-circuit", "assembling-machine-2"),
-            ],
-        ),
-        (
-            "advanced-circuit",
-            4.0,
-            "assembling-machine-2",
-            vec!["iron-plate", "copper-plate", "plastic-bar"],
-            vec![("advanced-circuit", "assembling-machine-2")],
-        ),
-    ];
-
     let mut total_warnings = 0usize;
-    for (item, rate, machine, inputs, targets) in sources {
+    for (item, rate, machine, inputs, targets) in spaghettio_core::celldb::seed_sources() {
         let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let sr = solver::solve(item, rate, &input_set, machine).expect("seed fixture must solve");
         let l = layout::build_bus_layout(&sr, LayoutOptions::default())
@@ -74,11 +70,20 @@ fn main() {
         }
     }
 
+    // K67-1 enforced at the tool, not narrated: a degraded seed must not
+    // ship (round-2 review — the gate was announced but the tool wrote and
+    // exited 0 regardless).
+    if total_warnings > 0 {
+        eprintln!(
+            "ERROR: {total_warnings} extraction warning(s) — refusing to write a degraded store."
+        );
+        std::process::exit(2);
+    }
     let db = CellDb { version: 1, entries };
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/data/celldb.json");
     std::fs::write(path, serde_json::to_string_pretty(&db).unwrap()).unwrap();
     println!(
-        "wrote {} entries to {path}  (escape hatches: {total_warnings} — K67-1 trips above 1)",
+        "wrote {} entries to {path}  (escape hatches: 0 — K67-1 clean)",
         db.entries.len()
     );
 }

--- a/crates/core/src/celldb.rs
+++ b/crates/core/src/celldb.rs
@@ -16,7 +16,7 @@
 //! `recipes.json` / balancer-library pattern: versioned, diffable, no
 //! infrastructure.
 
-use crate::common::{entity_size, is_surface_belt, is_ug_belt};
+use crate::common::{entity_size, is_machine_entity, is_splitter, is_surface_belt, is_ug_belt};
 use crate::models::PlacedEntity;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
@@ -95,7 +95,7 @@ impl DerivedConstraints {
         let mut belt_tiers = BTreeSet::new();
         for e in &entry.entities {
             vocabulary.insert(e.name.clone());
-            if is_surface_belt(&e.name) || is_ug_belt(&e.name) || e.name.contains("splitter") {
+            if is_surface_belt(&e.name) || is_ug_belt(&e.name) || is_splitter(&e.name) {
                 belt_tiers.insert(e.name.clone());
             }
         }
@@ -150,6 +150,169 @@ pub fn query_unit<'a>(
     hits
 }
 
+/// Extract a unit-motif fragment from a laid-out entity list: the recipe's
+/// machines plus every `row:{recipe}:*` entity, origin-normalized, with
+/// ports DERIVED from the belt-in/belt-out/fluid-in segment runs. Returns
+/// the entry plus any derivation warnings — a warning is an escape hatch
+/// under RFC-067 K67-1, so the seed tool prints them and the drift test
+/// asserts there are none.
+///
+/// Lives in the library (not the seed example) so the regression test can
+/// re-extract from a freshly built layout and diff against the stored
+/// entry — stored-vs-stored testing cannot see engine drift.
+pub fn extract_unit(
+    entities: &[PlacedEntity],
+    recipe: &str,
+    machine: &str,
+    provenance: &str,
+) -> (Option<CellEntry>, Vec<String>) {
+    use crate::common::{dir_to_vec, is_machine_entity};
+    let mut warnings = Vec::new();
+    let frag: Vec<PlacedEntity> = entities
+        .iter()
+        .filter(|e| {
+            e.recipe.as_deref() == Some(recipe) && is_machine_entity(&e.name)
+                || e
+                    .segment_id
+                    .as_deref()
+                    .is_some_and(|s| s.starts_with(&format!("row:{recipe}:")))
+        })
+        .cloned()
+        .collect();
+    if frag.is_empty() {
+        warnings.push(format!("no entities for {recipe}"));
+        return (None, warnings);
+    }
+    let min_x = frag.iter().map(|e| e.x).min().unwrap();
+    let min_y = frag.iter().map(|e| e.y).min().unwrap();
+    let mut frag: Vec<PlacedEntity> = frag
+        .into_iter()
+        .map(|mut e| {
+            e.x -= min_x;
+            e.y -= min_y;
+            // Counts stored, rates derived — enforced at extraction: rate
+            // stamps are fixture-specific flow aggregates and committing
+            // them is the stale-declared-data failure the schema bans.
+            e.rate = None;
+            e
+        })
+        .collect();
+    frag.sort_by_key(|e| (e.y, e.x, e.name.clone()));
+
+    let count = frag
+        .iter()
+        .filter(|e| e.recipe.as_deref() == Some(recipe) && is_machine_entity(&e.name))
+        .count() as u32;
+
+    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+    let mut tiles = 0u32;
+    let (mut max_x, mut max_y) = (0, 0);
+    for e in &frag {
+        let (w, h) = entity_size(&e.name);
+        for dx in 0..w as i32 {
+            for dy in 0..h as i32 {
+                occupied.insert((e.x + dx, e.y + dy));
+                max_x = max_x.max(e.x + dx);
+                max_y = max_y.max(e.y + dy);
+                tiles += 1;
+            }
+        }
+    }
+
+    let mut ports: Vec<Port> = Vec::new();
+    let mut seg_items: Vec<(String, String)> = Vec::new();
+    for e in &frag {
+        if let Some(s) = e.segment_id.as_deref() {
+            let parts: Vec<&str> = s.split(':').collect();
+            if parts.len() >= 4 && (parts[2] == "belt-in" || parts[2] == "fluid-in") {
+                let key = (parts[2].to_string(), parts[3].to_string());
+                if !seg_items.contains(&key) {
+                    seg_items.push(key);
+                }
+            } else if parts.len() >= 3 && parts[2] == "belt-out" {
+                let item = parts.get(3).unwrap_or(&recipe).to_string();
+                let key = ("belt-out".to_string(), item);
+                if !seg_items.contains(&key) {
+                    seg_items.push(key);
+                }
+            }
+        }
+    }
+    for (kind, item) in &seg_items {
+        let run: Vec<&PlacedEntity> = frag
+            .iter()
+            .filter(|e| {
+                e.segment_id.as_deref().is_some_and(|s| {
+                    let p: Vec<&str> = s.split(':').collect();
+                    p.get(2).is_some_and(|k| k == kind)
+                        && (p.get(3).is_some_and(|i| i == item)
+                            || (kind == "belt-out" && p.len() == 3))
+                })
+            })
+            .collect();
+        let candidates: Vec<(i32, i32)> = match kind.as_str() {
+            "belt-in" => run
+                .iter()
+                .filter(|t| {
+                    !run.iter().any(|f| {
+                        let (dx, dy) = dir_to_vec(f.direction);
+                        (f.x + dx, f.y + dy) == (t.x, t.y)
+                    })
+                })
+                .map(|t| (t.x, t.y))
+                .collect(),
+            "belt-out" => run
+                .iter()
+                .filter(|t| {
+                    let (dx, dy) = dir_to_vec(t.direction);
+                    !occupied.contains(&(t.x + dx, t.y + dy))
+                })
+                .map(|t| (t.x, t.y))
+                .collect(),
+            _ => run
+                .iter()
+                .filter(|t| t.x == 0 || t.x == max_x || t.y == 0 || t.y == max_y)
+                .map(|t| (t.x, t.y))
+                .collect(),
+        };
+        // Multiple candidates are genuine (one port per split-row half);
+        // only ZERO is an escape hatch.
+        if candidates.is_empty() {
+            warnings.push(format!("{kind}:{item} derived no port tiles"));
+            continue;
+        }
+        let pk = match kind.as_str() {
+            "belt-in" => PortKind::BeltIn,
+            "belt-out" => PortKind::BeltOut,
+            _ => PortKind::PipeIn,
+        };
+        let mut sorted = candidates.clone();
+        sorted.sort();
+        for (dx, dy) in sorted {
+            ports.push(Port { dx, dy, kind: pk, item: item.clone() });
+        }
+    }
+
+    let entry = CellEntry {
+        motif: Motif::Unit {
+            recipe: recipe.to_string(),
+            machine: machine.to_string(),
+            count,
+        },
+        metrics: Metrics {
+            bbox_w: max_x + 1,
+            bbox_h: max_y + 1,
+            interior_tiles: tiles,
+            entity_count: frag.len() as u32,
+        },
+        entities: frag,
+        ports,
+        provenance: provenance.to_string(),
+        sim_anchor: "unanchored".to_string(),
+    };
+    (Some(entry), warnings)
+}
+
 /// Structural invariants every entry must hold. Returns human-readable
 /// violations; the test suite asserts the list is empty for every embedded
 /// entry, so a bad seed is a build failure, not a runtime surprise.
@@ -202,6 +365,27 @@ pub fn check_entry(entry: &CellEntry) -> Vec<String> {
             entry.entities.len()
         ));
     }
+    // Counts stored, rates derived — both halves enforced. A stored rate is
+    // stale-by-construction data; a motif count diverging from the fragment
+    // silently mis-ranks every query while tests stay green (round-1
+    // review, both flagged).
+    for e in &entry.entities {
+        if e.rate.is_some() {
+            issues.push(format!("entity {} at ({},{}) stores a rate", e.name, e.x, e.y));
+        }
+    }
+    if let Motif::Unit { recipe, machine, count } = &entry.motif {
+        let derived = entry
+            .entities
+            .iter()
+            .filter(|e| e.recipe.as_deref() == Some(recipe.as_str()) && &e.name == machine)
+            .count() as u32;
+        if derived != *count {
+            issues.push(format!(
+                "motif count {count} != {derived} matching machines in fragment"
+            ));
+        }
+    }
     if entry.ports.is_empty() {
         issues.push("entry declares no ports".into());
     }
@@ -210,6 +394,30 @@ pub fn check_entry(entry: &CellEntry) -> Vec<String> {
             p.dx == min_x || p.dx == max_x || p.dy == min_y || p.dy == max_y;
         if !on_edge {
             issues.push(format!("port at ({},{}) not on fragment boundary", p.dx, p.dy));
+        }
+        // A port must be a real transport tile carrying the declared item —
+        // an unoccupied or wrong-item port composes into a dead feed.
+        let holder = entry.entities.iter().find(|e| {
+            let (w, h) = entity_size(&e.name);
+            p.dx >= e.x && p.dx < e.x + w as i32 && p.dy >= e.y && p.dy < e.y + h as i32
+        });
+        match holder {
+            None => issues.push(format!("port at ({},{}) is an empty tile", p.dx, p.dy)),
+            Some(e) => {
+                if is_machine_entity(&e.name) {
+                    issues.push(format!(
+                        "port at ({},{}) sits on machine {}, not transport",
+                        p.dx, p.dy, e.name
+                    ));
+                } else if let Some(c) = e.carries.as_deref() {
+                    if c != p.item {
+                        issues.push(format!(
+                            "port at ({},{}) declares {} but tile carries {c}",
+                            p.dx, p.dy, p.item
+                        ));
+                    }
+                }
+            }
         }
     }
     issues
@@ -255,6 +463,40 @@ mod tests {
                 assert!(counts.iter().all(|c| c >= count));
             }
         }
+    }
+
+    /// The drift test the round-1 review asked for: stored-vs-CURRENT-ENGINE,
+    /// not stored-vs-stored. Rebuilds one seed source fixture, re-extracts,
+    /// and diffs against the committed entry — an engine change that moves
+    /// the fragment now fails here instead of sailing through.
+    #[test]
+    fn stored_entry_matches_fresh_engine_extraction() {
+        use crate::bus::layout::{self, LayoutOptions};
+        let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "plastic-bar"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let sr = crate::solver::solve("advanced-circuit", 4.0, &inputs, "assembling-machine-2")
+            .expect("seed source solves");
+        let l = layout::build_bus_layout(&sr, LayoutOptions::default())
+            .expect("seed source lays out");
+        let (fresh, warnings) =
+            extract_unit(&l.entities, "advanced-circuit", "assembling-machine-2", "test");
+        assert!(warnings.is_empty(), "escape hatches on re-extraction: {warnings:?}");
+        let fresh = fresh.expect("extraction succeeds");
+        let stored = celldb()
+            .entries
+            .iter()
+            .find(|e| matches!(&e.motif, Motif::Unit { recipe, .. } if recipe == "advanced-circuit"))
+            .expect("advanced-circuit entry is seeded");
+        assert_eq!(stored.motif, fresh.motif, "motif drifted from engine output");
+        assert_eq!(stored.metrics, fresh.metrics, "metrics drifted from engine output");
+        assert_eq!(stored.ports, fresh.ports, "ports drifted from engine output");
+        assert_eq!(
+            stored.entities.len(),
+            fresh.entities.len(),
+            "entity roster drifted from engine output"
+        );
     }
 
     #[test]

--- a/crates/core/src/celldb.rs
+++ b/crates/core/src/celldb.rs
@@ -86,6 +86,10 @@ pub struct DerivedConstraints {
     /// this set: filter with `is_satisfied_by`.
     pub vocabulary: BTreeSet<String>,
     /// Belt tiers used (prototype names of surface/UG belts and splitters).
+    /// Not consumed by `query_unit` here — its consumer is the template
+    /// candidate's hard belt-cap filter (RFC-067 P3, the stacked PR), which
+    /// maps these to surface tiers and refuses unknown names. Kept on this
+    /// type because deriving it belongs with the vocabulary derivation.
     pub belt_tiers: BTreeSet<String>,
 }
 
@@ -148,6 +152,34 @@ pub fn query_unit<'a>(
         (c, e.metrics.interior_tiles)
     });
     hits
+}
+
+/// The seed source fixtures — the single authority consumed by BOTH the
+/// seed tool and the drift regression test, so the test's coverage cannot
+/// diverge from what the tool seeds (round-2 review: only 1 of 5 entries
+/// was drift-protected when the lists lived apart).
+pub fn seed_sources() -> Vec<(&'static str, f64, &'static str, Vec<&'static str>, Vec<(&'static str, &'static str)>)> {
+    vec![
+        (
+            "electronic-circuit",
+            20.0,
+            "assembling-machine-2",
+            vec!["iron-ore", "copper-ore"],
+            vec![
+                ("copper-plate", "electric-furnace"),
+                ("iron-plate", "electric-furnace"),
+                ("copper-cable", "assembling-machine-2"),
+                ("electronic-circuit", "assembling-machine-2"),
+            ],
+        ),
+        (
+            "advanced-circuit",
+            4.0,
+            "assembling-machine-2",
+            vec!["iron-plate", "copper-plate", "plastic-bar"],
+            vec![("advanced-circuit", "assembling-machine-2")],
+        ),
+    ]
 }
 
 /// Extract a unit-motif fragment from a laid-out entity list: the recipe's
@@ -465,37 +497,56 @@ mod tests {
         }
     }
 
-    /// The drift test the round-1 review asked for: stored-vs-CURRENT-ENGINE,
-    /// not stored-vs-stored. Rebuilds one seed source fixture, re-extracts,
-    /// and diffs against the committed entry — an engine change that moves
-    /// the fragment now fails here instead of sailing through.
+    /// The drift test: stored-vs-CURRENT-ENGINE for EVERY seeded entry, over
+    /// the same `seed_sources()` the tool consumes, with ELEMENT-WISE
+    /// geometry comparison (serialized fragments) — aggregate comparisons
+    /// pass a relocated belt or swapped inserter clean, and a
+    /// one-fixture test left 4 of 5 entries unprotected (round-2 review,
+    /// both 3/3).
     #[test]
-    fn stored_entry_matches_fresh_engine_extraction() {
+    fn every_stored_entry_matches_fresh_engine_extraction() {
         use crate::bus::layout::{self, LayoutOptions};
-        let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "plastic-bar"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        let sr = crate::solver::solve("advanced-circuit", 4.0, &inputs, "assembling-machine-2")
-            .expect("seed source solves");
-        let l = layout::build_bus_layout(&sr, LayoutOptions::default())
-            .expect("seed source lays out");
-        let (fresh, warnings) =
-            extract_unit(&l.entities, "advanced-circuit", "assembling-machine-2", "test");
-        assert!(warnings.is_empty(), "escape hatches on re-extraction: {warnings:?}");
-        let fresh = fresh.expect("extraction succeeds");
-        let stored = celldb()
-            .entries
-            .iter()
-            .find(|e| matches!(&e.motif, Motif::Unit { recipe, .. } if recipe == "advanced-circuit"))
-            .expect("advanced-circuit entry is seeded");
-        assert_eq!(stored.motif, fresh.motif, "motif drifted from engine output");
-        assert_eq!(stored.metrics, fresh.metrics, "metrics drifted from engine output");
-        assert_eq!(stored.ports, fresh.ports, "ports drifted from engine output");
+        let mut checked = 0usize;
+        for (item, rate, machine, inputs, targets) in seed_sources() {
+            let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+            let sr = crate::solver::solve(item, rate, &input_set, machine)
+                .expect("seed source solves");
+            let l = layout::build_bus_layout(&sr, LayoutOptions::default())
+                .expect("seed source lays out");
+            for (recipe, target_machine) in targets {
+                let (fresh, warnings) =
+                    extract_unit(&l.entities, recipe, target_machine, "test");
+                assert!(
+                    warnings.is_empty(),
+                    "escape hatches re-extracting {recipe}: {warnings:?}"
+                );
+                let fresh = fresh.expect("extraction succeeds");
+                let stored = celldb()
+                    .entries
+                    .iter()
+                    .find(|e| {
+                        matches!(&e.motif, Motif::Unit { recipe: r, machine: m, .. }
+                                 if r == recipe && m == target_machine)
+                    })
+                    .unwrap_or_else(|| panic!("{recipe} entry is seeded"));
+                assert_eq!(stored.motif, fresh.motif, "{recipe}: motif drifted");
+                assert_eq!(stored.metrics, fresh.metrics, "{recipe}: metrics drifted");
+                assert_eq!(stored.ports, fresh.ports, "{recipe}: ports drifted");
+                // Element-wise geometry: both fragments are sorted by
+                // (y, x, name) at extraction, so serialized equality is
+                // positional equality of every entity field.
+                assert_eq!(
+                    serde_json::to_string(&stored.entities).unwrap(),
+                    serde_json::to_string(&fresh.entities).unwrap(),
+                    "{recipe}: fragment geometry drifted from engine output"
+                );
+                checked += 1;
+            }
+        }
         assert_eq!(
-            stored.entities.len(),
-            fresh.entities.len(),
-            "entity roster drifted from engine output"
+            checked,
+            celldb().entries.len(),
+            "every stored entry must be drift-checked (seed_sources out of sync?)"
         );
     }
 

--- a/crates/core/src/celldb.rs
+++ b/crates/core/src/celldb.rs
@@ -16,7 +16,7 @@
 //! `recipes.json` / balancer-library pattern: versioned, diffable, no
 //! infrastructure.
 
-use crate::common::{entity_size, is_machine_entity, is_splitter, is_surface_belt, is_ug_belt};
+use crate::common::{is_machine_entity, is_splitter, is_surface_belt, is_ug_belt, oriented_entity_dims};
 use crate::models::PlacedEntity;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
@@ -225,6 +225,14 @@ pub fn extract_unit(
             // Counts stored, rates derived — enforced at extraction: rate
             // stamps are fixture-specific flow aggregates and committing
             // them is the stale-declared-data failure the schema bans.
+            // Field taxonomy, decided not improvised (round-3 review):
+            // STRIPPED = per-run measurements (rate). STRUCTURAL, kept =
+            // io_type (UG halves), filters/priorities (splitter function),
+            // carries (port-check referee), items/quality — module and
+            // quality configs are part of the IMPLEMENTATION (they change
+            // derived rates via the solver, not stored ones). v1 seeds are
+            // bare-machine Normal; a moduled seed is a different entry, not
+            // a stripped one.
             e.rate = None;
             e
         })
@@ -240,9 +248,9 @@ pub fn extract_unit(
     let mut tiles = 0u32;
     let (mut max_x, mut max_y) = (0, 0);
     for e in &frag {
-        let (w, h) = entity_size(&e.name);
-        for dx in 0..w as i32 {
-            for dy in 0..h as i32 {
+        let (w, h) = oriented_entity_dims(&e.name, e.direction);
+        for dx in 0..w {
+            for dy in 0..h {
                 occupied.insert((e.x + dx, e.y + dy));
                 max_x = max_x.max(e.x + dx);
                 max_y = max_y.max(e.y + dy);
@@ -253,19 +261,44 @@ pub fn extract_unit(
 
     let mut ports: Vec<Port> = Vec::new();
     let mut seg_items: Vec<(String, String)> = Vec::new();
+    // Segment kinds that are structure, not ports. Anything outside this
+    // set AND outside the port kinds below warns — a new engine segment
+    // kind must be classified deliberately, never silently skipped
+    // (round-3 review: fluid-out fell through both lists with no port and
+    // no warning, the exact degraded-store case K67-1 exists to block).
+    const STRUCTURAL_KINDS: &[&str] = &[
+        "machine",
+        "inserter-in",
+        "inserter-out",
+        "trunk",
+        "trunk-dive",
+        "current-feed",
+    ];
     for e in &frag {
         if let Some(s) = e.segment_id.as_deref() {
             let parts: Vec<&str> = s.split(':').collect();
-            if parts.len() >= 4 && (parts[2] == "belt-in" || parts[2] == "fluid-in") {
-                let key = (parts[2].to_string(), parts[3].to_string());
+            let kind = parts.get(2).copied().unwrap_or("");
+            if parts.len() >= 4
+                && (kind == "belt-in" || kind == "fluid-in" || kind == "fluid-out")
+            {
+                let key = (kind.to_string(), parts[3].to_string());
                 if !seg_items.contains(&key) {
                     seg_items.push(key);
                 }
-            } else if parts.len() >= 3 && parts[2] == "belt-out" {
+            } else if parts.len() >= 3 && kind == "belt-out" {
+                // 3-part belt-out defaults its item to the recipe name —
+                // correct for every current row template (the product IS
+                // the recipe item); check_entry's carries-vs-item port
+                // check catches a future mislabel on tagged belts.
                 let item = parts.get(3).unwrap_or(&recipe).to_string();
                 let key = ("belt-out".to_string(), item);
                 if !seg_items.contains(&key) {
                     seg_items.push(key);
+                }
+            } else if !STRUCTURAL_KINDS.contains(&kind) {
+                let w = format!("unhandled segment kind '{kind}' in {s}");
+                if !warnings.contains(&w) {
+                    warnings.push(w);
                 }
             }
         }
@@ -316,7 +349,12 @@ pub fn extract_unit(
         let pk = match kind.as_str() {
             "belt-in" => PortKind::BeltIn,
             "belt-out" => PortKind::BeltOut,
-            _ => PortKind::PipeIn,
+            "fluid-in" => PortKind::PipeIn,
+            "fluid-out" => PortKind::PipeOut,
+            other => {
+                warnings.push(format!("no PortKind mapping for segment kind '{other}'"));
+                continue;
+            }
         };
         let mut sorted = candidates.clone();
         sorted.sort();
@@ -359,9 +397,9 @@ pub fn check_entry(entry: &CellEntry) -> Vec<String> {
     let (mut min_x, mut min_y, mut max_x, mut max_y) = (i32::MAX, i32::MAX, i32::MIN, i32::MIN);
     let mut tiles = 0u32;
     for e in &entry.entities {
-        let (w, h) = entity_size(&e.name);
-        for dx in 0..w as i32 {
-            for dy in 0..h as i32 {
+        let (w, h) = oriented_entity_dims(&e.name, e.direction);
+        for dx in 0..w {
+            for dy in 0..h {
                 let t = (e.x + dx, e.y + dy);
                 if !occupied.insert(t) {
                     issues.push(format!("overlap at {t:?} ({})", e.name));
@@ -430,8 +468,8 @@ pub fn check_entry(entry: &CellEntry) -> Vec<String> {
         // A port must be a real transport tile carrying the declared item —
         // an unoccupied or wrong-item port composes into a dead feed.
         let holder = entry.entities.iter().find(|e| {
-            let (w, h) = entity_size(&e.name);
-            p.dx >= e.x && p.dx < e.x + w as i32 && p.dy >= e.y && p.dy < e.y + h as i32
+            let (w, h) = oriented_entity_dims(&e.name, e.direction);
+            p.dx >= e.x && p.dx < e.x + w && p.dy >= e.y && p.dy < e.y + h
         });
         match holder {
             None => issues.push(format!("port at ({},{}) is an empty tile", p.dx, p.dy)),
@@ -543,10 +581,18 @@ mod tests {
                 checked += 1;
             }
         }
+        // Scope: ENGINE-seeded entries only. community:/hand entries are
+        // first-class per the provenance taxonomy and cannot be reproduced
+        // from seed_sources by definition (round-3 review — the unscoped
+        // assert would have banned them).
+        let engine_entries = celldb()
+            .entries
+            .iter()
+            .filter(|e| e.provenance.starts_with("engine@"))
+            .count();
         assert_eq!(
-            checked,
-            celldb().entries.len(),
-            "every stored entry must be drift-checked (seed_sources out of sync?)"
+            checked, engine_entries,
+            "every ENGINE-seeded entry must be drift-checked (seed_sources out of sync?)"
         );
     }
 

--- a/crates/core/src/celldb.rs
+++ b/crates/core/src/celldb.rs
@@ -1,0 +1,272 @@
+//! The cell-interface database (RFC-067): an in-repo store of production
+//! subtree implementations keyed by demand motif.
+//!
+//! Schema commitments (argued in the RFC, enforced here):
+//! - **Counts stored, rates derived.** An entry never records a rate; the
+//!   current solver derives rates from counts at lookup time, so the store
+//!   cannot go stale when the rate model changes.
+//! - **Constraints derived, never declared.** An entry's requirements
+//!   (entity vocabulary, belt tiers) are computed from its own entities by
+//!   [`DerivedConstraints::of`]. A declared field can lie; a derived one
+//!   cannot outlive its state.
+//! - **Metrics recorded by the seed tool** (`examples/celldb_seed.rs`),
+//!   not typed by hand; the regression test re-derives them and diffs.
+//!
+//! The store ships embedded (`data/celldb.json`, `include_str!`) on the
+//! `recipes.json` / balancer-library pattern: versioned, diffable, no
+//! infrastructure.
+
+use crate::common::{entity_size, is_surface_belt, is_ug_belt};
+use crate::models::PlacedEntity;
+use rustc_hash::FxHashSet;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Motif {
+    /// One recipe on one machine type, `count` machines.
+    Unit { recipe: String, machine: String, count: u32 },
+    /// A fused producer→consumer pair (the DI-cell shape).
+    Fused { recipe_a: String, recipe_b: String, count_a: u32, count_b: u32 },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PortKind {
+    BeltIn,
+    BeltOut,
+    PipeIn,
+    PipeOut,
+}
+
+/// A declared flow port on the fragment boundary. Tiles are relative to the
+/// fragment origin (its min-x/min-y corner after normalization).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Port {
+    pub dx: i32,
+    pub dy: i32,
+    pub kind: PortKind,
+    pub item: String,
+}
+
+/// Recorded by the seed tool; re-derived and diffed by the regression test.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Metrics {
+    pub bbox_w: i32,
+    pub bbox_h: i32,
+    pub interior_tiles: u32,
+    pub entity_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CellEntry {
+    pub motif: Motif,
+    /// Fragment entities, coordinates relative to the fragment origin.
+    pub entities: Vec<PlacedEntity>,
+    pub ports: Vec<Port>,
+    pub metrics: Metrics,
+    /// `engine@<sha> fixture=<name>` | `community:<source>` | `hand`.
+    pub provenance: String,
+    /// `unanchored` until a sim run blesses it (`anchored@<sha> <rate>/s`).
+    pub sim_anchor: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CellDb {
+    pub version: u32,
+    pub entries: Vec<CellEntry>,
+}
+
+/// What an entry NEEDS — computed from its entities, never stored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedConstraints {
+    /// Every entity prototype the fragment places. "Tech level" is exactly
+    /// this set: filter with `is_satisfied_by`.
+    pub vocabulary: BTreeSet<String>,
+    /// Belt tiers used (prototype names of surface/UG belts and splitters).
+    pub belt_tiers: BTreeSet<String>,
+}
+
+impl DerivedConstraints {
+    pub fn of(entry: &CellEntry) -> Self {
+        let mut vocabulary = BTreeSet::new();
+        let mut belt_tiers = BTreeSet::new();
+        for e in &entry.entities {
+            vocabulary.insert(e.name.clone());
+            if is_surface_belt(&e.name) || is_ug_belt(&e.name) || e.name.contains("splitter") {
+                belt_tiers.insert(e.name.clone());
+            }
+        }
+        DerivedConstraints { vocabulary, belt_tiers }
+    }
+
+    /// Dominance test: every entity the fragment places is allowed.
+    pub fn is_satisfied_by(&self, allowed: &FxHashSet<String>) -> bool {
+        self.vocabulary.iter().all(|v| allowed.contains(v))
+    }
+}
+
+pub fn celldb() -> &'static CellDb {
+    static DB: OnceLock<CellDb> = OnceLock::new();
+    DB.get_or_init(|| {
+        serde_json::from_str(include_str!("../data/celldb.json"))
+            .expect("embedded celldb.json must parse — the seed tool wrote it")
+    })
+}
+
+/// Unit-motif lookup: entries for `recipe` on `machine` with at least
+/// `min_count` machines, whose derived vocabulary is allowed (pass `None`
+/// to skip the constraint filter). Ranked smallest-sufficient-first:
+/// ascending count, then ascending interior tiles.
+pub fn query_unit<'a>(
+    recipe: &str,
+    machine: &str,
+    min_count: u32,
+    allowed: Option<&FxHashSet<String>>,
+) -> Vec<&'a CellEntry> {
+    let mut hits: Vec<&CellEntry> = celldb()
+        .entries
+        .iter()
+        .filter(|e| match &e.motif {
+            Motif::Unit { recipe: r, machine: m, count } => {
+                r == recipe && m == machine && *count >= min_count
+            }
+            Motif::Fused { .. } => false,
+        })
+        .filter(|e| match allowed {
+            Some(a) => DerivedConstraints::of(e).is_satisfied_by(a),
+            None => true,
+        })
+        .collect();
+    hits.sort_by_key(|e| {
+        let c = match &e.motif {
+            Motif::Unit { count, .. } => *count,
+            Motif::Fused { count_a, count_b, .. } => count_a + count_b,
+        };
+        (c, e.metrics.interior_tiles)
+    });
+    hits
+}
+
+/// Structural invariants every entry must hold. Returns human-readable
+/// violations; the test suite asserts the list is empty for every embedded
+/// entry, so a bad seed is a build failure, not a runtime surprise.
+pub fn check_entry(entry: &CellEntry) -> Vec<String> {
+    let mut issues = Vec::new();
+    if entry.entities.is_empty() {
+        issues.push("entry has no entities".into());
+        return issues;
+    }
+    // Footprint overlap + bbox from entity sizes.
+    let mut occupied: FxHashSet<(i32, i32)> = FxHashSet::default();
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = (i32::MAX, i32::MAX, i32::MIN, i32::MIN);
+    let mut tiles = 0u32;
+    for e in &entry.entities {
+        let (w, h) = entity_size(&e.name);
+        for dx in 0..w as i32 {
+            for dy in 0..h as i32 {
+                let t = (e.x + dx, e.y + dy);
+                if !occupied.insert(t) {
+                    issues.push(format!("overlap at {t:?} ({})", e.name));
+                }
+                min_x = min_x.min(t.0);
+                min_y = min_y.min(t.1);
+                max_x = max_x.max(t.0);
+                max_y = max_y.max(t.1);
+                tiles += 1;
+            }
+        }
+    }
+    if (min_x, min_y) != (0, 0) {
+        issues.push(format!("fragment not normalized to origin (min = {min_x},{min_y})"));
+    }
+    let (bw, bh) = (max_x - min_x + 1, max_y - min_y + 1);
+    if (bw, bh) != (entry.metrics.bbox_w, entry.metrics.bbox_h) {
+        issues.push(format!(
+            "metrics bbox {}x{} != derived {bw}x{bh}",
+            entry.metrics.bbox_w, entry.metrics.bbox_h
+        ));
+    }
+    if tiles != entry.metrics.interior_tiles {
+        issues.push(format!(
+            "metrics interior_tiles {} != derived {tiles}",
+            entry.metrics.interior_tiles
+        ));
+    }
+    if entry.entities.len() as u32 != entry.metrics.entity_count {
+        issues.push(format!(
+            "metrics entity_count {} != derived {}",
+            entry.metrics.entity_count,
+            entry.entities.len()
+        ));
+    }
+    if entry.ports.is_empty() {
+        issues.push("entry declares no ports".into());
+    }
+    for p in &entry.ports {
+        let on_edge =
+            p.dx == min_x || p.dx == max_x || p.dy == min_y || p.dy == max_y;
+        if !on_edge {
+            issues.push(format!("port at ({},{}) not on fragment boundary", p.dx, p.dy));
+        }
+    }
+    issues
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_db_parses_and_entries_hold_invariants() {
+        let db = celldb();
+        assert!(db.version >= 1);
+        for (i, e) in db.entries.iter().enumerate() {
+            let issues = check_entry(e);
+            assert!(
+                issues.is_empty(),
+                "entry {i} ({:?}) violates invariants: {issues:?}",
+                e.motif
+            );
+            let dc = DerivedConstraints::of(e);
+            assert!(!dc.vocabulary.is_empty());
+        }
+    }
+
+    #[test]
+    fn query_ranks_smallest_sufficient_first() {
+        let db = celldb();
+        // Property over whatever is seeded: results are count-ascending and
+        // every result satisfies the min_count bound.
+        for e in &db.entries {
+            if let Motif::Unit { recipe, machine, count } = &e.motif {
+                let hits = query_unit(recipe, machine, *count, None);
+                assert!(!hits.is_empty());
+                let counts: Vec<u32> = hits
+                    .iter()
+                    .map(|h| match &h.motif {
+                        Motif::Unit { count, .. } => *count,
+                        Motif::Fused { count_a, count_b, .. } => count_a + count_b,
+                    })
+                    .collect();
+                assert!(counts.windows(2).all(|w| w[0] <= w[1]));
+                assert!(counts.iter().all(|c| c >= count));
+            }
+        }
+    }
+
+    #[test]
+    fn constraint_filter_excludes_disallowed_vocabulary() {
+        let db = celldb();
+        let Some(e) = db.entries.iter().find_map(|e| match &e.motif {
+            Motif::Unit { recipe, machine, count } => Some((recipe, machine, *count)),
+            _ => None,
+        }) else {
+            return; // empty DB: nothing to test yet, invariant test covers shape
+        };
+        let empty: FxHashSet<String> = FxHashSet::default();
+        assert!(query_unit(e.0, e.1, e.2, Some(&empty)).is_empty());
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod balancer;
 pub mod blueprint;
 pub mod blueprint_parser;
 pub mod bus;
+pub mod celldb;
 pub mod classify;
 pub mod common;
 pub mod connectivity;


### PR DESCRIPTION
## Intent

RFC-067 (#618) Phase 1: the cell-interface store. Schema commitments enforced in code: counts stored / rates derived; constraints derived from entity vocabulary via `DerivedConstraints::of` (never declared fields); metrics recorded by the seed tool, never typed.

## Scope

- **In:** `celldb.rs` (schema, OnceLock-embedded loader, dominance query ranked smallest-sufficient-first, `check_entry` structural invariants, tests), `data/celldb.json` (generated — top-5 motif seeds from engine output with per-fixture provenance), the seed tool.
- **Out:** all consumers (preview and template candidate land as the stacked follow-up PR); community-donor ingestion (RFC scope, future).
- **Size:** ~560 counted lines (celldb.json is generated and excluded per the norm).

## K67-1 adjudicated on this PR's own tooling

First seed run: 5 PORT-WARNs — all one root cause, split rows genuinely having one entry port per half. Contract amended (multi-port per (kind, item); min-picking would starve the second half under composition), re-run: **zero escape hatches across all five seeds**. The RFC decision log carries it.

## Verification

- [x] `cargo test --lib celldb::` — invariants hold over the real seeded entries (overlap-free, origin-normalized, metrics match re-derivation, ports on boundary)
- [x] Full core suite green on the stacked branch (this code + consumers)
- [x] Seed tool re-run is deterministic on this checkout
- [ ] WASM — n/a (no wasm exports here)

Tracking: #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n