### PR TITLE
chore: commit two loose session artifacts, and fix what that falsifies

### DIFF
--- a/crates/meter/examples/cable_probe.rs
+++ b/crates/meter/examples/cable_probe.rs
@@ -1,68 +1,145 @@
 //! Where does copper-cable sit along its belt, and who can reach it?
-use std::path::PathBuf;
+//!
+//! Usage: `cable_probe [label] [warmup_ticks] [measure_ticks]`
+//!
+//! Defaults match `check_one.rs`'s calibrated window (108k warmup / 216k
+//! measure). The short windows this probe originally shipped with (7.2k/10.8k)
+//! read buffer fill as throughput on multi-stage chains — the same trap
+//! `CLAUDE.md` flags for the sim harness's dim-scaled default warmup. Override
+//! only when you want a deliberate cold-start capture, and say so if you quote
+//! the numbers.
 use spaghettio_meter::factory::Endpoint;
-use spaghettio_meter::{Factory, Manifest, MachineState};
+use spaghettio_meter::{Factory, Manifest};
+use std::path::PathBuf;
+
+const ITEM: &str = "copper-cable";
 
 fn main() {
-    let label = std::env::args().nth(1).unwrap_or_else(|| "tier2-ec10-lift".into());
+    let mut args = std::env::args().skip(1);
+    let label = args.next().unwrap_or_else(|| "tier2-ec10-lift".into());
+    let warmup: u64 = args.next().and_then(|s| s.parse().ok()).unwrap_or(108_000);
+    let measure: u64 = args.next().and_then(|s| s.parse().ok()).unwrap_or(216_000);
+
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../core/target/tmp");
     let bp = std::fs::read_to_string(dir.join(format!("{label}.bp"))).expect("bp");
     let m = Manifest::from_path(dir.join(format!("{label}.manifest.json"))).expect("m");
     let mut f = Factory::build(&bp, m).expect("build");
-    f.run_for(60 * 60 * 2);
+
+    f.run_for(warmup);
     f.reset_counters();
-    f.run_for(60 * 60 * 3);
+    // `reset_counters` clears the factory-level maps, `machines[].crafts` and
+    // `feeds[].*`, but NOT the per-inserter counters — `Inserter::delivered`
+    // and `starved_ticks` are documented as totals "over the run" and keep
+    // accumulating across the warmup. Snapshot them here and subtract below,
+    // or every printed `starved=` carries the cold-start transient during
+    // which belts are still filling and every pickup inserter legitimately
+    // starves. That would invert the exact signal this probe exists to read.
+    let base: Vec<(u64, u64)> = f
+        .inserters
+        .iter()
+        .map(|w| (w.core.delivered, w.core.starved_ticks))
+        .collect();
+
+    f.run_for(measure);
+
+    println!("window: {warmup} warmup + {measure} measured ticks");
 
     // machines by recipe, with crafts
-    println!("machines (recipe, pos, state, crafts over window):");
+    println!("\nmachines (recipe, pos, state, crafts over window):");
     let mut ms: Vec<_> = f.machines.iter().collect();
     ms.sort_by_key(|m| (m.recipe.clone(), m.pos.0, m.pos.1));
     for mc in &ms {
         println!("  {:<20} at {:?}  {:?}  crafts={}", mc.recipe, mc.pos, mc.state, mc.crafts);
     }
 
-    // who drops cable onto which tile, who picks it up
-    println!("\ncable inserters (machine->belt = producer tap, belt->machine = consumer tap):");
-    for w in &f.inserters {
-        let p = match w.pickup { Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[t].pos),
-                                 Endpoint::Machine(i) => format!("mach {}{:?}", f.machines[i].recipe, f.machines[i].pos),
-                                 Endpoint::Nothing => "-".into() };
-        let d = match w.drop { Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[t].pos),
-                               Endpoint::Machine(i) => format!("mach {}{:?}", f.machines[i].recipe, f.machines[i].pos),
-                               Endpoint::Nothing => "-".into() };
-        let belt_to_belt = matches!(w.pickup, Endpoint::Belt(_)) && matches!(w.drop, Endpoint::Belt(_));
-        if belt_to_belt {
-            println!("  {:<12} {:?} {p} -> {d}  delivered={} starved={}",
-                format!("{:?}", w.core.kind), w.pos, w.core.delivered, w.core.starved_ticks);
+    // Tiles holding the item at end of window. Used both to report occupancy
+    // and to decide which inserters are worth printing. Caveat: a belt that is
+    // genuinely empty at this instant drops out, so this under-selects rather
+    // than over-selects — fine for "who can reach it", wrong for a census.
+    let item_tiles: Vec<usize> = f
+        .net
+        .tiles
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| {
+            t.lanes.iter().any(|lane| {
+                lane.slots_debug().iter().flatten().any(|it| f.items.name(*it) == ITEM)
+            })
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    let touches_item = |e: &Endpoint| match e {
+        Endpoint::Belt(t) => item_tiles.contains(t),
+        _ => false,
+    };
+
+    println!(
+        "\n{ITEM} belt<->belt inserters (machine->belt = producer tap, belt->machine = consumer tap):"
+    );
+    println!("  counters are window-scoped (warmup subtracted)");
+    for (w, (d0, s0)) in f.inserters.iter().zip(&base) {
+        let belt_to_belt =
+            matches!(w.pickup, Endpoint::Belt(_)) && matches!(w.drop, Endpoint::Belt(_));
+        if !belt_to_belt || !(touches_item(&w.pickup) || touches_item(&w.drop)) {
+            continue;
+        }
+        let ep = |e: &Endpoint| match e {
+            Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[*t].pos),
+            Endpoint::Machine(i) => {
+                format!("mach {}{:?}", f.machines[*i].recipe, f.machines[*i].pos)
+            }
+            Endpoint::Nothing => "-".into(),
+        };
+        println!(
+            "  {:<12} {:?} {} -> {}  delivered={} starved={}",
+            format!("{:?}", w.core.kind),
+            w.pos,
+            ep(&w.pickup),
+            ep(&w.drop),
+            w.core.delivered.saturating_sub(*d0),
+            w.core.starved_ticks.saturating_sub(*s0),
+        );
+    }
+
+    // Per-lane occupancy along each row that carries the item. Rows are
+    // derived, not hardcoded — the original probe pinned y=11, which was only
+    // ever right for the fixture it was written against.
+    let mut rows: Vec<i32> = item_tiles.iter().map(|&i| f.net.tiles[i].pos.1).collect();
+    rows.sort_unstable();
+    rows.dedup();
+    for row in rows {
+        println!("\n=== y={row}, PER-LANE slot occupancy (whole row, all items) ===");
+        let mut in_row: Vec<_> = f.net.tiles.iter().filter(|t| t.pos.1 == row).collect();
+        in_row.sort_by_key(|t| t.pos.0);
+        for t in in_row {
+            let lanes: Vec<String> = t
+                .lanes
+                .iter()
+                .map(|l| {
+                    let slots = l.slots_debug();
+                    let filled = slots.iter().filter(|s| s.is_some()).count();
+                    format!("{filled}/{}", slots.len())
+                })
+                .collect();
+            println!("  x={:<3} lanes {:?}", t.pos.0, lanes);
         }
     }
 
-    // occupancy of every tile carrying cable
-    println!("\n=== y=11 drop belt, PER-LANE slot occupancy ===");
-    let mut t11: Vec<_> = f.net.tiles.iter().filter(|t| t.pos.1 == 11).collect();
-    t11.sort_by_key(|t| t.pos.0);
-    for t in t11 {
-        let lanes: Vec<String> = t.lanes.iter().map(|l| {
-            let slots = l.slots_debug();
-            let filled = slots.iter().filter(|s| s.is_some()).count();
-            format!("{filled}/{}", slots.len())
-        }).collect();
-        println!("  x={:<3} lanes {:?}", t.pos.0, lanes);
-    }
-    println!("\nbelt tiles carrying copper-cable (occ/8):");
-    let mut tiles: Vec<_> = f.net.tiles.iter().enumerate().collect();
-    tiles.sort_by_key(|(_, t)| (t.pos.1, t.pos.0));
-    for (_i, t) in tiles {
+    println!("\nbelt tiles carrying {ITEM} (occ/8):");
+    let mut sorted = item_tiles.clone();
+    sorted.sort_by_key(|&i| (f.net.tiles[i].pos.1, f.net.tiles[i].pos.0));
+    for i in sorted {
+        let t = &f.net.tiles[i];
         let mut names: Vec<String> = Vec::new();
         for lane in &t.lanes {
             for it in lane.slots_debug().iter().flatten() {
                 let n = f.items.name(*it).to_string();
-                if !names.contains(&n) { names.push(n); }
+                if !names.contains(&n) {
+                    names.push(n);
+                }
             }
         }
-        if names.iter().any(|n| n == "copper-cable") {
-            println!("  {:?} occ {}/8  {:?}", t.pos, t.occupancy(), names);
-        }
+        println!("  {:?} occ {}/8  {:?}", t.pos, t.occupancy(), names);
     }
-    let _ = MachineState::Working;
 }

--- a/crates/meter/examples/cable_probe.rs
+++ b/crates/meter/examples/cable_probe.rs
@@ -44,8 +44,11 @@ fn main() {
 
     println!("window: {warmup} warmup + {measure} measured ticks");
 
-    // machines by recipe, with crafts
-    println!("\nmachines (recipe, pos, state, crafts over window):");
+    // machines by recipe, with crafts. `crafts` is a window total; `state` is
+    // a single instantaneous sample taken at window end, NOT a window
+    // aggregate — a machine that worked throughout can print `ItemShortage`
+    // because of where the last tick fell. Read them differently.
+    println!("\nmachines (recipe, pos, state AT END OF WINDOW, crafts over window):");
     let mut ms: Vec<_> = f.machines.iter().collect();
     ms.sort_by_key(|m| (m.recipe.clone(), m.pos.0, m.pos.1));
     for mc in &ms {
@@ -75,15 +78,22 @@ fn main() {
     };
 
     println!(
-        "\n{ITEM} belt<->belt inserters (machine->belt = producer tap, belt->machine = consumer tap):"
+        "\n{ITEM} inserters (machine->belt = producer tap, belt->machine = consumer tap, belt->belt = transfer):"
     );
     println!("  counters are window-scoped (warmup subtracted)");
+    // No `belt_to_belt` predicate here, deliberately. The original probe
+    // required BOTH endpoints to be `Endpoint::Belt`, which excludes exactly
+    // the two things the header names — a producer tap is Machine->Belt and a
+    // consumer tap is Belt->Machine, so both were silently dropped and the
+    // section reported only bus transfer inserters. `touches_item` alone is
+    // the right filter: it catches a producer's drop tile and a consumer's
+    // pickup tile as well as belt->belt.
+    let mut printed = 0usize;
     for (w, (d0, s0)) in f.inserters.iter().zip(&base) {
-        let belt_to_belt =
-            matches!(w.pickup, Endpoint::Belt(_)) && matches!(w.drop, Endpoint::Belt(_));
-        if !belt_to_belt || !(touches_item(&w.pickup) || touches_item(&w.drop)) {
+        if !(touches_item(&w.pickup) || touches_item(&w.drop)) {
             continue;
         }
+        printed += 1;
         let ep = |e: &Endpoint| match e {
             Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[*t].pos),
             Endpoint::Machine(i) => {
@@ -99,6 +109,26 @@ fn main() {
             ep(&w.drop),
             w.core.delivered.saturating_sub(*d0),
             w.core.starved_ticks.saturating_sub(*s0),
+        );
+    }
+    // Non-vacuity guard. Lesson 6 of the handoff note committed alongside this
+    // file: "a check that stops discriminating is worse than one that fails",
+    // and any scoping change needs a guard asserting the probe still has
+    // something to inspect. Both this section and `item_tiles` are scoped, and
+    // an empty scope here looks identical to a healthy factory with nothing to
+    // report.
+    if item_tiles.is_empty() {
+        eprintln!(
+            "\n!! VACUOUS: no belt tile held {ITEM} at sample time, so every {ITEM}-scoped \
+             section above is empty by construction, not by finding. Wrong fixture, wrong \
+             item, or a window that ended mid-gap."
+        );
+    } else if printed == 0 {
+        eprintln!(
+            "\n!! VACUOUS: {} tiles hold {ITEM} but no inserter touches any of them. \
+             Nothing was filtered out — there is genuinely nothing to report, which for \
+             this probe is itself the finding.",
+            item_tiles.len()
         );
     }
 

--- a/crates/meter/examples/cable_probe.rs
+++ b/crates/meter/examples/cable_probe.rs
@@ -89,11 +89,15 @@ fn main() {
     // the right filter: it catches a producer's drop tile and a consumer's
     // pickup tile as well as belt->belt.
     let mut printed = 0usize;
+    let mut machine_taps = 0usize;
     for (w, (d0, s0)) in f.inserters.iter().zip(&base) {
         if !(touches_item(&w.pickup) || touches_item(&w.drop)) {
             continue;
         }
         printed += 1;
+        if matches!(w.pickup, Endpoint::Machine(_)) || matches!(w.drop, Endpoint::Machine(_)) {
+            machine_taps += 1;
+        }
         let ep = |e: &Endpoint| match e {
             Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[*t].pos),
             Endpoint::Machine(i) => {
@@ -114,14 +118,21 @@ fn main() {
     // Non-vacuity guard. Lesson 6 of the handoff note committed alongside this
     // file: "a check that stops discriminating is worse than one that fails",
     // and any scoping change needs a guard asserting the probe still has
-    // something to inspect. Both this section and `item_tiles` are scoped, and
-    // an empty scope here looks identical to a healthy factory with nothing to
-    // report.
+    // something to inspect. Every section below the machines listing is scoped
+    // to ITEM via `item_tiles`, and an empty scope looks identical to a healthy
+    // factory with nothing to report.
+    //
+    // Three failure levels, not two. The partial case is the dangerous one:
+    // `item_tiles` is a single end-of-window sample, and a tap tile that
+    // happens to be empty at that instant drops out silently while other tiles
+    // keep the set non-empty — so an entire tap population can vanish with the
+    // output still looking complete.
     if item_tiles.is_empty() {
         eprintln!(
-            "\n!! VACUOUS: no belt tile held {ITEM} at sample time, so every {ITEM}-scoped \
-             section above is empty by construction, not by finding. Wrong fixture, wrong \
-             item, or a window that ended mid-gap."
+            "\n!! VACUOUS: no belt tile held {ITEM} at sample time. Every {ITEM}-scoped \
+             section (the inserter list and both occupancy blocks — NOT the machines \
+             listing, which is unscoped) is empty by construction, not by finding. Wrong \
+             fixture, wrong item, or a window that ended mid-gap."
         );
     } else if printed == 0 {
         eprintln!(
@@ -129,6 +140,15 @@ fn main() {
              Nothing was filtered out — there is genuinely nothing to report, which for \
              this probe is itself the finding.",
             item_tiles.len()
+        );
+    } else if machine_taps == 0 {
+        eprintln!(
+            "\n!! PARTIALLY VACUOUS: {printed} inserters touch {ITEM}, but NONE has a \
+             machine endpoint — no producer or consumer tap was found, only belt->belt \
+             transfers. Since selection here rests on one end-of-window sample of \
+             `item_tiles`, the likeliest cause is tap tiles being momentarily empty \
+             rather than the taps not existing. Re-run before concluding anything about \
+             saturation."
         );
     }
 
@@ -156,7 +176,7 @@ fn main() {
         }
     }
 
-    println!("\nbelt tiles carrying {ITEM} (occ/8):");
+    println!("\nbelt tiles carrying {ITEM}:");
     let mut sorted = item_tiles.clone();
     sorted.sort_by_key(|&i| (f.net.tiles[i].pos.1, f.net.tiles[i].pos.0));
     for i in sorted {
@@ -170,6 +190,12 @@ fn main() {
                 }
             }
         }
-        println!("  {:?} occ {}/8  {:?}", t.pos, t.occupancy(), names);
+        // Denominator derived, not hardcoded. This printed `occ/8`, right only
+        // because SLOTS_PER_TILE is 4 and there are two lanes — while the
+        // per-lane block above already derived its own from `slots.len()`. The
+        // same quantity, computed two ways in one file, is how a constant
+        // change silently desyncs one of them.
+        let cap: usize = t.lanes.iter().map(|l| l.slots_debug().len()).sum();
+        println!("  {:?} occ {}/{cap}  {:?}", t.pos, t.occupancy(), names);
     }
 }

--- a/crates/meter/examples/cable_probe.rs
+++ b/crates/meter/examples/cable_probe.rs
@@ -1,0 +1,68 @@
+//! Where does copper-cable sit along its belt, and who can reach it?
+use std::path::PathBuf;
+use spaghettio_meter::factory::Endpoint;
+use spaghettio_meter::{Factory, Manifest, MachineState};
+
+fn main() {
+    let label = std::env::args().nth(1).unwrap_or_else(|| "tier2-ec10-lift".into());
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../core/target/tmp");
+    let bp = std::fs::read_to_string(dir.join(format!("{label}.bp"))).expect("bp");
+    let m = Manifest::from_path(dir.join(format!("{label}.manifest.json"))).expect("m");
+    let mut f = Factory::build(&bp, m).expect("build");
+    f.run_for(60 * 60 * 2);
+    f.reset_counters();
+    f.run_for(60 * 60 * 3);
+
+    // machines by recipe, with crafts
+    println!("machines (recipe, pos, state, crafts over window):");
+    let mut ms: Vec<_> = f.machines.iter().collect();
+    ms.sort_by_key(|m| (m.recipe.clone(), m.pos.0, m.pos.1));
+    for mc in &ms {
+        println!("  {:<20} at {:?}  {:?}  crafts={}", mc.recipe, mc.pos, mc.state, mc.crafts);
+    }
+
+    // who drops cable onto which tile, who picks it up
+    println!("\ncable inserters (machine->belt = producer tap, belt->machine = consumer tap):");
+    for w in &f.inserters {
+        let p = match w.pickup { Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[t].pos),
+                                 Endpoint::Machine(i) => format!("mach {}{:?}", f.machines[i].recipe, f.machines[i].pos),
+                                 Endpoint::Nothing => "-".into() };
+        let d = match w.drop { Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[t].pos),
+                               Endpoint::Machine(i) => format!("mach {}{:?}", f.machines[i].recipe, f.machines[i].pos),
+                               Endpoint::Nothing => "-".into() };
+        let belt_to_belt = matches!(w.pickup, Endpoint::Belt(_)) && matches!(w.drop, Endpoint::Belt(_));
+        if belt_to_belt {
+            println!("  {:<12} {:?} {p} -> {d}  delivered={} starved={}",
+                format!("{:?}", w.core.kind), w.pos, w.core.delivered, w.core.starved_ticks);
+        }
+    }
+
+    // occupancy of every tile carrying cable
+    println!("\n=== y=11 drop belt, PER-LANE slot occupancy ===");
+    let mut t11: Vec<_> = f.net.tiles.iter().filter(|t| t.pos.1 == 11).collect();
+    t11.sort_by_key(|t| t.pos.0);
+    for t in t11 {
+        let lanes: Vec<String> = t.lanes.iter().map(|l| {
+            let slots = l.slots_debug();
+            let filled = slots.iter().filter(|s| s.is_some()).count();
+            format!("{filled}/{}", slots.len())
+        }).collect();
+        println!("  x={:<3} lanes {:?}", t.pos.0, lanes);
+    }
+    println!("\nbelt tiles carrying copper-cable (occ/8):");
+    let mut tiles: Vec<_> = f.net.tiles.iter().enumerate().collect();
+    tiles.sort_by_key(|(_, t)| (t.pos.1, t.pos.0));
+    for (_i, t) in tiles {
+        let mut names: Vec<String> = Vec::new();
+        for lane in &t.lanes {
+            for it in lane.slots_debug().iter().flatten() {
+                let n = f.items.name(*it).to_string();
+                if !names.contains(&n) { names.push(n); }
+            }
+        }
+        if names.iter().any(|n| n == "copper-cable") {
+            println!("  {:?} occ {}/8  {:?}", t.pos, t.occupancy(), names);
+        }
+    }
+    let _ = MachineState::Working;
+}

--- a/crates/meter/examples/cable_probe.rs
+++ b/crates/meter/examples/cable_probe.rs
@@ -2,6 +2,11 @@
 //!
 //! Usage: `cable_probe [label] [warmup_ticks] [measure_ticks]`
 //!
+//! Membership of the ITEM-scoped sections is sampled at several spaced instants
+//! and unioned; the per-tile occupancy NUMBERS are still instantaneous, read at
+//! window end. A tile can therefore be listed at 0/4 — that is the union
+//! working, not a contradiction.
+//!
 //! Defaults match `check_one.rs`'s calibrated window (108k warmup / 216k
 //! measure). The short windows this probe originally shipped with (7.2k/10.8k)
 //! read buffer fill as throughput on multi-stage chains — the same trap
@@ -40,9 +45,33 @@ fn main() {
         .map(|w| (w.core.delivered, w.core.starved_ticks))
         .collect();
 
-    f.run_for(measure);
+    // Membership is sampled at SAMPLES spaced instants across the window and
+    // UNIONED, not read once at the end. A single end-of-window sample is what
+    // made every earlier version of this probe under-select: a tile is only
+    // "carrying ITEM" if an item happens to occupy a slot at the instant we
+    // look, and on a tight chain with low belt residency — the zero-headroom
+    // population this probe exists to study — a producer's drop tile is empty
+    // most ticks by design. Sampling once there drops real taps and reports the
+    // remainder as if complete.
+    const SAMPLES: usize = 8;
+    let chunk = (measure / SAMPLES as u64).max(1);
+    let mut seen: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+    let mut ticked = 0u64;
+    for k in 0..SAMPLES {
+        let run = if k == SAMPLES - 1 { measure.saturating_sub(ticked) } else { chunk };
+        f.run_for(run);
+        ticked += run;
+        for (i, t) in f.net.tiles.iter().enumerate() {
+            let holds = t.lanes.iter().any(|lane| {
+                lane.slots_debug().iter().flatten().any(|it| f.items.name(*it) == ITEM)
+            });
+            if holds {
+                seen.insert(i);
+            }
+        }
+    }
 
-    println!("window: {warmup} warmup + {measure} measured ticks");
+    println!("window: {warmup} warmup + {ticked} measured ticks ({SAMPLES} membership samples)");
 
     // machines by recipe, with crafts. `crafts` is a window total; `state` is
     // a single instantaneous sample taken at window end, NOT a window
@@ -55,25 +84,20 @@ fn main() {
         println!("  {:<20} at {:?}  {:?}  crafts={}", mc.recipe, mc.pos, mc.state, mc.crafts);
     }
 
-    // Tiles holding the item at end of window. Used both to report occupancy
-    // and to decide which inserters are worth printing. Caveat: a belt that is
-    // genuinely empty at this instant drops out, so this under-selects rather
-    // than over-selects — fine for "who can reach it", wrong for a census.
-    let item_tiles: Vec<usize> = f
-        .net
-        .tiles
-        .iter()
-        .enumerate()
-        .filter(|(_, t)| {
-            t.lanes.iter().any(|lane| {
-                lane.slots_debug().iter().flatten().any(|it| f.items.name(*it) == ITEM)
-            })
-        })
-        .map(|(i, _)| i)
-        .collect();
+    // Every tile that held ITEM at ANY of the sampled instants. Still a lower
+    // bound — a tile empty at all eight would drop out — but no longer a
+    // single-instant artifact. Two things to keep straight when reading the
+    // output below: MEMBERSHIP is unioned across the window, while the
+    // occupancy NUMBERS printed per tile are instantaneous, read at the end.
+    // So a tile can appear in the list at 0/4 on both lanes; that is the
+    // sampling working, not a contradiction.
+    let item_tiles: Vec<usize> = seen.iter().copied().collect();
 
+    // Membership test against the set, not a linear scan of the Vec — the
+    // union is larger than the old single sample and this is inside a loop
+    // over every inserter.
     let touches_item = |e: &Endpoint| match e {
-        Endpoint::Belt(t) => item_tiles.contains(t),
+        Endpoint::Belt(t) => seen.contains(t),
         _ => false,
     };
 
@@ -89,14 +113,22 @@ fn main() {
     // the right filter: it catches a producer's drop tile and a consumer's
     // pickup tile as well as belt->belt.
     let mut printed = 0usize;
-    let mut machine_taps = 0usize;
+    // Counted as two classes, not one. A combined `machine_taps` counter is
+    // satisfied by EITHER class surviving, so producer taps could vanish
+    // entirely while consumer taps kept the count positive and no guard fired
+    // — losing exactly the producer-saturation signal this probe is for.
+    let mut producer_taps = 0usize; // machine -> belt
+    let mut consumer_taps = 0usize; // belt -> machine
     for (w, (d0, s0)) in f.inserters.iter().zip(&base) {
         if !(touches_item(&w.pickup) || touches_item(&w.drop)) {
             continue;
         }
         printed += 1;
-        if matches!(w.pickup, Endpoint::Machine(_)) || matches!(w.drop, Endpoint::Machine(_)) {
-            machine_taps += 1;
+        if matches!(w.pickup, Endpoint::Machine(_)) && touches_item(&w.drop) {
+            producer_taps += 1;
+        }
+        if matches!(w.drop, Endpoint::Machine(_)) && touches_item(&w.pickup) {
+            consumer_taps += 1;
         }
         let ep = |e: &Endpoint| match e {
             Endpoint::Belt(t) => format!("belt{:?}", f.net.tiles[*t].pos),
@@ -122,11 +154,12 @@ fn main() {
     // to ITEM via `item_tiles`, and an empty scope looks identical to a healthy
     // factory with nothing to report.
     //
-    // Three failure levels, not two. The partial case is the dangerous one:
-    // `item_tiles` is a single end-of-window sample, and a tap tile that
-    // happens to be empty at that instant drops out silently while other tiles
-    // keep the set non-empty — so an entire tap population can vanish with the
-    // output still looking complete.
+    // Four failure levels. The partial ones are the dangerous ones, and they
+    // are named separately because a single combined counter hides them: with
+    // membership derived from belt contents, a whole tap CLASS can drop out
+    // while the other keeps any combined count positive, leaving output that
+    // looks complete. Union sampling above makes this much less likely; it
+    // does not make it impossible, so the guard still checks.
     if item_tiles.is_empty() {
         eprintln!(
             "\n!! VACUOUS: no belt tile held {ITEM} at sample time. Every {ITEM}-scoped \
@@ -141,15 +174,23 @@ fn main() {
              this probe is itself the finding.",
             item_tiles.len()
         );
-    } else if machine_taps == 0 {
-        eprintln!(
-            "\n!! PARTIALLY VACUOUS: {printed} inserters touch {ITEM}, but NONE has a \
-             machine endpoint — no producer or consumer tap was found, only belt->belt \
-             transfers. Since selection here rests on one end-of-window sample of \
-             `item_tiles`, the likeliest cause is tap tiles being momentarily empty \
-             rather than the taps not existing. Re-run before concluding anything about \
-             saturation."
-        );
+    } else {
+        if producer_taps == 0 {
+            eprintln!(
+                "\n!! PARTIALLY VACUOUS: {printed} inserters touch {ITEM} but NONE is a \
+                 producer tap (machine -> {ITEM} belt). Producer-side saturation is this \
+                 probe's headline output, so treat it as absent, not as zero. Either no \
+                 machine produces {ITEM} in this fixture, or every producer drop tile was \
+                 empty at all {SAMPLES} samples."
+            );
+        }
+        if consumer_taps == 0 {
+            eprintln!(
+                "\n!! PARTIALLY VACUOUS: {printed} inserters touch {ITEM} but NONE is a \
+                 consumer tap ({ITEM} belt -> machine). Nothing downstream is reading this \
+                 belt, which is either the finding or a sampling miss."
+            );
+        }
     }
 
     // Per-lane occupancy along each row that carries the item. Rows are

--- a/crates/meter/examples/cable_probe.rs
+++ b/crates/meter/examples/cable_probe.rs
@@ -58,7 +58,13 @@ fn main() {
     let mut seen: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
     let mut ticked = 0u64;
     for k in 0..SAMPLES {
-        let run = if k == SAMPLES - 1 { measure.saturating_sub(ticked) } else { chunk };
+        // Clamp every iteration to what is left, not just the last one. With
+        // `chunk` floored at 1, a `measure` smaller than SAMPLES would
+        // otherwise run one tick per iteration and OVERSHOOT the requested
+        // window (measure=5 ran 7 ticks). Unreachable at the defaults, wrong
+        // regardless.
+        let remaining = measure.saturating_sub(ticked);
+        let run = if k == SAMPLES - 1 { remaining } else { chunk.min(remaining) };
         f.run_for(run);
         ticked += run;
         for (i, t) in f.net.tiles.iter().enumerate() {

--- a/docs/handoff-meter-as-gate-2026-08-07.md
+++ b/docs/handoff-meter-as-gate-2026-08-07.md
@@ -250,3 +250,9 @@ triangulate it. Not run (5540+ entities, ~20+ min).
 
 Both scripts are on `tooling/sim-graphite-export` (#604), **not yet on
 `main`** — check that branch out or run them from it.
+
+> **Correction, 2026-08-10 (at commit time).** Stale: #604 has since merged.
+> Both `scripts/sim-to-graphite.py` and `scripts/sim-live.sh` are on `main`.
+> Run them from there, not from the branch. Left in place rather than rewritten
+> because this is a dated note — but corrected, since it tells the reader to go
+> somewhere, and RFC-066 now links here.

--- a/docs/handoff-meter-as-gate-2026-08-07.md
+++ b/docs/handoff-meter-as-gate-2026-08-07.md
@@ -1,0 +1,252 @@
+# Handoff: wire the meter into a gate (and what else 2026-08-07 left open)
+
+**Status: session note, committed 2026-08-10 to stop it being lost.** Written at
+the end of a long session on 2026-08-07; treat every number here as sourced
+(each says where from) but the framing as one session's read. It carries no
+durability contract — archive or delete it once absorbed.
+
+**Take me to the work:** `main` at `cedc01ae` *as of writing*; well behind now.
+Nothing was blocked at the time. The next thread was §1 — since superseded in
+part by [RFC-066](rfc-066-lane-rate-arbitration.md), which cites this note's
+§2d/§2e framing but depends on none of it.
+
+---
+
+## 0. What landed today
+
+| PR | what | state |
+|---|---|---|
+| #601 | `PlacedEntity::rate` semantics settled — it is an aggregate at all 89 stamp sites, never per-tile flow | merged |
+| #603 | `physical_utilization` lost fractional-duty scaling on the banded path | merged |
+| #605 | lifted the `input-rate-delivery` selection exemption | merged |
+| #604 | Graphite export, dashboard, live streaming incl. warmup, divergence log | **open, on CI** |
+
+Product outcome: three target configs went from broken to working —
+`processing-unit@1/s` **68.2 → 102.0%** of plan, `advanced-circuit@5/s`
+**83.3 → 99.7%**, `tier2_electronic_circuit` **58 → 91%**, with
+`big-electric-pole@1` holding at plan as the regression canary. All four
+sim-measured, kit-clean, converged.
+
+`docs/status.md` recorded this deficit class as "a throughput/distribution
+ceiling, NOT a productivity-modelling error". It was neither — it was
+candidate selection being blind to a starvation warning the validator was
+already emitting.
+
+---
+
+## 1. THE NEXT THREAD — meter as a gate
+
+**Why it's worth doing:** `crates/meter/` predicts below-plan in **~19
+seconds** where the headless sim takes 10–20 minutes. It would have caught
+`tier2_electronic_circuit` before any of today happened.
+
+### The distinction I got wrong first, stated properly
+
+"Safe as a floor" is meaningless without saying what the gate *does*:
+
+- **Report-only** cares about **missed defects** — meter says at-plan when
+  reality is below. That quadrant is **empty across all 41 compared corpus
+  rows at every threshold ≥90%** (only appears at a bit-exact 100% cutoff,
+  where the hits are sim readings of 99.0–99.7% against a meter 100.0%,
+  i.e. inside the noise band). **Safe today.**
+- **Blocking** cares about **false accusations** — meter says below-plan
+  when reality is fine. There the corpus has a bad one: `PU-from-ore` reads
+  **85.8% where the sim reads 99.4%** — a **13.6pp** false accusation. At a
+  95% threshold that rejects a good layout. **Not safe today.**
+
+### Critical path
+
+1. **Land the research-productivity axis.** PU's −13.6pp is exactly this —
+   both PU rows match `docs/meter-divergence.md`'s recorded ≈−13% for the
+   unmerged axis. It is a missing feature on a branch, not a modelling
+   mystery, and it is the single largest false positive. Removing it is the
+   unlock.
+2. **Re-characterise** with `crates/meter/examples/sweep_corpus.rs` against
+   `~/spaghettio-corpora/job2-sim-baselines/2026-08-01/` (54 reports, ~minutes).
+3. **Wire report-only first**, per `validator-trust.md`'s own trust ladder —
+   rate models report before they steer. At 19s/fixture it cannot run in the
+   default suite; it wants STRESSGOLD-style opt-in.
+4. **Only then consider teeth**, with the false-positive rate measured.
+
+### Calibration facts you can rely on (41 compared rows, corpus-wide)
+
+- 25 pessimistic, 6 optimistic, 10 at ~0pp. Mean −1.27pp, median −0.3pp.
+- **Every optimistic error is ≤ +1.3pp anywhere in the corpus.** Pessimistic
+  errors run to −13.6pp.
+- **The meter's own convergence floor is ~20–40k ticks**, measured down to
+  warmup 0 on the deepest fixture (6499 entities: 78.9% at zero, plateau by
+  ~40k). The 108k that `check_one.rs` and `sweep_corpus.rs` both use has a
+  3–5× margin even there.
+- **"The default warmup is too short" does NOT transfer to the meter.** That
+  caveat is a property of headless Factorio's convergence needs (hence the
+  corpus's escalating per-fixture warmups). Assuming it carries over is a
+  mistake I made and it cost a round trip.
+
+---
+
+## 2. Open, with evidence
+
+### 2a. The meter's post-lift optimism — unexplained
+
+On the **post-lift** `tier2_electronic_circuit` layout the meter reads
+**96%** where the sim reads **90–91%** — optimistic by ~5–6pp, which is **4×
+the largest optimistic error in the whole corpus**. The corpus's own tier2
+row is the **pre-lift** layout and reads *pessimistic* (56.0% vs 57.7–58.1%).
+Different layouts; do not average them.
+
+Warmup mismatch was the obvious suspect and is **falsified**: the meter reads
+96.0% at every warmup from 108k to 864k (8× range, including the sim's own
+432k), zero movement, converged throughout. The corpus was checked too — 11
+of ~20 fixture families genuinely did run sim baselines at 288k against the
+meter's 108k, and re-running moved nothing by more than 0.5pp.
+
+So it is **genuine model-level disagreement** and needs snapshot/trace-level
+work. **This matters for §1**: the floor property is established for the
+corpus and NOT for post-lift layouts, which is the population a gate runs on.
+
+### 2b. Zero-headroom integral machine counts — prevalent, not sufficient
+
+When a stage's planned count lands exactly on an integer there is no rounding
+headroom, so the plan implicitly demands 100% duty forever. Measured:
+`copper-cable` plans at exactly 10.0 machines (30.0/s capacity vs 30.0/s
+required) and runs at 90% duty; EC inherits it stoichiometrically (3 cable
+per EC → 27/3 = 9.0 vs 9.09 measured).
+
+- **69/146 stages (47%) are exactly zero-headroom**, across 28/40 fixtures.
+- The near-miss class is as large: **92/146 (63%) under 2% headroom**.
+- Cost: a flat "+1 machine when headroom < X%" is ~3× cheaper than
+  multiplicative (+107 machines at <5% vs +357 at ×1.05). Entity cost is not
+  linear — ~10 entities per bumped machine shallow, 50–75 on deep chains.
+- **NECESSARY BUT NOT SUFFICIENT.** Every fixture below plan has a
+  zero-headroom stage, but several whose *target* stage has zero headroom
+  measure 97–107%. Decisive:
+  `stress_advanced_circuit_partitioned_5s_from_plates` has **identical**
+  solver output and headroom in its pooled vs partitioned variants and
+  measures **80% vs 98–100%**. Layout strategy is a confound.
+
+**Measured cost: ~8–10% per fully-zero-headroom fixture** (see §2e, which
+separated it from the selection bug). So zero-headroom is the **removal of the
+margin** that would otherwise absorb routing/inserter loss, not the defect
+itself — which means *reducing the
+loss* is as valid a direction as *adding machines*. **Adding headroom costs
+footprint, and that trade is the owner's call.**
+
+### 2c. `input-rate-delivery` is blind to zero-headroom
+
+The check now steering selection derives required rate at **nominal duty**, so
+it structurally cannot warn on an exactly-integral-count stage — ~47% of
+stages. The re-ranked tier2 winner has **zero** warnings from it and still
+sims at 91%. Recorded at the call site in `validate/mod.rs`. The lift is a
+partial fix to a class with at least two independent causes.
+
+### 2d. Two lane-rate models disagree
+
+`belt_flow::compute_lane_rates` and `belt_structural::compute_lane_rates`
+both exist; `validate/mod.rs` dispatches **`belt_structural`**, while
+`bus/template_validate.rs` uses **`belt_flow`**. They disagree on the S=1 ore
+belts (36/s vs nothing over cap). Both are independent Python→Rust ports —
+the duplication is a port artifact. `belt_flow` has the #519 consumption
+decrement and an iterative convergence pass; `belt_structural` has neither.
+
+**Parked during the session — but §2e weakens the reason.** I parked it on the
+arithmetic that `belt_flow`'s 36-on-a-30 predicts a ~17% throttle where the
+fixture measured ~50%, i.e. the wrong order of magnitude to be the cause. Post
+lift those fixtures measure **~90%**, a ~10% shortfall — now the *same* order
+as that prediction. So `belt_flow` flagging the S=1 ore belts may be pointing
+at the same residual §2b attributes to zero-headroom, and the two explanations
+are not obviously distinct.
+
+That does not make `belt_flow` right — it is the *non*-dispatched model and
+neither has ever been arbitrated — but "it can't be the cause, wrong
+magnitude" no longer holds. Worth re-examining alongside §2b rather than
+staying parked. Full reasoning in `docs/rate-stamp-semantics.md`.
+
+### 2e. RESOLVED — the zero-headroom tax is ~8–10%, not ~50%
+
+Both stress-EC fixtures re-measured post-lift. Valid runs (`kit_errors` empty,
+`fluid_errors` empty, converged, 4 checkpoints), pushed to Grafana as
+`arm=postlift`.
+
+| fixture | pre-lift | post-lift |
+|---|---|---|
+| `stress_electronic_circuit_30s_from_ore` | ~50% | **~92%** (27.27/s vs 30 planned) |
+| `stress_electronic_circuit_60s_red_from_ore` | ~50–51% | **~90%** (53.90/s vs 60 planned) |
+
+**The historical ~50% was overwhelmingly the selection bug**, the same jump PU
+(68.2→102%) and AC (83.3→99.7%) made. My scoping report suspected the two
+defects were confounded; this separates them by measurement rather than
+inference.
+
+**But a real residual remains, and it is the zero-headroom tax.** Both land at
+~90–92%, not ~100%, and the shortfall is *uniform across every stage with no
+dispersion* — a 360s wide-window cross-check on all four stages of the 30s
+fixture reads 91.8% on every one (EC 27.55, cable 82.61, copper-plate 41.29,
+iron-plate 27.54). Both fixtures have **all four stages exactly
+zero-headroom**, and the shape and magnitude match tier2's already-root-caused
+residual. Drift 0.6–2.0%, so this is not noise.
+
+**So: read §2b's 47%-of-stages prevalence against an ~8–10% typical cost per
+fully-zero-headroom fixture — not against the dramatic pre-lift deltas.** That
+changes the economics of a fix substantially, and it is the number to weigh
+against the footprint cost.
+
+**Not settled**: two data points, same recipe family (EC-from-ore), adjacent
+rates. Whether ~8–10% is a general zero-headroom tax or specific to this
+chain's inserter/belt geometry needs a structurally different fixture —
+`tier5_processing_unit_from_ore_am3` also has 4 exactly-zero stages and would
+triangulate it. Not run (5540+ entities, ~20+ min).
+
+---
+
+## 3. Traps that cost time today — each one bit
+
+1. **Raising `--warmup` requires raising `--timeout-secs`.** The derived
+   timeout is 4× the tick budget at the *requested* speed; a loaded box runs
+   slower, so a long warmup gets killed mid-warmup. The failure is quiet:
+   no verdict, no `kit_errors`, empty `timeseries.csv`, and no Factorio
+   process — which reads exactly like a completed run. I reported a result
+   that did not exist. Grep for `timed out after Ns waiting for
+   harness-result.json`. Documented in `sim-harness.md` (#604).
+2. **Research-productivity parity refuses runs ~16 minutes in.** The install
+   has productivity on `plastic-bar`, `processing-unit`, `steel-plate`. If a
+   chain touches one and the manifest doesn't declare it, `kit_errors` is
+   non-empty and the verdict is forced `NO DATA`. Read the realized set from
+   any existing report's `raw_result.productivity_force` before exporting.
+   **Never quote a run with non-empty `kit_errors`.**
+3. **`base_hand_size()` IS `hand_size(0)`**, not an additive constant. I
+   added a force bonus on top, double-counted L0, and "found" a bulk
+   hand-size bug that does not exist. `entity_data.rs` says *transcribe,
+   don't derive* because this table already attracted one wrong fix (#458).
+   Mine would have been the second.
+4. **Grafana wiring produced four separate false successes** — `perSecond()`
+   on backfilled data, interval-unaligned timestamps, stale-point rejection
+   (Grafana Cloud silently drops >~1 day old while returning `200
+   {published: N}`), and unset dashboard variables. Every one reported
+   success with an empty panel. **Verify a panel returns data; never trust
+   the write.**
+5. **Do not copy files between branches.** I copied `validate/mod.rs` from a
+   branch off `main` onto the lift branch and silently **reverted the lift
+   itself** — the one line #605 exists for. Only the test suite caught it.
+6. **A check that stops discriminating is worse than one that fails.** I
+   scoped two fixture probes to a headline item and made both **vacuous**;
+   review caught them. Any scoping change needs a non-vacuity guard asserting
+   the probe still has something to inspect.
+
+---
+
+## 4. Instruments now available (use them)
+
+- **Dashboard** `/d/spaghettio-sim` — per-stage % of plan, production,
+  delivered, raw input, and cumulative production. Filter by `fixture`/`arm`.
+- **`scripts/sim-to-graphite.py`** — push any `report.json`; `--anchor now`
+  for anything older than a day. Works retroactively on the whole corpus.
+- **`scripts/sim-live.sh`** — run a fixture with live streaming and print a
+  pre-filtered dashboard link. Includes the **warmup ramp**.
+- **The y=mx+c reading** (`sim-harness-forensics.md`) — a healthy stage is
+  piecewise {flat, ramp, straight line}. **Straightness is the starvation
+  test**: a starved stage is a staircase that averages to a plausible rate.
+  Uniform slope-scaling across stages ⇒ shared constraint; one shallow slope
+  ⇒ that stage is the bottleneck and downstream inherits it.
+
+Both scripts are on `tooling/sim-graphite-export` (#604), **not yet on
+`main`** — check that branch out or run them from it.

--- a/docs/handoff-meter-as-gate-2026-08-07.md
+++ b/docs/handoff-meter-as-gate-2026-08-07.md
@@ -88,6 +88,20 @@ seconds** where the headless sim takes 10–20 minutes. It would have caught
 
 ### 2a. The meter's post-lift optimism — unexplained
 
+> **Correction, 2026-08-10 (at commit time).** Partly superseded. The *deficit*
+> this section is measured against was root-caused on 2026-08-08 by #607/#608 —
+> `docs/status.md` §1015 records it as the `di-bridge` belt→belt transfer bank
+> loading one lane only (~21.4/s against 30/s of demand), and marks the
+> zero-headroom attribution **falsified for this fixture** with an explicit
+> "do not cite". Post-#608 selection ships the bus-lane variant, which measures
+> **100.0% of plan** headless. The *meter-vs-sim divergence* below is not
+> superseded and has since become its own record:
+> [`meter-divergence.md`](meter-divergence.md) §2026-08-08 is the current head,
+> and its conclusion is stronger than "unexplained" — **the floor property does
+> not hold on the gate population**, which is why the fast meter can refute but
+> never clear. Read this section for its falsification of the warmup suspect;
+> go there for the calibration.
+
 On the **post-lift** `tier2_electronic_circuit` layout the meter reads
 **96%** where the sim reads **90–91%** — optimistic by ~5–6pp, which is **4×
 the largest optimistic error in the whole corpus**. The corpus's own tier2

--- a/docs/rfc-066-lane-rate-arbitration.md
+++ b/docs/rfc-066-lane-rate-arbitration.md
@@ -1,6 +1,9 @@
 # RFC-066: Arbitrate the two lane-rate walkers against the meter
 
-**Status: proposed 2026-08-09.** Tracking issue: #609. No code written.
+**Status: proposed 2026-08-09.** Tracking issue: #609. No *engine* code written —
+no phase has started. The four `crates/core/examples/probe_*.rs` binaries listed
+in the verification plan are committed evidence instruments and touch nothing the
+engine dispatches.
 
 ## Summary
 
@@ -87,9 +90,11 @@ the oracle**. The meter caught that defect — nine of ten copper-cable machines
 saturated, the stage able to make plan, the binding constraint elsewhere — which
 is exactly the per-lane discrimination Phase 0 needs it to have.
 
-A local, uncommitted session handoff (`handoff-meter-as-gate-2026-08-07.md`)
-covers similar ground and is where I first read the framing, but it is **not in
-the repo** and nothing here depends on it.
+A session handoff ([`handoff-meter-as-gate-2026-08-07.md`](handoff-meter-as-gate-2026-08-07.md))
+covers similar ground and is where I first read the framing. It was untracked
+when this RFC was reviewed — see the 2026-08-09 decision-log entry — and was
+committed afterwards. Nothing here depends on it, and that has not changed: it
+is a session note, not a source.
 
 ## Design
 

--- a/docs/rfc-066-lane-rate-arbitration.md
+++ b/docs/rfc-066-lane-rate-arbitration.md
@@ -377,7 +377,10 @@ has them. An earlier draft of this RFC quoted a figure produced that way.
 - *2026-08-09 — review pass (#615, `second-opinion`) landed five findings, all
   valid, all fixed in the same PR. The material one: the original draft rested its
   "named, parked suspect" argument on `handoff-meter-as-gate-2026-08-07.md`, which
-  is **not committed** — an untracked local file. Re-pointed to `docs/status.md`
+  is **not committed** — an untracked local file. [**Annotation 2026-08-10 (#622):**
+  that file has since been committed to `docs/`, so it is readable now. The finding
+  and the re-pointing below both stand — the argument should not have rested on it
+  either way, and nothing was reverted.] Re-pointed to `docs/status.md`
   (post-lift 92.1% / 90.7%, "a real ~8-10% residual remains on both") and
   `docs/rate-stamp-semantics.md` (same two-walker split, same "arbitrate them"
   conclusion), so nothing load-bearing depends on an unreadable source. Also fixed:


### PR DESCRIPTION
## Intent

Two files had sat untracked in the shared checkout for three days, one `git clean` from gone. Neither is gitignored — they were just never added. Committing one of them falsified a sentence in the merged RFC-066, so that is fixed here too.

Surfaced while repairing a stale index in the shared checkout (`refs/heads/main` had been moved with `git branch -f`, leaving index and working tree three commits behind HEAD, so `git status` was rendering #610/#611/#612 backwards as 1131 staged deletions). That repair needed no commit — discarding it *restored* three merged commits. These two files were the only bytes actually at risk.

## Scope

- **In:**
  - `crates/meter/examples/cable_probe.rs` — meter probe for copper-cable belt position and inserter reach. `crates/meter/examples` is a tracked directory; 11 of its 12 files were already committed, this was the outlier. (`crates/core/examples` is the gitignored one — different directory, different rule.)
  - `docs/handoff-meter-as-gate-2026-08-07.md` — 2026-08-07 session note. Taxonomy class **Notes**: no durability contract. Two dated correction markers added where it tells the reader to *do* something that is now wrong.
  - `docs/rfc-066-lane-rate-arbitration.md` — three truth fixes, below.
- **Out:** the remaining #609 round-7 minors (single-cause attribution being over-broad; the `probe_b8_modes.rs` limits list covering only under-counting; the `probe_overcap_triage.rs` 933 bucket conflating two cases). Those are substantive evidence changes belonging to RFC-066 Phase 1, not to a tidy-up. They stay on #609.
- **Size:** **533 added lines against the ~400 norm.** 252 of those are the handoff note committed verbatim as a historical artifact — not reviewable prose, and splitting it changes nothing. The rest is one debug probe plus dated doc markers. A split would mean landing the note without the probe, or the probe without the RFC-066 corrections that committing the note *makes necessary* — either leaves the tree self-contradictory mid-stack.

## The RFC-066 fixes

1. RFC-066 said the handoff note "is **not in the repo** and nothing here depends on it." Committing it makes the first half false. The second half still holds and is the part that matters, so the line now says both.
2. The status line said "No code written" while the RFC's own verification plan lists four committed `probe_*.rs` binaries. Reworded to "no *engine* code written — no phase has started."
3. The 2026-08-09 decision-log entry recording the note as untracked now carries a dated in-place annotation. I initially left it alone as a historical record; that was inconsistent with having added dated markers to the note itself in the same PR, and CLAUDE.md calls the decision log "the canonical record".

## Verification

- [x] `cargo clippy -p spaghettio_meter --examples -- -D warnings` — clean. This is the check that matters: `cable_probe.rs` is now a tracked example, so CI builds it.
- [x] `cargo check -p spaghettio_meter --examples` — clean.
- [x] Five `second-opinion` rounds absorbed (below).
- [ ] `cargo test --manifest-path crates/core/Cargo.toml` — **not run, deliberately.** No engine code touched; the only compiled addition is an example binary. CI's `rust` job covers it.
- [ ] WASM rebuild / snapshot inspection — N/A, no engine, web or layout change.

## Review history — the probe was broken in four distinct ways

Worth recording, because the pattern is the finding:

| round | worst | what |
|---|---|---|
| 1 | minor ×4 | inserter counters not window-scoped — `reset_counters` never touches them, so every `starved=` carried the warmup. **Inverted the probe's headline signal.** |
| 2 | **major** | `belt_to_belt` required *both* endpoints to be `Belt`, excluding exactly the producer (Machine→Belt) and consumer (Belt→Machine) taps its own header advertised |
| 3 | minor ×4 | vacuity guard covered the total case, not the partial |
| 4 | minor (2/2) | guard *still* covered only the total case — root cause was single-instant membership sampling |
| 5 | minor (2/3) | sampling loop could overshoot the requested window |

Rounds 2 and 4 found defects **in the code written to fix the previous round**. The window was also 1/15 of `check_one.rs`'s calibrated `measure(108_000, 216_000)` — the buffer-fill-as-throughput trap `CLAUDE.md` flags for the sim harness.

Every one of these compiled and passed `clippy -D warnings` throughout. In this class of code that pair carries close to zero information about whether the output means anything.

## Deviations from intent

The RFC-066 edits were not part of "commit the loose files" as scoped. Committing the handoff note *causes* the first inaccuracy, so leaving it would ship a doc contradicting the tree. The probe rewrite was not planned either — it followed from review, and I kept going rather than merging a knowingly-misleading instrument into a tracked directory.

Three round-5 minors were **declined** with reasons in `review fixes 5`: a possible false-fire on the consumer guard (deliberate bias toward crying wolf over going silent), a suggested nonzero exit code (contract change with no caller wanting it), and annotating §0's historical status table (starts the rewrite the Notes taxonomy exists to avoid).

## Models / contracts touched

None. No engine, validator, or layout behaviour changes. RFC-066 remains **proposed, no phase started**; nothing here advances or alters its design.