### PR TITLE
RFC-067 donor probe: community copper-plate cells, pre-registered gate, adjudication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,10 @@ web/src/wasm-pkg/
 # community entries must be reproducible from the manifest-verified corpus
 # and the hand-declared port specs must be reviewable.
 !/crates/core/examples/celldb_donor.rs
+# Donor sim exporter: tracked because the RFC-067 decision log's sim
+# receipts (donor cells PASS at matched demand) must be re-derivable —
+# it synthesizes the boundary records TemplateCandidate::produce omits.
+!/crates/core/examples/donor_sim_export.rs
 
 # not sure what this is even lol
 *:Zone.Identifier

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,10 @@ web/src/wasm-pkg/
 # ...and the hotspot probe (RFC-067 follow-up): produces the area-budget /
 # whitespace-decomposition numbers; same tracked-producer reasoning.
 !/crates/core/examples/probe_hotspots.rs
+# Donor translator (RFC-067 donor probe): tracked because the store's
+# community entries must be reproducible from the manifest-verified corpus
+# and the hand-declared port specs must be reviewable.
+!/crates/core/examples/celldb_donor.rs
 
 # not sure what this is even lol
 *:Zone.Identifier

--- a/crates/core/data/celldb.json
+++ b/crates/core/data/celldb.json
@@ -13304,6 +13304,8085 @@
       },
       "provenance": "engine@d2a93e71 fixture=advanced-circuit@4",
       "sim_anchor": "unanchored"
+    },
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "copper-plate",
+        "machine": "electric-furnace",
+        "count": 48
+      },
+      "entities": [
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 29,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 31,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 30,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 33,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 32,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 35,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 34,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 37,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 36,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 39,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 38,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 41,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 40,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 43,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 42,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 45,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 44,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 49,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 51,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 50,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 53,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 52,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 55,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 54,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 57,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 56,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 59,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 58,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 61,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 60,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 63,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 62,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 65,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 64,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 67,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 66,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 69,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 68,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 0,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 1,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 2,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 4,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 5,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 11,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 16,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 23,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 22,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 29,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 28,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 35,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 34,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 41,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 40,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 47,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 46,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 53,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 52,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 59,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 58,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 65,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 64,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 70,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 71,
+          "y": 1,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 4,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 8,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 17,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 20,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 23,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 26,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 29,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 32,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 35,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 38,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 41,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 44,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 47,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 50,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 53,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 56,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 59,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 62,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 65,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 68,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 71,
+          "y": 2,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 5,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 4,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 5,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 11,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 16,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 23,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 22,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 29,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 28,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 29,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 31,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 30,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 33,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 32,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 35,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 34,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 35,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 34,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 37,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 36,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 39,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 38,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 41,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 40,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 41,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 40,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 43,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 42,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 45,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 44,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 47,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 46,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 49,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 51,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 50,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 53,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 52,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 53,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 52,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 55,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 54,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 57,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 56,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 59,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 58,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 59,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 58,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 61,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 60,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 63,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 62,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 65,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 64,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 65,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 64,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 67,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 66,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 69,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 68,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 70,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 71,
+          "y": 5,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 73,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 72,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-splitter",
+          "x": 0,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 7,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 8,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 4,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 5,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 11,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 16,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 23,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 22,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 29,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 28,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 35,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 34,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 41,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 40,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 47,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 46,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 53,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 52,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 59,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 58,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 65,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 64,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 70,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 71,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 9,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 10,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 8,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 17,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 20,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 23,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 26,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 29,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 32,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 35,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 38,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 41,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 44,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 47,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 50,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 53,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 56,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 59,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 62,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 65,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 68,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 71,
+          "y": 8,
+          "direction": "North",
+          "recipe": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 11,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 4,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 5,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 11,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 16,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 23,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 22,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 29,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 28,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 29,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 31,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 30,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 33,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 32,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 35,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 34,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 35,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 34,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 37,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 36,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 39,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 38,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 41,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 40,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 41,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 40,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 43,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 42,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 45,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 44,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 47,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 46,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 49,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 51,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 50,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 53,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 52,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 53,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 52,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 55,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 54,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 57,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 56,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 59,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 58,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 59,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 58,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 61,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 60,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 63,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 62,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 65,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 64,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 65,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 64,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 67,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 66,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 69,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 68,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 70,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 71,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        }
+      ],
+      "ports": [
+        {
+          "dx": 0,
+          "dy": 6,
+          "kind": "belt-in",
+          "item": "copper-ore"
+        },
+        {
+          "dx": 73,
+          "dy": 6,
+          "kind": "belt-out",
+          "item": "copper-plate"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 74,
+        "bbox_h": 13,
+        "interior_tiles": 753,
+        "entity_count": 368
+      },
+      "provenance": "community:factorioprints/-OL38TX27JmPIivo#8",
+      "sim_anchor": "unanchored"
+    },
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "copper-plate",
+        "machine": "electric-furnace",
+        "count": 50
+      },
+      "entities": [
+        {
+          "name": "electric-furnace",
+          "x": 0,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 3,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 7,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 10,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 17,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 21,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 24,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 28,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 31,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 35,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 38,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 42,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 45,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 49,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 52,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 56,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 59,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 63,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 66,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 70,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 73,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 77,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 80,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 84,
+          "y": 0,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 0,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 2,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 3,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 5,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 7,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 9,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 10,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 14,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 16,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 17,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 19,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 21,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 23,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 24,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 26,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 28,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 29,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 30,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 30,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 31,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 31,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 32,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 33,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 33,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 34,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 35,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 35,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 36,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 37,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 37,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 38,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 38,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 39,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 40,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 40,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 41,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 42,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 42,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 43,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 44,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 44,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 45,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 45,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 47,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 49,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 49,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 50,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 51,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 51,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 52,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 52,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 53,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 54,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 54,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 55,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 56,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 56,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 57,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 58,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 58,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 59,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 59,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 60,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 61,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 61,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 62,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 63,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 63,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 64,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 65,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 65,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 66,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 66,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 67,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 68,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 68,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 69,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 70,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 72,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 72,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 73,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 73,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 74,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 75,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 75,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 76,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 77,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 77,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 78,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 79,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 79,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 80,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 80,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 81,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 83,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 82,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 82,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 85,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 84,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 84,
+          "y": 3,
+          "direction": "South",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 86,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 86,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 0,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 1,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 0,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 2,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 3,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 2,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 4,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 5,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 5,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 6,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 7,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 7,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 8,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 9,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 9,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 10,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 11,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 10,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 12,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 13,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 12,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 14,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 15,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 14,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 16,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 17,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 16,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 17,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 18,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 19,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 19,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 20,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 21,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 21,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 22,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 23,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 23,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 24,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 25,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 24,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 26,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 27,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 26,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 28,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 29,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 28,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 30,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 31,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 30,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 31,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 32,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 33,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 33,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 34,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 35,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 35,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 36,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 37,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 37,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 38,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 39,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 38,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 40,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 41,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 40,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 42,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 43,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 42,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 44,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 45,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 44,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 45,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 46,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 47,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 47,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 48,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 49,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 49,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 50,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 51,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 51,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 52,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 53,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 52,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 54,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 55,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 54,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 56,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 57,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 56,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 58,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 59,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 58,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 59,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 60,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 61,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 61,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 62,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 63,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 63,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 64,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 65,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 65,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 66,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 67,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 66,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 68,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 69,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 68,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 70,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 71,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 70,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 72,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 73,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 72,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 73,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 74,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 75,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 75,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 76,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 77,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 77,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 78,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 79,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 79,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 80,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 81,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 80,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 83,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 82,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "inserter",
+          "x": 82,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 84,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 85,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 84,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "inserter",
+          "x": 86,
+          "y": 6,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-transport-belt",
+          "x": 86,
+          "y": 5,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 0,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 3,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 7,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 10,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 17,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 21,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 24,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 28,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 31,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 35,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 38,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 42,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 45,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 49,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 52,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 56,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 59,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 63,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 66,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 70,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 73,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 77,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 80,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "electric-furnace",
+          "x": 84,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "efficiency-module",
+              "count": 2
+            }
+          ]
+        }
+      ],
+      "ports": [
+        {
+          "dx": 0,
+          "dy": 5,
+          "kind": "belt-in",
+          "item": "copper-ore"
+        },
+        {
+          "dx": 86,
+          "dy": 4,
+          "kind": "belt-out",
+          "item": "copper-plate"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 87,
+        "bbox_h": 10,
+        "interior_tiles": 722,
+        "entity_count": 322
+      },
+      "provenance": "community:factorioprints/-Lxr8KxgJup5AsKyTygI#6",
+      "sim_anchor": "unanchored"
+    },
+    {
+      "motif": {
+        "kind": "unit",
+        "recipe": "copper-plate",
+        "machine": "electric-furnace",
+        "count": 52
+      },
+      "entities": [
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 0,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 2,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 2,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 1,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 2,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 2,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 1,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 2,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 2,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 2,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 1,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 2,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 2,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 4,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 3,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 4,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 4,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 4,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 3,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 4,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 4,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 3,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 5,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 5,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 6,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 5,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 5,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 6,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 5,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 6,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 8,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 8,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 8,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 8,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 7,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 8,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 8,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 7,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 10,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 9,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 10,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 10,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 10,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 9,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 10,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 10,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 10,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 9,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 10,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 9,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 10,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 12,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 11,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 12,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 12,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 12,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 11,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 12,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 12,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 11,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 14,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 13,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 14,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 13,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 14,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 14,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 13,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 14,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 14,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 14,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 13,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 14,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 13,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 14,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 16,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 15,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 16,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 15,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 16,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 15,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 16,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 16,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 15,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 16,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 16,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 15,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 18,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 17,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 18,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 17,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 18,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 18,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 17,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 18,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 18,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 18,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 17,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 18,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 17,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 18,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 20,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 19,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 20,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 19,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 20,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 19,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 20,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 20,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 19,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 20,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 20,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 19,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 22,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 21,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 22,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 21,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 22,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 22,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 21,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 22,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 22,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 22,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 21,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 22,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 21,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 22,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 24,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 23,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 24,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 23,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 24,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 23,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 24,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 24,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 23,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 24,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 24,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 23,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 26,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 25,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 26,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 25,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 26,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 26,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 25,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 26,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 26,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 26,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 25,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 26,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 25,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 26,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 28,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 27,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 28,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 27,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 28,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 27,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 28,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 28,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 27,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 28,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 28,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 27,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 29,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 30,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 30,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 29,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 30,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 30,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 29,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 30,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 30,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 30,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 29,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 30,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 29,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 30,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 32,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 31,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 32,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 31,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 32,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 31,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 32,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 32,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 31,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 32,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 32,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 31,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 33,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 34,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 34,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 33,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 34,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 34,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 33,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 34,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 34,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 34,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 33,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 34,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 33,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 34,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 36,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 35,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 36,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 35,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 36,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 35,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 36,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 36,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 35,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 36,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 36,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 35,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 37,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 38,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 38,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 37,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 38,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 38,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 37,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 38,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 38,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 38,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 37,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 38,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 37,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 38,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 40,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 39,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 40,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 39,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 40,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 39,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 40,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 40,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 39,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 40,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 40,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 39,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 41,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 42,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 42,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 41,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 42,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 42,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 41,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 42,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 42,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 42,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 41,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 42,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 41,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 42,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 44,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 43,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 44,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 43,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 44,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 43,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 44,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 44,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 43,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 44,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 44,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 43,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 45,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 46,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 46,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 45,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 46,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 46,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 45,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 46,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 46,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 46,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 45,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 46,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 45,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 46,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 48,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 47,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 48,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 47,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 48,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 47,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 48,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 48,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 47,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 48,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 48,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 47,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 49,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 50,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 1,
+          "y": 50,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 2,
+          "y": 49,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 6,
+          "y": 50,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 50,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 49,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 50,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 50,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 12,
+          "y": 50,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 14,
+          "y": 49,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 17,
+          "y": 50,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 49,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 50,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 0,
+          "y": 52,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 51,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 3,
+          "y": 52,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 5,
+          "y": 51,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "fast-inserter",
+          "x": 8,
+          "y": 52,
+          "direction": "East",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 51,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 52,
+          "direction": "North",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "fast-inserter",
+          "x": 10,
+          "y": 52,
+          "direction": "West",
+          "carries": "copper-plate"
+        },
+        {
+          "name": "electric-furnace",
+          "x": 11,
+          "y": 51,
+          "direction": "North",
+          "recipe": "copper-plate",
+          "items": [
+            {
+              "item": "speed-module",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "name": "long-handed-inserter",
+          "x": 15,
+          "y": 52,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 17,
+          "y": 52,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 51,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 53,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 0,
+          "y": 54,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 1,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 2,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 3,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 4,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 5,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 6,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 7,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 53,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 54,
+          "direction": "West",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 53,
+          "direction": "South",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 11,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 13,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 12,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 15,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 14,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 17,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 16,
+          "y": 54,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 53,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 18,
+          "y": 54,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 9,
+          "y": 55,
+          "direction": "East",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-splitter",
+          "x": 8,
+          "y": 56,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 8,
+          "y": 55,
+          "direction": "North",
+          "carries": "copper-ore"
+        },
+        {
+          "name": "express-transport-belt",
+          "x": 10,
+          "y": 55,
+          "direction": "North",
+          "carries": "copper-ore"
+        }
+      ],
+      "ports": [
+        {
+          "dx": 8,
+          "dy": 56,
+          "kind": "belt-in",
+          "item": "copper-ore"
+        },
+        {
+          "dx": 9,
+          "dy": 0,
+          "kind": "belt-out",
+          "item": "copper-plate"
+        }
+      ],
+      "metrics": {
+        "bbox_w": 19,
+        "bbox_h": 57,
+        "interior_tiles": 806,
+        "entity_count": 363
+      },
+      "provenance": "community:factorioprints/-ON0-7RmLQJjDfgq7s_W#2",
+      "sim_anchor": "unanchored"
     }
   ]
 }

--- a/crates/core/data/celldb.json
+++ b/crates/core/data/celldb.json
@@ -15926,325 +15926,175 @@
           "x": 0,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 3,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 7,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 10,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 14,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 17,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 21,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 24,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 28,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 31,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 35,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 38,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 42,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 45,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 49,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 52,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 56,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 59,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 63,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 66,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 70,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 73,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 77,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 80,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 84,
           "y": 0,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -18155,325 +18005,175 @@
           "x": 0,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 3,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 7,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 10,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 14,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 17,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 21,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 24,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 28,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 31,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 35,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 38,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 42,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 45,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 49,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 52,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 56,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 59,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 63,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 66,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 70,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 73,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 77,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 80,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "electric-furnace",
           "x": 84,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "efficiency-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         }
       ],
       "ports": [
@@ -18533,13 +18233,7 @@
           "x": 2,
           "y": 1,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 1
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -18588,13 +18282,7 @@
           "x": 14,
           "y": 1,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 1
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -18636,13 +18324,7 @@
           "x": 5,
           "y": 3,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 1
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -18677,13 +18359,7 @@
           "x": 11,
           "y": 3,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 1
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -18732,13 +18408,7 @@
           "x": 2,
           "y": 5,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -18787,13 +18457,7 @@
           "x": 14,
           "y": 5,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -18842,13 +18506,7 @@
           "x": 5,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -18883,13 +18541,7 @@
           "x": 11,
           "y": 7,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -18938,13 +18590,7 @@
           "x": 2,
           "y": 9,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -18993,13 +18639,7 @@
           "x": 14,
           "y": 9,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19048,13 +18688,7 @@
           "x": 5,
           "y": 11,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19089,13 +18723,7 @@
           "x": 11,
           "y": 11,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19144,13 +18772,7 @@
           "x": 2,
           "y": 13,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19199,13 +18821,7 @@
           "x": 14,
           "y": 13,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19254,13 +18870,7 @@
           "x": 5,
           "y": 15,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19295,13 +18905,7 @@
           "x": 11,
           "y": 15,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19350,13 +18954,7 @@
           "x": 2,
           "y": 17,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19405,13 +19003,7 @@
           "x": 14,
           "y": 17,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19460,13 +19052,7 @@
           "x": 5,
           "y": 19,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19501,13 +19087,7 @@
           "x": 11,
           "y": 19,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19556,13 +19136,7 @@
           "x": 2,
           "y": 21,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19611,13 +19185,7 @@
           "x": 14,
           "y": 21,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19666,13 +19234,7 @@
           "x": 5,
           "y": 23,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19707,13 +19269,7 @@
           "x": 11,
           "y": 23,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19762,13 +19318,7 @@
           "x": 2,
           "y": 25,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19817,13 +19367,7 @@
           "x": 14,
           "y": 25,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19872,13 +19416,7 @@
           "x": 5,
           "y": 27,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -19913,13 +19451,7 @@
           "x": 11,
           "y": 27,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -19968,13 +19500,7 @@
           "x": 2,
           "y": 29,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20023,13 +19549,7 @@
           "x": 14,
           "y": 29,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20078,13 +19598,7 @@
           "x": 5,
           "y": 31,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20119,13 +19633,7 @@
           "x": 11,
           "y": 31,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20174,13 +19682,7 @@
           "x": 2,
           "y": 33,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20229,13 +19731,7 @@
           "x": 14,
           "y": 33,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20284,13 +19780,7 @@
           "x": 5,
           "y": 35,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20325,13 +19815,7 @@
           "x": 11,
           "y": 35,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20380,13 +19864,7 @@
           "x": 2,
           "y": 37,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20435,13 +19913,7 @@
           "x": 14,
           "y": 37,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20490,13 +19962,7 @@
           "x": 5,
           "y": 39,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20531,13 +19997,7 @@
           "x": 11,
           "y": 39,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20586,13 +20046,7 @@
           "x": 2,
           "y": 41,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20641,13 +20095,7 @@
           "x": 14,
           "y": 41,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20696,13 +20144,7 @@
           "x": 5,
           "y": 43,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20737,13 +20179,7 @@
           "x": 11,
           "y": 43,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20792,13 +20228,7 @@
           "x": 2,
           "y": 45,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20847,13 +20277,7 @@
           "x": 14,
           "y": 45,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20902,13 +20326,7 @@
           "x": 5,
           "y": 47,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -20943,13 +20361,7 @@
           "x": 11,
           "y": 47,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -20998,13 +20410,7 @@
           "x": 2,
           "y": 49,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",
@@ -21053,13 +20459,7 @@
           "x": 14,
           "y": 49,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -21108,13 +20508,7 @@
           "x": 5,
           "y": 51,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "fast-inserter",
@@ -21149,13 +20543,7 @@
           "x": 11,
           "y": 51,
           "direction": "North",
-          "recipe": "copper-plate",
-          "items": [
-            {
-              "item": "speed-module",
-              "count": 2
-            }
-          ]
+          "recipe": "copper-plate"
         },
         {
           "name": "long-handed-inserter",

--- a/crates/core/examples/celldb_donor.rs
+++ b/crates/core/examples/celldb_donor.rs
@@ -333,6 +333,24 @@ fn translate(spec: &DonorSpec, corpus: &str) -> CellEntry {
         }
         entities.push(e.clone());
     }
+    // Donors donate GEOMETRY only. Module payloads are stripped: the
+    // incumbent competes module-less (module planning is the solver's
+    // RFC-044 axis, not the fragment's), and a speed-moduled donor would
+    // claim capability the plan never funded — the ON0 donor shipped with
+    // speed modules that made its first sim read 45/s from a 32.5/s plan.
+    let mut stripped_modules = 0usize;
+    for e in entities.iter_mut() {
+        if !e.items.is_empty() {
+            stripped_modules += e.items.len();
+            e.items.clear();
+        }
+    }
+    if stripped_modules > 0 {
+        println!(
+            "{}: stripped {stripped_modules} module payload(s) (geometry-only donation)",
+            spec.provenance
+        );
+    }
     // The motif recipe is a declaration, not a read: furnace arrays are
     // item-agnostic and community furnaces carry no recipe field. Refuse
     // if the source DID declare one — overriding a real declaration would

--- a/crates/core/examples/celldb_donor.rs
+++ b/crates/core/examples/celldb_donor.rs
@@ -84,11 +84,12 @@ fn specs() -> Vec<DonorSpec> {
                 (73, 6, PortKind::BeltOut, "copper-plate"),
             ],
         },
-        // "Mass Plate Production": tileable double-row yellow... fast-belt
-        // cell, long-handed feeders from the lower ore belt, plates drain
-        // onto the upper belt; both belts exit east (ore pass-through is
-        // the design's chaining feature). 50 furnaces. Ports are in
-        // POST-pole-strip coordinates (strip shifts x by -1).
+        // "Mass Plate Production": tileable double-row fast-belt cell
+        // (its inserters are yellow, its belts are not), long-handed
+        // feeders from the lower ore belt, plates drain onto the upper
+        // belt; both belts exit east (ore pass-through is the design's
+        // chaining feature). 50 furnaces. Ports are in POST-pole-strip
+        // coordinates (strip shifts x by -1).
         DonorSpec {
             source_file: "-Lxr8KxgJup5AsKyTygI_factory_blueprints.json",
             record_index: 6,

--- a/crates/core/examples/celldb_donor.rs
+++ b/crates/core/examples/celldb_donor.rs
@@ -230,8 +230,8 @@ fn assign_carries(entities: &mut [PlacedEntity], spec: &DonorSpec) {
             }
         }
     }
-    // Seeds from inserters; also set inserter carries.
-    let mut seed: BTreeMap<usize, &'static str> = BTreeMap::new();
+    // Classify every inserter (drop side = its direction, engine
+    // semantics) and refuse anything a smelter cell shouldn't contain.
     let mut ins_item: Vec<Option<&'static str>> = vec![None; n];
     for (i, e) in entities.iter().enumerate() {
         if !is_inserter(&e.name) {
@@ -246,22 +246,13 @@ fn assign_carries(entities: &mut [PlacedEntity], spec: &DonorSpec) {
         match (feeds_machine, drains_machine) {
             (true, false) => {
                 ins_item[i] = Some(spec.in_item);
-                if let Some(&t) = tile_of.get(&pick) {
-                    seed.insert(find(&mut parent, t), spec.in_item);
-                } else {
+                if !tile_of.contains_key(&pick) {
                     fail(&format!("feeder inserter at ({},{}) picks from a non-transport tile", e.x, e.y));
                 }
             }
             (false, true) => {
                 ins_item[i] = Some(spec.out_item);
-                if let Some(&t) = tile_of.get(&drop) {
-                    let root = find(&mut parent, t);
-                    if let Some(prev) = seed.insert(root, spec.out_item) {
-                        if prev != spec.out_item {
-                            fail(&format!("belt run reached by both items near ({},{})", e.x, e.y));
-                        }
-                    }
-                } else {
+                if !tile_of.contains_key(&drop) {
                     fail(&format!("drain inserter at ({},{}) drops onto a non-transport tile", e.x, e.y));
                 }
             }
@@ -269,10 +260,9 @@ fn assign_carries(entities: &mut [PlacedEntity], spec: &DonorSpec) {
             (false, false) => fail(&format!("inserter at ({},{}) touches no machine", e.x, e.y)),
         }
     }
-    // Conflict check: a root seeded twice with different items already
-    // refused above for drains; feeders can conflict with drains too.
-    // (seed.insert refuses via the drain arm; feeder arm inserts blindly —
-    // re-verify all seeds agree per root.)
+    // Seed each belt-run root from its inserters and refuse on conflict —
+    // the SINGLE conflict authority (an earlier duplicate map invited
+    // fixing the wrong copy; second-opinion round on the donor-probe PR).
     let mut root_item: BTreeMap<usize, &'static str> = BTreeMap::new();
     for (i, e) in entities.iter().enumerate() {
         if !is_inserter(&e.name) {

--- a/crates/core/examples/celldb_donor.rs
+++ b/crates/core/examples/celldb_donor.rs
@@ -67,7 +67,59 @@ const STRIP: &[&str] = &["small-electric-pole", "medium-electric-pole", "big-ele
 
 fn specs() -> Vec<DonorSpec> {
     vec![
-        // Filled in per donor after the geometry maps; see PR body.
+        // Double-row fast-belt smelter: ore enters a west-edge splitter
+        // feeding top/bottom ore belts via two distribution columns; the
+        // shared middle belt drains east. 48 furnaces.
+        DonorSpec {
+            source_file: "-OL38TX27JmPIivo_F3R_factorio_handbook.json",
+            record_index: 8,
+            record_label: "[item=electric-furnace] 30/s",
+            provenance: "community:factorioprints/-OL38TX27JmPIivo#8",
+            recipe: "copper-plate",
+            machine: "electric-furnace",
+            in_item: "copper-ore",
+            out_item: "copper-plate",
+            ports: &[
+                (0, 6, PortKind::BeltIn, "copper-ore"),
+                (73, 6, PortKind::BeltOut, "copper-plate"),
+            ],
+        },
+        // "Mass Plate Production": tileable double-row yellow... fast-belt
+        // cell, long-handed feeders from the lower ore belt, plates drain
+        // onto the upper belt; both belts exit east (ore pass-through is
+        // the design's chaining feature). 50 furnaces. Ports are in
+        // POST-pole-strip coordinates (strip shifts x by -1).
+        DonorSpec {
+            source_file: "-Lxr8KxgJup5AsKyTygI_factory_blueprints.json",
+            record_index: 6,
+            record_label: "Mass Plate Production",
+            provenance: "community:factorioprints/-Lxr8KxgJup5AsKyTygI#6",
+            recipe: "copper-plate",
+            machine: "electric-furnace",
+            in_item: "copper-ore",
+            out_item: "copper-plate",
+            ports: &[
+                (0, 5, PortKind::BeltIn, "copper-ore"),
+                (86, 4, PortKind::BeltOut, "copper-plate"),
+            ],
+        },
+        // Vertical express column cell: ore enters a south-edge splitter,
+        // climbs both side columns (inline splitters as lane balancers);
+        // plates merge onto the center column and exit north. 52 furnaces.
+        DonorSpec {
+            source_file: "-ON0-7RmLQJjDfgq7s_W_all_the_book.json",
+            record_index: 2,
+            record_label: "[item=iron-plate][item=copper-plate]45/s 2700/m",
+            provenance: "community:factorioprints/-ON0-7RmLQJjDfgq7s_W#2",
+            recipe: "copper-plate",
+            machine: "electric-furnace",
+            in_item: "copper-ore",
+            out_item: "copper-plate",
+            ports: &[
+                (8, 56, PortKind::BeltIn, "copper-ore"),
+                (9, 0, PortKind::BeltOut, "copper-plate"),
+            ],
+        },
     ]
 }
 

--- a/crates/core/examples/celldb_donor.rs
+++ b/crates/core/examples/celldb_donor.rs
@@ -1,0 +1,368 @@
+//! Community-donor translator for the celldb store (RFC-067 donor probe,
+//! decision log 2026-08-12).
+//!
+//! Translates hand-shortlisted community blueprint cells into celldb
+//! entries. The split of labor is deliberate and mirrors the reopening
+//! path's wording ("community/hand donors with inferred ports"): geometry
+//! comes mechanically from the parsed blueprint, `carries` assignment is
+//! derived from the engine's own inserter semantics and refused on any
+//! ambiguity, and the PORTS are hand-declared in the spec table below —
+//! port inference from wild blueprints stays out of scope (the recorded
+//! v1 gap). Everything hand-declared is machine-verified: ports by
+//! `celldb::check_entry`, provenance by SHA256 against the Phase-0 corpus
+//! manifest, and metrics are derived here, never typed.
+//!
+//! Usage:
+//!   CORPUS=<dir> cargo run -p spaghettio_core --example celldb_donor
+//!
+//! Reads `$CORPUS/<spec.source_file>`, verifies its SHA256 against
+//! `scripts/celldb-phase0/corpus-manifest.tsv`, and rewrites
+//! `crates/core/data/celldb.json` with this tool's donor entries replaced
+//! in place (engine@ entries untouched). Refuses (exit 2) on any
+//! extraction ambiguity or invariant violation.
+
+use spaghettio_core::analysis;
+use spaghettio_core::celldb::{self, CellDb, CellEntry, Metrics, Motif, Port, PortKind};
+use spaghettio_core::common::{dir_to_vec, inserter_reach, is_inserter, oriented_entity_dims};
+use spaghettio_core::connectivity::build_ug_pairs;
+use spaghettio_core::models::PlacedEntity;
+use std::collections::{BTreeMap, BTreeSet};
+
+struct DonorSpec {
+    /// Corpus filename (factorioprints export) — provenance + SHA source.
+    source_file: &'static str,
+    /// Index into `analyze_blueprint_string_any`'s record list.
+    record_index: usize,
+    /// Asserted against the record's label — drift guard on the index.
+    record_label: &'static str,
+    /// Short provenance id written into the entry.
+    provenance: &'static str,
+    recipe: &'static str,
+    machine: &'static str,
+    in_item: &'static str,
+    out_item: &'static str,
+    /// Hand-declared ports, in POST-normalization coordinates (after pole
+    /// strip). check_entry verifies boundary-ness, occupancy, and carries.
+    ports: &'static [(i32, i32, PortKind, &'static str)],
+}
+
+/// Entity names allowed to remain in a donor fragment. Anything else after
+/// the pole strip is a refusal, not a silent drop.
+const KEEP: &[&str] = &[
+    "electric-furnace",
+    "transport-belt",
+    "fast-transport-belt",
+    "express-transport-belt",
+    "underground-belt",
+    "fast-underground-belt",
+    "express-underground-belt",
+    "splitter",
+    "fast-splitter",
+    "express-splitter",
+    "inserter",
+    "fast-inserter",
+    "long-handed-inserter",
+];
+const STRIP: &[&str] = &["small-electric-pole", "medium-electric-pole", "big-electric-pole", "substation"];
+
+fn specs() -> Vec<DonorSpec> {
+    vec![
+        // Filled in per donor after the geometry maps; see PR body.
+    ]
+}
+
+fn fail(msg: &str) -> ! {
+    eprintln!("REFUSE: {msg}");
+    std::process::exit(2);
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    // No sha2 dependency in core; shell out (tool runs dev-side only).
+    use std::io::Write as _;
+    use std::process::{Command, Stdio};
+    let mut c = Command::new("sha256sum")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("sha256sum");
+    c.stdin.as_mut().unwrap().write_all(bytes).unwrap();
+    let out = c.wait_with_output().unwrap();
+    String::from_utf8(out.stdout).unwrap().split_whitespace().next().unwrap().to_string()
+}
+
+fn manifest_sha(file: &str) -> String {
+    let manifest = std::fs::read_to_string("scripts/celldb-phase0/corpus-manifest.tsv")
+        .expect("corpus-manifest.tsv (run from repo root)");
+    for line in manifest.lines() {
+        let mut it = line.split('\t');
+        if it.next() == Some(file) {
+            return it.next().expect("manifest sha").to_string();
+        }
+    }
+    fail(&format!("{file} not in corpus-manifest.tsv"));
+}
+
+fn is_transport(name: &str) -> bool {
+    name.ends_with("transport-belt") || name.ends_with("underground-belt") || name.ends_with("splitter")
+}
+
+fn occupied_tiles(e: &PlacedEntity) -> Vec<(i32, i32)> {
+    let (w, h) = oriented_entity_dims(&e.name, e.direction);
+    let mut v = Vec::new();
+    for dx in 0..w {
+        for dy in 0..h {
+            v.push((e.x + dx, e.y + dy));
+        }
+    }
+    v
+}
+
+/// Assign `carries` to every transport entity and inserter, mechanically:
+/// seed from inserter pick/drop tiles (engine semantics: direction is the
+/// DROP side, reach from `inserter_reach`), propagate across the directed
+/// belt-flow graph's weak components, refuse on conflict or unreached
+/// transport.
+fn assign_carries(entities: &mut [PlacedEntity], spec: &DonorSpec) {
+    let furnace_tiles: BTreeSet<(i32, i32)> = entities
+        .iter()
+        .filter(|e| e.name == spec.machine)
+        .flat_map(|e| occupied_tiles(e))
+        .collect();
+    // tile -> transport entity index
+    let mut tile_of: BTreeMap<(i32, i32), usize> = BTreeMap::new();
+    for (i, e) in entities.iter().enumerate() {
+        if is_transport(&e.name) {
+            for t in occupied_tiles(e) {
+                tile_of.insert(t, i);
+            }
+        }
+    }
+    // Union-find over transport indices, joined by directed flow adjacency
+    // (a belt's output tile landing on another transport entity — covers
+    // in-line flow and sideloads; parallel belts never join) plus UG pairs.
+    let n = entities.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(parent: &mut Vec<usize>, i: usize) -> usize {
+        if parent[i] != i {
+            let r = find(parent, parent[i]);
+            parent[i] = r;
+        }
+        parent[i]
+    }
+    let join = |parent: &mut Vec<usize>, a: usize, b: usize| {
+        let (ra, rb) = (find(parent, a), find(parent, b));
+        if ra != rb {
+            parent[ra] = rb;
+        }
+    };
+    let ug_pairs = build_ug_pairs(entities);
+    for (i, e) in entities.iter().enumerate() {
+        if !is_transport(&e.name) {
+            continue;
+        }
+        let (dx, dy) = dir_to_vec(e.direction);
+        for t in occupied_tiles(e) {
+            let out = (t.0 + dx, t.1 + dy);
+            if let Some(&j) = tile_of.get(&out) {
+                if j != i {
+                    join(&mut parent, i, j);
+                }
+            }
+        }
+    }
+    for (a, b) in &ug_pairs {
+        if let (Some(&i), Some(&j)) = (tile_of.get(a), tile_of.get(b)) {
+            if i != j {
+                join(&mut parent, i, j);
+            }
+        }
+    }
+    // Seeds from inserters; also set inserter carries.
+    let mut seed: BTreeMap<usize, &'static str> = BTreeMap::new();
+    let mut ins_item: Vec<Option<&'static str>> = vec![None; n];
+    for (i, e) in entities.iter().enumerate() {
+        if !is_inserter(&e.name) {
+            continue;
+        }
+        let (dx, dy) = dir_to_vec(e.direction);
+        let r = inserter_reach(&e.name);
+        let drop = (e.x + dx * r, e.y + dy * r);
+        let pick = (e.x - dx * r, e.y - dy * r);
+        let feeds_machine = furnace_tiles.contains(&drop);
+        let drains_machine = furnace_tiles.contains(&pick);
+        match (feeds_machine, drains_machine) {
+            (true, false) => {
+                ins_item[i] = Some(spec.in_item);
+                if let Some(&t) = tile_of.get(&pick) {
+                    seed.insert(find(&mut parent, t), spec.in_item);
+                } else {
+                    fail(&format!("feeder inserter at ({},{}) picks from a non-transport tile", e.x, e.y));
+                }
+            }
+            (false, true) => {
+                ins_item[i] = Some(spec.out_item);
+                if let Some(&t) = tile_of.get(&drop) {
+                    let root = find(&mut parent, t);
+                    if let Some(prev) = seed.insert(root, spec.out_item) {
+                        if prev != spec.out_item {
+                            fail(&format!("belt run reached by both items near ({},{})", e.x, e.y));
+                        }
+                    }
+                } else {
+                    fail(&format!("drain inserter at ({},{}) drops onto a non-transport tile", e.x, e.y));
+                }
+            }
+            (true, true) => fail(&format!("inserter at ({},{}) touches machines on both sides", e.x, e.y)),
+            (false, false) => fail(&format!("inserter at ({},{}) touches no machine", e.x, e.y)),
+        }
+    }
+    // Conflict check: a root seeded twice with different items already
+    // refused above for drains; feeders can conflict with drains too.
+    // (seed.insert refuses via the drain arm; feeder arm inserts blindly —
+    // re-verify all seeds agree per root.)
+    let mut root_item: BTreeMap<usize, &'static str> = BTreeMap::new();
+    for (i, e) in entities.iter().enumerate() {
+        if !is_inserter(&e.name) {
+            continue;
+        }
+        let (dx, dy) = dir_to_vec(e.direction);
+        let r = inserter_reach(&e.name);
+        let (t, item) = if ins_item[i] == Some(spec.in_item) {
+            ((e.x - dx * r, e.y - dy * r), spec.in_item)
+        } else {
+            ((e.x + dx * r, e.y + dy * r), spec.out_item)
+        };
+        let root = find(&mut parent, *tile_of.get(&t).unwrap());
+        if let Some(prev) = root_item.insert(root, item) {
+            if prev != item {
+                fail(&format!("belt run near ({},{}) is claimed by both {} and {}", t.0, t.1, spec.in_item, spec.out_item));
+            }
+        }
+    }
+    // Apply.
+    let roots: Vec<Option<usize>> = (0..n)
+        .map(|i| if is_transport(&entities[i].name) { Some(find(&mut parent, i)) } else { None })
+        .collect();
+    for (i, e) in entities.iter_mut().enumerate() {
+        if let Some(root) = roots[i] {
+            match root_item.get(&root) {
+                Some(item) => e.carries = Some(item.to_string()),
+                None => fail(&format!("transport {} at ({},{}) belongs to a run no inserter touches", e.name, e.x, e.y)),
+            }
+        } else if is_inserter(&e.name) {
+            e.carries = ins_item[i].map(|s| s.to_string());
+        }
+    }
+}
+
+fn translate(spec: &DonorSpec, corpus: &str) -> CellEntry {
+    let path = format!("{corpus}/{}", spec.source_file);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| fail(&format!("{path}: {e}")));
+    let want = manifest_sha(spec.source_file);
+    let got = sha256_hex(&bytes);
+    if got != want {
+        fail(&format!("{}: SHA {got} != manifest {want} — not the Phase-0 corpus bytes", spec.source_file));
+    }
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let bp = v["blueprintString"].as_str().unwrap_or_else(|| fail("no blueprintString"));
+    let records = analysis::analyze_blueprint_string_any(bp).unwrap_or_else(|e| fail(&e));
+    let rec = records.get(spec.record_index).unwrap_or_else(|| fail("record index out of range"));
+    let label = rec.label.as_deref().unwrap_or("");
+    if label != spec.record_label {
+        fail(&format!("record {} label {:?} != expected {:?}", spec.record_index, label, spec.record_label));
+    }
+    let mut entities: Vec<PlacedEntity> = Vec::new();
+    for e in &rec.layout.entities {
+        if STRIP.contains(&e.name.as_str()) {
+            continue;
+        }
+        if !KEEP.contains(&e.name.as_str()) {
+            fail(&format!("unexpected entity {} at ({},{}) — extend KEEP/STRIP deliberately", e.name, e.x, e.y));
+        }
+        entities.push(e.clone());
+    }
+    // The motif recipe is a declaration, not a read: furnace arrays are
+    // item-agnostic and community furnaces carry no recipe field. Refuse
+    // if the source DID declare one — overriding a real declaration would
+    // be misattribution, not translation.
+    let mut count = 0u32;
+    for e in entities.iter_mut() {
+        if e.name == spec.machine {
+            if let Some(r) = e.recipe.as_deref() {
+                fail(&format!("furnace at ({},{}) declares recipe {r}; expected none", e.x, e.y));
+            }
+            e.recipe = Some(spec.recipe.to_string());
+            count += 1;
+        }
+        e.rate = None;
+        e.segment_id = None;
+    }
+    assign_carries(&mut entities, spec);
+    // Normalize to origin.
+    let min_x = entities.iter().map(|e| e.x).min().unwrap();
+    let min_y = entities.iter().map(|e| e.y).min().unwrap();
+    for e in entities.iter_mut() {
+        e.x -= min_x;
+        e.y -= min_y;
+    }
+    // Metrics: derived with check_entry's own loop shape.
+    let (mut max_x, mut max_y, mut tiles) = (0i32, 0i32, 0u32);
+    for e in &entities {
+        for (tx, ty) in occupied_tiles(e) {
+            max_x = max_x.max(tx);
+            max_y = max_y.max(ty);
+            tiles += 1;
+        }
+    }
+    let entry = CellEntry {
+        motif: Motif::Unit {
+            recipe: spec.recipe.to_string(),
+            machine: spec.machine.to_string(),
+            count,
+        },
+        ports: spec
+            .ports
+            .iter()
+            .map(|&(dx, dy, kind, item)| Port { dx, dy, kind, item: item.to_string() })
+            .collect(),
+        metrics: Metrics {
+            bbox_w: max_x + 1,
+            bbox_h: max_y + 1,
+            interior_tiles: tiles,
+            entity_count: entities.len() as u32,
+        },
+        provenance: spec.provenance.to_string(),
+        sim_anchor: "unanchored".to_string(),
+        entities,
+    };
+    let issues = celldb::check_entry(&entry);
+    if !issues.is_empty() {
+        fail(&format!("{}: check_entry: {issues:#?}", spec.provenance));
+    }
+    entry
+}
+
+fn main() {
+    let corpus = std::env::var("CORPUS")
+        .unwrap_or_else(|_| fail("set CORPUS to the Phase-0 blueprint corpus directory"));
+    let path = "crates/core/data/celldb.json";
+    let mut db: CellDb = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    let specs = specs();
+    let ours: BTreeSet<&str> = specs.iter().map(|s| s.provenance).collect();
+    db.entries.retain(|e| !ours.contains(e.provenance.as_str()));
+    for spec in &specs {
+        let entry = translate(spec, &corpus);
+        let Motif::Unit { count, .. } = &entry.motif else { unreachable!() };
+        println!(
+            "{}: {}x{} bbox, {} interior tiles, {} entities, count={count}",
+            spec.provenance,
+            entry.metrics.bbox_w,
+            entry.metrics.bbox_h,
+            entry.metrics.interior_tiles,
+            entry.metrics.entity_count,
+        );
+        db.entries.push(entry);
+    }
+    std::fs::write(path, serde_json::to_string_pretty(&db).unwrap()).unwrap();
+    println!("wrote {} entries to {path}", db.entries.len());
+}

--- a/crates/core/examples/celldb_seed.rs
+++ b/crates/core/examples/celldb_seed.rs
@@ -79,8 +79,20 @@ fn main() {
         );
         std::process::exit(2);
     }
-    let db = CellDb { version: 1, entries };
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/data/celldb.json");
+    // This tool owns engine@ rows ONLY. Donor entries (community:/hand
+    // provenance, RFC-067 donor probe) pass through a re-seed untouched —
+    // rebuilding the store from seed_sources() used to silently drop them.
+    if let Ok(existing) = std::fs::read_to_string(path) {
+        let existing: CellDb = serde_json::from_str(&existing).expect("celldb.json parses");
+        entries.extend(
+            existing
+                .entries
+                .into_iter()
+                .filter(|e| !e.provenance.starts_with("engine@")),
+        );
+    }
+    let db = CellDb { version: 1, entries };
     std::fs::write(path, serde_json::to_string_pretty(&db).unwrap()).unwrap();
     println!(
         "wrote {} entries to {path}  (escape hatches: 0 — K67-1 clean)",

--- a/crates/core/examples/donor_sim_export.rs
+++ b/crates/core/examples/donor_sim_export.rs
@@ -1,0 +1,77 @@
+//! One-off: export the donor-stamped copper-plate layouts (counts 48, 52)
+//! as sim-harness bp+manifest pairs, synthesizing the boundary records
+//! from the celldb entry ports (TemplateCandidate::produce emits none).
+
+use rustc_hash::FxHashSet;
+use spaghettio_core::blueprint;
+use spaghettio_core::bus::decomposition_search::DecompositionCandidate;
+use spaghettio_core::bus::layout::LayoutOptions;
+use spaghettio_core::bus::template_candidate::TemplateCandidate;
+use spaghettio_core::models::{BoundaryRecord, EntityDirection};
+use spaghettio_core::solver;
+
+fn main() {
+    let out_root = std::env::args().nth(1).expect("out dir");
+    // (count, label, in-record, out-record)
+    let cases = [
+        (
+            48u32,
+            "donor48-f3r",
+            BoundaryRecord {
+                item: "copper-ore".into(),
+                x: 0,
+                y: 6,
+                direction: EntityDirection::East,
+                is_fluid: false,
+                entity: "fast-transport-belt".into(),
+            },
+            BoundaryRecord {
+                item: "copper-plate".into(),
+                x: 73,
+                y: 6,
+                direction: EntityDirection::East,
+                is_fluid: false,
+                entity: "fast-transport-belt".into(),
+            },
+        ),
+        (
+            52u32,
+            "donor52-on0",
+            BoundaryRecord {
+                item: "copper-ore".into(),
+                x: 8,
+                y: 56,
+                direction: EntityDirection::North,
+                is_fluid: false,
+                entity: "express-transport-belt".into(),
+            },
+            BoundaryRecord {
+                item: "copper-plate".into(),
+                x: 9,
+                y: 0,
+                direction: EntityDirection::North,
+                is_fluid: false,
+                entity: "express-transport-belt".into(),
+            },
+        ),
+    ];
+    for (count, label, rec_in, rec_out) in cases {
+        let inputs: FxHashSet<String> = ["copper-ore".to_string()].into_iter().collect();
+        let probe = solver::solve("copper-plate", 1.0, &inputs, "electric-furnace").unwrap();
+        let rate = (count as f64 - 0.01) / probe.machines[0].count;
+        let sr = solver::solve("copper-plate", rate, &inputs, "electric-furnace").unwrap();
+        let mut layout = TemplateCandidate.produce(&sr, &LayoutOptions::default()).unwrap();
+        layout.boundary_inputs = vec![rec_in];
+        layout.boundary_outputs = vec![rec_out];
+        let (bp, manifest) = blueprint::export_with_manifest(&layout, &sr, label);
+        let dir = format!("{out_root}/{label}");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(format!("{dir}/bp.txt"), &bp).unwrap();
+        std::fs::write(
+            format!("{dir}/manifest-real.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        println!("{label}: rate={rate:.3} -> {dir}");
+    }
+}

--- a/crates/core/examples/donor_sim_export.rs
+++ b/crates/core/examples/donor_sim_export.rs
@@ -61,6 +61,33 @@ fn main() {
         let rate = (count as f64 - 0.01) / probe.machines[0].count;
         let sr = solver::solve("copper-plate", rate, &inputs, "electric-furnace").unwrap();
         let mut layout = TemplateCandidate.produce(&sr, &LayoutOptions::default()).unwrap();
+        // The hand-keyed records are verified against the layout produce()
+        // actually returned: each port tile must hold a transport entity
+        // whose SURFACE tier matches the record's belt prototype. The
+        // record deliberately names the surface belt, never a splitter —
+        // the sim kit builds its own rig belts from `entity`, and a
+        // splitter prototype there would stamp splitters down the rig.
+        for rec in [&rec_in, &rec_out] {
+            let holder = layout
+                .entities
+                .iter()
+                .find(|e| {
+                    let (w, h) =
+                        spaghettio_core::common::oriented_entity_dims(&e.name, e.direction);
+                    rec.x >= e.x && rec.x < e.x + w && rec.y >= e.y && rec.y < e.y + h
+                })
+                .unwrap_or_else(|| panic!("port tile ({},{}) is empty", rec.x, rec.y));
+            let surface = holder
+                .name
+                .strip_suffix("-splitter")
+                .map(|b| format!("{b}-transport-belt"))
+                .unwrap_or_else(|| holder.name.clone());
+            assert_eq!(
+                surface, rec.entity,
+                "boundary record at ({},{}) names {} but the tile holds {}",
+                rec.x, rec.y, rec.entity, holder.name
+            );
+        }
         layout.boundary_inputs = vec![rec_in];
         layout.boundary_outputs = vec![rec_out];
         let (bp, manifest) = blueprint::export_with_manifest(&layout, &sr, label);

--- a/crates/core/src/celldb.rs
+++ b/crates/core/src/celldb.rs
@@ -563,7 +563,13 @@ mod tests {
                     .entries
                     .iter()
                     .find(|e| {
-                        matches!(&e.motif, Motif::Unit { recipe: r, machine: m, .. }
+                        // Provenance-scoped: community donor rows (RFC-067
+                        // donor probe) can share a motif with an engine
+                        // seed — count-48 copper-plate already does — and
+                        // an unscoped find would compare the wrong entry
+                        // the moment store order changes.
+                        e.provenance.starts_with("engine@")
+                            && matches!(&e.motif, Motif::Unit { recipe: r, machine: m, .. }
                                  if r == recipe && m == target_machine)
                     })
                     .unwrap_or_else(|| panic!("{recipe} entry is seeded"));

--- a/crates/core/tests/celldb_template.rs
+++ b/crates/core/tests/celldb_template.rs
@@ -98,7 +98,29 @@ fn template_vs_incumbent_copper_plate_smelting_demand_matched() {
     // of the five seeds, exactly three (iron-plate, copper-plate,
     // copper-cable) admit single-group demands — ec/ac always co-solve
     // with their cable/circuit inputs and refuse by v1 design.
+    //
+    // Since the donor probe (RFC-067 decision log 2026-08-12), count 48 is
+    // shared with community donor -OL38TX27JmPIivo#8, which wins the
+    // (count, interior_tiles) sort at 753 < 817 — so THIS fixture stamps
+    // the DONOR, per the pre-registered collision rule. The engine seed's
+    // own tie verdict stays recorded in the decision log; re-deriving it
+    // requires a store without the donor row.
     run_fixture("copper-plate", 48, "electric-furnace", &["copper-ore"]);
+}
+
+#[test]
+fn template_vs_incumbent_copper_plate_donor_lxr_demand_matched() {
+    // 50 = community donor -Lxr8KxgJup5AsKyTygI#6 ("Mass Plate
+    // Production", RFC-067 donor probe): the only count-50 entry, so the
+    // stamp is the donor by construction.
+    run_fixture("copper-plate", 50, "electric-furnace", &["copper-ore"]);
+}
+
+#[test]
+fn template_vs_incumbent_copper_plate_donor_on0_demand_matched() {
+    // 52 = community donor -ON0-7RmLQJjDfgq7s_W#2 (vertical express
+    // column cell, RFC-067 donor probe): the only count-52 entry.
+    run_fixture("copper-plate", 52, "electric-furnace", &["copper-ore"]);
 }
 
 #[test]

--- a/docs/rfc-067-cell-interface-db.md
+++ b/docs/rfc-067-cell-interface-db.md
@@ -307,14 +307,30 @@ ordering is a deliberate trade recorded here, not an oversight.
   at matched demand** — 30.1/s vs 29.99 planned (48/48 working) and,
   module-less, 32.1/s vs 32.49 (52/52 working, stable windows;
   east/north feed directions carry the harness's uncalibrated-direction
-  flag). Verdict by the gate's own structure: the kill's denominator
-  holds 1 loss of 3; two adjudications are invalidated by an
-  instrument defect (the separate-verdict class the registration
-  reserved); the win condition cannot fire while the floor cannot
-  evaluate splitter-fed cells. **Phase 3 stays parked. The gate
-  re-arms after the #624 walker fix** — re-adjudication needs no new
+  flag). Verdict accounting, both readings recorded (the K67-1
+  discipline; a review round correctly objected that this entry's first
+  draft claimed the registration had reserved an instrument-defect
+  verdict class — it had not, it reserved exactly belt-tier
+  inadmissibility and contract narrowness, and that claim is
+  RETRACTED): **under the registration as written, the kill FIRES** —
+  zero donors won, and the letter offers the two blocked donors no
+  shelter. The response is an AMENDMENT, logged here as its own
+  decision exactly as K67-1's contract amendment was: a verdict whose
+  floor input is a measured instrument false positive (receipts: #624
+  seed-stats, plus both sim clears above) adjudicates the
+  *instrument*, not donor value, and is recorded as
+  instrument-invalidated rather than as a loss. Under the amended
+  registration the kill's denominator holds 1 loss of 3 and the kill
+  does not fire; the letter-firing above is the recorded event and is
+  not erased by the amendment. **Phase 3 stays parked either way. The
+  post-#624 re-adjudication is a FRESH gate under the amended
+  registration** — not a continuation of this one — and needs no new
   harvest: the store rows, fixtures, and the tracked `donor_sim_export`
-  are all in place. What the probe changed regardless of verdict: the
+  are all in place. Ripple, recorded: the donor rows change
+  `query_unit`'s first pick for copper-plate (753 < 817 interior
+  tiles), which also moves the killed preview module's reference
+  geometry — `celldb_preview_calibration` re-runs on a donor-bearing
+  store are NOT comparable to the K67-2 sequence quoted above. What the probe changed regardless of verdict: the
   count-48 fixture now stamps the F3R donor (753 < 817 interior tiles
   wins the sort — the pre-registered collision rule, recorded in the
   test), and the composite margins say community geometry beats the

--- a/docs/rfc-067-cell-interface-db.md
+++ b/docs/rfc-067-cell-interface-db.md
@@ -242,3 +242,36 @@ ordering is a deliberate trade recorded here, not an oversight.
   complete over everything v1 stamping can express; ec/ac require
   multi-group stamping, which is exactly the parked work. The reopening path is community/hand donors with inferred ports,
   plus count ladders so matched demand is the common case.*
+- *2026-08-12 — **donor-probe reopening attempt OPENED, gate pre-registered
+  before any measurement.** The hotspot scoreboard
+  ([`hotspot-scoreboard-2026-08.md`](hotspot-scoreboard-2026-08.md), #623)
+  priced the donor targets; copper-plate is the largest single-group-
+  realizable prize (5,987 pooled overhead tiles). K67-3's NULL covers
+  engine-derived seeds only; whether a denser community cell exists is the
+  untested half, and this entry registers its adjudication terms in
+  advance. **Scope:** hand-translated community copper-plate smelter
+  cell(s) under port contract v1 — the recorded port-inference gap stands,
+  translation is by hand, provenance `community:<source>`,
+  `sim_anchor: unanchored`, metrics machine-verified by the loader
+  invariant test (`embedded_db_parses_and_entries_hold_invariants`).
+  **Procedure, fixed now:** each donor keeps its natural machine count N; a
+  new demand-matched fixture in `crates/core/tests/celldb_template.rs`
+  derives the rate demanding exactly N (same `rate_for_count`), incumbent =
+  `FullSelectionCandidate`, candidate = `TemplateCandidate`, same
+  `Policy::fold()` and 0.5/0.5 composite weights as K67-3. If N collides
+  with an engine entry's count, the donor must win `query_unit`'s
+  (count, interior_tiles) sort to be stamped at all — recorded if it
+  happens, not worked around. **Donor WINS** = passes the never-worse
+  floor AND composite > +0.02 (`COMPOSITE_TIE_EPSILON`) vs the incumbent;
+  that reopens Phase 3 toward multi-group stamping (the ac/ec prizes),
+  with sim-anchor still required before any selection influence (K67-4,
+  inherited verbatim). **KILL** = after a documented harvest (target ≥3
+  translatable donors; fewer only if the harvest cannot produce 3, with
+  the shortfall recorded), no donor wins: the community-donor reopening
+  path is adjudicated dead for single-group smelters and Phase 3 stays
+  parked. **Distinct verdicts, counted separately from losses:** a donor
+  whose belt tiers exceed the fixture's allowed set is inadmissible by
+  construction (K67-4), and if no harvested design is expressible under
+  port contract v1 at all, the binding constraint is the contract, not
+  donor value — a contract-narrowness finding, which neither reopens
+  Phase 3 nor counts toward the kill's denominator.*

--- a/docs/rfc-067-cell-interface-db.md
+++ b/docs/rfc-067-cell-interface-db.md
@@ -275,3 +275,49 @@ ordering is a deliberate trade recorded here, not an oversight.
   port contract v1 at all, the binding constraint is the contract, not
   donor value — a contract-narrowness finding, which neither reopens
   Phase 3 nor counts toward the kill's denominator.*
+- *2026-08-12 — **donor probe ADJUDICATED: no win under the registered
+  gate, kill does not fire — the floor instrument was caught
+  false-positive on 2 of 3 donors, and the gate re-arms after #624.**
+  Harvest: the manifest-verified Phase-0 corpus held exactly 7
+  engine-legal electric-furnace arrays; 3 distinct designs shortlisted
+  and ALL translated cleanly under port contract v1 (`celldb_donor`:
+  ports hand-declared, carries derived from inserter drop-side
+  semantics with refuse-on-ambiguity, zero refusals — so no
+  contract-narrowness verdict). One translation lesson banked: the ON0
+  donor's furnaces carried speed-module payloads (its "45/s" label was
+  the tell) which inflated its first sim to 44.9/s against a 32.5/s
+  plan; donors donate GEOMETRY only, the translator now strips module
+  payloads, and the store was regenerated (harness numbers unchanged).
+  Results at matched demand, per the registration: composites +0.366
+  (F3R#8, count 48) / +0.289 (Lxr#6, 50) / +0.447 (ON0#2, 52) — all
+  far above the +0.02 win bar — but all three FAIL the never-worse
+  floor, so **no donor wins as registered**. Floor forensics
+  (instrument-before-finding): Lxr#6's failure is genuine physics —
+  31.24/s demanded through a 30/s fast-belt feed; its own label sells
+  it as a chained 30/s cell — **one real loss**. F3R#8 and ON0#2 fail
+  on `input-rate-delivery` alone, and that is a MEASURED false
+  positive: the walker seeds their entry splitters correctly
+  (seed-stats demand-consistent) then strands the rate — propagation
+  through unsegmented splitters never runs, and ON0's half-fed inline
+  balancer tiles read as 28 phantom sources (Σdemand 48.7 vs 32.5).
+  Engine layouts never reach this path (balancer:-segmented splitters
+  are skipped), so the hole was real but unreachable until community
+  geometry arrived — receipts in #624 and validator-trust.md hole 7.
+  **Sim anchors, the only clearing instrument: both blocked donors PASS
+  at matched demand** — 30.1/s vs 29.99 planned (48/48 working) and,
+  module-less, 32.1/s vs 32.49 (52/52 working, stable windows;
+  east/north feed directions carry the harness's uncalibrated-direction
+  flag). Verdict by the gate's own structure: the kill's denominator
+  holds 1 loss of 3; two adjudications are invalidated by an
+  instrument defect (the separate-verdict class the registration
+  reserved); the win condition cannot fire while the floor cannot
+  evaluate splitter-fed cells. **Phase 3 stays parked. The gate
+  re-arms after the #624 walker fix** — re-adjudication needs no new
+  harvest: the store rows, fixtures, and the tracked `donor_sim_export`
+  are all in place. What the probe changed regardless of verdict: the
+  count-48 fixture now stamps the F3R donor (753 < 817 interior tiles
+  wins the sort — the pre-registered collision rule, recorded in the
+  test), and the composite margins say community geometry beats the
+  engine's strip-shaped cells on aspect by an order of magnitude more
+  than the tie epsilon, which is exactly the shape of value RFC-067
+  predicted donors would carry if any did.*

--- a/docs/validator-trust.md
+++ b/docs/validator-trust.md
@@ -294,6 +294,24 @@ Severity `E/W` = both emitted, condition-dependent. "Sel" = counts in
    the bullet changing. Rule going forward: an exclusion or severity choice
    made for *trust* reasons gets a row here with its graduation
    precondition and the receipt that would satisfy it.
+7. **The lane walker cannot evaluate splitter-headed input paths without
+   segment ids** (#624, found 2026-08-12 by the RFC-067 donor probe).
+   External-input seeds landing on an unsegmented splitter tile strand
+   there (every downstream feeder reads 0.0/s → per-machine
+   `input-rate-delivery` false positives), and an inline splitter's unfed
+   second tile is miscounted as a fresh external source (observed: 28
+   phantom sources, Σdemand 48.7 vs solver total 32.5). Engine layouts
+   never reach the path — their splitters are `balancer:`-segmented and
+   skipped — so the hole only fires on foreign geometry (celldb community
+   donors today; anything stamped from wild blueprints tomorrow).
+   Measured cost: both splitter-fed donor adjudications in the RFC-067
+   probe were invalidated (never-worse floor failed on IRD alone while
+   the sim PASSED both cells at matched demand — 30.1/s vs 29.99 planned
+   and 32.1/s vs 32.49; receipts in #624). Trust rule until fixed: an
+   `input-rate-delivery` wall covering every feeder of a layout whose
+   input path crosses an unsegmented splitter is the *instrument*, not
+   the layout — check seed-stats (`SPAGHETTIO_LANE_WALK_STATS=1`) before
+   believing it.
 
 ## Receipts (sim anchors and falsifications)
 


### PR DESCRIPTION
## Intent

Run RFC-067's recorded reopening path (community donors) for copper-plate under a pre-registered gate, cheaply enough to kill the donor thesis if it fails. The gate was committed BEFORE any measurement (decision log 2026-08-12): win = never-worse floor pass AND composite > +0.02 at matched demand; kill = documented harvest (≥3 translatable donors) with no winner; inadmissibility/contract-narrowness recorded as distinct verdicts.

## What's here

- **`celldb_donor.rs`** (tracked): translates manifest-SHA-verified community cells into store entries. Geometry parsed, `carries` derived from the engine's inserter drop-side semantics with refuse-on-ambiguity, module payloads stripped (donors donate geometry only), metrics derived, `check_entry` the final arbiter. Only the ports are hand-declared, in the reviewed spec table.
- **3 donor entries** in `crates/core/data/celldb.json` (pure data, +7.4k lines): F3R#8 (48 furnaces, 753 interior tiles — wins the count-48 sort vs the engine entry's 817), Lxr#6 (50), ON0#2 (52, vertical). Engine rows byte-identical to main.
- **`celldb_seed.rs` passthrough**: re-seeding no longer silently drops non-`engine@` rows.
- **2 new demand-matched fixtures** + a comment on the count-48 test recording the pre-registered collision outcome.
- **Adjudication** (RFC-067 decision log): no win, no kill. All three donors clear the +0.02 composite bar by 14–22× but fail the never-worse floor. One failure is genuine physics (Lxr#6: 31.24/s through a 30/s feed). Two are measured lane-walker false positives — seeds strand on unsegmented splitters, half-fed inline splitter tiles read as phantom sources (#624, validator-trust.md hole 7) — refuted by sim anchors: 30.1/s vs 29.99 planned and 32.1/s vs 32.49, all furnaces working. Phase 3 stays parked; the gate re-arms after #624.
- **`donor_sim_export.rs`** (tracked): re-derives the sim receipts (synthesizes the boundary records `TemplateCandidate::produce` omits).

## Verification actually run

- Full core suite green post-change (1043 lib + all integration targets, one clean invocation, 0 failed).
- `celldb_donor` run end-to-end against the manifest-verified corpus (SHA-checked per file); store invariant tests cover the donor rows on every build.
- Demand-matched harness run on all 5 fixtures; composites and floor verdicts quoted from that run.
- Floor forensics: `donor_verdict_detail` (per-category regressions) + `SPAGHETTIO_LANE_WALK_STATS=1` seed-stats receipts (quoted in #624).
- Two headless sim runs at matched demand (2.0.77 pinned install, 7200-tick warmup, converged, no kit errors); `check-data` clean on the install. East/north feed directions carry the harness's uncalibrated-direction flag.
- Not run: WASM build (data-only growth of an already-embedded JSON; no API change) — flagging rather than claiming.

## Size

Non-fixture delta is ~640 added lines, over the 400 norm. Why not split: the probe is one pre-registered evidential unit — landing the gate registration, instruments, store rows, and fixtures without the adjudication would leave main recording an armed gate with no verdict (the records-outlive-state failure class), and the store rows are unreviewable without the translator that proves their provenance. The 7.4k-line store file is pure fixture data and outside the norm's denominator.

## Deviations

The sim leg was not in the original 'both' scope — added under the verification protocol when the floor's false-positive pattern emerged (the sim is the only clearing instrument). The vertical donor was re-simmed module-less after the speed-module discovery; the first (moduled) run is quoted only as the artifact that exposed the translator hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n