### PR TITLE
ci: trivial-delta gate for second-opinion — docs/comment-only pushes skip the re-review (#632 C8)

### DIFF
--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -133,14 +133,25 @@ jobs:
             # unreviewed one. Require the review header too; if the
             # action ever rewords it, the baseline is lost and the gate
             # fails toward review — the safe direction.
+            # grep -v ^$ is belt-and-braces: jq `empty` should emit no line
+            # for marker-less pages, but a blank line reaching tail -n1
+            # would silently lose the baseline (fail-toward-review, so safe
+            # but defeats the gate on long threads).
             last=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
               --jq '[.[] | select(.body | test("^<!-- second-opinion sha=[0-9a-f]{40} -->")) | select(.body | contains("### 🤖 Second opinion")) | .body | capture("sha=(?<s>[0-9a-f]{40})").s] | last // empty' \
-              | tail -n1 || true)
+              | grep -v '^$' | tail -n1 || true)
             if [ -z "$last" ]; then
               reason="no prior review marker on this PR"
             else
               verdict=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${last}...${HEAD_SHA}" --jq '
                 if .status != "ahead" then "review:history-diverged"
+                # null/absent .files is a malformed or partial response, NOT
+                # an empty delta — it must fail toward review (bot round-3
+                # major: null[] iterates to zero and read as "skip"). A
+                # genuinely EMPTY list (status ahead, zero changed files —
+                # e.g. an empty commit) stays a skip: there is nothing to
+                # review and the runner per-SHA gate cannot catch it.
+                elif (.files == null) then "review:compare-api-failed"
                 elif (.files | length) >= 300 then "review:file-list-truncated"
                 else
                   [ .files[] |
@@ -185,6 +196,13 @@ jobs:
           LAST: ${{ steps.delta.outputs.last }}
         run: |
           set -euo pipefail
+          # Dedup per head: a same-head re-event (reopened /
+          # ready_for_review) re-runs the gate; don't re-post the notice.
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+               --jq '.[].body' | grep -qF "<!-- second-opinion-skip sha=${HEAD_SHA} -->"; then
+            echo "skip notice already posted for ${HEAD_SHA:0:9}"
+            exit 0
+          fi
           printf '<!-- second-opinion-skip sha=%s -->\n**Second opinion — skipped for %s**: the delta since the last reviewed head (%s) is docs-only / comment-only. Trivial deltas accumulate — the first push whose cumulative delta touches code gets a full-PR review. Apply the `force-review` label to force one.\n' \
             "$HEAD_SHA" "${HEAD_SHA:0:9}" "${LAST:0:9}" > /tmp/skip-comment.md
           gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -F body=@/tmp/skip-comment.md >/dev/null

--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -10,7 +10,13 @@ name: Second Opinion
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    # `labeled` exists for the trivial-delta gate's `force-review` escape
+    # hatch: after a docs-only skip there may be nothing left to push, so
+    # applying the label must itself trigger the review. Stray label
+    # events on quiet PRs are near-free: an already-reviewed head exits
+    # via the gate's `identical` fast path with no container spin; a
+    # skipped head re-skips with a deduped notice.
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
     # KNOWN GAP (from this workflow's own first review, #561): no `edited`
     # type, so a base-branch retarget — which rewrites the effective diff
     # without a new head SHA — keeps the old SHA's green check. Adding the
@@ -117,6 +123,7 @@ jobs:
         run: |
           set -euo pipefail
           trivial=false
+          notice=false
           last=""
           if jq -e '[.pull_request.labels[].name] | index("force-review")' "$GITHUB_EVENT_PATH" >/dev/null; then
             reason="force-review label present"
@@ -137,14 +144,37 @@ jobs:
             # for marker-less pages, but a blank line reaching tail -n1
             # would silently lose the baseline (fail-toward-review, so safe
             # but defeats the gate on long threads).
-            last=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
-              --jq '[.[] | select(.body | test("^<!-- second-opinion sha=[0-9a-f]{40} -->")) | select(.body | contains("### 🤖 Second opinion")) | .body | capture("sha=(?<s>[0-9a-f]{40})").s] | last // empty' \
+            anchor=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+              --jq '[.[] | select(.body | test("^<!-- second-opinion sha=[0-9a-f]{40} -->")) | select(.body | contains("### 🤖 Second opinion")) | {s: (.body | capture("sha=(?<s>[0-9a-f]{40})").s), t: .created_at}] | last // empty | "\(.s) \(.t)"' \
               | grep -v '^$' | tail -n1 || true)
+            last=${anchor%% *}
+            last_at=${anchor#* }
             if [ -z "$last" ]; then
               reason="no prior review marker on this PR"
+            # BASE-RETARGET GUARD (round-4 critical): the compare below sees
+            # only head-side commits. A base retarget rewrites the effective
+            # base...head diff with NO new head SHA — the workflow's known
+            # `edited`-trigger gap — and pre-gate, the next push healed it
+            # with a full review. The gate must not turn that push into a
+            # skip. Detect: any base_ref_changed (or automatic base change)
+            # timeline event NEWER than the anchor review forces a review.
+            # Every failure here (timeline API error, jq error, missing
+            # anchor timestamp) also forces a review.
+            elif ! tl=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/timeline" --paginate 2>/dev/null); then
+              reason="review:timeline-api-failed"
             else
+              retarget=$(jq -rn '[inputs] | add // [] | [.[] | select(.event == "base_ref_changed" or .event == "automatic_base_change_succeeded") | .created_at // "unknown-time"] | last // empty' <<<"$tl" 2>/dev/null) || retarget="jq-failed"
+              if [ -n "$retarget" ] && { [ "$retarget" = "jq-failed" ] || [ "$retarget" = "unknown-time" ] || [ -z "$last_at" ] || [[ "$retarget" > "$last_at" ]]; }; then
+                reason="review:base-retargeted-since-anchor"
+              else
               verdict=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${last}...${HEAD_SHA}" --jq '
-                if .status != "ahead" then "review:history-diverged"
+                # identical = a same-head re-event (reopened /
+                # ready_for_review / stray label) on the reviewed head:
+                # skip WITHOUT a notice, saving the container spin the
+                # action would burn reaching its own per-SHA gate. Do not
+                # "fix" this into history-diverged — nor vice versa.
+                if .status == "identical" then "identical"
+                elif .status != "ahead" then "review:history-diverged"
                 # null/absent .files is a malformed or partial response, NOT
                 # an empty delta — it must fail toward review (bot round-3
                 # major: null[] iterates to zero and read as "skip"). A
@@ -173,13 +203,19 @@ jobs:
                 end' 2>/dev/null || echo "review:compare-api-failed")
               if [ "$verdict" = "skip" ]; then
                 trivial=true
+                notice=true
                 reason="docs/comment-only delta since reviewed ${last:0:9}"
+              elif [ "$verdict" = "identical" ]; then
+                trivial=true
+                reason="head is already the reviewed head (same-head re-event)"
               else
                 reason="$verdict"
+              fi
               fi
             fi
           fi
           echo "trivial=$trivial" >> "$GITHUB_OUTPUT"
+          echo "notice=$notice" >> "$GITHUB_OUTPUT"
           echo "last=$last" >> "$GITHUB_OUTPUT"
           echo "gate: trivial=$trivial ($reason)"
       - name: Record skipped review
@@ -187,8 +223,12 @@ jobs:
         # the review marker (so the gate above keeps measuring against the
         # last real review), naming the baseline and the escape hatch. A
         # skip must never be silent — silence ≠ clean is this workflow's
-        # founding rule.
-        if: steps.delta.outputs.trivial == 'true'
+        # founding rule. Deliberately load-bearing: if this POST fails, the
+        # job fails — a green skip with no audit trail would be the silent
+        # clearance this workflow exists to prevent (same philosophy as
+        # fail-on-degraded). The `identical` fast path sets notice=false —
+        # nothing new to say about a head that already carries its review.
+        if: steps.delta.outputs.trivial == 'true' && steps.delta.outputs.notice == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -125,8 +125,16 @@ jobs:
             # >100-comment thread can emit one line per page — tail -n1
             # keeps the newest marker across pages (pages arrive oldest
             # first).
+            # The marker alone is NOT proof of ownership: claude[bot]
+            # posts byte-identical `<!-- second-opinion sha=... -->`
+            # markers naming DIFFERENT commits (live evidence:
+            # storkme/second-opinion#49), and a foreign marker naming a
+            # mid-PR commit measures a SMALLER delta than the truly
+            # unreviewed one. Require the review header too; if the
+            # action ever rewords it, the baseline is lost and the gate
+            # fails toward review — the safe direction.
             last=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
-              --jq '[.[] | select(.body | test("^<!-- second-opinion sha=[0-9a-f]{40} -->")) | .body | capture("sha=(?<s>[0-9a-f]{40})").s] | last // empty' \
+              --jq '[.[] | select(.body | test("^<!-- second-opinion sha=[0-9a-f]{40} -->")) | select(.body | contains("### 🤖 Second opinion")) | .body | capture("sha=(?<s>[0-9a-f]{40})").s] | last // empty' \
               | tail -n1 || true)
             if [ -z "$last" ]; then
               reason="no prior review marker on this PR"
@@ -139,8 +147,13 @@ jobs:
                     if .previous_filename then "code"
                     elif (.filename | test("\\.md$")) then "ok"
                     elif (.filename | test("\\.rs$")) and .status == "modified" and (.patch != null) then
+                      # Compare-API patches start at the first @@ hunk and
+                      # carry NO +++/--- file headers — do not "skip" them:
+                      # that exclusion misreads a genuine added line whose
+                      # content begins with "++" (found in upstreaming,
+                      # storkme/second-opinion#47).
                       if ([ .patch | split("\n")[] |
-                            select(test("^[+-]") and (test("^\\+\\+\\+ |^--- ") | not)) |
+                            select(test("^[+-]")) |
                             select(test("^[+-][[:space:]]*(//.*)?$") | not)
                           ] | length) == 0
                       then "ok" else "code" end

--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -24,11 +24,12 @@ on:
     # trigger wouldn't help: the runner's per-SHA marker comment would
     # suppress the re-review anyway, and the action exposes no force
     # input. The gate's timeline guard now forces a full review on the
-    # NEXT event after a retarget (push or label — apply `force-review`
-    # if there is nothing to push), so the residual gap is only a
-    # retarget followed by no further event before merge: re-review THAT
-    # case session-side (the stacked-PR retarget-to-main case is the one
-    # that occurs here).
+    # next PUSH after a retarget. A label event cannot heal it: the gate
+    # votes review, but the head SHA is unchanged and the runner's
+    # per-SHA gate suppresses the re-review (the force-input gap above).
+    # So the residual gap is a retarget followed by no further push
+    # before merge: re-review THAT case session-side (the stacked-PR
+    # retarget-to-main case is the one that occurs here).
 
 # One concurrency group per PR; cancellation is CONDITIONAL on the event.
 # Only `synchronize` — the one trigger that means "a new head SHA exists" —
@@ -260,12 +261,19 @@ jobs:
           set -euo pipefail
           # Dedup per head: a same-head re-event (reopened /
           # ready_for_review) re-runs the gate; don't re-post the notice.
-          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
-               --jq '.[].body' | grep -qF "<!-- second-opinion-skip sha=${HEAD_SHA} -->"; then
-            echo "skip notice already posted for ${HEAD_SHA:0:9}"
-            exit 0
-          fi
-          printf '<!-- second-opinion-skip sha=%s -->\n**Second opinion — skipped for %s**: the delta since the last reviewed head (%s) is docs-only / comment-only. Trivial deltas accumulate — the first push whose cumulative delta touches code gets a full-PR review. Apply the `force-review` label to force one.\n' \
+          # Capture-then-match, NOT a pipe into grep -q: -q closes the
+          # pipe on first match, the still-writing gh gets SIGPIPE (141),
+          # pipefail turns the hit into a non-zero condition, and the
+          # step falls through to re-post — the round-5 review
+          # demonstrated the race on long threads.
+          bodies=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+            --jq '.[].body' || true)
+          case "$bodies" in
+            *"<!-- second-opinion-skip sha=${HEAD_SHA} -->"*)
+              echo "skip notice already posted for ${HEAD_SHA:0:9}"
+              exit 0;;
+          esac
+          printf '<!-- second-opinion-skip sha=%s -->\n**Second opinion — skipped for %s**: the delta since the last reviewed head (%s) is docs-only / comment-only. Trivial deltas accumulate — the first push whose cumulative delta touches code gets a full-PR review. Apply the `force-review` label to force one (and remove it afterwards — the gate is disabled while it is present).\n' \
             "$HEAD_SHA" "${HEAD_SHA:0:9}" "${LAST:0:9}" > /tmp/skip-comment.md
           gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -F body=@/tmp/skip-comment.md >/dev/null
       - name: Second opinion review

--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -79,13 +79,111 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v4
+      - name: Trivial-delta gate
+        # #632 C8 (review-tail): a push whose delta since the last ACTUALLY
+        # REVIEWED head is docs-only (*.md) and/or comment-only Rust does not
+        # buy a new K=3 review. The repo's own conventions generate such
+        # pushes constantly (decision-log commits, attribution-comment
+        # sweeps), and each cost a full review (~$0.02-0.32, 15-20 min) that
+        # can only re-find already-adjudicated items — 4 of PR #630's 10
+        # rounds were this loop.
+        #
+        # Semantics, chosen so skips can never hide code:
+        # - The baseline is the newest `<!-- second-opinion sha=... -->`
+        #   marker — the last head a review actually POSTED for. Skipped
+        #   pushes deliberately post a DIFFERENT marker, so trivial deltas
+        #   ACCUMULATE against the reviewed baseline: the first push whose
+        #   cumulative delta touches code gets a full-PR-diff review.
+        # - Comment-only Rust = every +/- patch line is blank or starts
+        #   with `//` after indent (compare-API patch, headers excluded).
+        #   A code line with a trailing comment edit does NOT match — that
+        #   counts as code. Known residual over-skip: an .rs string literal
+        #   whose line starts with `//` inside the quotes; accepted, none
+        #   exist in this codebase's committed source today.
+        # - Everything else fails toward review: no prior marker, diverged
+        #   or force-pushed history, renames, non-md/rs files, missing or
+        #   oversized patches (>=300 files), any API error.
+        # - Escape hatch: the `force-review` label disables the gate for
+        #   the PR.
+        # Fork PRs skip the gate (read-only token can't post the audit
+        # comment); they keep today's behavior — no review, session-side
+        # rule applies.
+        id: delta
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          trivial=false
+          last=""
+          if jq -e '[.pull_request.labels[].name] | index("force-review")' "$GITHUB_EVENT_PATH" >/dev/null; then
+            reason="force-review label present"
+          else
+            # NB --paginate + --jq filters PER PAGE and concatenates, so a
+            # >100-comment thread can emit one line per page — tail -n1
+            # keeps the newest marker across pages (pages arrive oldest
+            # first).
+            last=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate \
+              --jq '[.[] | select(.body | test("^<!-- second-opinion sha=[0-9a-f]{40} -->")) | .body | capture("sha=(?<s>[0-9a-f]{40})").s] | last // empty' \
+              | tail -n1 || true)
+            if [ -z "$last" ]; then
+              reason="no prior review marker on this PR"
+            else
+              verdict=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${last}...${HEAD_SHA}" --jq '
+                if .status != "ahead" then "review:history-diverged"
+                elif (.files | length) >= 300 then "review:file-list-truncated"
+                else
+                  [ .files[] |
+                    if .previous_filename then "code"
+                    elif (.filename | test("\\.md$")) then "ok"
+                    elif (.filename | test("\\.rs$")) and .status == "modified" and (.patch != null) then
+                      if ([ .patch | split("\n")[] |
+                            select(test("^[+-]") and (test("^\\+\\+\\+ |^--- ") | not)) |
+                            select(test("^[+-][[:space:]]*(//.*)?$") | not)
+                          ] | length) == 0
+                      then "ok" else "code" end
+                    else "code" end
+                  ] | if length == 0 or all(. == "ok") then "skip" else "review:code-in-delta" end
+                end' 2>/dev/null || echo "review:compare-api-failed")
+              if [ "$verdict" = "skip" ]; then
+                trivial=true
+                reason="docs/comment-only delta since reviewed ${last:0:9}"
+              else
+                reason="$verdict"
+              fi
+            fi
+          fi
+          echo "trivial=$trivial" >> "$GITHUB_OUTPUT"
+          echo "last=$last" >> "$GITHUB_OUTPUT"
+          echo "gate: trivial=$trivial ($reason)"
+      - name: Record skipped review
+        # The audit trail for a skip: a comment with a marker DISTINCT from
+        # the review marker (so the gate above keeps measuring against the
+        # last real review), naming the baseline and the escape hatch. A
+        # skip must never be silent — silence ≠ clean is this workflow's
+        # founding rule.
+        if: steps.delta.outputs.trivial == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LAST: ${{ steps.delta.outputs.last }}
+        run: |
+          set -euo pipefail
+          printf '<!-- second-opinion-skip sha=%s -->\n**Second opinion — skipped for %s**: the delta since the last reviewed head (%s) is docs-only / comment-only. Trivial deltas accumulate — the first push whose cumulative delta touches code gets a full-PR review. Apply the `force-review` label to force one.\n' \
+            "$HEAD_SHA" "${HEAD_SHA:0:9}" "${LAST:0:9}" > /tmp/skip-comment.md
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -F body=@/tmp/skip-comment.md >/dev/null
       - name: Second opinion review
         # Fork PRs get no secrets on `pull_request` (by design, not a leak),
         # so the action would fail on an empty key and red an unclearable
         # required check for an outside contributor. Such PRs need
         # session-side review — same rule as workflow-file PRs (CLAUDE.md
         # "Workflow"). The skipped step still yields a real job conclusion.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        # `!= 'true'` not `== 'false'`: on fork PRs the gate step is skipped
+        # and its output is empty — empty must mean "review", not "skip".
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.delta.outputs.trivial != 'true'
         uses: storkme/second-opinion@v1
         with:
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -17,13 +17,18 @@ on:
     # via the gate's `identical` fast path with no container spin; a
     # skipped head re-skips with a deduped notice.
     types: [opened, synchronize, ready_for_review, reopened, labeled]
-    # KNOWN GAP (from this workflow's own first review, #561): no `edited`
-    # type, so a base-branch retarget — which rewrites the effective diff
-    # without a new head SHA — keeps the old SHA's green check. Adding the
-    # trigger wouldn't help yet: the runner's per-SHA marker comment would
-    # suppress the re-review anyway, and the action exposes no force input.
-    # Until upstream grows one, re-review base-retargeted PRs session-side
-    # (the stacked-PR retarget-to-main case is the one that occurs here).
+    # KNOWN GAP (from this workflow's own first review, #561), NARROWED by
+    # the trivial-delta gate (#633): no `edited` type, so a base-branch
+    # retarget — which rewrites the effective diff without a new head
+    # SHA — keeps the old SHA's green check *at retarget time*. Adding the
+    # trigger wouldn't help: the runner's per-SHA marker comment would
+    # suppress the re-review anyway, and the action exposes no force
+    # input. The gate's timeline guard now forces a full review on the
+    # NEXT event after a retarget (push or label — apply `force-review`
+    # if there is nothing to push), so the residual gap is only a
+    # retarget followed by no further event before merge: re-review THAT
+    # case session-side (the stacked-PR retarget-to-main case is the one
+    # that occurs here).
 
 # One concurrency group per PR; cancellation is CONDITIONAL on the event.
 # Only `synchronize` — the one trigger that means "a new head SHA exists" —
@@ -164,7 +169,19 @@ jobs:
               reason="review:timeline-api-failed"
             else
               retarget=$(jq -rn '[inputs] | add // [] | [.[] | select(.event == "base_ref_changed" or .event == "automatic_base_change_succeeded") | .created_at // "unknown-time"] | last // empty' <<<"$tl" 2>/dev/null) || retarget="jq-failed"
-              if [ -n "$retarget" ] && { [ "$retarget" = "jq-failed" ] || [ "$retarget" = "unknown-time" ] || [ -z "$last_at" ] || [[ "$retarget" > "$last_at" ]]; }; then
+              # The anchor timestamp is the review's POST time — up to a
+              # full job budget (timeout-minutes: 90) after the diff was
+              # actually fetched. A retarget landing DURING the in-flight
+              # review is older than the anchor yet unreviewed, so compare
+              # against anchor minus that budget (round-5 major). A false
+              # fire inside the margin costs one full review — the safe
+              # direction — and this also closes the same-second >-vs->=
+              # nit. date failure leaves threshold empty, forcing review.
+              threshold=""
+              if [ -n "$last_at" ]; then
+                threshold=$(date -u -d "${last_at} -90 minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+              fi
+              if [ -n "$retarget" ] && { [ "$retarget" = "jq-failed" ] || [ "$retarget" = "unknown-time" ] || [ -z "$threshold" ] || [[ "$retarget" > "$threshold" ]]; }; then
                 reason="review:base-retargeted-since-anchor"
               else
               verdict=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${last}...${HEAD_SHA}" --jq '
@@ -187,12 +204,17 @@ jobs:
                   [ .files[] |
                     if .previous_filename then "code"
                     elif (.filename | test("\\.md$")) then "ok"
-                    elif (.filename | test("\\.rs$")) and .status == "modified" and (.patch != null) then
+                    elif (.filename | test("\\.rs$")) and .status == "modified" and (.patch != null) and ((.patch | length) < 10000) then
                       # Compare-API patches start at the first @@ hunk and
                       # carry NO +++/--- file headers — do not "skip" them:
                       # that exclusion misreads a genuine added line whose
                       # content begins with "++" (found in upstreaming,
                       # storkme/second-opinion#47).
+                      # The <10000-char cap is truncation insurance: a
+                      # partially-delivered patch could show only comment
+                      # lines while cut hunks hide code. Genuine
+                      # comment-only sweeps are small; a big patch is
+                      # "code" regardless of its visible lines.
                       if ([ .patch | split("\n")[] |
                             select(test("^[+-]")) |
                             select(test("^[+-][[:space:]]*(//.*)?$") | not)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,11 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
   subscription's usage windows) reviews every non-draft PR and posts one
   advisory comment per head SHA (known gap, accepted: a base-branch
   retarget keeps the old SHA's green check — see the workflow's trigger
-  comment; re-review those session-side). Its silent-failure mode is loud: a
+  comment; re-review those session-side). Exception: a push whose delta
+  since the last-reviewed head is docs/comment-only posts a
+  `second-opinion-skip` marker instead of buying a re-review (#632 C8;
+  semantics + escape hatch in [`docs/review-bot.md`](docs/review-bot.md)
+  §"Trivial-delta gate"). Its silent-failure mode is loud: a
   degraded pass that posts no review FAILS the `second-opinion` check
   (`fail-on-degraded`), and that check is **required on main**
   (`enforce_admins=true`; escape hatch `scripts/review-gate.sh unrequire`).

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -125,8 +125,11 @@ semantics below).
 
 A workflow-level step in `second-opinion.yml` (before the action step)
 skips the K=3 review when the delta since the last **actually reviewed**
-head — the newest `<!-- second-opinion sha=... -->` marker — is
-docs-only (`*.md`) and/or comment-only Rust. Rationale: this repo's
+head — the newest `<!-- second-opinion sha=... -->` marker **whose body
+also carries the review header** (`### 🤖 Second opinion`; the marker
+alone is forgeable and claude[bot] posts byte-identical ones naming
+different commits — storkme/second-opinion#49) — is docs-only (`*.md`)
+and/or comment-only Rust. Rationale: this repo's
 conventions generate doc-only pushes constantly (decision-log commits,
 attribution sweeps), and each bought a full re-review of the whole PR
 diff that could only re-find already-adjudicated items (4 of PR #630's

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -155,16 +155,25 @@ Semantics that matter for forensics:
   pushes.
 - **Escape hatch**: the `force-review` label disables the gate for the
   PR — and applying it is itself a trigger (`labeled` event), so it
-  works even when there is nothing left to push. The gate's decision
-  and reason are one log line in the "Trivial-delta gate" step
-  (`gate: trivial=... (reason)`).
-- **Base retargets force a review.** The compare sees only head-side
-  commits, and a retarget rewrites the effective diff with no new head
-  SHA (the workflow's known `edited`-trigger gap) — pre-gate, the next
-  push healed that with a full review, and the gate must not turn that
-  push into a skip. Any `base_ref_changed` /
+  works even when there is nothing left to push, *provided the head was
+  previously skipped rather than reviewed* (an already-reviewed head
+  hits the action's own per-SHA gate, which no label can force — the
+  upstream force-input gap). **Remove the label after use**: it
+  disables the gate for every subsequent push while present. The
+  gate's decision and reason are one log line in the "Trivial-delta
+  gate" step (`gate: trivial=... (reason)`).
+- **Base retargets force a review on the next PUSH.** The compare sees
+  only head-side commits, and a retarget rewrites the effective diff
+  with no new head SHA (the workflow's known `edited`-trigger gap) —
+  pre-gate, the next push healed that with a full review, and the gate
+  must not turn that push into a skip. Any `base_ref_changed` /
   `automatic_base_change_succeeded` timeline event newer than the
-  anchor review forces a review; so does any failure to determine this.
+  anchor review **minus the 90-minute job budget** (a mid-review
+  retarget is older than the anchor yet unreviewed) forces a review;
+  so does any failure to determine this. A label event cannot heal a
+  retarget on an already-reviewed head (per-SHA gate, above), so the
+  residual gap is a retarget followed by no further push before
+  merge — re-review that case session-side.
 - **Same-head re-events** (reopened / ready_for_review / stray label)
   on the already-reviewed head skip with NO notice — nothing to review,
   nothing new to say, and no container spin.

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -150,10 +150,26 @@ Semantics that matter for forensics:
   `.rs` string literal whose changed line starts with `//` inside the
   quotes (none committed today).
 - **Escape hatch**: the `force-review` label disables the gate for the
-  PR. The gate's decision and reason are one log line in the
-  "Trivial-delta gate" step (`gate: trivial=... (reason)`).
+  PR — and applying it is itself a trigger (`labeled` event), so it
+  works even when there is nothing left to push. The gate's decision
+  and reason are one log line in the "Trivial-delta gate" step
+  (`gate: trivial=... (reason)`).
+- **Base retargets force a review.** The compare sees only head-side
+  commits, and a retarget rewrites the effective diff with no new head
+  SHA (the workflow's known `edited`-trigger gap) — pre-gate, the next
+  push healed that with a full review, and the gate must not turn that
+  push into a skip. Any `base_ref_changed` /
+  `automatic_base_change_succeeded` timeline event newer than the
+  anchor review forces a review; so does any failure to determine this.
+- **Same-head re-events** (reopened / ready_for_review / stray label)
+  on the already-reviewed head skip with NO notice — nothing to review,
+  nothing new to say, and no container spin.
 - Fork PRs bypass the gate entirely (kept on today's no-review,
   session-side-rule path).
+- **Tests**: `scripts/test_second_opinion_gate.py` extracts the gate's
+  bash and all three jq programs VERBATIM from the workflow and drives
+  them through ~24 fixtures. Not CI-wired; run it when touching the
+  gate.
 
 ## Failure-class history
 

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -145,10 +145,14 @@ Semantics that matter for forensics:
   first push whose cumulative delta since the last real review touches
   code gets a full-PR-diff review.
 - **Everything ambiguous fails toward review**: no prior marker,
-  force-push/diverged history, renames, any non-md/rs file, missing or
-  truncated compare patches, API errors. The one known over-skip: an
+  force-push/diverged history, renames, any non-md/rs file, missing,
+  oversized (≥10k chars, truncation insurance) or truncated compare
+  patches, API errors. Known over-skips, both accepted by design: an
   `.rs` string literal whose changed line starts with `//` inside the
-  quotes (none committed today).
+  quotes (none committed today), and `.md` *content* — the md-only skip
+  is the feature, so programmatic content embedded in docs (commands,
+  JSON, CI snippets) is outside the gate's review scope on skipped
+  pushes.
 - **Escape hatch**: the `force-review` label disables the gate for the
   PR — and applying it is itself a trigger (`labeled` event), so it
   works even when there is nothing left to push. The gate's decision
@@ -165,10 +169,13 @@ Semantics that matter for forensics:
   on the already-reviewed head skip with NO notice — nothing to review,
   nothing new to say, and no container spin.
 - Fork PRs bypass the gate entirely (kept on today's no-review,
-  session-side-rule path).
+  session-side-rule path) — which means the `force-review` label is
+  also inert on forks; their review remains session-side by rule.
 - **Tests**: `scripts/test_second_opinion_gate.py` extracts the gate's
-  bash and all three jq programs VERBATIM from the workflow and drives
-  them through ~24 fixtures. Not CI-wired; run it when touching the
+  bash and all three jq programs VERBATIM from the workflow, drives the
+  jq through fixtures AND the full bash orchestration end-to-end under
+  a fake `gh` (label handling, anchor parsing, retarget-margin date
+  arithmetic, verdict dispatch). Not CI-wired; run it when touching the
   gate.
 
 ## Failure-class history

--- a/docs/review-bot.md
+++ b/docs/review-bot.md
@@ -121,6 +121,37 @@ non-draft PRs with ≥20 changed lines, zero review activity, and a
 transcript that doesn't bear the cheap gate-skip signature (see Guard
 semantics below).
 
+## Trivial-delta gate (#632 C8, 2026-08-14)
+
+A workflow-level step in `second-opinion.yml` (before the action step)
+skips the K=3 review when the delta since the last **actually reviewed**
+head — the newest `<!-- second-opinion sha=... -->` marker — is
+docs-only (`*.md`) and/or comment-only Rust. Rationale: this repo's
+conventions generate doc-only pushes constantly (decision-log commits,
+attribution sweeps), and each bought a full re-review of the whole PR
+diff that could only re-find already-adjudicated items (4 of PR #630's
+10 rounds).
+
+Semantics that matter for forensics:
+
+- **A skip is never silent.** It posts a comment with the DISTINCT
+  marker `<!-- second-opinion-skip sha=... -->`. If a head has neither
+  marker and the check is green, that's the pre-existing
+  reviewer-malfunction class, not a gate skip.
+- **Trivial deltas accumulate.** Skips don't advance the baseline; the
+  first push whose cumulative delta since the last real review touches
+  code gets a full-PR-diff review.
+- **Everything ambiguous fails toward review**: no prior marker,
+  force-push/diverged history, renames, any non-md/rs file, missing or
+  truncated compare patches, API errors. The one known over-skip: an
+  `.rs` string literal whose changed line starts with `//` inside the
+  quotes (none committed today).
+- **Escape hatch**: the `force-review` label disables the gate for the
+  PR. The gate's decision and reason are one log line in the
+  "Trivial-delta gate" step (`gate: trivial=... (reason)`).
+- Fork PRs bypass the gate entirely (kept on today's no-review,
+  session-side-rule path).
+
 ## Failure-class history
 
 Classes 1–6 share one symptom — green check, nothing posted — and each is

--- a/scripts/test_second_opinion_gate.py
+++ b/scripts/test_second_opinion_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Fixture tests for the trivial-delta gate in second-opinion.yml.
+
+The gate's decision logic lives in jq/bash embedded in workflow YAML —
+outside any compiler or test harness — and every hardening round of PR
+#633 fixed a misclassification found in production. This script closes
+that gap: it extracts the gate's run script and its jq programs VERBATIM
+from the workflow (a hand-copied twin already drifted from reality once,
+on the +++/--- file-header assumption) and drives them through fixtures.
+
+Run: python3 scripts/test_second_opinion_gate.py   (needs python3-yaml, jq)
+Exit 1 on any failure. Not CI-wired; run it when touching the gate.
+"""
+import json
+import re
+import subprocess
+import sys
+
+import yaml
+
+WF = ".github/workflows/second-opinion.yml"
+
+failures = []
+
+
+def check(name, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'} {name}" + (f"  {detail}" if detail and not ok else ""))
+    if not ok:
+        failures.append(name)
+
+
+def jq(prog, doc, raw_input=None, null_input=False):
+    # null_input mirrors the workflow's `jq -rn` timeline invocation: with
+    # -n, `inputs` reads ALL page arrays; without it, the first page is
+    # consumed as `.` and silently dropped — running the program under the
+    # wrong mode is itself a bug this suite once had.
+    inp = raw_input if raw_input is not None else json.dumps(doc)
+    cmd = ["jq", "-rn" if null_input else "-r", prog]
+    p = subprocess.run(cmd, input=inp, capture_output=True, text=True)
+    if p.returncode != 0:
+        return f"ERR:{p.stderr.strip()}"
+    return p.stdout.strip()
+
+
+wf = yaml.safe_load(open(WF))
+steps = wf["jobs"]["second-opinion"]["steps"]
+gate = next(s for s in steps if s.get("name") == "Trivial-delta gate")
+record = next(s for s in steps if s.get("name") == "Record skipped review")
+script = gate["run"]
+
+# --- bash syntax of both run blocks ---
+for label, body in [("gate", script), ("record", record["run"])]:
+    p = subprocess.run(["bash", "-n"], input=body, capture_output=True, text=True)
+    check(f"bash -n ({label} step)", p.returncode == 0, p.stderr.strip())
+
+# --- extract the three jq programs verbatim ---
+m = re.search(r"compare/\$\{last\}\.\.\.\$\{HEAD_SHA\}\" --jq '(.*?)' 2>/dev/null", script, re.S)
+assert m, "verdict jq not found"
+verdict_jq = m.group(1)
+
+m = re.search(r"issues/\$\{PR\}/comments\" --paginate \\\n\s*--jq '(.*?)' \\\n", script, re.S)
+assert m, "anchor jq not found"
+anchor_jq = m.group(1)
+
+m = re.search(r"retarget=\$\(jq -rn '(.*?)' <<<", script, re.S)
+assert m, "timeline jq not found"
+timeline_jq = m.group(1)
+
+# --- verdict jq ---
+V = [
+    ("null-files -> api-failed", {"status": "ahead"}, "review:compare-api-failed"),
+    ("empty-list -> skip", {"status": "ahead", "files": []}, "skip"),
+    ("identical -> identical", {"status": "identical", "files": []}, "identical"),
+    ("behind -> diverged", {"status": "behind", "files": []}, "review:history-diverged"),
+    ("md-only -> skip", {"status": "ahead", "files": [{"filename": "docs/a.md", "status": "modified"}]}, "skip"),
+    ("comment-only-rs -> skip", {"status": "ahead", "files": [
+        {"filename": "x.rs", "status": "modified", "patch": "@@ -1,2 +1,2 @@\n-// a\n+// b\n+\n-"}]}, "skip"),
+    ("mixed md+comment-rs -> skip", {"status": "ahead", "files": [
+        {"filename": "d.md", "status": "added"},
+        {"filename": "x.rs", "status": "modified", "patch": "@@ -1 +1 @@\n-// a\n+// b"}]}, "skip"),
+    ("code -> review", {"status": "ahead", "files": [
+        {"filename": "x.rs", "status": "modified", "patch": "@@ -1 +1 @@\n-let a=1;\n+let a=2;"}]}, "review:code-in-delta"),
+    ("trailing-comment edit -> review", {"status": "ahead", "files": [
+        {"filename": "x.rs", "status": "modified", "patch": "@@ -1 +1 @@\n-let a=1; // x\n+let a=1; // y"}]}, "review:code-in-delta"),
+    ("++-content line -> review", {"status": "ahead", "files": [
+        {"filename": "x.rs", "status": "modified", "patch": "@@ -1 +1,2 @@\n     // ctx\n+++ x;\n+// note"}]}, "review:code-in-delta"),
+    ("new rs file -> review", {"status": "ahead", "files": [
+        {"filename": "y.rs", "status": "added", "patch": "@@ -0,0 +1 @@\n+// only comments"}]}, "review:code-in-delta"),
+    ("rename -> review", {"status": "ahead", "files": [
+        {"filename": "b.md", "previous_filename": "a.md", "status": "renamed"}]}, "review:code-in-delta"),
+    ("py -> review", {"status": "ahead", "files": [
+        {"filename": "s.py", "status": "modified", "patch": "@@ -1 +1 @@\n-# a\n+# b"}]}, "review:code-in-delta"),
+    ("rs no patch -> review", {"status": "ahead", "files": [
+        {"filename": "x.rs", "status": "modified"}]}, "review:code-in-delta"),
+    ("300 files -> truncated", {"status": "ahead", "files": [
+        {"filename": f"f{i}.md", "status": "modified"} for i in range(300)]}, "review:file-list-truncated"),
+]
+for name, doc, exp in V:
+    got = jq(verdict_jq, doc)
+    check(f"verdict: {name}", got == exp, f"got {got!r} want {exp!r}")
+
+# --- anchor jq (sha + created_at pair; foreign markers and skip markers ignored) ---
+comments = [
+    {"body": "<!-- second-opinion sha=" + "a" * 40 + " -->\n### 🤖 Second opinion — union ×2\n...",
+     "created_at": "2026-08-14T10:00:00Z"},
+    {"body": "<!-- second-opinion sha=" + "f" * 40 + " -->\n### Claude finished\nforeign bot, marker only",
+     "created_at": "2026-08-14T10:30:00Z"},
+    {"body": "<!-- second-opinion-skip sha=" + "b" * 40 + " -->\n**Second opinion — skipped**",
+     "created_at": "2026-08-14T11:00:00Z"},
+    {"body": "<!-- second-opinion sha=" + "c" * 40 + " -->\n### 🤖 Second opinion — union ×3\n...",
+     "created_at": "2026-08-14T12:00:00Z"},
+]
+got = jq(anchor_jq, comments)
+check("anchor: newest owned review, with timestamp",
+      got == "c" * 40 + " 2026-08-14T12:00:00Z", f"got {got!r}")
+check("anchor: no comments -> empty", jq(anchor_jq, []) == "", "")
+
+# --- timeline jq (input is CONCATENATED page arrays, as gh --paginate emits) ---
+pages = json.dumps([{"event": "labeled"}, {"event": "base_ref_changed", "created_at": "2026-08-14T11:30:00Z"}]) \
+    + json.dumps([{"event": "committed"}])
+got = jq(timeline_jq, None, raw_input=pages, null_input=True)
+check("timeline: base_ref_changed found across pages", got == "2026-08-14T11:30:00Z", f"got {got!r}")
+got = jq(timeline_jq, None, raw_input=json.dumps([{"event": "labeled"}]), null_input=True)
+check("timeline: no retarget -> empty", got == "", f"got {got!r}")
+got = jq(timeline_jq, None, raw_input=json.dumps([{"event": "automatic_base_change_succeeded"}]), null_input=True)
+check("timeline: auto base change, no timestamp -> unknown-time", got == "unknown-time", f"got {got!r}")
+
+print("ALL PASS" if not failures else f"{len(failures)} FAILURES: {failures}")
+sys.exit(1 if failures else 0)

--- a/scripts/test_second_opinion_gate.py
+++ b/scripts/test_second_opinion_gate.py
@@ -94,6 +94,9 @@ V = [
         {"filename": "x.rs", "status": "modified"}]}, "review:code-in-delta"),
     ("300 files -> truncated", {"status": "ahead", "files": [
         {"filename": f"f{i}.md", "status": "modified"} for i in range(300)]}, "review:file-list-truncated"),
+    ("oversized rs patch -> review (truncation insurance)", {"status": "ahead", "files": [
+        {"filename": "x.rs", "status": "modified",
+         "patch": "@@ -1,3000 +1,3000 @@\n" + "+// c\n" * 3000}]}, "review:code-in-delta"),
 ]
 for name, doc, exp in V:
     got = jq(verdict_jq, doc)
@@ -124,6 +127,92 @@ got = jq(timeline_jq, None, raw_input=json.dumps([{"event": "labeled"}]), null_i
 check("timeline: no retarget -> empty", got == "", f"got {got!r}")
 got = jq(timeline_jq, None, raw_input=json.dumps([{"event": "automatic_base_change_succeeded"}]), null_input=True)
 check("timeline: auto base change, no timestamp -> unknown-time", got == "unknown-time", f"got {got!r}")
+
+# --- end-to-end orchestration harness (round-5 major: the bash between
+# the jq programs — label handling, anchor parsing, the retarget-margin
+# date arithmetic, verdict dispatch — was untested; a reversed comparison
+# would have passed this suite green) ---
+import os
+import tempfile
+
+ANCHOR_SHA = "a" * 40
+
+
+def run_gate(labels, comments_out, timeline, compare_out,
+             timeline_fail=False):
+    with tempfile.TemporaryDirectory() as td:
+        fix = os.path.join(td, "fix")
+        os.mkdir(fix)
+        open(os.path.join(fix, "comments.out"), "w").write(comments_out)
+        if timeline_fail:
+            open(os.path.join(fix, "timeline.fail"), "w").write("")
+        else:
+            open(os.path.join(fix, "timeline.json"), "w").write(timeline)
+        open(os.path.join(fix, "compare.out"), "w").write(compare_out)
+        shim = os.path.join(td, "gh")
+        open(shim, "w").write(
+            '#!/bin/bash\nargs="$*"\ncase "$args" in\n'
+            '  *"/comments"*) cat "$FIXDIR/comments.out";;\n'
+            '  *"/timeline"*) [ -e "$FIXDIR/timeline.fail" ] && exit 1; cat "$FIXDIR/timeline.json";;\n'
+            '  *"/compare/"*) cat "$FIXDIR/compare.out";;\n'
+            '  *) echo "unexpected gh call: $args" >&2; exit 1;;\n'
+            'esac\n')
+        os.chmod(shim, 0o755)
+        event = os.path.join(td, "event.json")
+        open(event, "w").write(json.dumps(
+            {"pull_request": {"labels": [{"name": n} for n in labels]}}))
+        out = os.path.join(td, "output")
+        open(out, "w").write("")
+        env = dict(os.environ,
+                   PATH=td + os.pathsep + os.environ["PATH"],
+                   FIXDIR=fix, GITHUB_EVENT_PATH=event, GITHUB_OUTPUT=out,
+                   GH_TOKEN="test", PR="633", HEAD_SHA="d" * 40,
+                   GITHUB_REPOSITORY="storkme/spaghettio")
+        p = subprocess.run(["bash", "-c", script], env=env,
+                           capture_output=True, text=True)
+        outputs = dict(line.split("=", 1) for line in
+                       open(out).read().splitlines() if "=" in line)
+        return p, outputs
+
+
+E2E = [
+    # (name, labels, comments.out, timeline pages, compare.out,
+    #  timeline_fail, want_trivial, want_notice, want_reason_substr)
+    ("force-review label -> review", ["force-review"], "", "[]", "skip",
+     False, "false", "false", "force-review label present"),
+    ("no marker -> review", [], "", "[]", "skip",
+     False, "false", "false", "no prior review marker"),
+    ("trivial delta -> skip+notice", [],
+     f"{ANCHOR_SHA} 2026-08-14T10:00:00Z\n", "[]", "skip",
+     False, "true", "true", "docs/comment-only delta"),
+    ("retarget inside 90m margin -> review", [],
+     f"{ANCHOR_SHA} 2026-08-14T10:00:00Z\n",
+     json.dumps([{"event": "base_ref_changed",
+                  "created_at": "2026-08-14T09:30:00Z"}]), "skip",
+     False, "false", "false", "base-retargeted"),
+    ("ancient retarget -> skip", [],
+     f"{ANCHOR_SHA} 2026-08-14T10:00:00Z\n",
+     json.dumps([{"event": "base_ref_changed",
+                  "created_at": "2026-08-14T07:00:00Z"}]), "skip",
+     False, "true", "true", "docs/comment-only delta"),
+    ("identical head -> skip, no notice", [],
+     f"{ANCHOR_SHA} 2026-08-14T10:00:00Z\n", "[]", "identical",
+     False, "true", "false", "same-head re-event"),
+    ("timeline API failure -> review", [],
+     f"{ANCHOR_SHA} 2026-08-14T10:00:00Z\n", "", "skip",
+     True, "false", "false", "timeline-api-failed"),
+    ("code delta -> review", [],
+     f"{ANCHOR_SHA} 2026-08-14T10:00:00Z\n", "[]", "review:code-in-delta",
+     False, "false", "false", "review:code-in-delta"),
+]
+for name, labels, c, tl, cmp_out, tlf, w_triv, w_not, w_reason in E2E:
+    p, outputs = run_gate(labels, c, tl, cmp_out, timeline_fail=tlf)
+    ok = (p.returncode == 0
+          and outputs.get("trivial") == w_triv
+          and outputs.get("notice") == w_not
+          and w_reason in p.stdout)
+    check(f"e2e: {name}", ok,
+          f"rc={p.returncode} outputs={outputs} stdout={p.stdout!r} stderr={p.stderr!r}")
 
 print("ALL PASS" if not failures else f"{len(failures)} FAILURES: {failures}")
 sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Intent

#632 C8 (churn-reduction campaign, priority 1): stop paying a full K=3 review (~$0.02–0.32, 15–20 min) for pushes whose delta since the last **actually reviewed** head is docs-only (`*.md`) and/or comment-only Rust. This repo's conventions generate such pushes constantly — decision-log commits, attribution-comment sweeps — and each could only re-find already-adjudicated findings (4 of PR #630's 10 rounds were this loop).

## Scope

- `.github/workflows/second-opinion.yml`: a `Trivial-delta gate` step before the action step, plus a skip-audit comment step. The review step's `if:` gains `&& steps.delta.outputs.trivial != 'true'`. **No job-level `if`** — required-check semantics untouched, same step-gate pattern as the existing fork gate.
- `docs/review-bot.md`: new §"Trivial-delta gate" (semantics, forensics, escape hatch).
- `CLAUDE.md`: one-line exception note on the per-SHA-comment contract.

## Design (safety directions)

- Baseline = newest `<!-- second-opinion sha=... -->` marker. Skips post a **distinct** marker (`second-opinion-skip`), so trivial deltas **accumulate** — the first push whose cumulative delta touches code gets a full-PR-diff review. A skip is never silent.
- Comparison via the compare API (no history fetch): `status != ahead` (force-push), renames, non-md/rs files, missing/truncated patches (≥300 files), and API errors ALL fail toward review.
- Comment-only Rust = every ± patch line blank or `//`-leading after indent; a trailing-comment edit on a code line counts as **code**. Known residual over-skip: an `.rs` string literal whose changed line starts with `//` inside the quotes — none committed today.
- Escape hatch: `force-review` label. Fork PRs bypass the gate (read-only token; they keep today's no-review, session-side-rule path).

## Verification actually run

- YAML parse-checked.
- The verdict jq unit-tested against 14 synthetic compare payloads (md-only ✓skip, comment-only-rs ✓skip, mixed ✓skip, empty delta ✓skip, code/trailing-comment/new-file/rename/py/no-patch/diverged/truncated ✓review; marker lookup ignores skip markers and picks the newest review across pages).
- NOT yet exercised against a live PR — that happens when this PR is marked ready (see below).

## Deviations / notes

- **Draft on purpose**: a PR editing second-opinion.yml runs its own modified workflow with `OPENROUTER_API_KEY` in reach (CLAUDE.md "Workflow"). Owner eyeball requested before marking ready. The added steps use only `github.token` (read comments/compare, post one comment) and touch no secrets.
- On THIS PR the gate will always vote "review" (no prior marker), so marking ready gives one live full-review run of the modified workflow; the skip path gets its first live exercise on the next doc-only push to any reviewed PR.
- `gh --paginate --jq` per-page concatenation handled (`tail -n1`).

Closes nothing; ticks the C8 box on #632 at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n