### PR TITLE
ci: timeline retarget detection uses max, not last (#633 follow-up)

### DIFF
--- a/.github/workflows/second-opinion.yml
+++ b/.github/workflows/second-opinion.yml
@@ -169,7 +169,13 @@ jobs:
             elif ! tl=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/timeline" --paginate 2>/dev/null); then
               reason="review:timeline-api-failed"
             else
-              retarget=$(jq -rn '[inputs] | add // [] | [.[] | select(.event == "base_ref_changed" or .event == "automatic_base_change_succeeded") | .created_at // "unknown-time"] | last // empty' <<<"$tl" 2>/dev/null) || retarget="jq-failed"
+              # max, not last: `last` silently assumes the timeline API
+              # returns events oldest-first (true today, but an ordering
+              # change would make `last` pick the OLDEST of several
+              # retargets and miss a recent one). ISO-8601 UTC max is
+              # chronological max regardless of order; "unknown-time"
+              # sorts above any date and keeps forcing review.
+              retarget=$(jq -rn '[inputs] | add // [] | [.[] | select(.event == "base_ref_changed" or .event == "automatic_base_change_succeeded") | .created_at // "unknown-time"] | max // empty' <<<"$tl" 2>/dev/null) || retarget="jq-failed"
               # The anchor timestamp is the review's POST time — up to a
               # full job budget (timeout-minutes: 90) after the diff was
               # actually fetched. A retarget landing DURING the in-flight

--- a/scripts/test_second_opinion_gate.py
+++ b/scripts/test_second_opinion_gate.py
@@ -127,6 +127,25 @@ got = jq(timeline_jq, None, raw_input=json.dumps([{"event": "labeled"}]), null_i
 check("timeline: no retarget -> empty", got == "", f"got {got!r}")
 got = jq(timeline_jq, None, raw_input=json.dumps([{"event": "automatic_base_change_succeeded"}]), null_input=True)
 check("timeline: auto base change, no timestamp -> unknown-time", got == "unknown-time", f"got {got!r}")
+# max is order-independent: the newest of several retargets must win under
+# BOTH orderings (`last` assumed oldest-first and picked the oldest when
+# the order flipped — the post-merge round-6 critical).
+multi_old_first = json.dumps([
+    {"event": "base_ref_changed", "created_at": "2026-08-14T08:00:00Z"},
+    {"event": "base_ref_changed", "created_at": "2026-08-14T11:30:00Z"}])
+multi_new_first = json.dumps([
+    {"event": "base_ref_changed", "created_at": "2026-08-14T11:30:00Z"},
+    {"event": "base_ref_changed", "created_at": "2026-08-14T08:00:00Z"}])
+for label, payload in [("oldest-first", multi_old_first), ("newest-first", multi_new_first)]:
+    got = jq(timeline_jq, None, raw_input=payload, null_input=True)
+    check(f"timeline: multi-retarget {label} -> newest wins", got == "2026-08-14T11:30:00Z", f"got {got!r}")
+# A timestamp-less event mixed with dated ones must still force review:
+# "unknown-time" sorts above ISO dates, so max surfaces it.
+mixed = json.dumps([
+    {"event": "base_ref_changed", "created_at": "2026-08-14T08:00:00Z"},
+    {"event": "automatic_base_change_succeeded"}])
+got = jq(timeline_jq, None, raw_input=mixed, null_input=True)
+check("timeline: dated + timestamp-less -> unknown-time wins", got == "unknown-time", f"got {got!r}")
 
 # --- end-to-end orchestration harness (round-5 major: the bash between
 # the jq programs — label handling, anchor parsing, the retarget-margin


### PR DESCRIPTION
## Intent

Follow-up to #633, absorbing the one genuinely new finding from its post-merge round-6 review: the retarget guard's `last // empty` silently assumed the timeline API returns events oldest-first. True today — main's current behavior is correct — but an ordering change would make `last` pick the **oldest** of several retargets and miss a recent one, weakening the guard exactly when it matters. `max` is order-independent (ISO-8601 UTC lexicographic max = chronological max), and `unknown-time` sorts above any date so timestamp-less events keep forcing review.

## Scope

One jq word (`last` → `max`) plus its comment; three new fixtures in `scripts/test_second_opinion_gate.py` (multi-retarget in both orderings, dated + timestamp-less mix).

## Verification actually run

`python3 scripts/test_second_opinion_gate.py`: **36/36 PASS** (includes the new ordering fixtures); YAML parse-checked.

## Notes

- The other round-6 critical (string-literal concealment) is the accepted residual's fourth appearance — adjudicated on #633 rounds 3/5/6 with receipts; unchanged.
- This PR is also the gate's first live exercise on a fresh PR post-merge: first push has no review marker, so the gate must vote `review` and the full K=3 review must run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n