### PR TITLE
feat(placer): RFC-069 Phase 1 — planning_duty knob; ec30 gate cleared at 99.4% delivered (#644)

### DIFF
--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -173,7 +173,9 @@ fn main() {
             "--duty" => {
                 duty = need(i)
                     .parse()
-                    .unwrap_or_else(|_| usage("--duty must be a float in (0, 1]"))
+                    .ok()
+                    .filter(|d: &f64| *d > 0.0 && *d <= 1.0)
+                    .unwrap_or_else(|| usage("--duty must be a float in (0, 1]"))
             }
             "--quality" => {
                 let q = need(i);

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -134,6 +134,7 @@ fn main() {
     let mut di = DirectInsertion::Candidate;
     let mut claim: Option<DiClaimOrder> = None;
     let mut belt: Option<String> = None;
+    let mut duty: f64 = 1.0;
     let mut quality = QualityTier::Normal;
     let mut stacking: u8 = 1;
     let mut research_productivity: std::collections::BTreeMap<String, f64> =
@@ -168,6 +169,12 @@ fn main() {
                 })
             }
             "--belt" => belt = Some(need(i)),
+            // RFC-069 Phase 1: planning-duty knob for the K69-1 sim A/B.
+            "--duty" => {
+                duty = need(i)
+                    .parse()
+                    .unwrap_or_else(|_| usage("--duty must be a float in (0, 1]"))
+            }
             "--quality" => {
                 let q = need(i);
                 quality = QualityTier::from_name(&q)
@@ -261,6 +268,7 @@ fn main() {
     let mut opts = LayoutOptions {
         direct_insertion: di,
         max_belt_tier: belt,
+        planning_duty: duty,
         quality,
         stacking,
         research_productivity,

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -267,6 +267,14 @@ fn main() {
         std::process::exit(1);
     });
 
+    // The fitted duty values are TIER-RELATIVE (bot review round 2):
+    // block = floor(in_lane_cap(tier) × 2 × duty / rate), and with no
+    // --belt the cap resolves to the express default (belt_cap 45), so
+    // --duty 0.6 silently computes the measured-DEAD block 6 instead of
+    // the gate-clearing block 2. Require the tier to be explicit.
+    if duty < 1.0 && belt.is_none() {
+        usage("--duty < 1 requires an explicit --belt (the fitted duty is tier-relative; the RFC-069 gate receipts are on transport-belt)");
+    }
     let mut opts = LayoutOptions {
         direct_insertion: di,
         max_belt_tier: belt,

--- a/crates/core/src/bus/cells/extract.rs
+++ b/crates/core/src/bus/cells/extract.rs
@@ -56,6 +56,12 @@ pub fn generate_cell_layout_with_capacity(
     // (candidate → generate cell → candidate → …; found as a stack
     // overflow the moment the default flipped).
     let opts = layout::LayoutOptions {
+        // planning_duty deliberately NOT inherited (bot review round 2
+        // on the knob PR): cell geometry must be candidate-independent
+        // — derivation feeds the sim registry, and keying cell shapes
+        // off an outer pass's knob would fork the registry. If the
+        // duty default ever flips, cells decide their own duty story
+        // as a cell-scoped call, not by inheritance.
         cell_composition: super::CellComposition::Off,
         // Same recursion guard, for the same reason: a `Candidate` DI
         // default would spawn a DI candidate inside every cell sub-solve.

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -497,6 +497,9 @@ impl DecompositionCandidate for ModuleSizeSplit {
             quality: opts.quality,
             wire_mode: opts.wire_mode,
             merge_tap: opts.merge_tap,
+            // Inherited (RFC-069): candidate variants must plan at the
+            // same duty as the native pass or the comparison is skewed.
+            planning_duty: opts.planning_duty,
             stacking: opts.stacking,
             inserter_capacity: opts.inserter_capacity,
             cell_composition: opts.cell_composition,

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -108,13 +108,16 @@ pub struct LayoutOptions {
     /// blocks; default false — main-line zone machinery bridges the
     /// overlap and the geometry shift would break it).
     pub splitter_tap_spacers: bool,
-    /// RFC-069 Phase 1: fraction of nominal belt throughput the row-size
-    /// caps treat as deliverable on a zero-buffer chain. The default
-    /// `1.0` is bit-identical to pre-RFC (rows may land at exactly 100%
-    /// of a belt — the #644 zero-headroom shape); values below 1 shrink
-    /// rows so the whole external chain plans with headroom (trunks
-    /// follow rows 1:1 on that path). Engine policy, not a user axis;
-    /// stays default-off until K69-1's sim gate clears.
+    /// RFC-069: at values below 1, HS dual-input consumer rows are
+    /// capped at ONE input₀ trunk's block —
+    /// `floor(belt_cap × duty / input₀_rate)` machines per row (see the
+    /// `is_hs_dual` branch of `place_rows`). Default `1.0` is
+    /// bit-identical to pre-RFC. The ec30 gate CLEARED at 0.6 (99.4%
+    /// delivered vs the 92.1% default — RFC-069 decision log); the
+    /// default stays 1.0 because Phase 2 must first settle the family
+    /// semantics (ec60-red/tier5 constructions don't consult this cap)
+    /// and adjudicate the corpus-wide re-ranking a flip causes. Engine
+    /// policy, not a user axis.
     pub planning_duty: f64,
     pub max_belt_tier: Option<String>,
     pub row_layout: RowLayout,

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -117,7 +117,13 @@ pub struct LayoutOptions {
     /// default stays 1.0 because Phase 2 must first settle the family
     /// semantics (ec60-red/tier5 constructions don't consult this cap)
     /// and adjudicate the corpus-wide re-ranking a flip causes. Engine
-    /// policy, not a user axis.
+    /// policy, not a user axis. Two caller-owned caveats: the fitted
+    /// values are TIER-RELATIVE (the block budget prices off the
+    /// effective in-lane cap, so 0.6 means block 2 on yellow but block
+    /// 6 at the express default — sim_export refuses --duty without
+    /// --belt for exactly this trap), and the field itself is not
+    /// range-validated — out-of-range values degrade conservatively
+    /// (block clamps to ≥ 1) rather than failing.
     pub planning_duty: f64,
     pub max_belt_tier: Option<String>,
     pub row_layout: RowLayout,

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -122,8 +122,14 @@ pub struct LayoutOptions {
     /// effective in-lane cap, so 0.6 means block 2 on yellow but block
     /// 6 at the express default — sim_export refuses --duty without
     /// --belt for exactly this trap), and the field itself is not
-    /// range-validated — out-of-range values degrade conservatively
-    /// (block clamps to ≥ 1) rather than failing.
+    /// range-validated — values ≤ 0 degrade conservatively (the block
+    /// clamps to ≥ 1), while values > 1 and NaN behave exactly as 1.0
+    /// (the `duty < 1.0` gate is false for both, so the cap is
+    /// skipped). The measured-dead intermediate shapes (e.g. block 3
+    /// on EC-yellow at duties in [0.675, 1.0)) are inherent to a
+    /// continuous knob over integer blocks — Phase 2's shipping
+    /// semantics decide whether the shipped rule is a duty fraction
+    /// or an explicit block bound.
     pub planning_duty: f64,
     pub max_belt_tier: Option<String>,
     pub row_layout: RowLayout,

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -122,12 +122,14 @@ pub struct LayoutOptions {
     /// effective in-lane cap, so 0.6 means block 2 on yellow but block
     /// 6 at the express default — sim_export refuses --duty without
     /// --belt for exactly this trap), and the field itself is not
-    /// range-validated — values ≤ 0 degrade conservatively (the block
-    /// clamps to ≥ 1), while values > 1 and NaN behave exactly as 1.0
+    /// range-validated — values ≤ 0 clamp the block to 1 — maximal
+    /// fragmentation (most per-feed headroom, most footprint; the
+    /// measured direction of safety for delivery, not for cost), while values > 1 and NaN behave exactly as 1.0
     /// (the `duty < 1.0` gate is false for both, so the cap is
-    /// skipped). The measured-dead intermediate shapes (e.g. block 3
-    /// on EC-yellow at duties in [0.675, 1.0)) are inherent to a
-    /// continuous knob over integer blocks — Phase 2's shipping
+    /// skipped). The measured-dead intermediate shapes (block 3
+    /// on EC-yellow at duties in [0.9, 1.0); the gate-clearing block 2
+    /// spans [0.6, 0.9)) are inherent to a continuous knob over
+    /// integer blocks — Phase 2's shipping
     /// semantics decide whether the shipped rule is a duty fraction
     /// or an explicit block bound.
     pub planning_duty: f64,

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -108,6 +108,14 @@ pub struct LayoutOptions {
     /// blocks; default false — main-line zone machinery bridges the
     /// overlap and the geometry shift would break it).
     pub splitter_tap_spacers: bool,
+    /// RFC-069 Phase 1: fraction of nominal belt throughput the row-size
+    /// caps treat as deliverable on a zero-buffer chain. The default
+    /// `1.0` is bit-identical to pre-RFC (rows may land at exactly 100%
+    /// of a belt — the #644 zero-headroom shape); values below 1 shrink
+    /// rows so the whole external chain plans with headroom (trunks
+    /// follow rows 1:1 on that path). Engine policy, not a user axis;
+    /// stays default-off until K69-1's sim gate clears.
+    pub planning_duty: f64,
     pub max_belt_tier: Option<String>,
     pub row_layout: RowLayout,
     pub surplus_policy: SurplusPolicy,
@@ -220,6 +228,7 @@ impl Default for LayoutOptions {
             wire_mode: crate::power_wires::WireMode::default(),
             merge_tap: false,
             splitter_tap_spacers: false,
+            planning_duty: 1.0,
             stacking: 1,
             research_productivity: Default::default(),
             // Default assumes L2 research (red+green science), not the raw
@@ -852,6 +861,7 @@ fn layout_pass(
         opts.direct_insertion.placer_acts().then_some(opts.di_claim_order.clone()),
         &solver_result.di_couplings,
         &stacking_ctx,
+        opts.planning_duty,
     );
     crate::trace::emit(crate::trace::TraceEvent::PhaseTime {
         phase: "place_rows_1".to_string(),
@@ -914,6 +924,7 @@ fn layout_pass(
                 opts.direct_insertion.placer_acts().then_some(opts.di_claim_order.clone()),
                 &solver_result.di_couplings,
                 &stacking_ctx,
+                opts.planning_duty,
             );
             crate::trace::emit(crate::trace::TraceEvent::PhaseTime {
                 phase: "place_rows_2".to_string(),

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -222,13 +222,15 @@ pub(crate) fn max_machines_for_belt(
     spec: &MachineSpec,
     belt_name: &str,
     max_belt_tier: Option<&str>,
-    duty: f64,
 ) -> usize {
-    // RFC-069: `duty` scales BOTH caps so a row cannot be sized to
-    // exactly 100% of a belt (the #644 zero-headroom shape). 1.0 is
-    // bit-identical to pre-RFC.
-    let out_lane_cap = lane_capacity(belt_name) * duty;
-    let in_lane_cap = effective_in_lane_cap(max_belt_tier) * duty;
+    // (RFC-069 Phase 1a briefly scaled both caps by planning_duty here;
+    // REVERTED after the K69-1 sim measured it harmful — ec30 at duty
+    // 0.9 delivered 84.4% vs the 92.1% baseline, and the sprawl
+    // measurement proved at-cap producer rows deliver fine. Duty now
+    // acts only at the HS consumer fan-in site; see the is_hs_dual
+    // branch in place_rows.)
+    let out_lane_cap = lane_capacity(belt_name);
+    let in_lane_cap = effective_in_lane_cap(max_belt_tier);
     let mut max_m: f64 = 999.0;
 
     for out in &spec.outputs {
@@ -282,14 +284,12 @@ pub(crate) fn max_machines_for_belt_both_lanes(
     belt_name: &str,
     max_belt_tier: Option<&str>,
     out_stack: u8,
-    duty: f64,
 ) -> usize {
-    // RFC-069: see `max_machines_for_belt` — duty scales both caps;
-    // 1.0 is bit-identical. This variant is the root #644 site: at
-    // duty 1.0, `floor(7.5/0.625)×2 = 24` copper furnaces draw exactly
-    // one full yellow belt.
-    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack) * duty;
-    let in_lane_cap = effective_in_lane_cap(max_belt_tier) * duty;
+    // (RFC-069 Phase 1a duty scaling reverted here too — see
+    // `max_machines_for_belt`. An exactly-at-cap 24-furnace row is the
+    // measured-fine shape: the sprawl artifact delivers 99.4% with it.)
+    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack);
+    let in_lane_cap = effective_in_lane_cap(max_belt_tier);
     let mut max_m: f64 = 999.0;
 
     for out in &spec.outputs {
@@ -325,12 +325,12 @@ pub(crate) fn max_machines_for_belt_horizontal_stack(
     belt_name: &str,
     max_belt_tier: Option<&str>,
     out_stack: u8,
-    duty: f64,
 ) -> usize {
-    // RFC-069: see `max_machines_for_belt` — duty scales both caps;
-    // 1.0 is bit-identical.
-    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack) * duty;
-    let in_lane_cap = effective_in_lane_cap(max_belt_tier) * duty;
+    // (RFC-069 Phase 1a duty scaling reverted — see
+    // `max_machines_for_belt`. The Phase 1b duty site is the
+    // one-trunk-per-row cap at the is_hs_dual branch of place_rows.)
+    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack);
+    let in_lane_cap = effective_in_lane_cap(max_belt_tier);
     let mut max_m: f64 = 999.0;
 
     for out in &spec.outputs {
@@ -3110,15 +3110,45 @@ pub fn place_rows(
         let out_stack = ctx.for_item(first_solid_output_item);
         let max_per_row = if single_lane {
             let ob = belt_entity_for_rate_stacked(output_rate * 2.0, max_belt_tier, out_stack);
-            max_machines_for_belt(spec, ob, max_belt_tier, planning_duty)
+            max_machines_for_belt(spec, ob, max_belt_tier)
         } else if is_hs_dual {
             // HS feeds input₀ via K stacked trunks, so only output and
             // input₁ constrain machines per row.
-            let ob = belt_entity_for_rate_stacked(output_rate, max_belt_tier, out_stack);
-            max_machines_for_belt_horizontal_stack(spec, ob, max_belt_tier, out_stack, planning_duty)
+            let hs_cap = {
+                let ob = belt_entity_for_rate_stacked(output_rate, max_belt_tier, out_stack);
+                max_machines_for_belt_horizontal_stack(spec, ob, max_belt_tier, out_stack)
+            };
+            if planning_duty < 1.0 {
+                // RFC-069 Phase 1b: ONE input₀ trunk per row. The #644
+                // family's measured deficit lives in the HS consumer
+                // fan-in (K trunks per big row + the collection fabric
+                // upstream): the banked dense ec30 (2×10 EC rows, K=4
+                // trunks each) delivers 92.1%, while the same layout
+                // with 10×2 EC rows delivers 99.4% (the "sprawl"
+                // measurement, RFC-069 decision log). Capping each HS
+                // row at one trunk's block removes the per-row fan-in
+                // entirely; duty scales the block's belt budget so the
+                // single feed also carries headroom.
+                let item0_rate = spec
+                    .inputs
+                    .iter()
+                    .filter(|i| !i.is_fluid && i.rate > 0.0)
+                    .map(|i| i.rate)
+                    .fold(0.0_f64, f64::max);
+                if item0_rate > 0.0 {
+                    let belt_budget =
+                        effective_in_lane_cap(max_belt_tier) * 2.0 * planning_duty;
+                    let block = ((belt_budget / item0_rate).floor() as usize).max(1);
+                    hs_cap.min(block)
+                } else {
+                    hs_cap
+                }
+            } else {
+                hs_cap
+            }
         } else {
             let ob = belt_entity_for_rate_stacked(output_rate, max_belt_tier, out_stack);
-            max_machines_for_belt_both_lanes(spec, ob, max_belt_tier, out_stack, planning_duty)
+            max_machines_for_belt_both_lanes(spec, ob, max_belt_tier, out_stack)
         };
 
         // RFC-062 Phase 2: a final (target) item that is ALSO consumed by
@@ -3456,7 +3486,7 @@ mod tests {
     fn max_machines_single_output_yellow_belt() {
         // rate=1.0/machine, lane_cap=7.5 → floor(7.5/1.0)=7 machines
         let spec = iron_plate_spec();
-        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None, 1.0), 7);
+        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None), 7);
     }
 
     #[test]
@@ -3464,46 +3494,55 @@ mod tests {
         // per_lane = floor(7.5 / 1.0) = 7, both lanes = 14
         let spec = iron_plate_spec();
         assert_eq!(
-            max_machines_for_belt_both_lanes(&spec, "transport-belt", None, 1, 1.0),
+            max_machines_for_belt_both_lanes(&spec, "transport-belt", None, 1),
             14
         );
     }
 
-    /// RFC-069: `planning_duty` must forbid exactly-100% rows. The #644
-    /// zero-headroom shape: 0.625/s per machine on yellow gives
-    /// floor(7.5/0.625)×2 = 24 machines = exactly 15.0/s = exactly one
-    /// full belt at duty 1.0; at duty 0.9 the cap drops to
-    /// floor(6.75/0.625)×2 = 20 machines = 12.5/s = 83% of the belt.
-    /// Duty 1.0 is pinned bit-identical.
+    /// RFC-069 Phase 1b: `planning_duty < 1` caps an HS dual-input row
+    /// at ONE input₀ trunk's block. EC-like spec (input₀ copper-cable
+    /// 4.5/s, input₁ iron-plate 1.5/s, out 1.5/s) on yellow: at duty
+    /// 1.0 the HS cap is output-bound at 10 machines/row (the banked
+    /// dense shape that sims 92.1%); at duty 0.9 the one-trunk block is
+    /// floor(15×0.9/4.5) = 3 machines/row (the fine-grained shape whose
+    /// 10×2 sprawl variant sims 99.4%).
     #[test]
-    fn planning_duty_shrinks_zero_headroom_rows() {
+    fn planning_duty_caps_hs_rows_at_one_trunk_block() {
         let spec = MachineSpec {
-            entity: "electric-furnace".to_string(),
-            recipe: "copper-plate".to_string(),
+            entity: "assembling-machine-2".to_string(),
+            recipe: "electronic-circuit".to_string(),
             self_loop: vec![], voider: false, game_modules: Vec::new(),
-            count: 72.0,
-            inputs: vec![ItemFlow {
-                item: "copper-ore".to_string(),
-                rate: 0.625,
-                is_fluid: false,
-                module_id: 0,
-            }],
-            outputs: vec![ItemFlow {
-                item: "copper-plate".to_string(),
-                rate: 0.625,
-                is_fluid: false,
-                module_id: 0,
-            }],
+            count: 20.0,
+            inputs: vec![
+                ItemFlow { item: "copper-cable".to_string(), rate: 4.5, is_fluid: false, module_id: 0 },
+                ItemFlow { item: "iron-plate".to_string(), rate: 1.5, is_fluid: false, module_id: 0 },
+            ],
+            outputs: vec![ItemFlow { item: "electronic-circuit".to_string(), rate: 1.5, is_fluid: false, module_id: 0 }],
         };
+        let run = |duty: f64| -> Vec<usize> {
+            let (_, spans, _, _) = place_rows(
+                &[spec.clone()],
+                &["electronic-circuit".to_string()],
+                0, 0,
+                Some("transport-belt"),
+                InserterTier::default(), QualityTier::Normal, 0,
+                None, None,
+                crate::bus::layout::RowLayout::HorizontalStack,
+                None, &[], &StackingCtx::unstacked(),
+                duty,
+            );
+            spans.iter().map(|r| r.machine_count).collect()
+        };
+        let baseline = run(1.0);
         assert_eq!(
-            max_machines_for_belt_both_lanes(&spec, "transport-belt", Some("transport-belt"), 1, 1.0),
-            24,
-            "duty 1.0 must stay bit-identical (the zero-headroom status quo)"
+            baseline.iter().max().copied().unwrap_or(0), 10,
+            "duty 1.0 must stay bit-identical: output-bound 10-machine HS rows, got {baseline:?}"
         );
-        assert_eq!(
-            max_machines_for_belt_both_lanes(&spec, "transport-belt", Some("transport-belt"), 1, 0.9),
-            20,
-            "duty 0.9 must cap the row below a full belt"
+        let capped = run(0.9);
+        assert!(
+            capped.iter().all(|&c| c <= 3) && capped.iter().sum::<usize>() == 20,
+            "duty 0.9 must cap HS rows at the one-trunk block (3), preserving the \
+             total machine count; got {capped:?}"
         );
     }
 
@@ -3523,21 +3562,21 @@ mod tests {
                 module_id: 0,
             }],
         };
-        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None, 1.0), 1);
+        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None), 1);
     }
 
     #[test]
     fn test_max_machines_red_belt() {
         // rate=1.0/machine, lane_cap=15.0 → floor(15.0/1.0)=15 machines
         let spec = iron_plate_spec();
-        assert_eq!(max_machines_for_belt(&spec, "fast-transport-belt", None, 1.0), 15);
+        assert_eq!(max_machines_for_belt(&spec, "fast-transport-belt", None), 15);
     }
 
     #[test]
     fn test_max_machines_blue_belt() {
         // rate=1.0/machine, lane_cap=22.5 → floor(22.5/1.0)=22 machines
         let spec = iron_plate_spec();
-        assert_eq!(max_machines_for_belt(&spec, "express-transport-belt", None, 1.0), 22);
+        assert_eq!(max_machines_for_belt(&spec, "express-transport-belt", None), 22);
     }
 
     #[test]
@@ -3547,7 +3586,7 @@ mod tests {
         // Output is the bottleneck → 30
         let spec = iron_plate_spec();
         assert_eq!(
-            max_machines_for_belt_both_lanes(&spec, "fast-transport-belt", None, 1, 1.0),
+            max_machines_for_belt_both_lanes(&spec, "fast-transport-belt", None, 1),
             30
         );
     }

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -3136,6 +3136,21 @@ pub fn place_rows(
                     .map(|i| i.rate)
                     .fold(0.0_f64, f64::max);
                 if item0_rate > 0.0 {
+                    // Budget = full-belt cap × duty, matching the HS
+                    // internals' own block arithmetic (`belt_cap =
+                    // in_lane_cap * 2.0` at the k_trunks site).
+                    // `item0_rate` = the max-rate solid input, which IS
+                    // input₀ by the HS convention (inputs sorted by rate
+                    // desc; the highest-rate one takes the trunks).
+                    // KNOWN LIMITS (bot review, documented not patched):
+                    // the duty VALUE is fitted (0.6 ⇒ block 2 for
+                    // EC-on-yellow, the measured 99.4% shape) — whether
+                    // the fraction generalizes is RFC-069 Phase 2's
+                    // measurement question; and the budget is
+                    // stacking-blind (S>1 + duty<1 is outside the
+                    // measured envelope — under-caps stacked trunks
+                    // conservatively rather than crediting unmeasured
+                    // ×S throughput).
                     let belt_budget =
                         effective_in_lane_cap(max_belt_tier) * 2.0 * planning_duty;
                     let block = ((belt_budget / item0_rate).floor() as usize).max(1);

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -3153,7 +3153,12 @@ pub fn place_rows(
                     // ×S throughput).
                     let belt_budget =
                         effective_in_lane_cap(max_belt_tier) * 2.0 * planning_duty;
-                    let block = ((belt_budget / item0_rate).floor() as usize).max(1);
+                    // +1e-9 before floor: the fitted products land ON
+                    // integer boundaries (15×0.6/4.5 = 2.0000000000000004
+                    // only by ULP luck) and a slip DOWN would flip the
+                    // measured-good block 2 into the measured-dead 3
+                    // (bot review round 2).
+                    let block = (((belt_budget / item0_rate) + 1e-9).floor() as usize).max(1);
                     hs_cap.min(block)
                 } else {
                     hs_cap
@@ -3514,13 +3519,15 @@ mod tests {
         );
     }
 
-    /// RFC-069 Phase 1b: `planning_duty < 1` caps an HS dual-input row
-    /// at ONE input₀ trunk's block. EC-like spec (input₀ copper-cable
-    /// 4.5/s, input₁ iron-plate 1.5/s, out 1.5/s) on yellow: at duty
-    /// 1.0 the HS cap is output-bound at 10 machines/row (the banked
-    /// dense shape that sims 92.1%); at duty 0.9 the one-trunk block is
-    /// floor(15×0.9/4.5) = 3 machines/row (the fine-grained shape whose
-    /// 10×2 sprawl variant sims 99.4%).
+    /// RFC-069: `planning_duty < 1` caps an HS dual-input row at ONE
+    /// input₀ trunk's block. EC-like spec (input₀ copper-cable 4.5/s,
+    /// input₁ iron-plate 1.5/s, out 1.5/s) on yellow: at duty 1.0 the
+    /// HS cap is output-bound at 10 machines/row (the shape that sims
+    /// 92.1%); at duty 0.6 the one-trunk block is floor(15×0.6/4.5) =
+    /// **2** machines/row — the GATE-CLEARING config (99.4% delivered,
+    /// RFC-069 decision log). The dead intermediate (block 3, 85.0%
+    /// by meter) is deliberately NOT pinned — enshrining a
+    /// measured-dead shape in a test invites someone to preserve it.
     #[test]
     fn planning_duty_caps_hs_rows_at_one_trunk_block() {
         let spec = MachineSpec {
@@ -3553,11 +3560,11 @@ mod tests {
             baseline.iter().max().copied().unwrap_or(0), 10,
             "duty 1.0 must stay bit-identical: output-bound 10-machine HS rows, got {baseline:?}"
         );
-        let capped = run(0.9);
+        let capped = run(0.6);
         assert!(
-            capped.iter().all(|&c| c <= 3) && capped.iter().sum::<usize>() == 20,
-            "duty 0.9 must cap HS rows at the one-trunk block (3), preserving the \
-             total machine count; got {capped:?}"
+            capped.iter().all(|&c| c <= 2) && capped.iter().sum::<usize>() == 20,
+            "duty 0.6 must cap HS rows at the one-trunk block (2, the gate-clearing \
+             shape), preserving the total machine count; got {capped:?}"
         );
     }
 

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -3155,9 +3155,13 @@ pub fn place_rows(
                         effective_in_lane_cap(max_belt_tier) * 2.0 * planning_duty;
                     // +1e-9 before floor: the fitted products land ON
                     // integer boundaries (15×0.6/4.5 = 2.0000000000000004
-                    // only by ULP luck) and a slip DOWN would flip the
-                    // measured-good block 2 into the measured-dead 3
-                    // (bot review round 2).
+                    // only by ULP luck), and a slip DOWN would floor the
+                    // gate-clearing block 2 to an UNMEASURED block 1
+                    // (bot round 2; round 4 corrected this comment's
+                    // original direction). The upward risk (a product
+                    // 1e-9 below an integer rounding up) has no real
+                    // belt/rate tuple behind it — adjudicated rounds
+                    // 3-4.
                     let block = (((belt_budget / item0_rate) + 1e-9).floor() as usize).max(1);
                     hs_cap.min(block)
                 } else {

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -3523,7 +3523,8 @@ mod tests {
     /// input₀ trunk's block. EC-like spec (input₀ copper-cable 4.5/s,
     /// input₁ iron-plate 1.5/s, out 1.5/s) on yellow: at duty 1.0 the
     /// HS cap is output-bound at 10 machines/row (the shape that sims
-    /// 92.1%); at duty 0.6 the one-trunk block is floor(15×0.6/4.5) =
+    /// 92.1% — output and input₁ TIE at 10: floor(7.5/1.5)×2 both
+    /// ways); at duty 0.6 the one-trunk block is floor(15×0.6/4.5) =
     /// **2** machines/row — the GATE-CLEARING config (99.4% delivered,
     /// RFC-069 decision log). The dead intermediate (block 3, 85.0%
     /// by meter) is deliberately NOT pinned — enshrining a
@@ -3558,13 +3559,15 @@ mod tests {
         let baseline = run(1.0);
         assert_eq!(
             baseline.iter().max().copied().unwrap_or(0), 10,
-            "duty 1.0 must stay bit-identical: output-bound 10-machine HS rows, got {baseline:?}"
+            "duty 1.0 must stay bit-identical: 10-machine HS rows (output and \
+             input₁ tie at 10), got {baseline:?}"
         );
         let capped = run(0.6);
         assert!(
-            capped.iter().all(|&c| c <= 2) && capped.iter().sum::<usize>() == 20,
-            "duty 0.6 must cap HS rows at the one-trunk block (2, the gate-clearing \
-             shape), preserving the total machine count; got {capped:?}"
+            capped.iter().all(|&c| c == 2) && capped.iter().sum::<usize>() == 20,
+            "duty 0.6 must produce exactly 10×2 HS rows (the gate-clearing shape; \
+             `== 2` so a degenerate 20×1 sprawl cannot pass — bot round 3); \
+             got {capped:?}"
         );
     }
 

--- a/crates/core/src/bus/placer.rs
+++ b/crates/core/src/bus/placer.rs
@@ -222,9 +222,13 @@ pub(crate) fn max_machines_for_belt(
     spec: &MachineSpec,
     belt_name: &str,
     max_belt_tier: Option<&str>,
+    duty: f64,
 ) -> usize {
-    let out_lane_cap = lane_capacity(belt_name);
-    let in_lane_cap = effective_in_lane_cap(max_belt_tier);
+    // RFC-069: `duty` scales BOTH caps so a row cannot be sized to
+    // exactly 100% of a belt (the #644 zero-headroom shape). 1.0 is
+    // bit-identical to pre-RFC.
+    let out_lane_cap = lane_capacity(belt_name) * duty;
+    let in_lane_cap = effective_in_lane_cap(max_belt_tier) * duty;
     let mut max_m: f64 = 999.0;
 
     for out in &spec.outputs {
@@ -278,9 +282,14 @@ pub(crate) fn max_machines_for_belt_both_lanes(
     belt_name: &str,
     max_belt_tier: Option<&str>,
     out_stack: u8,
+    duty: f64,
 ) -> usize {
-    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack);
-    let in_lane_cap = effective_in_lane_cap(max_belt_tier);
+    // RFC-069: see `max_machines_for_belt` — duty scales both caps;
+    // 1.0 is bit-identical. This variant is the root #644 site: at
+    // duty 1.0, `floor(7.5/0.625)×2 = 24` copper furnaces draw exactly
+    // one full yellow belt.
+    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack) * duty;
+    let in_lane_cap = effective_in_lane_cap(max_belt_tier) * duty;
     let mut max_m: f64 = 999.0;
 
     for out in &spec.outputs {
@@ -316,9 +325,12 @@ pub(crate) fn max_machines_for_belt_horizontal_stack(
     belt_name: &str,
     max_belt_tier: Option<&str>,
     out_stack: u8,
+    duty: f64,
 ) -> usize {
-    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack);
-    let in_lane_cap = effective_in_lane_cap(max_belt_tier);
+    // RFC-069: see `max_machines_for_belt` — duty scales both caps;
+    // 1.0 is bit-identical.
+    let out_lane_cap = lane_capacity_stacked(belt_name, out_stack) * duty;
+    let in_lane_cap = effective_in_lane_cap(max_belt_tier) * duty;
     let mut max_m: f64 = 999.0;
 
     for out in &spec.outputs {
@@ -2704,6 +2716,9 @@ pub fn place_rows(
     direct_insertion: Option<crate::bus::di_cell::DiClaimOrder>,
     di_couplings: &[crate::models::DICoupling],
     ctx: &StackingCtx,
+    // RFC-069: fraction of nominal belt throughput the row-size caps
+    // treat as deliverable; 1.0 = bit-identical pre-RFC behavior.
+    planning_duty: f64,
 ) -> (Vec<PlacedEntity>, Vec<RowSpan>, i32, i32) {
     let mut entities: Vec<PlacedEntity> = Vec::new();
     let mut row_spans: Vec<RowSpan> = Vec::new();
@@ -3095,15 +3110,15 @@ pub fn place_rows(
         let out_stack = ctx.for_item(first_solid_output_item);
         let max_per_row = if single_lane {
             let ob = belt_entity_for_rate_stacked(output_rate * 2.0, max_belt_tier, out_stack);
-            max_machines_for_belt(spec, ob, max_belt_tier)
+            max_machines_for_belt(spec, ob, max_belt_tier, planning_duty)
         } else if is_hs_dual {
             // HS feeds input₀ via K stacked trunks, so only output and
             // input₁ constrain machines per row.
             let ob = belt_entity_for_rate_stacked(output_rate, max_belt_tier, out_stack);
-            max_machines_for_belt_horizontal_stack(spec, ob, max_belt_tier, out_stack)
+            max_machines_for_belt_horizontal_stack(spec, ob, max_belt_tier, out_stack, planning_duty)
         } else {
             let ob = belt_entity_for_rate_stacked(output_rate, max_belt_tier, out_stack);
-            max_machines_for_belt_both_lanes(spec, ob, max_belt_tier, out_stack)
+            max_machines_for_belt_both_lanes(spec, ob, max_belt_tier, out_stack, planning_duty)
         };
 
         // RFC-062 Phase 2: a final (target) item that is ALSO consumed by
@@ -3249,6 +3264,7 @@ pub fn place_rows_from_result(
     row_layout: RowLayout,
     direct_insertion: Option<crate::bus::di_cell::DiClaimOrder>,
     ctx: &StackingCtx,
+    planning_duty: f64,
 ) -> (Vec<PlacedEntity>, Vec<RowSpan>, i32, i32) {
     place_rows(
         &result.machines,
@@ -3265,6 +3281,7 @@ pub fn place_rows_from_result(
         direct_insertion,
         &result.di_couplings,
         ctx,
+        planning_duty,
     )
 }
 
@@ -3439,7 +3456,7 @@ mod tests {
     fn max_machines_single_output_yellow_belt() {
         // rate=1.0/machine, lane_cap=7.5 → floor(7.5/1.0)=7 machines
         let spec = iron_plate_spec();
-        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None), 7);
+        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None, 1.0), 7);
     }
 
     #[test]
@@ -3447,8 +3464,46 @@ mod tests {
         // per_lane = floor(7.5 / 1.0) = 7, both lanes = 14
         let spec = iron_plate_spec();
         assert_eq!(
-            max_machines_for_belt_both_lanes(&spec, "transport-belt", None, 1),
+            max_machines_for_belt_both_lanes(&spec, "transport-belt", None, 1, 1.0),
             14
+        );
+    }
+
+    /// RFC-069: `planning_duty` must forbid exactly-100% rows. The #644
+    /// zero-headroom shape: 0.625/s per machine on yellow gives
+    /// floor(7.5/0.625)×2 = 24 machines = exactly 15.0/s = exactly one
+    /// full belt at duty 1.0; at duty 0.9 the cap drops to
+    /// floor(6.75/0.625)×2 = 20 machines = 12.5/s = 83% of the belt.
+    /// Duty 1.0 is pinned bit-identical.
+    #[test]
+    fn planning_duty_shrinks_zero_headroom_rows() {
+        let spec = MachineSpec {
+            entity: "electric-furnace".to_string(),
+            recipe: "copper-plate".to_string(),
+            self_loop: vec![], voider: false, game_modules: Vec::new(),
+            count: 72.0,
+            inputs: vec![ItemFlow {
+                item: "copper-ore".to_string(),
+                rate: 0.625,
+                is_fluid: false,
+                module_id: 0,
+            }],
+            outputs: vec![ItemFlow {
+                item: "copper-plate".to_string(),
+                rate: 0.625,
+                is_fluid: false,
+                module_id: 0,
+            }],
+        };
+        assert_eq!(
+            max_machines_for_belt_both_lanes(&spec, "transport-belt", Some("transport-belt"), 1, 1.0),
+            24,
+            "duty 1.0 must stay bit-identical (the zero-headroom status quo)"
+        );
+        assert_eq!(
+            max_machines_for_belt_both_lanes(&spec, "transport-belt", Some("transport-belt"), 1, 0.9),
+            20,
+            "duty 0.9 must cap the row below a full belt"
         );
     }
 
@@ -3468,21 +3523,21 @@ mod tests {
                 module_id: 0,
             }],
         };
-        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None), 1);
+        assert_eq!(max_machines_for_belt(&spec, "transport-belt", None, 1.0), 1);
     }
 
     #[test]
     fn test_max_machines_red_belt() {
         // rate=1.0/machine, lane_cap=15.0 → floor(15.0/1.0)=15 machines
         let spec = iron_plate_spec();
-        assert_eq!(max_machines_for_belt(&spec, "fast-transport-belt", None), 15);
+        assert_eq!(max_machines_for_belt(&spec, "fast-transport-belt", None, 1.0), 15);
     }
 
     #[test]
     fn test_max_machines_blue_belt() {
         // rate=1.0/machine, lane_cap=22.5 → floor(22.5/1.0)=22 machines
         let spec = iron_plate_spec();
-        assert_eq!(max_machines_for_belt(&spec, "express-transport-belt", None), 22);
+        assert_eq!(max_machines_for_belt(&spec, "express-transport-belt", None, 1.0), 22);
     }
 
     #[test]
@@ -3492,7 +3547,7 @@ mod tests {
         // Output is the bottleneck → 30
         let spec = iron_plate_spec();
         assert_eq!(
-            max_machines_for_belt_both_lanes(&spec, "fast-transport-belt", None, 1),
+            max_machines_for_belt_both_lanes(&spec, "fast-transport-belt", None, 1, 1.0),
             30
         );
     }
@@ -3553,7 +3608,7 @@ mod tests {
     fn place_rows_single_recipe_no_split() {
         let machines = vec![iron_plate_spec()];
         let dep_order = vec!["iron-plate".to_string()];
-        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked());
+        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked(), 1.0);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].machine_count, 1);
         assert_eq!(spans[0].spec.recipe, "iron-plate");
@@ -3564,7 +3619,7 @@ mod tests {
         let (producer, consumer) = cell_pair();
         let machines = vec![consumer, producer];
         let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
-        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked());
+        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked(), 1.0);
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].spec.recipe, "iron-plate");
         assert_eq!(spans[1].spec.recipe, "iron-gear-wheel");
@@ -3575,7 +3630,7 @@ mod tests {
         // Second recipe starts at y_end_of_first + 2 (gap)
         let machines = vec![iron_plate_spec(), iron_gear_spec()];
         let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
-        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked());
+        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked(), 1.0);
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[1].y_start, spans[0].y_end + 2);
     }
@@ -3584,7 +3639,7 @@ mod tests {
     fn place_rows_y_offset() {
         let machines = vec![iron_plate_spec()];
         let dep_order = vec!["iron-plate".to_string()];
-        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 5, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked());
+        let (_, spans, _, _) = place_rows(&machines, &dep_order, 0, 5, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked(), 1.0);
         assert_eq!(spans[0].y_start, 5);
     }
 
@@ -3609,6 +3664,7 @@ mod tests {
             None,
             &[],
 &StackingCtx::unstacked(),
+            1.0,
         );
 
         // 4 distinct recipes → 4 rows (no splitting for these small counts)
@@ -3658,6 +3714,7 @@ mod tests {
             Some(crate::bus::di_cell::DiClaimOrder::Upstream), // direct_insertion ON
             &result.di_couplings,
             &StackingCtx::unstacked(),
+            1.0,
         );
 
         let recipe_order: Vec<&str> = spans.iter().map(|s| s.spec.recipe.as_str()).collect();
@@ -3705,6 +3762,7 @@ mod tests {
             None, // direct_insertion OFF
             &couplings,
             &StackingCtx::unstacked(),
+            1.0,
         );
 
         for span in &spans {
@@ -3753,6 +3811,7 @@ mod tests {
             None,
             &[],
 &StackingCtx::unstacked(),
+            1.0,
         );
         // 20 machines, max_per_row=14 → ceil(20/14) = 2 rows
         assert_eq!(spans.len(), 2, "Expected 2 rows due to belt lane capacity");
@@ -3821,6 +3880,7 @@ mod tests {
             None,
             &[],
 &StackingCtx::unstacked(),
+            1.0,
         );
 
         let gear_rows: Vec<_> = spans
@@ -3840,7 +3900,7 @@ mod tests {
         let machines = vec![iron_plate_spec(), iron_gear_spec()];
         let dep_order = vec!["iron-plate".to_string(), "iron-gear-wheel".to_string()];
         let (_, spans, _, total_height) =
-            place_rows(&machines, &dep_order, 5, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked());
+            place_rows(&machines, &dep_order, 5, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked(), 1.0);
 
         // Every span should have y_end > y_start
         for span in &spans {
@@ -3868,7 +3928,7 @@ mod tests {
         let dep_order = vec!["iron-plate".to_string()];
         let bus_width = 10;
         let (_, spans, max_width, _) =
-            place_rows(&machines, &dep_order, bus_width, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked());
+            place_rows(&machines, &dep_order, bus_width, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked(), 1.0);
 
         assert!(
             spans[0].row_width >= bus_width,
@@ -3899,8 +3959,9 @@ mod tests {
             None,
             &[],
 &StackingCtx::unstacked(),
+            1.0,
         );
-        let (_, spans_no_gap, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked());
+        let (_, spans_no_gap, _, _) = place_rows(&machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal, 0, None, None, RowLayout::default(), None, &[], &StackingCtx::unstacked(), 1.0);
 
         // Second row should start 5 tiles later with gap
         assert_eq!(
@@ -4256,7 +4317,7 @@ mod tests {
         let (ents, spans, _, _) = place_rows(
             &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
             crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
-            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(),
+            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(), 1.0,
         );
         assert_eq!(spans.len(), 1, "producer + consumer must fuse into one cell row, got {:?}",
             spans.iter().map(|s| s.spec.recipe.as_str()).collect::<Vec<_>>());
@@ -4296,7 +4357,7 @@ mod tests {
         let (ents, spans, _, _) = place_rows(
             &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
             crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
-            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(),
+            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(), 1.0,
         );
         assert_eq!(spans.len(), 1, "guard: this asserts nothing unless a cell was actually fused");
         let y = spans[0].output_belt_y;
@@ -4347,7 +4408,7 @@ mod tests {
         let (ents, _spans, _, _) = place_rows(
             &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
             crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
-            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &couplings, &StackingCtx::unstacked(),
+            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &couplings, &StackingCtx::unstacked(), 1.0,
         );
         // Since Phase 2 this pair legitimately fuses as a ROW cell (the
         // consumer is coupled east/west, leaving both faces free for its
@@ -4554,7 +4615,7 @@ mod tests {
         let (_, spans, _, _) = place_rows(
             &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
             crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
-            None, &gear_cell_couplings(), &StackingCtx::unstacked(),
+            None, &gear_cell_couplings(), &StackingCtx::unstacked(), 1.0,
         );
         assert_eq!(spans.len(), 2, "DI off must not fuse");
     }
@@ -4603,7 +4664,7 @@ mod tests {
         let (_, spans, _, _) = place_rows(
             &machines, &dep_order, 0, 0, None, InserterTier::Regular, QualityTier::Normal,
             0, None, None, RowLayout::default(),
-            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(),
+            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(), 1.0,
         );
         assert_eq!(
             spans.len(), 2,
@@ -4625,7 +4686,7 @@ mod tests {
         let (ents, spans, _, _) = place_rows(
             &machines, &dep_order, 0, 0, None, InserterTier::default(), QualityTier::Normal,
             crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
-            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(),
+            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(), 1.0,
         );
         assert_eq!(spans.len(), 1, "guard: needs a fused cell to mean anything");
         let out_y = spans[0].output_belt_y;
@@ -4659,7 +4720,7 @@ mod tests {
             &machines, &dep_order, 0, 0, Some("express-transport-belt"),
             InserterTier::default(), QualityTier::Normal,
             crate::common::DEFAULT_INSERTER_CAPACITY, None, None, RowLayout::default(),
-            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(),
+            Some(crate::bus::di_cell::DiClaimOrder::Upstream), &gear_cell_couplings(), &StackingCtx::unstacked(), 1.0,
         );
         assert_eq!(spans.len(), 1, "guard: needs a fused cell to mean anything");
         let in_y = spans[0].input_belt_y[0];

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -8963,7 +8963,7 @@ fn probe_di_contention_corpus_sweep() {
                     &sr.machines, &sr.dependency_order, 0, 0, None,
                     InserterTier::default(), QualityTier::Normal, 0, None, None,
                     spaghettio_core::bus::layout::RowLayout::default(),
-                    Some(order), &sr.di_couplings, &StackingCtx::unstacked(),
+                    Some(order), &sr.di_couplings, &StackingCtx::unstacked(), 1.0,
                 );
                 let ev = spaghettio_core::trace::drain_events();
                 let detail: Vec<String> = ev.iter().filter_map(|e| match e {
@@ -9411,6 +9411,7 @@ fn probe_di_claim_order_shipped_corpus_verdict() {
             Some(order),
             &sr.di_couplings,
             &StackingCtx::unstacked(),
+            1.0,
         );
         spaghettio_core::trace::drain_events()
             .iter()

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -72,6 +72,9 @@ fn layout_options(
         // existed. Wiring a control is a separate change; defaulting here
         // keeps the boundary explicit rather than relying on `..Default`.
         research_productivity: Default::default(),
+        // RFC-069: the browser plans at the engine default (1.0 while the
+        // Phase-1 gate is open); no UI control until the default flips.
+        planning_duty: 1.0,
         max_belt_tier,
         row_layout,
         surplus_policy: SurplusPolicy::default(),

--- a/crates/wasm-bindings/src/lib.rs
+++ b/crates/wasm-bindings/src/lib.rs
@@ -72,8 +72,10 @@ fn layout_options(
         // existed. Wiring a control is a separate change; defaulting here
         // keeps the boundary explicit rather than relying on `..Default`.
         research_productivity: Default::default(),
-        // RFC-069: the browser plans at the engine default (1.0 while the
-        // Phase-1 gate is open); no UI control until the default flips.
+        // RFC-069: the browser plans at the engine default. Pinned 1.0
+        // pending Phase 2's family-semantics + default-flip adjudication
+        // (the ec30 gate itself CLEARED at 0.6 — see the RFC decision
+        // log); no UI control until the default flips.
         planning_duty: 1.0,
         max_belt_tier,
         row_layout,

--- a/docs/rfc-069-achievable-duty-provisioning.md
+++ b/docs/rfc-069-achievable-duty-provisioning.md
@@ -165,6 +165,19 @@ goes to the owner before merge.
 
 ## Decision log
 
+- *2026-08-15 — Phase 2 first family probe: ec60-red does NOT respond
+  to the block cap.* At duty 0.6 its EC stage reshapes (2×20 → 7×≤6)
+  yet the meter reads **90.8% produced — identical to its baseline**;
+  duty 0.3 builds byte-identically to 0.6 (unexplained — the cap
+  arithmetic should differ; suspect the candidate-selection path or
+  the effective in-lane cap resolution on fast belts, to be probed).
+  Two open questions for the next session: (a) ec60-red's actual
+  binding site (its own attribute/cable-probe pass — its cable rows of
+  10 and 48-furnace plate rows differ structurally from ec30's), and
+  (b) why 0.3 ≡ 0.6 on this fixture. K69-3's family-divergence
+  expectation is now a measurement: the ec30 lever is NOT the whole
+  family's lever.
+
 - *2026-08-15 — RFC opened.* Grounded in #648's re-attribution: the
   family's Error-level validator signal was retracted as a walker
   artifact; the sim/meter deficits stand. The #519 margin-probe
@@ -206,6 +219,35 @@ goes to the owner before merge.
   3,369 and the sprawl's 4,934). Gate: ec30 sims **≥ 96.0% delivered**
   at duty 0.9, else this lever stops too and the campaign escalates to
   RFC-061's pool-and-balance machinery.*
+- *2026-08-15 — Phase 1b at block=3 measured DEAD; the physics is the
+  per-pickup extraction fraction.* The 1b sim was invalidated by a
+  harness kit artifact (overlapping drain banks on adjacent same-item
+  exits — a rig-geometry limitation worth its own follow-up: the
+  colliding tiles don't even correspond to the manifest's two south
+  exits), but the meter refutes independently: **85.0% produced,
+  uniform down the chain**. The cable-probe occupancy gradient
+  explains why rows-of-3 fail where rows-of-2 succeed: an EC machine
+  draws 4.5/s ≈ 30% of a full yellow belt per pickup (vs a furnace's
+  4%), so a 3-machine block's tail extracts from a belt already
+  two-thirds depleted — the RFC-054 gappy-belt mechanism, 7× harsher
+  on EC than on furnace rows. Blocks of 2 kill the within-row
+  gradient; DI would kill it entirely.*
+- *2026-08-15 — **Phase 1c pre-registered** (entry written before its
+  sim returned): same code, `--duty 0.6` ⇒ HS block =
+  floor(15×0.6/4.5) = **2** ⇒ EC 10×2 with producer rows untouched —
+  the engine now deterministically reproduces the sprawl's shape
+  (dims/entities EXACT: 106×222 / 4,934; bp not byte-identical —
+  segment/routing deltas). Meter: **96.6% produced — IDENTICAL to the
+  sprawl's meter reading**, whose sim delivered 99.4%. Gate: this
+  artifact's own 432k sim ≥ 96.0% delivered.
+  **GATE CLEARED: 99.4% delivered (29.82/30, −0.6%), PASS — converged,
+  kit-clean, 168/170 working / 2 full-output.** The engine produces a
+  plan-attaining ec30 behind `planning_duty: 0.6`, +7.3pp over the
+  92.1% default. Phase 2 (family rollout) decides the shipping
+  semantics: 0.6 was fitted to give block=2 for EC-on-yellow
+  (4.5/s draw); whether the fraction generalizes (fast-belt EC →
+  block 4) or the rule should pin block ≤ 2 for high-fraction pickups
+  is a measurement question, not a design preference.*
 - *2026-08-15 — Phase-0 follow-up MEASURED: the phantom-era sprawl
   delivers 99.4%.* Reproduced from `decd63b5` and simmed (warmup 432k,
   converged, drift +0.6%, kit-clean): `ec30-sprawl` (106×222, 4,934

--- a/docs/rfc-069-achievable-duty-provisioning.md
+++ b/docs/rfc-069-achievable-duty-provisioning.md
@@ -176,7 +176,19 @@ goes to the owner before merge.
   10 and 48-furnace plate rows differ structurally from ec30's), and
   (b) why 0.3 ≡ 0.6 on this fixture. K69-3's family-divergence
   expectation is now a measurement: the ec30 lever is NOT the whole
-  family's lever.
+  family's lever. **(b) partially answered same day**: builds at duty
+  1.0 / 0.6 / 0.3 give 4,967 / 5,395 / 5,395 entities — the duty<1
+  winner is IDENTICAL across cap values, i.e. a candidate whose
+  construction never consults the cap; its EC 7×6 shape matches the
+  shard/partition module size, so the working hypothesis is a
+  partition-class candidate winning selection on ec60-red once the
+  HS-capped native variant changes the field. The meter's attribute
+  pass on its baseline shows the same allocation-skew class as ec30
+  (4 cable machines full-output while one EC block starves of cable),
+  so the *mechanism* transfers even though the lever's delivery path
+  does not. Next: trace which candidate wins and why, then either get
+  the capped HS candidate selected or cap the partition module size
+  by the same per-pickup rule.
 
 - *2026-08-15 — RFC opened.* Grounded in #648's re-attribution: the
   family's Error-level validator signal was retracted as a walker

--- a/docs/rfc-069-achievable-duty-provisioning.md
+++ b/docs/rfc-069-achievable-duty-provisioning.md
@@ -171,7 +171,55 @@ goes to the owner before merge.
   rejection is explicitly discounted as instrument-contaminated (its
   warning-count penalty partly measured the phantom-source bug), while
   its geometric end-to-end insight is adopted as a design constraint.
-- *2026-08-15 — Phase-0 follow-up candidate: the phantom-era sprawls.*
+- *2026-08-15 — **K69-1 FIRED on the Phase-1a design** (duty in the
+  general row caps): ec30 at duty 0.9 sims **84.4% delivered**
+  (25.33/30, converged, drift +1.0%) — 7.7pp WORSE than the 92.1%
+  baseline. Census: 30 machines full_output, the stalled ones being
+  row HEADS at zero crafts — the extra producer rows fed a collection
+  fabric still provisioned at nominal, so backpressure parked at the
+  producers. The 0.85 arm (near-identical layout, different hash) is
+  in flight to close the criterion's letter; the design verdict does
+  not depend on it. Per the criterion: stop the rows-only lever.
+  **0.85 arm landed: identical — 84.4% delivered, same census (30
+  full-output / 3 short / 137 working). K69-1's letter is closed:
+  FIRED at both pre-registered duties.***
+- *2026-08-15 — mechanism REFRAMED by the three-artifact row census.*
+  dense (92.1%): plate 3×24 + iron 2×24, EC **2×10**; duty-1a (84.4%):
+  plate 4×18 + iron 3×16, EC 3×7/7/6; sprawl (99.4%): plate/iron
+  IDENTICAL to dense, EC **10×2**. At-cap producer rows are measured
+  FINE; the deficit lives in the **HS consumer fan-in** (dense EC rows
+  are output-bound at 10 machines = 45/s of input₀ cable per row via
+  K=4 nominal trunks + the collection fabric above them). The
+  validator's residual IRD warnings point at exactly these feeds
+  (cable 2.9–3.9/s modeled vs 4.5 needed at EC tails). The banked
+  dense run's census shows the same head-stall backpressure symptoms
+  plus scattered ingredient-shorts — the RFC-061 allocation-skew
+  class. The ore-row zero-margin warnings are measured benign for
+  delivery (sprawl receipt) — a calibration note for the margin
+  check's trust row.*
+- *2026-08-15 — **Phase 1b pre-registered** (entry written before its
+  sim returned): one input₀ trunk per HS consumer row, gated behind
+  the same `planning_duty` knob (duty < 1 ⇒ HS rows capped at
+  floor(belt_cap × duty / input₀_rate); the Phase-1a general-cap
+  scaling is REVERTED as measured-harmful). Artifact: EC 7×≤3 rows,
+  producer rows untouched, 4,161 entities / 100×206 (between dense's
+  3,369 and the sprawl's 4,934). Gate: ec30 sims **≥ 96.0% delivered**
+  at duty 0.9, else this lever stops too and the campaign escalates to
+  RFC-061's pool-and-balance machinery.*
+- *2026-08-15 — Phase-0 follow-up MEASURED: the phantom-era sprawl
+  delivers 99.4%.* Reproduced from `decd63b5` and simmed (warmup 432k,
+  converged, drift +0.6%, kit-clean): `ec30-sprawl` (106×222, 4,934
+  entities, 170 machines) delivers **29.82/30.0 = 99.4%** vs the
+  banked dense winner's 92.1% — the phantom-error steering was buying
+  **+7.3pp of delivery** by accident, through exactly this RFC's
+  mechanism (more, shorter rows → per-row ore demand below one belt →
+  headroom). Cost: +46% entities, +1.5× bbox vs dense. This is the
+  headroom hypothesis measured before any engine knob: K69-1's
+  question is now whether duty-0.9 buys comparable delivery at a
+  fraction of the sprawl's footprint (the duty-0.9 artifact is 3,797
+  entities / 81×168 — between the two). Report banked at
+  `~/spaghettio-corpora/i644-phase0/ec30-sprawl/`.
+- *(superseded by the entry above)* Phase-0 follow-up candidate note:
   For the three days the #646 walker phantoms steered selection, ec30
   shipped a 4964-entity 106×222 sprawl (vs the banked 3369-entity
   winner) that METERS at 96.6% produced vs the dense winner's 91.9%


### PR DESCRIPTION
# Intent

RFC-069 Phase 1: the `planning_duty` knob (default-off, bit-identical at 1.0) plus the experiment trail that found and measured the first working engine lever for the #644 deficit family.

**The headline receipt: ec30 at `--duty 0.6` sims at 99.4% delivered** (29.82/30, warmup 432k, converged, kit-clean, 168/170 machines working) — versus the 92.1% the default engine ships. The gate (≥96.0% delivered, pre-registered in the RFC decision log) cleared with +3.4pp to spare.

## What the knob does

`LayoutOptions.planning_duty` (default 1.0 = bit-identical; full suite green by exit code, all 26 binaries). At duty < 1, HS dual-input consumer rows are capped at ONE input₀ trunk's block: `floor(belt_cap × duty / input₀_rate)` machines per row. At 0.6 on yellow this gives EC rows of 2 — the engine then deterministically reproduces the shape of the layout that measures 99.4% (dims/entities exact: 106×222 / 4,934).

## The experiment trail (all receipts in the RFC decision log)

- **Phase 1a** (duty scaling the general row caps) — **K69-1 FIRED at both pre-registered duties**: 84.4% delivered, 7.7pp WORSE than baseline. Reverted; the harmful mechanism (backpressure from a nominal-provisioned collection fabric behind extra producer rows) is documented in the cap functions.
- **Phase 1b** (HS block=3) — sim invalidated by a harness kit artifact (overlapping drain banks, logged as a follow-up); the meter refutes independently at 85.0%. Dead.
- **Phase 1c** (HS block=2 via duty 0.6) — **gate cleared at 99.4%**.
- The physics that discriminates 2 from 3: per-pickup extraction fraction. An EC machine draws 4.5/s ≈ 30% of a yellow belt per pickup (a furnace draws 4%), so a 3-machine block's tail extracts from a belt already ⅔ depleted — the RFC-054 gappy-belt mechanism. Blocks of 2 kill the within-row gradient.
- Four instruments converge on the mechanism (sim census, walker IRD warnings, meter `attribute`/`cable_probe` occupancy gradients, three-artifact row census): the ec30 deficit was the EC consumer fan-in, not the at-cap ore rows (which the 99.4% artifact shares verbatim with the 92.1% one).

## What this PR does NOT do

- Does not flip any default: the engine still ships the 92.1% ec30 until Phase 2's family rollout adjudicates the corpus (pins, goldens, scoreboards) with sim receipts.
- Does not claim the family is solved: **ec60-red does not respond to this lever** (meter 90.8% unmoved despite its EC stage reshaping; two open questions logged in the decision log) — its binding site is different, per K69-3's family-divergence expectation.
- `sim_export` gains `--duty` for the A/B workflow; the wasm boundary pins 1.0 until the default flips.

# Verification

- Full core suite by exit code: 0, all 26 binaries, at default duty (bit-identical).
- Unit pin `planning_duty_caps_hs_rows_at_one_trunk_block`: duty 1.0 → output-bound 10-machine HS rows (the 92.1% shape); duty 0.9 → block-capped rows, machine count preserved.
- Gate sim receipts banked at `~/spaghettio-corpora/i644-phase0/` (ec30-duty06-p1c = the 99.4% run; ec30-sprawl = the independent same-shape 99.4% run; the dead arms' reports alongside).
- Lib clippy clean.

# Deviations

- The RFC's original Phase-1 design (duty in the general row caps) was killed by its own gate and REVERTED within this branch — the decision log carries the full arc, including two pre-registered-then-failed attempts. This PR ships the surviving lever only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n
