### PR TITLE
fix(router): #652 PR-1 — conflict-aware zone commit + UG-pair atomicity + eviction span guard

### DIFF
--- a/crates/core/src/bus/eviction.rs
+++ b/crates/core/src/bus/eviction.rs
@@ -479,15 +479,16 @@ fn route_evicted_spec(
     let path = match recipe {
         EvictionRecipe::OppositePairUg => {
             // 2-tile path triggers `render_path`'s UG-emission branch.
-            // GUARD (#644 flip campaign): render_path emits the pair for
-            // ANY span, but the game's UG reach bounds a legal jump —
-            // an over-reach "pair" ships as an unpaired-UG validator
-            // Error (found on ac7-HS under the duty reshape: the second
-            // hop's exit landed beyond reach, leaving an orphan
-            // entrance at the crossing). Also require both endpoints on
-            // one axis (a diagonal 2-tile "jump" is not a UG) and the
-            // exit inside the bbox. Refusing here falls through to the
-            // A* recipes, which route contiguously.
+            // DEFENSE-IN-DEPTH GUARD: `select_specs` →
+            // `opposite_pair_fits` already enforces span/axis validity
+            // for the specs that reach this recipe (review traced the
+            // active pipeline and found this guard currently
+            // unreachable) — it stays as a second line so a future
+            // change to spec selection cannot silently reopen the
+            // over-reach class: render_path emits the pair for ANY
+            // span, and an over-reach "pair" ships as an unpaired-UG
+            // validator Error. Refusing falls through to the A*
+            // recipes, which route contiguously.
             let span = (exit.0 - entry.0).abs() + (exit.1 - entry.1).abs();
             let axis_aligned = entry.0 == exit.0 || entry.1 == exit.1;
             let max_span = crate::common::ug_max_reach(belt_name) as i32 + 1;

--- a/crates/core/src/bus/eviction.rs
+++ b/crates/core/src/bus/eviction.rs
@@ -479,6 +479,21 @@ fn route_evicted_spec(
     let path = match recipe {
         EvictionRecipe::OppositePairUg => {
             // 2-tile path triggers `render_path`'s UG-emission branch.
+            // GUARD (#644 flip campaign): render_path emits the pair for
+            // ANY span, but the game's UG reach bounds a legal jump —
+            // an over-reach "pair" ships as an unpaired-UG validator
+            // Error (found on ac7-HS under the duty reshape: the second
+            // hop's exit landed beyond reach, leaving an orphan
+            // entrance at the crossing). Also require both endpoints on
+            // one axis (a diagonal 2-tile "jump" is not a UG) and the
+            // exit inside the bbox. Refusing here falls through to the
+            // A* recipes, which route contiguously.
+            let span = (exit.0 - entry.0).abs() + (exit.1 - entry.1).abs();
+            let axis_aligned = entry.0 == exit.0 || entry.1 == exit.1;
+            let max_span = crate::common::ug_max_reach(belt_name) as i32 + 1;
+            if !axis_aligned || span > max_span || !bbox.contains(exit.0, exit.1) {
+                return None;
+            }
             vec![entry, exit]
         }
         EvictionRecipe::AstarLongest { ug_preferred, .. } => {

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3058,6 +3058,64 @@ pub fn route_bus_ghost(
             continue;
         };
 
+        // CONTEXT-CONFLICT check (#652, found via ac7-HS on the RFC-069
+        // flip; round-2 review MOVED this to before corridor_handled /
+        // template_regions / residue-release so the reject path leaves
+        // state identical to the capped-solve branch — the first
+        // placement left a stale CrossingZone region and handled-tile
+        // marks behind on `continue`).
+        // (original note follows) (#652, found via ac7-HS on the RFC-069
+        // flip): a solution entity landing on a Template/RowEntity-claimed
+        // tile whose existing entity DIFFERS (name/direction/io) means the
+        // solution was produced for different surroundings — a cache
+        // signature alias or a zone built against a stale claim view.
+        // The legacy behaviour silently dropped just those tiles, which
+        // mutilates routes (an orphaned UG entrance shipped as a
+        // validator Error; pair- and route-level post-prunes were
+        // prototyped and measured to only relocate the invalidity —
+        // RFC-069 decision log). Identical-entity overlaps remain a
+        // benign dedup (skipped below, as before); CONFLICTING overlaps
+        // reject the whole cluster into the existing cap/retry
+        // machinery, which re-lays with more room instead of committing
+        // a mutilated solution.
+        let context_conflict = sol.entities.iter().any(|ent| {
+            let tile = (ent.x, ent.y);
+            let claimed = matches!(
+                occupancy.claim_at(tile),
+                Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                    | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
+            );
+            claimed
+                && occupancy.entity_at(tile).is_some_and(|existing| {
+                    existing.name != ent.name
+                        || existing.direction != ent.direction
+                        || existing.io_type != ent.io_type
+                        // carries too (review, 3/3): same shape carrying a
+                        // DIFFERENT item is the "solution built for other
+                        // surroundings" class this check exists for — a
+                        // shape-only match would dedup-drop it silently.
+                        || existing.carries != ent.carries
+                })
+        });
+        if context_conflict {
+            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
+                tap_item: String::new(),
+                tap_x: sol.footprint.x,
+                tap_y: sol.footprint.y,
+                reason: "context-conflict at commit: solution collides with                          differing committed entities; cluster capped for retry"
+                    .to_string(),
+            });
+            cap_coords.push(cluster[0]);
+            // Mirror the capped-solve branch's bookkeeping (review): the
+            // cluster's tiles stay in remaining_crossings so the retry
+            // pass (or, failing that, the unresolved-junction reporter)
+            // owns them — without this a conflicting crossing would ship
+            // silently dropped.
+            for &t in cluster {
+                remaining_crossings.insert(t);
+            }
+            continue;
+        }
         // Every cluster member is now handled, regardless of whether
         // it sits inside the solution footprint.
         for &t in cluster {
@@ -3287,58 +3345,6 @@ pub fn route_bus_ghost(
         } else {
             Some(&preserve_fixed_tiles)
         };
-        // CONTEXT-CONFLICT check (#652, found via ac7-HS on the RFC-069
-        // flip): a solution entity landing on a Template/RowEntity-claimed
-        // tile whose existing entity DIFFERS (name/direction/io) means the
-        // solution was produced for different surroundings — a cache
-        // signature alias or a zone built against a stale claim view.
-        // The legacy behaviour silently dropped just those tiles, which
-        // mutilates routes (an orphaned UG entrance shipped as a
-        // validator Error; pair- and route-level post-prunes were
-        // prototyped and measured to only relocate the invalidity —
-        // RFC-069 decision log). Identical-entity overlaps remain a
-        // benign dedup (skipped below, as before); CONFLICTING overlaps
-        // reject the whole cluster into the existing cap/retry
-        // machinery, which re-lays with more room instead of committing
-        // a mutilated solution.
-        let context_conflict = sol.entities.iter().any(|ent| {
-            let tile = (ent.x, ent.y);
-            let claimed = matches!(
-                occupancy.claim_at(tile),
-                Some(crate::bus::ghost_occupancy::Claim::Template { .. })
-                    | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
-            );
-            claimed
-                && occupancy.entity_at(tile).is_some_and(|existing| {
-                    existing.name != ent.name
-                        || existing.direction != ent.direction
-                        || existing.io_type != ent.io_type
-                        // carries too (review, 3/3): same shape carrying a
-                        // DIFFERENT item is the "solution built for other
-                        // surroundings" class this check exists for — a
-                        // shape-only match would dedup-drop it silently.
-                        || existing.carries != ent.carries
-                })
-        });
-        if context_conflict {
-            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
-                tap_item: participating_keys.iter().next().cloned().unwrap_or_default().to_string(),
-                tap_x: footprint.x,
-                tap_y: footprint.y,
-                reason: "context-conflict at commit: solution collides with                          differing committed entities; cluster capped for retry"
-                    .to_string(),
-            });
-            cap_coords.push(cluster[0]);
-            // Mirror the capped-solve branch's bookkeeping (review): the
-            // cluster's tiles stay in remaining_crossings so the retry
-            // pass (or, failing that, the unresolved-junction reporter)
-            // owns them — without this a conflicting crossing would ship
-            // silently dropped.
-            for &t in cluster {
-                remaining_crossings.insert(t);
-            }
-            continue;
-        }
         let released_count =
             occupancy.release_for_pertile_template(&release_rect, None, preserve_ref);
         trace::emit(trace::TraceEvent::GhostResidueCleared {

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3287,6 +3287,45 @@ pub fn route_bus_ghost(
         } else {
             Some(&preserve_fixed_tiles)
         };
+        // CONTEXT-CONFLICT check (#652, found via ac7-HS on the RFC-069
+        // flip): a solution entity landing on a Template/RowEntity-claimed
+        // tile whose existing entity DIFFERS (name/direction/io) means the
+        // solution was produced for different surroundings — a cache
+        // signature alias or a zone built against a stale claim view.
+        // The legacy behaviour silently dropped just those tiles, which
+        // mutilates routes (an orphaned UG entrance shipped as a
+        // validator Error; pair- and route-level post-prunes were
+        // prototyped and measured to only relocate the invalidity —
+        // RFC-069 decision log). Identical-entity overlaps remain a
+        // benign dedup (skipped below, as before); CONFLICTING overlaps
+        // reject the whole cluster into the existing cap/retry
+        // machinery, which re-lays with more room instead of committing
+        // a mutilated solution.
+        let context_conflict = sol.entities.iter().any(|ent| {
+            let tile = (ent.x, ent.y);
+            let claimed = matches!(
+                occupancy.claim_at(tile),
+                Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                    | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
+            );
+            claimed
+                && occupancy.entity_at(tile).is_some_and(|existing| {
+                    existing.name != ent.name
+                        || existing.direction != ent.direction
+                        || existing.io_type != ent.io_type
+                })
+        });
+        if context_conflict {
+            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
+                tap_item: participating_keys.iter().next().cloned().unwrap_or_default().to_string(),
+                tap_x: footprint.x,
+                tap_y: footprint.y,
+                reason: "context-conflict at commit: solution collides with                          differing committed entities; cluster capped for retry"
+                    .to_string(),
+            });
+            cap_coords.push(cluster[0]);
+            continue;
+        }
         let released_count =
             occupancy.release_for_pertile_template(&release_rect, None, preserve_ref);
         trace::emit(trace::TraceEvent::GhostResidueCleared {

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3313,6 +3313,11 @@ pub fn route_bus_ghost(
                     existing.name != ent.name
                         || existing.direction != ent.direction
                         || existing.io_type != ent.io_type
+                        // carries too (review, 3/3): same shape carrying a
+                        // DIFFERENT item is the "solution built for other
+                        // surroundings" class this check exists for — a
+                        // shape-only match would dedup-drop it silently.
+                        || existing.carries != ent.carries
                 })
         });
         if context_conflict {
@@ -3324,6 +3329,14 @@ pub fn route_bus_ghost(
                     .to_string(),
             });
             cap_coords.push(cluster[0]);
+            // Mirror the capped-solve branch's bookkeeping (review): the
+            // cluster's tiles stay in remaining_crossings so the retry
+            // pass (or, failing that, the unresolved-junction reporter)
+            // owns them — without this a conflicting crossing would ship
+            // silently dropped.
+            for &t in cluster {
+                remaining_crossings.insert(t);
+            }
             continue;
         }
         let released_count =

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1716,6 +1716,30 @@ pub(crate) fn prune_dangling_sat_entities(
         .collect();
     let kept = pruned.len();
 
+    // Boundary-port hole guard (review on the hardening PR, 1/3 but
+    // right): if the prune removed an entity that SAT on a non-interior
+    // boundary tile, the perimeter check above (which ran on the
+    // pre-prune set) is retroactively violated — the port's flow entry
+    // vanishes with no downstream to fail visibly. Reject as degenerate
+    // (same semantics as the perimeter check itself): the caller falls
+    // through to the next strategy or caps for retry.
+    if kept < total {
+        let removed_boundary_port = boundaries.iter().any(|b| {
+            !b.interior
+                && by_tile.contains_key(&(b.x, b.y))
+                && !pruned.iter().any(|e| (e.x, e.y) == (b.x, b.y))
+        });
+        if removed_boundary_port {
+            trace::emit(trace::TraceEvent::SatPruned {
+                zone_x,
+                zone_y,
+                total,
+                kept: 0,
+            });
+            return Vec::new();
+        }
+    }
+
     if kept < total {
         if std::env::var("SPAGHETTIO_MEGA_DEBUG").is_ok() {
             for e in entities_dbg
@@ -1994,6 +2018,104 @@ mod tests {
             pruned.len(),
             4,
             "interior-boundary specs should retain their UG endpoints; got {pruned:#?}"
+        );
+    }
+
+    /// #652 hardening: a UG-in whose partner was NEVER EMITTED must be
+    /// pruned — shipping it is invalid geometry by construction (the
+    /// ac7-HS orphan class). The in sits mid-zone (not on a boundary
+    /// port), so the prune returns the rest of the flow rather than
+    /// rejecting the zone.
+    #[test]
+    fn prune_drops_partnerless_ug_in() {
+        let entities = vec![
+            // Valid pair carrying the flow boundary→boundary.
+            ug_in(2, 10, EntityDirection::East, "iron-plate"),
+            ug_out(5, 10, EntityDirection::East, "iron-plate"),
+            // Partner-less entrance on a side spur (never emitted out).
+            ug_in(3, 12, EntityDirection::South, "iron-plate"),
+        ];
+        let boundaries = vec![
+            ZoneBoundary {
+                x: 2, y: 10,
+                direction: EntityDirection::East,
+                item: "iron-plate".into(),
+                is_input: true,
+                interior: false,
+                belt_tier: None,
+                channel_id: 0,
+            },
+            ZoneBoundary {
+                x: 5, y: 10,
+                direction: EntityDirection::East,
+                item: "iron-plate".into(),
+                is_input: false,
+                interior: false,
+                belt_tier: None,
+                channel_id: 0,
+            },
+        ];
+        let pruned = prune_dangling_sat_entities(entities, &boundaries, 6, 0, 0);
+        assert!(
+            !pruned.iter().any(|e| (e.x, e.y) == (3, 12)),
+            "partner-less UG-in must be pruned; got {pruned:#?}"
+        );
+        assert_eq!(
+            pruned.len(),
+            2,
+            "the valid pair must survive; got {pruned:#?}"
+        );
+    }
+
+    /// #652 hardening (review round 1): if pruning would remove an
+    /// entity sitting ON a non-interior boundary port, the zone is
+    /// degenerate — losing the port's entity silently deletes the
+    /// item's entry with nothing downstream to fail visibly. The prune
+    /// must return EMPTY (the caller's degenerate-reject semantics)
+    /// rather than a set missing its port.
+    #[test]
+    fn prune_rejects_zone_when_boundary_port_entity_would_drop() {
+        let entities = vec![
+            // Partner-less UG-in ON the input boundary port itself.
+            ug_in(2, 10, EntityDirection::East, "iron-plate"),
+            // Unrelated valid pair for a second channel.
+            ug_in(2, 12, EntityDirection::East, "copper-cable"),
+            ug_out(5, 12, EntityDirection::East, "copper-cable"),
+        ];
+        let boundaries = vec![
+            ZoneBoundary {
+                x: 2, y: 10,
+                direction: EntityDirection::East,
+                item: "iron-plate".into(),
+                is_input: true,
+                interior: false,
+                belt_tier: None,
+                channel_id: 0,
+            },
+            ZoneBoundary {
+                x: 2, y: 12,
+                direction: EntityDirection::East,
+                item: "copper-cable".into(),
+                is_input: true,
+                interior: false,
+                belt_tier: None,
+                channel_id: 1,
+            },
+            ZoneBoundary {
+                x: 5, y: 12,
+                direction: EntityDirection::East,
+                item: "copper-cable".into(),
+                is_input: false,
+                interior: false,
+                belt_tier: None,
+                channel_id: 1,
+            },
+        ];
+        let pruned = prune_dangling_sat_entities(entities, &boundaries, 6, 0, 0);
+        assert!(
+            pruned.is_empty(),
+            "dropping a boundary-port entity must reject the whole zone as \
+             degenerate; got {pruned:#?}"
         );
     }
 

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1701,6 +1701,45 @@ pub(crate) fn prune_dangling_sat_entities(
             // pruned) is invalid geometry by construction — the ac7-HS
             // flake shipped exactly this as a validator Error. Prune it;
             // the flow it carried fails VISIBLY downstream instead.
+            //
+            // Unit-testability note (review round 2, confirmed by a
+            // mutation probe): for straight-line topologies this branch
+            // is SUBSUMED by base keep + the boundary-port guard (a
+            // partner-less in strands its downstream chain — this BFS
+            // deliberately doesn't walk sideloads — so a port dies and
+            // the zone degenerates first). Its live value is
+            // multi-channel zones where cross-channel propagation keeps
+            // a stranded entrance's tiles reachable (the ac7-HS field
+            // shape); parity_tier4_ac7_horizontal_stack is its
+            // regression anchor.
+            pair_ok.insert((e.x, e.y), false);
+        }
+    }
+    // Symmetric case (round-2 review): a UG-OUT whose entrance was never
+    // emitted can pass both BFS sets (an output boundary port seeds the
+    // upstream walk, and a preceding surface belt feeds the tile in the
+    // downstream walk) and would ship as the same unpaired-UG Error on
+    // the output side. Scan outs BACKWARD for their entrance.
+    for e in &entities {
+        if e.io_type.as_deref() != Some("output") {
+            continue;
+        }
+        if pair_ok.contains_key(&(e.x, e.y)) {
+            continue; // already adjudicated via its entrance's scan
+        }
+        let (dx, dy) = dir_delta(e.direction);
+        let mut found_partner = false;
+        for dist in 1..=(max_reach as i32 + 1) {
+            let nt = (e.x - dx * dist, e.y - dy * dist);
+            if let Some(&ni) = by_tile.get(&nt) {
+                let n = &entities[ni];
+                if n.io_type.as_deref() == Some("input") && n.direction == e.direction {
+                    found_partner = true;
+                    break;
+                }
+            }
+        }
+        if !found_partner {
             pair_ok.insert((e.x, e.y), false);
         }
     }
@@ -2018,52 +2057,6 @@ mod tests {
             pruned.len(),
             4,
             "interior-boundary specs should retain their UG endpoints; got {pruned:#?}"
-        );
-    }
-
-    /// #652 hardening: a UG-in whose partner was NEVER EMITTED must be
-    /// pruned — shipping it is invalid geometry by construction (the
-    /// ac7-HS orphan class). The in sits mid-zone (not on a boundary
-    /// port), so the prune returns the rest of the flow rather than
-    /// rejecting the zone.
-    #[test]
-    fn prune_drops_partnerless_ug_in() {
-        let entities = vec![
-            // Valid pair carrying the flow boundary→boundary.
-            ug_in(2, 10, EntityDirection::East, "iron-plate"),
-            ug_out(5, 10, EntityDirection::East, "iron-plate"),
-            // Partner-less entrance on a side spur (never emitted out).
-            ug_in(3, 12, EntityDirection::South, "iron-plate"),
-        ];
-        let boundaries = vec![
-            ZoneBoundary {
-                x: 2, y: 10,
-                direction: EntityDirection::East,
-                item: "iron-plate".into(),
-                is_input: true,
-                interior: false,
-                belt_tier: None,
-                channel_id: 0,
-            },
-            ZoneBoundary {
-                x: 5, y: 10,
-                direction: EntityDirection::East,
-                item: "iron-plate".into(),
-                is_input: false,
-                interior: false,
-                belt_tier: None,
-                channel_id: 0,
-            },
-        ];
-        let pruned = prune_dangling_sat_entities(entities, &boundaries, 6, 0, 0);
-        assert!(
-            !pruned.iter().any(|e| (e.x, e.y) == (3, 12)),
-            "partner-less UG-in must be pruned; got {pruned:#?}"
-        );
-        assert_eq!(
-            pruned.len(),
-            2,
-            "the valid pair must survive; got {pruned:#?}"
         );
     }
 

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1664,11 +1664,54 @@ pub(crate) fn prune_dangling_sat_entities(
 
     let total = entities.len();
     let entities_dbg = entities.clone();
+    let keep = |e: &PlacedEntity| {
+        let t = (e.x, e.y);
+        reachable_from_input.contains(&t) && reachable_to_output.contains(&t)
+    };
+    // UG-PAIR ATOMICITY (#644 flip campaign): the tile-set keep test
+    // above can retain one half of a UG pair while pruning the other —
+    // a kept entrance whose exit died ships as an "Unpaired underground
+    // belt" validator Error (found on ac7-HS under the duty reshape,
+    // where the flake first reproduced deterministically enough to
+    // trace; the same memory-recorded prune_dangling suspect as the
+    // "SAT solved but item missing" class). A pair lives only if BOTH
+    // halves pass; a half whose partner fails is pruned with it.
+    let mut pair_ok: FxHashMap<(i32, i32), bool> = FxHashMap::default();
+    for e in &entities {
+        if e.io_type.as_deref() != Some("input") {
+            continue;
+        }
+        let (dx, dy) = dir_delta(e.direction);
+        let mut found_partner = false;
+        for dist in 1..=(max_reach as i32 + 1) {
+            let nt = (e.x + dx * dist, e.y + dy * dist);
+            if let Some(&ni) = by_tile.get(&nt) {
+                let n = &entities[ni];
+                if n.io_type.as_deref() == Some("output") && n.direction == e.direction {
+                    let both = keep(e) && keep(n);
+                    pair_ok.insert((e.x, e.y), both);
+                    pair_ok.insert(nt, both);
+                    found_partner = true;
+                    break;
+                }
+            }
+        }
+        if !found_partner {
+            // A UG-in whose partner was NEVER EMITTED (not merely
+            // pruned) is invalid geometry by construction — the ac7-HS
+            // flake shipped exactly this as a validator Error. Prune it;
+            // the flow it carried fails VISIBLY downstream instead.
+            pair_ok.insert((e.x, e.y), false);
+        }
+    }
     let pruned: Vec<PlacedEntity> = entities
         .into_iter()
         .filter(|e| {
-            let t = (e.x, e.y);
-            reachable_from_input.contains(&t) && reachable_to_output.contains(&t)
+            let base = keep(e);
+            match pair_ok.get(&(e.x, e.y)) {
+                Some(&both) => base && both,
+                None => base,
+            }
         })
         .collect();
     let kept = pruned.len();


### PR DESCRIPTION
# Intent

First increment of #652 (the router unit gating RFC-069's default flip): three validity hardenings extracted from the flip campaign's probe spike. Each is correct independent of the flip; the corpus is **bit-neutral** at today's defaults (full suite by exit code: 0, all 26 binaries).

1. **Conflict-aware zone commit** — the commit-time collision filter dropped solution entities tile-by-tile with no route awareness; when the existing entity at a claimed tile DIFFERS (name/direction/io), the solution was produced for different surroundings (cache signature alias / stale claim view) and dropping tiles mutilates routes — the mechanism that shipped an unpaired-UG validator Error on ac7-HS under the duty reshape (root-cause receipts on #652 and in RFC-069's decision log). Conflicting overlaps now reject the whole cluster into the existing cap/retry machinery; identical overlaps stay a benign dedup.
2. **UG-pair atomicity in `prune_dangling_sat_entities`** — a pair lives or dies together, and an entrance whose partner was never emitted is pruned (invalid geometry by construction).
3. **`OppositePairUg` span/axis/bbox guard in eviction** — a 2-tile "jump" beyond the tier's UG reach, off-axis, or exiting the bbox refuses and falls through to the contiguous A* recipes.

Post-hoc pair- and route-level repairs at the commit site were prototyped and measured to only relocate the invalid geometry (orphan-UG → belt-dead-end → hollowed-zone cascade — receipts in the RFC decision log); reject-and-retry is the design that holds.

# Verification

- Full core suite by exit code: 0, all 26 binaries (bit-neutral at default duty — the hardenings only bite on the invalid-geometry classes).
- The motivating defect measured end-to-end on the flip branch: the ac7-HS orphan-UG Error is eliminated by (1) (the cluster caps and re-lays); its remaining red is a different crowding-class defect tracked on #652.
- lib clippy clean (pre-commit hook).

# Deviations

None — #652's remaining scope (stale-zone re-solve semantics, the tier5 mega-zone class, SAT-budget determinism) is explicitly not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n