### PR TITLE
fix(router): #652 PR-2 — deterministic cost descent (stacked on #653)

### DIFF
--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1466,6 +1466,20 @@ impl JunctionStrategy for SatStrategy {
             // round-2 all-or-nothing version was a strict quality
             // regression on oversized zones). Pure function of zone
             // size and cost — reproducibility untouched.
+            //
+            // HONEST LIMIT (round 4): when the clamp actually bites
+            // (natural cap > max_cap_for_bound) and the clamped solve
+            // is UNSAT, that proves nothing about the unexplored band
+            // (max_cap_for_bound, best_cost-1] — the zone keeps its
+            // base cost even if a cheaper layout exists there. That
+            // band is unencodable within the bound, so no deterministic
+            // scheme can probe it; forfeiting descent depth on
+            // oversized zones is the accepted price of boundedness
+            // (on the UNSAT branch the graduated clamp gains nothing
+            // over an outright skip — its gain is the SAT branch).
+            // The interactive "Improve region" pass (region_reimprove,
+            // wall-clock-budgeted, preview-only) can still find those
+            // layouts; it does not write back to the zone cache.
             const MAX_DESCENT_AUX_VARS: u64 = 200_000;
             let tiles = zone.width as u64 * zone.height as u64;
             let max_cap_for_bound = (MAX_DESCENT_AUX_VARS / (11 * tiles.max(1))) as u32;

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1396,17 +1396,25 @@ impl JunctionStrategy for SatStrategy {
             initial_cost.expect("entities_opt is Some here, so initial_cost is Some");
 
         // Cost descent: re-solve with a tighter cost cap until either
-        // UNSAT (current best is optimal at this cap), wall-clock
-        // budget runs out, or iter limit. Descent operates on RAW
-        // SAT output so the cap we compute lines up with what the
-        // encoder sees; pruning happens once at the end.
-        let deadline = web_time::Instant::now()
-            + std::time::Duration::from_millis(effective_budget_ms as u64);
-
+        // UNSAT (current best is optimal at this cap) or the iteration
+        // limit. Descent operates on RAW SAT output so the cap we
+        // compute lines up with what the encoder sees; pruning happens
+        // once at the end.
+        //
+        // DETERMINISM (#652): this loop used to ALSO carry a wall-clock
+        // deadline (`effective_budget_ms`), which made the number of
+        // completed descent iterations — and therefore the chosen
+        // layout — depend on machine speed and build profile. Measured
+        // directly: debug and release builds produced different layouts
+        // for identical inputs (ac7-HS under the RFC-069 reshape), and
+        // this is the recorded 2026-05-02 AC@5 CI-flake class. The
+        // iteration cap (4) is the sole budget now: at most 4 extra
+        // solves per zone, each of the same class as the base solve
+        // that just succeeded — bounded AND reproducible.
+        // `effective_budget_ms` remains only as the cache's
+        // UNSAT-vs-Timeout classification threshold (a bookkeeping
+        // bias between two refusal flavors, noted on #652).
         for descent_iter in 0..self.constraints.cost_descent_max_iters {
-            if web_time::Instant::now() >= deadline {
-                break;
-            }
             let Some(cap) = best_cost.checked_sub(1) else {
                 break; // cost already zero — nothing to tighten
             };

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1133,6 +1133,12 @@ impl JunctionStrategy for SatStrategy {
         // strategy rung won't produce a solution, so we fall through to None
         // immediately rather than re-running the solver.
         use crate::zone_cache::ZoneLookupResult;
+        // Effective budget (env override wins). Post-#652 this is the
+        // UNSAT-vs-Timeout CLASSIFICATION threshold only; computed here
+        // so the cache lookup's Timeout comparison uses the same value
+        // the record side writes.
+        let effective_budget_ms = env_descent_budget_ms()
+            .unwrap_or(self.constraints.cost_descent_budget_ms);
         let cache_result = crate::zone_cache::lookup_zone_result(
             &zone,
             &channel_reaches,
@@ -1147,7 +1153,11 @@ impl JunctionStrategy for SatStrategy {
             // Timeout: re-attempt only if we now have a larger budget;
             // otherwise treat as UNSAT-equivalent (won't finish anyway).
             ZoneLookupResult::Timeout { budget_ms }
-                if *budget_ms >= self.constraints.cost_descent_budget_ms =>
+                // Compare against the EFFECTIVE budget (env override
+                // included) — round-3 review: comparing against the
+                // strategy default made a lowered env budget re-solve
+                // its own Timeout records on every encounter.
+                if *budget_ms >= effective_budget_ms =>
             {
                 return None;
             }
@@ -1237,12 +1247,10 @@ impl JunctionStrategy for SatStrategy {
             }
         }
 
-        // Effective cost-descent budget: env override wins over strategy default.
-        // `SPAGHETTIO_SAT_DESCENT_BUDGET_MS` lets test runs use a shorter
-        // budget (e.g. 20ms) since the cache handles known-UNSAT/timeout zones.
-        // Web app and production binaries leave this unset.
-        let effective_budget_ms = env_descent_budget_ms()
-            .unwrap_or(self.constraints.cost_descent_budget_ms);
+        // (effective_budget_ms is computed before the cache lookup above;
+        // post-#652 it is CLASSIFICATION-only — the descent loop ignores
+        // it entirely. The stale "keeps the descent loop short" account
+        // was removed in round 3.)
 
         // Flow-balance pre-check: a channel with inputs but no outputs (or vice
         // versa) cannot conserve flow, so the zone is UNSAT — but varisat can
@@ -1416,8 +1424,12 @@ impl JunctionStrategy for SatStrategy {
         // for identical inputs (ac7-HS under the RFC-069 reshape), and
         // this is the recorded 2026-05-02 AC@5 CI-flake class. The
         // iteration cap (4) is the sole budget now: at most 4 extra
-        // solves per zone, each of the same class as the base solve
-        // that just succeeded — bounded AND reproducible.
+        // solves per zone — bounded AND reproducible. (The capped
+        // encodings are LARGER than the base solve — see the corrected
+        // hang note below — and additionally bounded by the graduated
+        // size breaker in the loop; round 3 removed this sentence's
+        // original "same class" claim, which the correction below had
+        // contradicted.)
         // `effective_budget_ms` remains only as the cache's
         // UNSAT-vs-Timeout classification threshold (a bookkeeping
         // bias between two refusal flavors, noted on #652).
@@ -1444,18 +1456,23 @@ impl JunctionStrategy for SatStrategy {
             let Some(cap) = best_cost.checked_sub(1) else {
                 break; // cost already zero — nothing to tighten
             };
-            // Deterministic size breaker (#654 round 2): the capped
-            // encoding adds ~11·tiles·cap Sinz auxiliaries. Skip
-            // descent when that blows past a generous bound — a pure
-            // function of zone size and cap, so reproducibility is
-            // untouched. Observed corpus instances sit well under this.
+            // Deterministic size breaker, GRADUATED (#654 rounds 2-3):
+            // the capped encoding adds ~11·tiles·cap Sinz auxiliaries.
+            // Rather than skipping descent outright when the natural
+            // cap (best_cost - 1) blows the bound, clamp the cap DOWN
+            // so the encoding fits — descent caps may jump (any value
+            // below best_cost is a valid tightening), so this attempts
+            // a deeper deterministic cut instead of giving up (the
+            // round-2 all-or-nothing version was a strict quality
+            // regression on oversized zones). Pure function of zone
+            // size and cost — reproducibility untouched.
             const MAX_DESCENT_AUX_VARS: u64 = 200_000;
-            let aux_estimate = 11u64
-                * (zone.width as u64 * zone.height as u64)
-                * cap as u64;
-            if aux_estimate > MAX_DESCENT_AUX_VARS {
-                break;
+            let tiles = zone.width as u64 * zone.height as u64;
+            let max_cap_for_bound = (MAX_DESCENT_AUX_VARS / (11 * tiles.max(1))) as u32;
+            if max_cap_for_bound == 0 {
+                break; // zone too large for ANY capped encoding in bound
             }
+            let cap = cap.min(max_cap_for_bound);
             let (next_opt, next_stats) =
                 crate::sat::solve_crossing_zone_per_channel_with_cost_cap(
                     &zone,

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1422,19 +1422,40 @@ impl JunctionStrategy for SatStrategy {
         // UNSAT-vs-Timeout classification threshold (a bookkeeping
         // bias between two refusal flavors, noted on #652).
         //
-        // Hang-risk rationale (review on the determinism PR): descent
-        // re-solves — including the UNSAT-terminal one — run on a zone
-        // that already passed the `MAX_ZONE_SAT_VARS` ≤ 700 gate, and
-        // that ceiling's own calibration found VARIABLE COUNT (not
-        // clause count) to be the hang discriminator: the observed hang
-        // was 756 vars / 7,871 clauses while 20k+-clause zones solved
-        // in milliseconds. Cost caps add only clauses. So descent
-        // solves sit inside the calibrated-safe var range; the residual
-        // risk is accepted and this note is the record.
+        // Hang-risk rationale, CORRECTED (review round 2 verified that
+        // this note's first version was factually wrong — `encode_cost_cap`
+        // feeds an 11·tiles literal list into the Sinz encoder, which
+        // allocates n·k AUXILIARY variables, so capped solves run at
+        // tens of thousands of vars and the base-encoding 756-var hang
+        // calibration does not apply to them in either direction). The
+        // correct account: the old wall-clock deadline was checked
+        // BETWEEN iterations only — it never interrupted a running
+        // solve (no thread watchdog natively, none possible in WASM) —
+        // so old and new both bound the NUMBER of capped solves
+        // attempted, never a single solve's duration. The iteration cap
+        // (4) bounds attempts deterministically at the same order the
+        // 25ms deadline allowed on release hardware. Residual exposure
+        // vs the old scheme: up to ~3 more attempts of an encoding
+        // class that has empirically never hung (corpus-wide, every
+        // capped solve — including 30k+-aux-var instances — completes
+        // in milliseconds; Sinz chains propagate cheaply). Plus the
+        // deterministic size breaker below.
         for descent_iter in 0..self.constraints.cost_descent_max_iters {
             let Some(cap) = best_cost.checked_sub(1) else {
                 break; // cost already zero — nothing to tighten
             };
+            // Deterministic size breaker (#654 round 2): the capped
+            // encoding adds ~11·tiles·cap Sinz auxiliaries. Skip
+            // descent when that blows past a generous bound — a pure
+            // function of zone size and cap, so reproducibility is
+            // untouched. Observed corpus instances sit well under this.
+            const MAX_DESCENT_AUX_VARS: u64 = 200_000;
+            let aux_estimate = 11u64
+                * (zone.width as u64 * zone.height as u64)
+                * cap as u64;
+            if aux_estimate > MAX_DESCENT_AUX_VARS {
+                break;
+            }
             let (next_opt, next_stats) =
                 crate::sat::solve_crossing_zone_per_channel_with_cost_cap(
                     &zone,

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1480,6 +1480,20 @@ impl JunctionStrategy for SatStrategy {
             // The interactive "Improve region" pass (region_reimprove,
             // wall-clock-budgeted, preview-only) can still find those
             // layouts; it does not write back to the zone cache.
+            //
+            // DORMANCY (round 5, correct arithmetic): under today's
+            // base ceiling (MAX_ZONE_SAT_VARS = 700, gated before any
+            // solve) a zone that reaches this loop has ≤ ~63 tiles
+            // single-channel, so max_cap_for_bound ≈ 288 — far above
+            // any real crossing cost — and the clamp effectively
+            // never bites. The REAL aux bound in the reachable regime
+            // is therefore ~11·63·best_cost ≈ low tens of thousands,
+            // i.e. inside the empirically-exercised envelope; the
+            // loop's boundedness comes from the base ceiling + the
+            // iteration cap, its determinism from the deadline
+            // removal. This clamp's live role is backstopping a
+            // future raise of MAX_ZONE_SAT_VARS (which would
+            // otherwise silently widen descent encodings too).
             const MAX_DESCENT_AUX_VARS: u64 = 200_000;
             let tiles = zone.width as u64 * zone.height as u64;
             let max_cap_for_bound = (MAX_DESCENT_AUX_VARS / (11 * tiles.max(1))) as u32;

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -56,12 +56,16 @@ use crate::trace::{self, BoundarySnapshot, ExternalFeederSnapshot, SatProposedEn
 /// reuses any Timeout entry (a lookup at a strictly larger budget re-attempts).
 const MAX_ZONE_SAT_VARS: u32 = 700;
 
-/// Read the effective cost-descent budget from the environment.
+/// Read the effective descent-budget CLASSIFICATION threshold from the
+/// environment.
 ///
 /// `SPAGHETTIO_SAT_DESCENT_BUDGET_MS` overrides the per-strategy default.
-/// Intended for test runs: the cache handles known-UNSAT/timeout zones, so
-/// new SAT solves are rare and the descent loop can be kept short.  Web app
-/// and production paths leave this unset and use the strategy's own default.
+/// Since #652's determinism change this value no longer bounds the
+/// descent loop (the iteration cap is the sole budget); it survives only
+/// as the cache's UNSAT-vs-Timeout classification threshold — a refusal
+/// recorded as Timeout is re-attempted at larger budgets, one recorded
+/// as Unsat is permanent for the signature. Web app and production
+/// paths leave this unset and use the strategy's own default.
 ///
 /// Parsed once per process (via `OnceLock`) so it's cheap to call per solve.
 #[cfg(not(target_arch = "wasm32"))]
@@ -182,6 +186,9 @@ pub struct SatConstraints {
     /// Wall-clock budget (ms) for the descent loop, checked between
     /// iterations. Prevents pathological zones from blocking the
     /// solver for too long.
+    /// Since #652: CLASSIFICATION-only (UNSAT vs Timeout cache records)
+    /// — the descent loop itself is bounded by `cost_descent_max_iters`
+    /// alone, deterministically.
     pub cost_descent_budget_ms: u32,
     /// Whether to use per-channel native reaches (tight) or the
     /// zone's max tier reach (loose) for UG pairing.
@@ -1414,6 +1421,16 @@ impl JunctionStrategy for SatStrategy {
         // `effective_budget_ms` remains only as the cache's
         // UNSAT-vs-Timeout classification threshold (a bookkeeping
         // bias between two refusal flavors, noted on #652).
+        //
+        // Hang-risk rationale (review on the determinism PR): descent
+        // re-solves — including the UNSAT-terminal one — run on a zone
+        // that already passed the `MAX_ZONE_SAT_VARS` ≤ 700 gate, and
+        // that ceiling's own calibration found VARIABLE COUNT (not
+        // clause count) to be the hang discriminator: the observed hang
+        // was 756 vars / 7,871 clauses while 20k+-clause zones solved
+        // in milliseconds. Cost caps add only clauses. So descent
+        // solves sit inside the calibrated-safe var range; the residual
+        // risk is accepted and this note is the record.
         for descent_iter in 0..self.constraints.cost_descent_max_iters {
             let Some(cap) = best_cost.checked_sub(1) else {
                 break; // cost already zero — nothing to tighten

--- a/crates/core/src/bus/region_reimprove.rs
+++ b/crates/core/src/bus/region_reimprove.rs
@@ -11,10 +11,18 @@
 //! SatStrategy ran through this module — review round 2 caught that
 //! as stale.)
 //!
-//! Both callers want the same contract: start from a known-feasible
-//! entity list, repeatedly call `solve_crossing_zone_with_cost_cap` with
-//! `cap = current_cost - 1`, and report every strictly-cheaper layout
-//! until UNSAT (provably optimal), a deadline, or an iteration cap.
+//! Both callers share the same descent SHAPE — start from a
+//! known-feasible entity list, repeatedly re-solve with
+//! `cap = current_cost - 1`, keep every strictly-cheaper layout —
+//! but NOT the same bounds (round-4 review): this path stops on
+//! UNSAT (provably optimal), a deadline, or an iteration cap, and
+//! uses the natural cap; SatStrategy's inline loop additionally
+//! clamps its cap under a size bound, so there UNSAT can mean
+//! "none at or below the CLAMPED cap" — not proof of optimality.
+//! The interactive path may therefore find layouts the pipeline's
+//! bounded descent forfeits on oversized zones; that gap is the
+//! accepted price of pipeline determinism (its results are
+//! preview-only and are not written back to the zone cache).
 
 use web_time::Instant;
 

--- a/crates/core/src/bus/region_reimprove.rs
+++ b/crates/core/src/bus/region_reimprove.rs
@@ -1,9 +1,13 @@
 //! Cost-descent helper for SAT-solved crossing zones.
 //!
-//! Shared between the in-layout descent pass (a tight ~50 ms budget run
-//! by `SatStrategy`) and the interactive "Improve region" pass exposed
-//! by `wasm-bindings` (up to 10 s, streams each improvement back to the
-//! browser so the user can watch the layout get cheaper).
+//! Shared between the in-layout descent pass (run by `SatStrategy`;
+//! since #652 bounded by ITERATION COUNT alone — deterministic, no
+//! wall-clock deadline) and the interactive "Improve region" pass
+//! exposed by `wasm-bindings` (up to 10 s wall-clock, streams each
+//! improvement back to the browser so the user can watch the layout
+//! get cheaper). The two callers deliberately stop differently —
+//! reproducibility for the pipeline, responsiveness for the
+//! interactive pass.
 //!
 //! Both callers want the same contract: start from a known-feasible
 //! entity list, repeatedly call `solve_crossing_zone_with_cost_cap` with

--- a/crates/core/src/bus/region_reimprove.rs
+++ b/crates/core/src/bus/region_reimprove.rs
@@ -1,13 +1,15 @@
 //! Cost-descent helper for SAT-solved crossing zones.
 //!
-//! Shared between the in-layout descent pass (run by `SatStrategy`;
-//! since #652 bounded by ITERATION COUNT alone — deterministic, no
-//! wall-clock deadline) and the interactive "Improve region" pass
-//! exposed by `wasm-bindings` (up to 10 s wall-clock, streams each
-//! improvement back to the browser so the user can watch the layout
-//! get cheaper). The two callers deliberately stop differently —
-//! reproducibility for the pipeline, responsiveness for the
-//! interactive pass.
+//! Used by the interactive "Improve region" pass exposed by
+//! `wasm-bindings` (up to 10 s wall-clock, streams each improvement
+//! back to the browser so the user can watch the layout get cheaper).
+//! `SatStrategy`'s in-layout descent is a SEPARATE inline loop in
+//! `junction_sat_strategy.rs` — since #652 it is bounded by iteration
+//! count alone (deterministic, no wall-clock), while this interactive
+//! path keeps its deadline: reproducibility for the pipeline,
+//! responsiveness for the user. (An earlier header here claimed
+//! SatStrategy ran through this module — review round 2 caught that
+//! as stale.)
 //!
 //! Both callers want the same contract: start from a known-feasible
 //! entity list, repeatedly call `solve_crossing_zone_with_cost_cap` with

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1137,8 +1137,12 @@ pub enum TraceEvent {
     // on that attempt. `satisfied=true` means SAT found a layout
     // within the cap (descent continues with a tighter cap);
     // `satisfied=false` means UNSAT (descent halts, prior best is
-    // optimal at this cap). Terminal: at most `cost_descent_max_iters`
-    // per winning SAT invocation.
+    // optimal at this cap — note `cap` may have been CLAMPED below
+    // `best_cost - 1` by the descent size breaker, in which case
+    // UNSAT proves nothing about the band between the clamped cap
+    // and the natural one; see the HONEST LIMIT note at the breaker
+    // in `junction_sat_strategy.rs`). Terminal: at most
+    // `cost_descent_max_iters` per winning SAT invocation.
     SatCostDescent {
         seed_x: i32,
         seed_y: i32,

--- a/docs/test-suite-followups.md
+++ b/docs/test-suite-followups.md
@@ -128,6 +128,17 @@ second, independent reason goldens must never be enforced cross-machine
 without pinning the cache: solutions depend not just on cache state but
 on host speed and build optimization level.
 
+**Update 2026-08-15 (#652/#654):** the wall-clock dependence described
+above is fixed — the in-layout descent loop dropped its 25 ms deadline
+and is bounded by iteration count + a size clamp alone, both pure
+functions of the input; debug and release builds were measured
+producing identical layouts on the previously-divergent case. The
+cross-machine golden warning itself still stands, for a narrower
+reason: the zone cache's UNSAT-vs-Timeout *labels* for refused zones
+still derive from measured solve time (recorded on #652), so cache
+content — and therefore warm-replay behavior — can still differ
+across hosts. Fresh solves no longer do.
+
 ### 4. (Low priority) Fresh-worktree compile cost for agents
 
 Worktree-isolated agents pay a from-scratch build (minutes; dominated one


### PR DESCRIPTION
# Intent

Second #652 increment, **stacked on #653** (same file). Removes the SAT cost-descent loop's wall-clock deadline; the existing iteration cap (4) becomes the sole budget — bounded and reproducible.

This is the measured root of the long-recorded layout nondeterminism: the deadline made completed-iteration count (and therefore the chosen zone solution) depend on machine speed and build profile. Debug and release built **different layouts for identical inputs** (ac7-HS under the RFC-069 reshape) — the recorded 2026-05-02 AC@5 CI-flake class ("the layout pipeline *should* be deterministic, but isn't on CI").

`effective_budget_ms` survives only as the cache's UNSAT-vs-Timeout classification threshold (a bookkeeping bias between two refusal flavors, noted on #652).

# Verification

- Full suite by exit code: 0, all 26 binaries, **zero pin/golden drift**, ~2min wall (normal range — at most 4 extra bounded solves per zone).
- Direct receipt: debug and release now build **identical** ac7-HS layouts (109×124 / 2877 entities both; they diverged before this change).

# Deviations

None. Retarget note: if #653 merges first, retarget this to main before deleting the base branch (stacked-PR discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n