### PR TITLE
fix(router): #652 design half — fail-severed unresolved crossings

### DIFF
--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -4287,6 +4287,12 @@ pub fn route_bus_ghost(
             seg.and_then(|s| s.strip_prefix("ghost:"))
                 .is_some_and(|k| unresolved_keys.contains(k))
         };
+        // Known scope gaps, deliberate (session-side review): only a
+        // splitter's PRIMARY tile is keyed here (a feed into the second
+        // tile is invisible to this map), and row-template belts live
+        // in `row_entities`, not `entities`, so a ghost feed into a row
+        // belt cannot sever — the latter is fine per the owner-confirmed
+        // "the engine never side-feeds row input belts".
         let belt_carries_at: FxHashMap<(i32, i32), (Option<String>, bool)> = entities
             .iter()
             .filter(|e| {
@@ -4309,10 +4315,14 @@ pub fn route_bus_ghost(
             if !is_ghost {
                 return true;
             }
-            let is_feeder = e.name.ends_with("transport-belt")
-                || (e.name.ends_with("underground-belt")
-                    && e.io_type.as_deref() == Some("output"));
-            if !is_feeder {
+            // Surface belts ONLY (session-side review): severing a
+            // UG-output would orphan its input, and build_ug_pairs
+            // re-pairs greedily to the NEXT output down the lane —
+            // inventing a tunnel nobody designed, worse than the
+            // error. Measured across both duty-0.6 shapes: every
+            // sever decision was a plain transport-belt, so the
+            // UG-out arm bought nothing and carried the hazard.
+            if !e.name.ends_with("transport-belt") {
                 return true;
             }
             let Some(item) = e.carries.as_deref() else {

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3012,24 +3012,114 @@ pub fn route_bus_ghost(
             &pending_crossings,
         );
 
-        let Some(sol) = junction_solver::solve_crossing(
-            cluster.as_slice(),
-            &keys_at_tile,
-            &routed_paths,
-            &hard_for_junction,
-            &junction_hard,
-            &unreleasable_obstacles,
-            &spec_belt_tiers,
-            &spec_items,
-            &spec_exit_dirs,
-            &spec_kinds,
-            &entities,
-            strategies,
-            &pending_crossings,
-        ) else {
-            // Capped: `solve_crossing` returned `None`, matching the
-            // `JunctionGrowthCapped` event it emitted at this cluster's seed.
-            // Record it for the retry loop (control flow, not the trace stream).
+        // CONFLICT-RETRY solve (#652 design half): `junction_hard` is
+        // snapshotted BEFORE this cluster loop, so a later cluster's
+        // zone can be built blind to entities earlier clusters
+        // committed — SAT then returns a solution that collides with
+        // committed geometry. The conflict check below (#653) detects
+        // that; the fix here re-solves ONCE with the conflicting tiles
+        // added to the strict obstacle set (an obstacle tile is exactly
+        // what UG spans tunnel under, so "taken" is expressible and the
+        // re-solve can still cross). A second conflicting attempt caps
+        // the cluster for the layout-level retry — which is what the
+        // pre-fix path did on the FIRST conflict; since the row-widened
+        // second layout pass hits the same stale-snapshot conflict
+        // deterministically, that shipped the crossing unresolved as a
+        // flat sideload-merge (the 2026-08-15 #652 diagnosis measured
+        // ~90 of ac7-HS-duty-0.6's 111 lane-throughput errors as the
+        // downstream shadow of ONE such merge at (9,97)).
+        // Identical-entity overlaps remain a benign dedup (skipped at
+        // stamping, as before); only DIFFERING overlaps
+        // (name/direction/io/carries — #653 review, 3/3) conflict.
+        let conflict_tiles = |sol_entities: &[crate::models::PlacedEntity],
+                              occ: &crate::bus::ghost_occupancy::Occupancy|
+         -> Vec<(i32, i32)> {
+            sol_entities
+                .iter()
+                .filter(|ent| {
+                    let tile = (ent.x, ent.y);
+                    let claimed = matches!(
+                        occ.claim_at(tile),
+                        Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                            | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
+                    );
+                    claimed
+                        && occ.entity_at(tile).is_some_and(|existing| {
+                            existing.name != ent.name
+                                || existing.direction != ent.direction
+                                || existing.io_type != ent.io_type
+                                || existing.carries != ent.carries
+                        })
+                })
+                .map(|ent| (ent.x, ent.y))
+                .collect()
+        };
+        let mut sol_opt: Option<junction_solver::JunctionSolution> = None;
+        let mut conflict_obstacles: FxHashSet<(i32, i32)> = FxHashSet::default();
+        for attempt in 0..2u8 {
+            let strict_aug;
+            let strict: &FxHashSet<(i32, i32)> = if conflict_obstacles.is_empty() {
+                &junction_hard
+            } else {
+                let mut aug = junction_hard.clone();
+                aug.extend(conflict_obstacles.iter().copied());
+                strict_aug = aug;
+                &strict_aug
+            };
+            let Some(s) = junction_solver::solve_crossing(
+                cluster.as_slice(),
+                &keys_at_tile,
+                &routed_paths,
+                &hard_for_junction,
+                strict,
+                &unreleasable_obstacles,
+                &spec_belt_tiers,
+                &spec_items,
+                &spec_exit_dirs,
+                &spec_kinds,
+                &entities,
+                strategies,
+                &pending_crossings,
+            ) else {
+                // Capped: `solve_crossing` returned `None`, matching the
+                // `JunctionGrowthCapped` event it emitted at this
+                // cluster's seed. Fall through to the cap below.
+                break;
+            };
+            let conflicts = conflict_tiles(&s.entities, &occupancy);
+            if conflicts.is_empty() {
+                sol_opt = Some(s);
+                break;
+            }
+            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
+                tap_item: String::new(),
+                tap_x: s.footprint.x,
+                tap_y: s.footprint.y,
+                reason: {
+                    let mut sample = conflicts.clone();
+                    sample.truncate(4);
+                    if attempt == 0 {
+                        format!(
+                            "context-conflict at commit ({} tiles, {:?}); re-solving \
+                             with conflict tiles as strict obstacles",
+                            conflicts.len(),
+                            sample
+                        )
+                    } else {
+                        format!(
+                            "context-conflict persists after obstacle-augmented \
+                             re-solve ({} tiles, {:?}); cluster capped for retry",
+                            conflicts.len(),
+                            sample
+                        )
+                    }
+                },
+            });
+            conflict_obstacles.extend(conflicts);
+        }
+        let Some(sol) = sol_opt else {
+            // Solver refusal or twice-conflicted solution: record for the
+            // layout-level retry loop (control flow, not the trace stream).
             cap_coords.push(cluster[0]);
             // Diagnostic: when SPAGHETTIO_BLAME_JUNCTIONS=1 is set,
             // identify which spec's removal would let the cluster
@@ -3052,70 +3142,16 @@ pub fn route_bus_ghost(
                     &pending_crossings,
                 );
             }
+            // The cluster's tiles stay in remaining_crossings so the
+            // retry pass (or, failing that, the unresolved-junction
+            // reporter + the fail-sever pass in Step 6b) owns them —
+            // without this a conflicting crossing would ship silently
+            // dropped.
             for &t in cluster {
                 remaining_crossings.insert(t);
             }
             continue;
         };
-
-        // CONTEXT-CONFLICT check (#652, found via ac7-HS on the RFC-069
-        // flip; round-2 review MOVED this to before corridor_handled /
-        // template_regions / residue-release so the reject path leaves
-        // state identical to the capped-solve branch — the first
-        // placement left a stale CrossingZone region and handled-tile
-        // marks behind on `continue`).
-        // (original note follows) (#652, found via ac7-HS on the RFC-069
-        // flip): a solution entity landing on a Template/RowEntity-claimed
-        // tile whose existing entity DIFFERS (name/direction/io) means the
-        // solution was produced for different surroundings — a cache
-        // signature alias or a zone built against a stale claim view.
-        // The legacy behaviour silently dropped just those tiles, which
-        // mutilates routes (an orphaned UG entrance shipped as a
-        // validator Error; pair- and route-level post-prunes were
-        // prototyped and measured to only relocate the invalidity —
-        // RFC-069 decision log). Identical-entity overlaps remain a
-        // benign dedup (skipped below, as before); CONFLICTING overlaps
-        // reject the whole cluster into the existing cap/retry
-        // machinery, which re-lays with more room instead of committing
-        // a mutilated solution.
-        let context_conflict = sol.entities.iter().any(|ent| {
-            let tile = (ent.x, ent.y);
-            let claimed = matches!(
-                occupancy.claim_at(tile),
-                Some(crate::bus::ghost_occupancy::Claim::Template { .. })
-                    | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
-            );
-            claimed
-                && occupancy.entity_at(tile).is_some_and(|existing| {
-                    existing.name != ent.name
-                        || existing.direction != ent.direction
-                        || existing.io_type != ent.io_type
-                        // carries too (review, 3/3): same shape carrying a
-                        // DIFFERENT item is the "solution built for other
-                        // surroundings" class this check exists for — a
-                        // shape-only match would dedup-drop it silently.
-                        || existing.carries != ent.carries
-                })
-        });
-        if context_conflict {
-            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
-                tap_item: String::new(),
-                tap_x: sol.footprint.x,
-                tap_y: sol.footprint.y,
-                reason: "context-conflict at commit: solution collides with                          differing committed entities; cluster capped for retry"
-                    .to_string(),
-            });
-            cap_coords.push(cluster[0]);
-            // Mirror the capped-solve branch's bookkeeping (review): the
-            // cluster's tiles stay in remaining_crossings so the retry
-            // pass (or, failing that, the unresolved-junction reporter)
-            // owns them — without this a conflicting crossing would ship
-            // silently dropped.
-            for &t in cluster {
-                remaining_crossings.insert(t);
-            }
-            continue;
-        }
         // Every cluster member is now handled, regardless of whether
         // it sits inside the solution footprint.
         for &t in cluster {
@@ -3472,6 +3508,88 @@ pub fn route_bus_ghost(
             "ghost router: {} unresolved crossings (junction solver strategies exhausted)",
             remaining_crossings.len()
         ));
+    }
+
+    // FAIL-SEVERED fallback (#652 design half): an unresolved crossing
+    // must not ship as a flat sideload-merge. A feeder belt whose facing
+    // tile is an unresolved crossing tile occupied by a belt carrying a
+    // DIFFERENT item would, in game, dump its whole flow onto one lane
+    // of the crossed belt — mixing items and overloading the lane. The
+    // 2026-08-15 #652 diagnosis measured a single such merge fanning out
+    // as ~90 downstream lane-throughput errors (ac7-HS at duty 0.6) and
+    // tier5's accumulating 24→77/s cascade. Dropping the feeder makes
+    // the flow dead-end one tile short: starved consumers fail VISIBLY
+    // (input-rate-delivery, meter, sim) and the unresolved-junction
+    // region still reports the root cause. Scoped to unresolved-cluster
+    // tiles so item-mixing created by any OTHER path still reaches the
+    // validator (belt-item-isolation) instead of being silently tidied.
+    // (The severed tile's Occupancy claim is left in place — after this
+    // point only pole placement consults it, where "occupied" is safe.)
+    if !remaining_crossings.is_empty() {
+        // Specs whose routed path runs through an unresolved crossing:
+        // their ghost belts are the ones a failed crossing leaves
+        // pointing at (or crossing flat through) other flows. Mixing is
+        // severed anywhere along an unresolved spec's route (either
+        // side of the feed), not just at the cluster tiles — the ac7
+        // (15,124) cluster's failed specs mixed with EACH OTHER ten
+        // tiles below the cluster.
+        let unresolved_keys: FxHashSet<&str> = routed_paths
+            .iter()
+            .filter(|(_, path)| path.iter().any(|t| remaining_crossings.contains(t)))
+            .map(|(k, _)| k.as_str())
+            .collect();
+        let unresolved_seg = |seg: Option<&str>| -> bool {
+            seg.and_then(|s| s.strip_prefix("ghost:"))
+                .is_some_and(|k| unresolved_keys.contains(k))
+        };
+        let belt_carries_at: FxHashMap<(i32, i32), (Option<String>, bool)> = entities
+            .iter()
+            .filter(|e| {
+                e.name.ends_with("transport-belt")
+                    || e.name.ends_with("underground-belt")
+                    || e.name.ends_with("splitter")
+            })
+            .map(|e| {
+                (
+                    (e.x, e.y),
+                    (e.carries.clone(), unresolved_seg(e.segment_id.as_deref())),
+                )
+            })
+            .collect();
+        entities.retain(|e| {
+            let is_feeder = e.name.ends_with("transport-belt")
+                || (e.name.ends_with("underground-belt")
+                    && e.io_type.as_deref() == Some("output"));
+            if !is_feeder {
+                return true;
+            }
+            let Some(item) = e.carries.as_deref() else {
+                return true;
+            };
+            let (dx, dy) = crate::common::dir_to_vec(e.direction);
+            let facing = (e.x + dx, e.y + dy);
+            let Some((target_carries, target_unresolved)) = belt_carries_at.get(&facing)
+            else {
+                return true;
+            };
+            let differing = matches!(target_carries, Some(other) if other != item);
+            if !differing {
+                return true;
+            }
+            let in_scope = remaining_crossings.contains(&facing)
+                || *target_unresolved
+                || unresolved_seg(e.segment_id.as_deref());
+            if !in_scope {
+                return true;
+            }
+            trace::emit(trace::TraceEvent::CrossingSevered {
+                x: e.x,
+                y: e.y,
+                item: item.to_string(),
+                into_item: target_carries.clone().unwrap_or_default(),
+            });
+            false
+        });
     }
 
     // Step 6: sync `entities` to Occupancy's released state.

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3482,7 +3482,6 @@ pub fn route_bus_ghost(
         ));
     }
 
-
     // Step 6: sync `entities` to Occupancy's released state.
     //
     // Templates and SAT write to both `entities` and Occupancy during
@@ -4284,8 +4283,27 @@ pub fn route_bus_ghost(
             .map(|(k, _)| k.as_str())
             .collect();
         let unresolved_seg = |seg: Option<&str>| -> bool {
-            seg.and_then(|s| s.strip_prefix("ghost:"))
-                .is_some_and(|k| unresolved_keys.contains(k))
+            let Some(k) = seg.and_then(|s| s.strip_prefix("ghost:")) else {
+                return false;
+            };
+            if unresolved_keys.contains(k) {
+                return true;
+            }
+            // Last-tap alias (#655 round 3): the unified-spec pass folds
+            // the last tap's `tap:{item}:{x}:{y}` key (and its trunk)
+            // into `flow:{item}:{x}` in `routed_paths`, but the tap's
+            // belts were stamped with the ORIGINAL key — without this
+            // alias a last-tap feeder is invisible to the spec-scoped
+            // clauses and only severs when it faces a crossing tile
+            // exactly.
+            if let Some(rest) = k.strip_prefix("tap:") {
+                let mut it = rest.rsplitn(2, ':');
+                let _y = it.next();
+                if let Some(item_x) = it.next() {
+                    return unresolved_keys.contains(format!("flow:{item_x}").as_str());
+                }
+            }
+            false
         };
         // Known scope gaps, deliberate (session-side review): only a
         // splitter's PRIMARY tile is keyed here (a feed into the second
@@ -4334,6 +4352,11 @@ pub fn route_bus_ghost(
             else {
                 return true;
             };
+            // A facing belt with NO carries stamp keeps the feed (round-3
+            // review): item difference is undecidable without a stamp, and
+            // severing on "unknown" would tidy legitimate joins. Belts are
+            // normally stamped; an unstamped mixing target still reaches
+            // the validator's adjacency checks.
             let Some(other) = target_carries.as_deref() else {
                 return true;
             };

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3012,114 +3012,47 @@ pub fn route_bus_ghost(
             &pending_crossings,
         );
 
-        // CONFLICT-RETRY solve (#652 design half): `junction_hard` is
-        // snapshotted BEFORE this cluster loop, so a later cluster's
-        // zone can be built blind to entities earlier clusters
-        // committed — SAT then returns a solution that collides with
-        // committed geometry. The conflict check below (#653) detects
-        // that; the fix here re-solves ONCE with the conflicting tiles
-        // added to the strict obstacle set (an obstacle tile is exactly
-        // what UG spans tunnel under, so "taken" is expressible and the
-        // re-solve can still cross). A second conflicting attempt caps
-        // the cluster for the layout-level retry — which is what the
-        // pre-fix path did on the FIRST conflict; since the row-widened
-        // second layout pass hits the same stale-snapshot conflict
-        // deterministically, that shipped the crossing unresolved as a
-        // flat sideload-merge (the 2026-08-15 #652 diagnosis measured
-        // ~90 of ac7-HS-duty-0.6's 111 lane-throughput errors as the
-        // downstream shadow of ONE such merge at (9,97)).
-        // Identical-entity overlaps remain a benign dedup (skipped at
-        // stamping, as before); only DIFFERING overlaps
-        // (name/direction/io/carries — #653 review, 3/3) conflict.
-        let conflict_tiles = |sol_entities: &[crate::models::PlacedEntity],
-                              occ: &crate::bus::ghost_occupancy::Occupancy|
-         -> Vec<(i32, i32)> {
-            sol_entities
-                .iter()
-                .filter(|ent| {
-                    let tile = (ent.x, ent.y);
-                    let claimed = matches!(
-                        occ.claim_at(tile),
-                        Some(crate::bus::ghost_occupancy::Claim::Template { .. })
-                            | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
-                    );
-                    claimed
-                        && occ.entity_at(tile).is_some_and(|existing| {
-                            existing.name != ent.name
-                                || existing.direction != ent.direction
-                                || existing.io_type != ent.io_type
-                                || existing.carries != ent.carries
-                        })
-                })
-                .map(|ent| (ent.x, ent.y))
-                .collect()
-        };
-        let mut sol_opt: Option<junction_solver::JunctionSolution> = None;
-        let mut conflict_obstacles: FxHashSet<(i32, i32)> = FxHashSet::default();
-        for attempt in 0..2u8 {
-            let strict_aug;
-            let strict: &FxHashSet<(i32, i32)> = if conflict_obstacles.is_empty() {
-                &junction_hard
-            } else {
-                let mut aug = junction_hard.clone();
-                aug.extend(conflict_obstacles.iter().copied());
-                strict_aug = aug;
-                &strict_aug
-            };
-            let Some(s) = junction_solver::solve_crossing(
-                cluster.as_slice(),
-                &keys_at_tile,
-                &routed_paths,
-                &hard_for_junction,
-                strict,
-                &unreleasable_obstacles,
-                &spec_belt_tiers,
-                &spec_items,
-                &spec_exit_dirs,
-                &spec_kinds,
-                &entities,
-                strategies,
-                &pending_crossings,
-            ) else {
-                // Capped: `solve_crossing` returned `None`, matching the
-                // `JunctionGrowthCapped` event it emitted at this
-                // cluster's seed. Fall through to the cap below.
-                break;
-            };
-            let conflicts = conflict_tiles(&s.entities, &occupancy);
-            if conflicts.is_empty() {
-                sol_opt = Some(s);
-                break;
-            }
-            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
-                tap_item: String::new(),
-                tap_x: s.footprint.x,
-                tap_y: s.footprint.y,
-                reason: {
-                    let mut sample = conflicts.clone();
-                    sample.truncate(4);
-                    if attempt == 0 {
-                        format!(
-                            "context-conflict at commit ({} tiles, {:?}); re-solving \
-                             with conflict tiles as strict obstacles",
-                            conflicts.len(),
-                            sample
-                        )
-                    } else {
-                        format!(
-                            "context-conflict persists after obstacle-augmented \
-                             re-solve ({} tiles, {:?}); cluster capped for retry",
-                            conflicts.len(),
-                            sample
-                        )
-                    }
-                },
-            });
-            conflict_obstacles.extend(conflicts);
-        }
-        let Some(sol) = sol_opt else {
-            // Solver refusal or twice-conflicted solution: record for the
-            // layout-level retry loop (control flow, not the trace stream).
+        // Solve, then CONTEXT-CONFLICT check (#652/#653): `junction_hard`
+        // is snapshotted before this cluster loop, so a later cluster's
+        // zone can be solved blind to entities earlier clusters
+        // committed — a solution entity landing on a Template/RowEntity-
+        // claimed tile whose existing entity DIFFERS
+        // (name/direction/io/carries) means the solution was produced
+        // for different surroundings. Identical-entity overlaps remain a
+        // benign dedup (skipped at stamping); CONFLICTING overlaps
+        // reject the whole cluster into the cap/retry machinery.
+        //
+        // NO local re-solve is attempted (review on the fail-safe PR
+        // measured the obvious one as a deterministic no-op): adding the
+        // conflict tiles to `strict_obstacles` is filtered back out by
+        // `refresh_forbidden`'s surface-belt exemption (SAT is allowed
+        // to re-stamp surface belts — the benign identical re-derivation
+        // depends on it), and the zone cache's signature excludes the
+        // obstacle sets, so an unchanged zone replays the identical
+        // cached solution. A retry with teeth needs a
+        // forbidden-regardless-of-kind override threaded through
+        // `GrowingRegion` plus a cache-signature extension — recorded on
+        // #652. Until then a conflicted cluster caps for the
+        // layout-level retry and, failing that, is owned by the
+        // unresolved-junction reporter + the fail-sever pass.
+        let Some(sol) = junction_solver::solve_crossing(
+            cluster.as_slice(),
+            &keys_at_tile,
+            &routed_paths,
+            &hard_for_junction,
+            &junction_hard,
+            &unreleasable_obstacles,
+            &spec_belt_tiers,
+            &spec_items,
+            &spec_exit_dirs,
+            &spec_kinds,
+            &entities,
+            strategies,
+            &pending_crossings,
+        ) else {
+            // Capped: `solve_crossing` returned `None`, matching the
+            // `JunctionGrowthCapped` event it emitted at this cluster's seed.
+            // Record it for the retry loop (control flow, not the trace stream).
             cap_coords.push(cluster[0]);
             // Diagnostic: when SPAGHETTIO_BLAME_JUNCTIONS=1 is set,
             // identify which spec's removal would let the cluster
@@ -3142,16 +3075,55 @@ pub fn route_bus_ghost(
                     &pending_crossings,
                 );
             }
-            // The cluster's tiles stay in remaining_crossings so the
-            // retry pass (or, failing that, the unresolved-junction
-            // reporter + the fail-sever pass in Step 6b) owns them —
-            // without this a conflicting crossing would ship silently
-            // dropped.
             for &t in cluster {
                 remaining_crossings.insert(t);
             }
             continue;
         };
+        let conflicts: Vec<(i32, i32)> = sol
+            .entities
+            .iter()
+            .filter(|ent| {
+                let tile = (ent.x, ent.y);
+                let claimed = matches!(
+                    occupancy.claim_at(tile),
+                    Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                        | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
+                );
+                claimed
+                    && occupancy.entity_at(tile).is_some_and(|existing| {
+                        existing.name != ent.name
+                            || existing.direction != ent.direction
+                            || existing.io_type != ent.io_type
+                            || existing.carries != ent.carries
+                    })
+            })
+            .map(|ent| (ent.x, ent.y))
+            .collect();
+        if !conflicts.is_empty() {
+            let mut sample = conflicts.clone();
+            sample.truncate(4);
+            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
+                tap_item: String::new(),
+                tap_x: sol.footprint.x,
+                tap_y: sol.footprint.y,
+                reason: format!(
+                    "context-conflict at commit ({} tiles, {:?}): solution collides \
+                     with differing committed entities; cluster capped for retry",
+                    conflicts.len(),
+                    sample
+                ),
+            });
+            cap_coords.push(cluster[0]);
+            // The cluster's tiles stay in remaining_crossings so the
+            // retry pass (or, failing that, the unresolved-junction
+            // reporter + the fail-sever pass) owns them — without this a
+            // conflicting crossing would ship silently dropped.
+            for &t in cluster {
+                remaining_crossings.insert(t);
+            }
+            continue;
+        }
         // Every cluster member is now handled, regardless of whether
         // it sits inside the solution footprint.
         for &t in cluster {
@@ -3510,87 +3482,6 @@ pub fn route_bus_ghost(
         ));
     }
 
-    // FAIL-SEVERED fallback (#652 design half): an unresolved crossing
-    // must not ship as a flat sideload-merge. A feeder belt whose facing
-    // tile is an unresolved crossing tile occupied by a belt carrying a
-    // DIFFERENT item would, in game, dump its whole flow onto one lane
-    // of the crossed belt — mixing items and overloading the lane. The
-    // 2026-08-15 #652 diagnosis measured a single such merge fanning out
-    // as ~90 downstream lane-throughput errors (ac7-HS at duty 0.6) and
-    // tier5's accumulating 24→77/s cascade. Dropping the feeder makes
-    // the flow dead-end one tile short: starved consumers fail VISIBLY
-    // (input-rate-delivery, meter, sim) and the unresolved-junction
-    // region still reports the root cause. Scoped to unresolved-cluster
-    // tiles so item-mixing created by any OTHER path still reaches the
-    // validator (belt-item-isolation) instead of being silently tidied.
-    // (The severed tile's Occupancy claim is left in place — after this
-    // point only pole placement consults it, where "occupied" is safe.)
-    if !remaining_crossings.is_empty() {
-        // Specs whose routed path runs through an unresolved crossing:
-        // their ghost belts are the ones a failed crossing leaves
-        // pointing at (or crossing flat through) other flows. Mixing is
-        // severed anywhere along an unresolved spec's route (either
-        // side of the feed), not just at the cluster tiles — the ac7
-        // (15,124) cluster's failed specs mixed with EACH OTHER ten
-        // tiles below the cluster.
-        let unresolved_keys: FxHashSet<&str> = routed_paths
-            .iter()
-            .filter(|(_, path)| path.iter().any(|t| remaining_crossings.contains(t)))
-            .map(|(k, _)| k.as_str())
-            .collect();
-        let unresolved_seg = |seg: Option<&str>| -> bool {
-            seg.and_then(|s| s.strip_prefix("ghost:"))
-                .is_some_and(|k| unresolved_keys.contains(k))
-        };
-        let belt_carries_at: FxHashMap<(i32, i32), (Option<String>, bool)> = entities
-            .iter()
-            .filter(|e| {
-                e.name.ends_with("transport-belt")
-                    || e.name.ends_with("underground-belt")
-                    || e.name.ends_with("splitter")
-            })
-            .map(|e| {
-                (
-                    (e.x, e.y),
-                    (e.carries.clone(), unresolved_seg(e.segment_id.as_deref())),
-                )
-            })
-            .collect();
-        entities.retain(|e| {
-            let is_feeder = e.name.ends_with("transport-belt")
-                || (e.name.ends_with("underground-belt")
-                    && e.io_type.as_deref() == Some("output"));
-            if !is_feeder {
-                return true;
-            }
-            let Some(item) = e.carries.as_deref() else {
-                return true;
-            };
-            let (dx, dy) = crate::common::dir_to_vec(e.direction);
-            let facing = (e.x + dx, e.y + dy);
-            let Some((target_carries, target_unresolved)) = belt_carries_at.get(&facing)
-            else {
-                return true;
-            };
-            let differing = matches!(target_carries, Some(other) if other != item);
-            if !differing {
-                return true;
-            }
-            let in_scope = remaining_crossings.contains(&facing)
-                || *target_unresolved
-                || unresolved_seg(e.segment_id.as_deref());
-            if !in_scope {
-                return true;
-            }
-            trace::emit(trace::TraceEvent::CrossingSevered {
-                x: e.x,
-                y: e.y,
-                item: item.to_string(),
-                into_item: target_carries.clone().unwrap_or_default(),
-            });
-            false
-        });
-    }
 
     // Step 6: sync `entities` to Occupancy's released state.
     //
@@ -4358,6 +4249,101 @@ pub fn route_bus_ghost(
                 }
             }
         }
+    }
+
+    // FAIL-SEVERED fallback (#652 design half, FINAL pass — runs after
+    // Step 7 / tier renames so no later phase can stamp over a severed
+    // tile and resurrect the merge, and so `existing_tiles` snapshots
+    // taken from `entities` never disagree with it): an unresolved
+    // crossing must not ship as a flat sideload-merge. A GHOST feeder
+    // belt whose facing tile holds a belt carrying a DIFFERENT item
+    // would, in game, dump its whole flow onto one lane of the crossed
+    // belt — mixing items and overloading the lane. The 2026-08-15
+    // #652 diagnosis measured a single such merge fanning out as ~90
+    // downstream lane-throughput errors (ac7-HS at duty 0.6) and
+    // tier5's accumulating 24→77/s cascade. Dropping the feeder makes
+    // the flow dead-end one tile short: starved consumers fail VISIBLY
+    // (belt-dead-end, input-rate-delivery, meter, sim) and the
+    // unresolved-junction region still reports the root cause.
+    //
+    // Scope (review on the fail-safe PR tightened this): ONLY
+    // `ghost:`-segment entities are ever severed — committed trunk,
+    // balancer, tapoff, crossing and merger geometry is never dropped,
+    // however it mixes (mixing there still reaches the validator as
+    // belt-item-isolation; the balancer-over-trunk overlap is a
+    // recorded #652 residual). Within ghost geometry, a feed severs
+    // when it faces an unresolved-cluster tile or when either side
+    // belongs to a spec whose route runs through one (the ac7 (15,124)
+    // cluster's failed specs mixed with EACH OTHER ten tiles below the
+    // cluster). The severed tiles' Occupancy claims are left in place;
+    // nothing after this pass consults Occupancy for stamping.
+    if !remaining_crossings.is_empty() {
+        let unresolved_keys: FxHashSet<&str> = routed_paths
+            .iter()
+            .filter(|(_, path)| path.iter().any(|t| remaining_crossings.contains(t)))
+            .map(|(k, _)| k.as_str())
+            .collect();
+        let unresolved_seg = |seg: Option<&str>| -> bool {
+            seg.and_then(|s| s.strip_prefix("ghost:"))
+                .is_some_and(|k| unresolved_keys.contains(k))
+        };
+        let belt_carries_at: FxHashMap<(i32, i32), (Option<String>, bool)> = entities
+            .iter()
+            .filter(|e| {
+                e.name.ends_with("transport-belt")
+                    || e.name.ends_with("underground-belt")
+                    || e.name.ends_with("splitter")
+            })
+            .map(|e| {
+                (
+                    (e.x, e.y),
+                    (e.carries.clone(), unresolved_seg(e.segment_id.as_deref())),
+                )
+            })
+            .collect();
+        entities.retain(|e| {
+            let is_ghost = e
+                .segment_id
+                .as_deref()
+                .is_some_and(|seg| seg.starts_with("ghost:"));
+            if !is_ghost {
+                return true;
+            }
+            let is_feeder = e.name.ends_with("transport-belt")
+                || (e.name.ends_with("underground-belt")
+                    && e.io_type.as_deref() == Some("output"));
+            if !is_feeder {
+                return true;
+            }
+            let Some(item) = e.carries.as_deref() else {
+                return true;
+            };
+            let (dx, dy) = crate::common::dir_to_vec(e.direction);
+            let facing = (e.x + dx, e.y + dy);
+            let Some((target_carries, target_unresolved)) = belt_carries_at.get(&facing)
+            else {
+                return true;
+            };
+            let Some(other) = target_carries.as_deref() else {
+                return true;
+            };
+            if other == item {
+                return true;
+            }
+            let in_scope = remaining_crossings.contains(&facing)
+                || *target_unresolved
+                || unresolved_seg(e.segment_id.as_deref());
+            if !in_scope {
+                return true;
+            }
+            trace::emit(trace::TraceEvent::CrossingSevered {
+                x: e.x,
+                y: e.y,
+                item: item.to_string(),
+                into_item: other.to_string(),
+            });
+            false
+        });
     }
 
     // -------------------------------------------------------------------------

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -452,6 +452,18 @@ pub enum TraceEvent {
         tap_y: i32,
         reason: String,
     },
+    /// #652 fail-sever: an unresolved crossing's feeder belt pointed
+    /// into a belt carrying a DIFFERENT item (a flat sideload-merge —
+    /// the shape that dumps one flow onto a lane of another and fans
+    /// out as mass downstream lane-throughput errors). The feeder was
+    /// dropped so the flow dead-ends visibly one tile short instead.
+    /// One event per severed feeder entity.
+    CrossingSevered {
+        x: i32,
+        y: i32,
+        item: String,
+        into_item: String,
+    },
     /// A balancer block was requested for a lane family. `template_found
     /// == false` is not necessarily a bug by itself — it means no direct
     /// template, gcd-decomposition, nor the runtime generator could

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2237,6 +2237,57 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
     }
 }
 
+/// #652 fail-safe pin: ac7-HS at duty 0.6 (the RFC-069 flip shape) with
+/// unresolved crossings must fail SAFE, never merged. Pre-fix, one
+/// unrouted iron-plate crossing shipped as a flat sideload-merge into
+/// the copper-cable trunk and fanned out as ~90 downstream
+/// lane-throughput errors (111 total; #652 diagnosis 2026-08-15); the
+/// conflict-retry + fail-sever pass converts that to severed dead-ends
+/// plus the honest unresolved-junction reports. The pin is the
+/// invariant the fix guarantees — ZERO lane-throughput errors — which
+/// holds regardless of whether the crossings themselves later get
+/// resolved (then severs simply stop firing). Isolation errors are NOT
+/// pinned here: a residual balancer-over-trunk overlap (recorded on
+/// #652) still ships a handful, and that mechanism is out of this
+/// pin's scope.
+#[test]
+#[ntest::timeout(300000)]
+fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
+    use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions, RowLayout};
+
+    let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "coal", "water", "crude-oil"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let sr = solver::solve("advanced-circuit", 7.0, &inputs, "assembling-machine-2")
+        .expect("ac7 solves");
+    let layout = build_bus_layout(
+        &sr,
+        LayoutOptions {
+            max_belt_tier: Some("transport-belt".to_string()),
+            row_layout: RowLayout::HorizontalStack,
+            planning_duty: 0.6,
+            ..Default::default()
+        },
+    )
+    .expect("ac7 duty-0.6 lays out");
+    let issues = match validate::validate(&layout, Some(&sr), LayoutStyle::Bus) {
+        Ok(v) => v,
+        Err(e) => e.issues,
+    };
+    let lane_errors: Vec<&ValidationIssue> = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error && i.category == "lane-throughput")
+        .collect();
+    assert!(
+        lane_errors.is_empty(),
+        "ac7-HS duty-0.6 shipped {} lane-throughput errors — an unresolved \
+         crossing is merging flows again (fail-severed regressed): {:#?}",
+        lane_errors.len(),
+        lane_errors.iter().take(5).collect::<Vec<_>>()
+    );
+}
+
 /// Regression test for the `place_poles` rightward-only probe bug.
 /// `processing-unit @ 2.5/s` HorizontalStack puts six AM3s tight in one
 /// row with a 3-tile sideload bridge below the middle pair. The pole

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2293,9 +2293,7 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
     );
     // Anti-vacuity (review): the zero above must come from the fail-safe
     // actually engaging, not from the fixture drifting to a shape where
-    // nothing needed severing while merges ship elsewhere. Either every
-    // crossing resolved (no unresolved-junction errors — the fully-fixed
-    // future) or at least one feeder was severed.
+    // nothing needed severing while merges ship elsewhere.
     let unresolved = issues
         .iter()
         .filter(|i| i.severity == Severity::Error && i.category == "unresolved-junction")
@@ -2305,6 +2303,17 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
         "ac7-HS duty-0.6 has {unresolved} unresolved crossings but the \
          fail-sever pass dropped nothing — the zero-lane-error result is \
          vacuous (sever scope regressed?)"
+    );
+    // LIVENESS (session-side review): if this trips, the pin has stopped
+    // exercising the fail-safe path at all (duty stopped reaching the
+    // engine, or every crossing now resolves — ac7-HS at duty 1.0 has
+    // zero errors of ANY kind, so the lane assertion above is vacuous
+    // without this). Do NOT just delete it: re-point the pin at a shape
+    // that still produces unresolved crossings.
+    assert!(
+        severed > 0 || unresolved > 0,
+        "fail-safe pin no longer exercises the severed/unresolved path \
+         (severed=0, unresolved=0) — re-point it at a failing shape"
     );
 }
 

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2261,6 +2261,7 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
         .collect();
     let sr = solver::solve("advanced-circuit", 7.0, &inputs, "assembling-machine-2")
         .expect("ac7 solves");
+    let _guard = spaghettio_core::trace::start_trace();
     let layout = build_bus_layout(
         &sr,
         LayoutOptions {
@@ -2271,6 +2272,10 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
         },
     )
     .expect("ac7 duty-0.6 lays out");
+    let severed = spaghettio_core::trace::drain_events()
+        .iter()
+        .filter(|e| matches!(e, spaghettio_core::trace::TraceEvent::CrossingSevered { .. }))
+        .count();
     let issues = match validate::validate(&layout, Some(&sr), LayoutStyle::Bus) {
         Ok(v) => v,
         Err(e) => e.issues,
@@ -2285,6 +2290,21 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
          crossing is merging flows again (fail-severed regressed): {:#?}",
         lane_errors.len(),
         lane_errors.iter().take(5).collect::<Vec<_>>()
+    );
+    // Anti-vacuity (review): the zero above must come from the fail-safe
+    // actually engaging, not from the fixture drifting to a shape where
+    // nothing needed severing while merges ship elsewhere. Either every
+    // crossing resolved (no unresolved-junction errors — the fully-fixed
+    // future) or at least one feeder was severed.
+    let unresolved = issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error && i.category == "unresolved-junction")
+        .count();
+    assert!(
+        unresolved == 0 || severed > 0,
+        "ac7-HS duty-0.6 has {unresolved} unresolved crossings but the \
+         fail-sever pass dropped nothing — the zero-lane-error result is \
+         vacuous (sever scope regressed?)"
     );
 }
 


### PR DESCRIPTION
## Intent

#652 design half, part 1: make the crossing-failure path fail SAFE. The 2026-08-15 diagnosis (recorded on #652) traced **all** of ac7-HS-duty-0.6's 120 errors and the tier5 duty fixture's ~100 to four unresolved crossings shipping **flat sideload-merges** — one item's flow dumped onto one lane of another item's legal trunk, fanning out as ~90 downstream lane-throughput errors per site.

*(History: the PR originally also carried a local conflict-retry re-solve. Review round 1 + the session-side adversarial review independently proved it a deterministic no-op — `refresh_forbidden`'s surface-belt exemption filters the augmented obstacles back out (`tile_is_forbidden_kind = !is_surface_belt`), the port-tile exemption runs before the obstacle test, and the zone-cache signature excludes obstacle sets so the re-solve replays the cached solution. An A/B receipt showed the entire error delta comes from the fail-sever alone. The retry was removed; the retry-with-teeth design is recorded on #652.)*

## Changes

1. **Fail-severed fallback** (`ghost_router.rs`, final pass of `route_bus_ghost`, after Step 7 + tier renames; new `CrossingSevered` trace event): `ghost:`-segment surface belts that point into a belt carrying a DIFFERENT item are dropped when the feed faces an unresolved-cluster tile or either side belongs to an unresolved spec (route ∩ `remaining_crossings`). The flow dead-ends one tile short and fails visibly (belt-dead-end errors, starved consumers, the unresolved-junction region) instead of poisoning a legal trunk. Never severed: committed trunk/balancer/tapoff/crossing/merger geometry (mixing there still reaches `belt-item-isolation`), UG halves (severing an output orphans its input, and `build_ug_pairs` would re-pair to the next output down the lane — inventing a tunnel; measured: every sever decision on both duty shapes was a plain transport-belt, so the arm bought nothing).
2. **Context-conflict trace precision** (`ghost_router.rs`): the #653 conflict-cap path now reports the conflicting tile coordinates.
3. **e2e pin** `tier4_ac7_duty06_unresolved_crossings_fail_safe`: zero lane-throughput errors on the flip shape, plus two anti-vacuity guards — `unresolved > 0 ⇒ severed > 0`, and a liveness assertion (`severed > 0 ∨ unresolved > 0`) so the pin fails loudly if the shape ever stops exercising the fail-safe path (ac7-HS at duty 1.0 has zero errors of any kind, so the lane assertion alone would be vacuous).

## Verification

Fixtures (both at `planning_duty: 0.6`):
- **ac7-HS** = advanced-circuit @ 7/s, AM2, inputs {iron-plate, copper-plate, coal, water, crude-oil}, yellow belt, HorizontalStack.
- **tier5-pu2** = processing-unit @ 2/s via netflow multi, AM3, from-ore inputs {iron-ore, copper-ore, coal, water, crude-oil}, research productivity {plastic-bar: 0.1, processing-unit: 0.1}, red belt, default row layout.

Results (errors / warnings):
- ac7-HS: **120 → 17 errors** (lane-throughput 111 → **0**; isolation 6 unchanged = the pre-existing balancer-over-trunk overlap recorded on #652; +8 belt-dead-end; 3 unresolved-junction). **Warnings 44 → 96** (36→77 input-rate-delivery, 8→14 belt-flow-reachability, +4 belt-flow-path, +1 orphan-belt-segment) — that is the design: starvation is now *visible* where mixing used to hide it.
- tier5-pu2: **100+ → 20** (the accumulating 24→77/s lane cascade eliminated; 15 belt-dead-end + 5 unresolved-junction point at the mega-zone).
- On other unresolved-crossing shapes total **errors can go UP** (session-side review measured a PU AM2 reconstruction at 42 → 48: 10 real mixing sites removed for +6 honest dead-ends, lane-throughput 0 both sides). That is the intended trade — mixing converted to visible failure.
- Corpus at defaults: **byte-identical to main** — independently verified by the session-side review via the suite's SHA-256 layout-hash goldens, not just error counts. Full suite green by exit code (`CARGO_EXIT=0`, all 26 binaries), clippy (CI invocation) clean, WASM check clean.
- Sever accounting: 9 `CrossingSevered` events = 9 net entity removals on ac7 (the final-pass placement means the trace can no longer over-report severs of already-doomed duplicates).
- Determinism: session-side review ran three in-process + separate-process builds — identical FNV digest over the full entity vector and the ordered sever list.

## Session-side adversarial review

Run per the layout-engine protocol (isolated worktree, opus agent). Verdict: **SHIP-WITH-FIXES** — all fixes absorbed across rounds 1–2: retry removed (its A/B receipt: disabling the retry alone reproduces the branch byte-identically), sever ghost-scoped + surface-belt-only + relocated after Step 6/7, pin liveness guards, scope-gap comments (splitter second tile, row belts), stale-comment truth. Its under-sever enumeration found exactly the 6 recorded residual adjacencies and nothing else (PU census 10 → 0).

## Recorded residuals (on #652, not in scope here)

- **Retry-with-teeth**: forbidden-override through `GrowingRegion` + cache-signature extension; note the ac7 conflict tiles may be zone *ports*, where obstacle-override is structurally insufficient.
- **Balancer-over-trunk overlap**: the 6 remaining isolation errors (EC balancer stamped over the plastic-bar trunk; fragments survive under UG-span holes).
- Same-item lane-override at failed crossings: declined with the pin-to-build named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n
