### PR TITLE
fix(router): #652 mega-zone unit — stop region growth when every SAT attempt is over the var ceiling

### DIFF
--- a/crates/core/src/bus/eviction.rs
+++ b/crates/core/src/bus/eviction.rs
@@ -231,6 +231,8 @@ impl JunctionStrategy for EvictionStrategy {
                 strict_obstacles: ctx.strict_obstacles,
                 placed_entities: ctx.placed_entities,
                 unreleasable_obstacles: ctx.unreleasable_obstacles,
+                sat_invocations: ctx.sat_invocations,
+                sat_ceiling_refusals: ctx.sat_ceiling_refusals,
             };
 
             let sat_started = web_time::Instant::now();

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1139,6 +1139,21 @@ impl JunctionStrategy for SatStrategy {
         // the record side writes.
         let effective_budget_ms = env_descent_budget_ms()
             .unwrap_or(self.constraints.cost_descent_budget_ms);
+        // Ceiling-aware growth-stop bookkeeping (#652): counted on EVERY
+        // encounter — including warm-cache paths that early-return below
+        // — so the growth loop behaves identically cold and warm (a
+        // flag set only on the cold path made growth depend on cache
+        // state, the #654 divergence class). The user-visible gate
+        // (trace event + synthetic-Timeout record + refusal) stays in
+        // its original place downstream of the cache lookup, so trace
+        // and cache behavior are byte-identical to before this unit.
+        ctx.sat_invocations.set(ctx.sat_invocations.get() + 1);
+        let sat_var_count = crate::sat::crossing_zone_sat_var_count(&zone);
+        if sat_var_count > MAX_ZONE_SAT_VARS {
+            ctx.sat_ceiling_refusals
+                .set(ctx.sat_ceiling_refusals.get() + 1);
+        }
+
         let cache_result = crate::zone_cache::lookup_zone_result(
             &zone,
             &channel_reaches,
@@ -1285,8 +1300,9 @@ impl JunctionStrategy for SatStrategy {
         // the structurally-infeasible zones, but a balanced-but-hard zone could
         // still hang the unbounded base solve. Refuse zones over the ceiling and
         // record a synthetic Timeout so re-encounters skip via the normal cache
-        // path. See MAX_ZONE_SAT_VARS.
-        let sat_var_count = crate::sat::crossing_zone_sat_var_count(&zone);
+        // path. (The growth-stop counters for this refusal are maintained in
+        // the pre-pass above the cache lookup — see there.) See
+        // MAX_ZONE_SAT_VARS.
         if sat_var_count > MAX_ZONE_SAT_VARS {
             trace::emit(TraceEvent::CrossingZoneSkipped {
                 tap_item: zone

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -1037,8 +1037,17 @@ pub struct JunctionStrategyContext<'a> {
     /// size-hopeless for SAT", not "who emitted the refusal trace").
     /// When an iteration yields no candidates, no walker veto tiles,
     /// and EVERY SAT invocation was over-ceiling, growth is futile:
-    /// var count is monotonic in zone size (tier5 measured 935 -> 1547
-    /// while refused at 935 the whole way). The equality test (rather
+    /// var count is monotonic in zone size — tiles grow by
+    /// construction, and the channel count cannot DROP because an
+    /// absorbed/engulfed spec's flow is re-expressed as INTERIOR
+    /// boundaries (`interior: true` in the zone builder) which
+    /// `channel_info_from_boundaries` still counts; growth converts
+    /// perimeter crossings to interior ones, never removes a channel.
+    /// (Empirical check: 0 decreasing var-count steps across 463
+    /// (seed, variant) series on the tier5 probe. If zone construction
+    /// ever stops emitting interior boundaries for engulfed specs,
+    /// re-derive this lemma.) Tier5 measured 935 -> 1547 while refused
+    /// at 935 the whole way. The equality test (rather
     /// than any-refusal) matters because the SINGLE-SIDE VARIANT zones
     /// are one row/column larger than the primary — a variant can sit
     /// over the ceiling while the primary is under, and an
@@ -1308,7 +1317,8 @@ pub fn solve_crossing(
             // in the trace — a visible iter jump that marks the
             // ceiling-stop bonus round.
             //
-            // Two accepted asymmetries (session-side review): the
+            // Three accepted asymmetries (session-side review + round
+            // 3): the
             // bonus round re-runs the full-zone SAT rungs too (they
             // re-refuse at the ceiling pre-solve — four cheap checks,
             // duplicate skip events under the faked iter label; only
@@ -1319,7 +1329,11 @@ pub fn solve_crossing(
             // veto manufactured under the faked final-iter context
             // would contradict the stop's premise (measured: zero
             // discarded vetoes across all 15 bonus rounds on the tier5
-            // probe).
+            // probe). Third: the bonus round runs on the PRIMARY
+            // region only, not the four variants — eviction's value is
+            // shrinkage, and the primary is the smallest region on the
+            // table; variant regions are strictly larger, so their
+            // filtered zones are strictly less likely to fit.
             if iter + 1 < MAX_GROWTH_ITERS {
                 if let TryOutcome::Solved(sol) =
                     try_solve_on_region(&region, MAX_GROWTH_ITERS - 1, None, &solve_ctx)

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -1025,6 +1025,22 @@ pub struct JunctionStrategyContext<'a> {
     /// relies on release-in-footprint for trunk/tapoff cleanup. Computed
     /// once per `solve_crossing` call by the caller.
     pub unreleasable_obstacles: &'a FxHashSet<(i32, i32)>,
+    /// SAT invocations this growth iteration (every `SatStrategy`
+    /// rung, INCLUDING eviction's filtered inner attempts). Paired with
+    /// `sat_ceiling_refusals` below to drive the ceiling-aware growth
+    /// stop (#652 mega-zone class). Reset by the growth loop per iter.
+    pub sat_invocations: &'a std::cell::Cell<u32>,
+    /// How many of those invocations REFUSED the zone because its SAT
+    /// variable count exceeds `MAX_ZONE_SAT_VARS`. When an iteration
+    /// yields no candidates, no walker veto tiles, and EVERY SAT
+    /// invocation was over-ceiling, growth is futile: full-zone var
+    /// count is monotonic in zone size (tier5 measured 935 -> 1547
+    /// while refused at 935 the whole way). An UNDER-ceiling UNSAT —
+    /// eviction's filtered zone especially — justifies growth (a
+    /// default corpus fixture was measured regressing when the first
+    /// version of this rule stopped on the full-zone refusal alone:
+    /// its zone grew until eviction's filtered solve won).
+    pub sat_ceiling_refusals: &'a std::cell::Cell<u32>,
 }
 
 /// A strategy that attempts to produce a `JunctionSolution` for a
@@ -1119,6 +1135,8 @@ pub fn solve_crossing(
 
     let protected_balancer_tiles = build_protected_balancer_tiles(placed_entities);
     let cluster_seeds: FxHashSet<(i32, i32)> = seeds.iter().copied().collect();
+    let sat_invocations = std::cell::Cell::new(0u32);
+    let sat_ceiling_refusals = std::cell::Cell::new(0u32);
     let solve_ctx = SolveCtx {
         initial_tile,
         routed_paths,
@@ -1134,9 +1152,13 @@ pub fn solve_crossing(
         pending_crossings,
         cluster_seeds: &cluster_seeds,
         protected_balancer_tiles: &protected_balancer_tiles,
+        sat_invocations: &sat_invocations,
+        sat_ceiling_refusals: &sat_ceiling_refusals,
     };
 
     for iter in 0..MAX_GROWTH_ITERS {
+        solve_ctx.sat_invocations.set(0);
+        solve_ctx.sat_ceiling_refusals.set(0);
         // Collect every walker-valid candidate across the primary
         // region and the four single-side expansions. The cheapest by
         // `junction_cost::solution_cost` wins — no early-return on
@@ -1219,6 +1241,41 @@ pub fn solve_crossing(
             region.tile_count(),
         ) {
             return Some(best);
+        }
+
+        // Ceiling-aware stop (#652 mega-zone class): FULL-zone SAT var
+        // count is monotonically increasing in zone size, so growing a
+        // zone whose every SAT attempt was refused for being OVER the
+        // var ceiling can never make SAT succeed — tier5's mega-zone
+        // grew 935 -> 1020 -> 1547 vars while refused at 935 the whole
+        // way, reaching the tile cap at 91 tiles and leaving a 68-tile
+        // orphan field. Stop instead of escalating: a smaller, earlier
+        // failure site caps for the layout-level retry and leaves the
+        // fail-sever pass (#655) less to clean up.
+        //
+        // The rule is deliberately three-way conservative. It defers
+        // to: (a) any candidate (moot), (b) any walker veto tile —
+        // growth directed toward a non-SAT win (absorbed item-conflict
+        // tile, template shape), and (c) any UNDER-ceiling SAT attempt
+        // — UNSAT can become SAT with growth, and eviction's FILTERED
+        // zones stay under the ceiling at sizes where the full zone is
+        // over it (the first version of this rule stopped on the
+        // full-zone refusal alone and measurably regressed a default
+        // corpus fixture whose zone grew until eviction's filtered
+        // solve won).
+        let sat_inv = solve_ctx.sat_invocations.get();
+        if veto_tiles.is_empty()
+            && sat_inv > 0
+            && solve_ctx.sat_ceiling_refusals.get() == sat_inv
+        {
+            trace::emit(TraceEvent::JunctionGrowthCapped {
+                tile_x: initial_tile.0,
+                tile_y: initial_tile.1,
+                iters: iter,
+                region_tiles: region.tile_count(),
+                reason: "sat_var_ceiling".to_string(),
+            });
+            return None;
         }
 
         // Veto-directed growth: if the walker flagged tiles outside the
@@ -1469,6 +1526,9 @@ struct SolveCtx<'a> {
     /// are in the middle of solving.
     cluster_seeds: &'a FxHashSet<(i32, i32)>,
     protected_balancer_tiles: &'a FxHashSet<(i32, i32)>,
+    /// See `JunctionStrategyContext::sat_invocations`.
+    sat_invocations: &'a std::cell::Cell<u32>,
+    sat_ceiling_refusals: &'a std::cell::Cell<u32>,
 }
 
 /// Outcome of one strategy attempt on a given region state.
@@ -1625,6 +1685,8 @@ fn try_solve_on_region(
         strict_obstacles: ctx.strict_obstacles,
         placed_entities: ctx.placed_entities,
         unreleasable_obstacles: ctx.unreleasable_obstacles,
+        sat_invocations: ctx.sat_invocations,
+        sat_ceiling_refusals: ctx.sat_ceiling_refusals,
     };
 
     for strategy in ctx.strategies {

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -1035,15 +1035,19 @@ pub struct JunctionStrategyContext<'a> {
     /// including warm-cache paths whose refusal was recorded on an
     /// earlier encounter — the count answers "is this zone
     /// size-hopeless for SAT", not "who emitted the refusal trace").
-    /// When an iteration
-    /// yields no candidates, no walker veto tiles, and EVERY SAT
-    /// invocation was over-ceiling, growth is futile: full-zone var
-    /// count is monotonic in zone size (tier5 measured 935 -> 1547
-    /// while refused at 935 the whole way). An UNDER-ceiling UNSAT —
-    /// eviction's filtered zone especially — justifies growth (a
-    /// default corpus fixture was measured regressing when the first
-    /// version of this rule stopped on the full-zone refusal alone:
-    /// its zone grew until eviction's filtered solve won).
+    /// When an iteration yields no candidates, no walker veto tiles,
+    /// and EVERY SAT invocation was over-ceiling, growth is futile:
+    /// var count is monotonic in zone size (tier5 measured 935 -> 1547
+    /// while refused at 935 the whole way). The equality test (rather
+    /// than any-refusal) matters because the SINGLE-SIDE VARIANT zones
+    /// are one row/column larger than the primary — a variant can sit
+    /// over the ceiling while the primary is under, and an
+    /// under-ceiling UNSAT can still become SAT with growth, so mixed
+    /// iterations keep growing. (An earlier claim here that the
+    /// any-refusal version measurably regressed a corpus fixture via
+    /// eviction was RETRACTED on the PR — the observed red was
+    /// environmental, and session-side review measured the veto guard,
+    /// not this clause, as the fixture's protection.)
     pub sat_ceiling_refusals: &'a std::cell::Cell<u32>,
 }
 
@@ -1177,14 +1181,19 @@ pub fn solve_crossing(
         // on this iter. Drives veto-directed growth when no candidate
         // is accepted. See `docs/archive/rfc-veto-directed-growth.md`.
         let mut veto_tiles: FxHashSet<(i32, i32)> = FxHashSet::default();
+        // True when any attempt this iteration DISCARDED a valid
+        // solution via the deferred-exit check — growth is the remedy
+        // there, so the ceiling stop is suppressed (#656 review).
+        let mut deferred_any = false;
 
         match try_solve_on_region(&region, iter, None, &solve_ctx) {
             TryOutcome::Solved(sol) => {
                 let c = crate::bus::junction_cost::solution_cost(&sol.entities);
                 candidates.push((c, sol, String::new()));
             }
-            TryOutcome::Continue { veto_tiles: vt } => {
+            TryOutcome::Continue { veto_tiles: vt, deferred: d } => {
                 veto_tiles.extend(vt);
+                deferred_any |= d;
             }
         }
 
@@ -1232,8 +1241,9 @@ pub fn solve_crossing(
                     let c = crate::bus::junction_cost::solution_cost(&sol.entities);
                     candidates.push((c, sol, (*label).to_string()));
                 }
-                TryOutcome::Continue { veto_tiles: vt } => {
+                TryOutcome::Continue { veto_tiles: vt, deferred: d } => {
                     veto_tiles.extend(vt);
+                    deferred_any |= d;
                 }
             }
         }
@@ -1257,22 +1267,29 @@ pub fn solve_crossing(
         // failure site caps for the layout-level retry and leaves the
         // fail-sever pass (#655) less to clean up.
         //
-        // The rule is deliberately three-way conservative. It defers
-        // to: (a) any candidate (moot), (b) any walker veto tile —
-        // growth directed toward a non-SAT win (absorbed item-conflict
-        // tile, template shape), and (c) any UNDER-ceiling SAT attempt
-        // — UNSAT can become SAT with growth, and eviction's FILTERED
-        // zones stay under the ceiling at sizes where the full zone is
-        // over it (the first version of this rule stopped on the
-        // full-zone refusal alone and measurably regressed a default
-        // corpus fixture whose zone grew until eviction's filtered
-        // solve won).
+        // The rule is deliberately conservative on four conditions
+        // plus a bonus round. It defers to: (a) any candidate (moot),
+        // (b) any walker veto tile — growth directed toward a non-SAT
+        // win (absorbed item-conflict tile), (c) any UNDER-ceiling SAT
+        // attempt — the single-side VARIANT zones are one row/column
+        // larger than the primary, so a variant can be over the
+        // ceiling while the primary is under, and an under-ceiling
+        // UNSAT can still become SAT with growth, (d) the seed-sized
+        // region (`iter >= 1` below). When all four pass, the bonus
+        // round below still opens the final-iteration gate before the
+        // stop is final. Measured blast radius (session-side review,
+        // tier5 probe): the rule fires 15 times across 10 cluster
+        // seeds — most in the retried pass-1 whose trace is truncated
+        // — with error AND warning populations byte-identical to
+        // pre-rule main; only the two clusters named in the #656
+        // receipts change their capped size/reason in the final trace.
         let sat_inv = solve_ctx.sat_invocations.get();
         // `iter >= 1`: never stop on the seed-sized region (review) —
         // local template strategies get at least one grown region
         // before the ceiling verdict is treated as final.
         if iter >= 1
             && veto_tiles.is_empty()
+            && !deferred_any
             && sat_inv > 0
             && solve_ctx.sat_ceiling_refusals.get() == sat_inv
         {
@@ -1290,6 +1307,19 @@ pub fn solve_crossing(
             // attempt round is emitted with iter = MAX_GROWTH_ITERS - 1
             // in the trace — a visible iter jump that marks the
             // ceiling-stop bonus round.
+            //
+            // Two accepted asymmetries (session-side review): the
+            // bonus round re-runs the full-zone SAT rungs too (they
+            // re-refuse at the ceiling pre-solve — four cheap checks,
+            // duplicate skip events under the faked iter label; only
+            // eviction's participation is the point), and a
+            // `Continue { veto_tiles }` from the bonus round is
+            // DISCARDED rather than grown on — this iteration already
+            // established no vetoes at the true iter, and growing on a
+            // veto manufactured under the faked final-iter context
+            // would contradict the stop's premise (measured: zero
+            // discarded vetoes across all 15 bonus rounds on the tier5
+            // probe).
             if iter + 1 < MAX_GROWTH_ITERS {
                 if let TryOutcome::Solved(sol) =
                     try_solve_on_region(&region, MAX_GROWTH_ITERS - 1, None, &solve_ctx)
@@ -1576,9 +1606,17 @@ enum TryOutcome {
     /// the union of walker break tiles (and/or item-conflict tiles)
     /// collected across all strategies tried on this region. Empty when
     /// every strategy was skipped/unsat with no walker involvement.
+    /// `deferred` is true when a strategy DID produce a valid solution
+    /// that was discarded by the deferred-exit check (its frontier
+    /// exits at another cluster's pending crossing) — growth is that
+    /// path's documented remedy, so the ceiling stop must not fire on
+    /// such an iteration (#656 review).
     /// Used by `solve_crossing` to direct the next bbox expansion
     /// toward the tiles the walker actually cared about.
-    Continue { veto_tiles: Vec<(i32, i32)> },
+    Continue {
+        veto_tiles: Vec<(i32, i32)>,
+        deferred: bool,
+    },
 }
 
 /// Scan the boundary list for a tile that carries more than one
@@ -1694,6 +1732,7 @@ fn try_solve_on_region(
     // determinism, but the caller unions them with the other variants'
     // sets and order is lost there — so we don't rely on it.
     let mut veto_tiles: Vec<(i32, i32)> = Vec::new();
+    let mut deferred = false;
 
     if let Some((cx, cy, items)) = conflict {
         trace::emit(TraceEvent::JunctionStrategyAttempt {
@@ -1710,7 +1749,7 @@ fn try_solve_on_region(
         // the conflict into the bbox interior where SAT can route UGs
         // around it.
         veto_tiles.push((cx, cy));
-        return TryOutcome::Continue { veto_tiles };
+        return TryOutcome::Continue { veto_tiles, deferred };
     }
 
     let strategy_ctx = JunctionStrategyContext {
@@ -1773,6 +1812,7 @@ fn try_solve_on_region(
                 detail: "spec exits at another unresolved crossing".to_string(),
                 elapsed_us,
             });
+            deferred = true;
             break; // skip this iter's solution; fall through to grow
         }
 
@@ -1912,7 +1952,7 @@ fn try_solve_on_region(
         return TryOutcome::Solved(sol);
     }
 
-    TryOutcome::Continue { veto_tiles }
+    TryOutcome::Continue { veto_tiles, deferred }
 }
 
 /// Every tile inside `bbox` (inclusive on the min side, exclusive on the

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -1030,8 +1030,12 @@ pub struct JunctionStrategyContext<'a> {
     /// `sat_ceiling_refusals` below to drive the ceiling-aware growth
     /// stop (#652 mega-zone class). Reset by the growth loop per iter.
     pub sat_invocations: &'a std::cell::Cell<u32>,
-    /// How many of those invocations REFUSED the zone because its SAT
-    /// variable count exceeds `MAX_ZONE_SAT_VARS`. When an iteration
+    /// How many of those invocations found the zone OVER the
+    /// `MAX_ZONE_SAT_VARS` ceiling (counted on every encounter,
+    /// including warm-cache paths whose refusal was recorded on an
+    /// earlier encounter — the count answers "is this zone
+    /// size-hopeless for SAT", not "who emitted the refusal trace").
+    /// When an iteration
     /// yields no candidates, no walker veto tiles, and EVERY SAT
     /// invocation was over-ceiling, growth is futile: full-zone var
     /// count is monotonic in zone size (tier5 measured 935 -> 1547
@@ -1264,10 +1268,44 @@ pub fn solve_crossing(
         // corpus fixture whose zone grew until eviction's filtered
         // solve won).
         let sat_inv = solve_ctx.sat_invocations.get();
-        if veto_tiles.is_empty()
+        // `iter >= 1`: never stop on the seed-sized region (review) —
+        // local template strategies get at least one grown region
+        // before the ceiling verdict is treated as final.
+        if iter >= 1
+            && veto_tiles.is_empty()
             && sat_inv > 0
             && solve_ctx.sat_ceiling_refusals.get() == sat_inv
         {
+            // Before stopping, give the FINAL-ITERATION-GATED strategies
+            // one attempt round at the CURRENT size (review on the
+            // growth PR): eviction — the only strategy that can SHRINK
+            // the SAT instance (its filtered zones can be under the
+            // ceiling at any region size) — is gated on
+            // `growth_iter + 1 >= MAX_GROWTH_ITERS`, so a plain stop
+            // here would deny it entirely and the rule would collapse
+            // into the naive stop-on-any-refusal it exists to avoid.
+            // Running it now, at the smallest refused size, is strictly
+            // more likely to succeed than after futile growth to the
+            // cap (the filtered zones grow with the region too). The
+            // attempt round is emitted with iter = MAX_GROWTH_ITERS - 1
+            // in the trace — a visible iter jump that marks the
+            // ceiling-stop bonus round.
+            if iter + 1 < MAX_GROWTH_ITERS {
+                if let TryOutcome::Solved(sol) =
+                    try_solve_on_region(&region, MAX_GROWTH_ITERS - 1, None, &solve_ctx)
+                {
+                    let c = crate::bus::junction_cost::solution_cost(&sol.entities);
+                    let mut bonus = vec![(c, sol, String::new())];
+                    if let Some(best) = pick_cheapest_candidate(
+                        &mut bonus,
+                        initial_tile,
+                        MAX_GROWTH_ITERS - 1,
+                        region.tile_count(),
+                    ) {
+                        return Some(best);
+                    }
+                }
+            }
             trace::emit(TraceEvent::JunctionGrowthCapped {
                 tile_x: initial_tile.0,
                 tile_y: initial_tile.1,

--- a/docs/test-suite-followups.md
+++ b/docs/test-suite-followups.md
@@ -4,6 +4,34 @@ Deferred test-suite tooling work, from a session-time audit on 2026-07-19
 (originally `testing-time-audit.md`). Each item below has pick-up notes so a
 future session can start cold.
 
+## ⚠ Warning pins are CACHE-relative — local verification protocol (2026-08-15)
+
+Found while verifying the #652 growth unit: the e2e **warning-population
+pins** (`assert_warnings_golden`) are reproducible **only against the
+committed CI cache snapshot** (`crates/core/data/sat-zones-ci.bin`, the
+file `ci.yml` pins via `SPAGHETTIO_ZONE_CACHE_PATH` — refresh protocol in
+the workflow comment). Measured on `tier4_advanced_circuit_from_ore_am2`
+at main 308633b6: against the CI snapshot the pinned
+`input-rate-delivery 7` reproduces; against this host's drifted live
+cache **and** against a fresh path (embedded-cache baseline) the same
+source yields `belt-detour 1 + input-rate-delivery 8` — one belt of the
+layout differs. Nothing in the code changed; only which zone solutions
+replay. Consequences:
+
+- **A local full-suite run is pin-meaningful only with
+  `SPAGHETTIO_ZONE_CACHE_PATH=<copy of sat-zones-ci.bin>`** (a COPY —
+  tests write to the path). A bare `cargo test` verifies everything
+  else but can trip warning pins spuriously once the host cache drifts,
+  and today it does.
+- A pin trip in a bare local run is therefore weak evidence against a
+  change — re-run the CI way before investigating the diff (this unit
+  burned a session-hour attributing an environmental trip to a 60-line
+  diff that provably never executed on the tripping fixture).
+- `ci.yml`'s comment justifying the pin ("fresh solutions are
+  wall-clock-budget shaped") is stale post-#654 (the descent deadline
+  is gone); the pin's live rationale is cache-content determinism, not
+  wall-clock. Fix the comment at the next workflow-file touch.
+
 Status: **all items resolved 2026-07-19** — items 2 and 3 landed, item 1
 landed with its CI gate (3 consecutive green Rust-touching runs) tracked on
 the landing PR, item 4 measured and closed as not-worth-it host-side (open

--- a/docs/test-suite-followups.md
+++ b/docs/test-suite-followups.md
@@ -28,9 +28,15 @@ replay. Consequences:
   burned a session-hour attributing an environmental trip to a 60-line
   diff that provably never executed on the tripping fixture).
 - `ci.yml`'s comment justifying the pin ("fresh solutions are
-  wall-clock-budget shaped") is stale post-#654 (the descent deadline
-  is gone); the pin's live rationale is cache-content determinism, not
-  wall-clock. Fix the comment at the next workflow-file touch.
+  wall-clock-budget shaped") is MOSTLY stale post-#654: the SAT
+  descent deadline is gone (iteration-count bounded), so the pin's
+  main live rationale is cache-content determinism. One genuine
+  wall-clock input survives, though (session-side review on #656):
+  `eviction.rs` holds a live 200 ms recipe budget
+  (`total_budget_ms`) that gates how many eviction candidates reach
+  SAT, and eviction produces layout-changing solutions — so
+  slow-host fresh solves can still differ through that path. Fix the
+  comment (both halves) at the next workflow-file touch.
 
 Status: **all items resolved 2026-07-19** — items 2 and 3 landed, item 1
 landed with its CI gate (3 consecutive green Rust-touching runs) tracked on


### PR DESCRIPTION
## Intent

#652 mega-zone unit: stop region growth when it is provably futile. Full-zone SAT variable count is monotonic in zone size (growth only adds participating specs, so tiles and channels both grow), so a zone whose every SAT attempt was refused for exceeding `MAX_ZONE_SAT_VARS` cannot be rescued by growing the *full* zone — yet the growth loop kept expanding: tier5's mega-zone grew 935 → 1020 → 1547 vars while refused at 935 the whole way, reaching the tile cap at 91 tiles and leaving a 68-tile orphan field for #655's fail-sever pass to clean up.

## Changes

1. `JunctionStrategyContext`/`SolveCtx` gain per-iteration counters (`sat_invocations` / `sat_ceiling_refusals`); every `SatStrategy` rung increments them (including eviction's filtered inner attempts), in a pre-pass **above** the zone-cache lookup so cold and warm runs grow identically (the #654 divergence class). The user-visible gate (trace event + synthetic-Timeout record) stays in its original position — trace and cache behavior are byte-identical to before this unit.
2. The growth loop treats an iteration with **no candidate, no walker veto tiles, `iter ≥ 1`, and every SAT invocation over-ceiling** as SAT-hopeless. It then runs **one bonus attempt round at the current size with `growth_iter` forced to `MAX_GROWTH_ITERS − 1`** — eviction is final-iteration-gated and is the only strategy that can *shrink* the SAT instance (its filtered zones can be under the ceiling at any region size), so it gets its attempt at the smallest refused size, which is strictly more favorable than after futile growth. Only if that round also yields no candidate does the loop emit the new `JunctionGrowthCapped { reason: "sat_var_ceiling" }` and stop. The `iter ≥ 1` floor means local template strategies always see at least one grown region before the verdict.

*(Review history: the first version stopped on any full-zone refusal; round 1 identified that eviction's final-iteration gate made the "under-ceiling attempt justifies growth" refinement inert and that a plain stop denied eviction entirely — the bonus-round design is the fix. An earlier claim that v1 "measurably regressed a corpus fixture" is **retracted**: that red came from a bare-cache suite run of the kind since proven to trip the same pin on unmodified main — see the verification finding below.)*

## Verification

- **Blast radius (session-side review, corrected from the original body):** the rule fires **15 times across 10 distinct cluster seeds** on the tier5 probe — most firings live in the layout-level retry's *truncated pass-1 trace*, which is why the probe's final trace shows only two `JunctionGrowthCapped` events. Outcome verified **byte-identical to main in both error and warning populations** on the probe; the containment claim holds, but the original "one cluster" framing under-counted per `docs/validator-reporting.md`.
- tier5 duty-0.6 probe: the (29,179) cluster caps at **iter 1 / 55 tiles** with the honest `sat_var_ceiling` reason — its bonus eviction round also fails, correctly (was: grown to the 91-tile cap). The (25,173) mega-zone still reaches `tile_cap` — its iterations carry item-conflict veto tiles and the rule defers to them; that zone's real fix (zone-split / channel-reduction) stays recorded on #652. Error counts unchanged (15 belt-dead-end + 5 unresolved-junction): this unit is containment, not resolution.
- Full suite **the CI way** (`SPAGHETTIO_ZONE_CACHE_PATH=<copy of sat-zones-ci.bin>`): `CARGO_EXIT=0`, all 26 binaries — on both the original and the round-1 head.
- **Verification finding, recorded in `docs/test-suite-followups.md` (new section):** the e2e warning pins are *cache-relative* — on unmodified main (308633b6), `tier4_advanced_circuit_from_ore_am2` reproduces its pinned `input-rate-delivery 7` **only** against the committed CI cache snapshot; both this host's drifted live cache and the embedded-cache baseline yield `belt-detour 1 + input-rate-delivery 8`. A bare local `cargo test` currently trips that pin on ANY branch including main (receipts: main-source warm, cold, single-test, and full-suite runs all reproduce the trip; branch and main byte-identical on the fixture). The followups section documents the local protocol and flags `ci.yml`'s stale wall-clock rationale comment for the next workflow-file touch.
- Known gap (recorded on #652): no automated test yet asserts the `sat_var_ceiling` stop fires — a synthetic `solve_crossing` fixture must exceed 700 vars while clearing the item-conflict fast-fail; sketch in the #652 record.

## Session-side adversarial review

Verdict **SHIP-WITH-FIXES** (all fixes documentation-only, absorbed): claims A/B verified exactly (including branch-vs-main under an identical CI-cache copy: the (29,179) flip is real, everything else byte-identical); the v1 retraction verified *harder* — literal v1 semantics also passes CI-way, and instrumentation showed arm (c) was never load-bearing on the corpus fixture (the veto guard was); counter hygiene, template blind spot (structurally closed: the perp template only fires on 1-tile regions), determinism, WASM, and clippy all clean; monotonicity empirically confirmed (0 decreasing var-count steps across 463 series). Stale source records rewritten, blast radius corrected above, the eviction 200 ms wall-clock residual added to the followups doc.

## Deviations

The stop rule was redesigned once during review (see history note above); no other deviations. The tier5 mega-zone's actual resolution is out of scope per the #652 plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n
