### PR TITLE
feat(router): #652 retry-with-teeth — forbidden-override conflict retry, wired and measured

### DIFF
--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3022,20 +3022,19 @@ pub fn route_bus_ghost(
         // benign dedup (skipped at stamping); CONFLICTING overlaps
         // reject the whole cluster into the cap/retry machinery.
         //
-        // NO local re-solve is attempted (review on the fail-safe PR
-        // measured the obvious one as a deterministic no-op): adding the
-        // conflict tiles to `strict_obstacles` is filtered back out by
-        // `refresh_forbidden`'s surface-belt exemption (SAT is allowed
-        // to re-stamp surface belts — the benign identical re-derivation
-        // depends on it), and the zone cache's signature excludes the
-        // obstacle sets, so an unchanged zone replays the identical
-        // cached solution. A retry with teeth needs a
-        // forbidden-regardless-of-kind override threaded through
-        // `GrowingRegion` plus a cache-signature extension — recorded on
-        // #652. Until then a conflicted cluster caps for the
-        // layout-level retry and, failing that, is owned by the
+        // On conflict, ONE retry-with-teeth is attempted (#652): the
+        // conflicting tiles are re-solved as a `forbidden_override` —
+        // forbidden regardless of entity kind, so neither
+        // `refresh_forbidden`'s surface-belt exemption nor the port
+        // exemption filters them back out (the exemptions are what made
+        // the naive strict-obstacles retry a measured no-op, together
+        // with cache-signature replay — the override reaches the zone's
+        // `forced_empty`, which IS in the signature, so the retried
+        // zone is a distinct cached problem). A cluster whose retry
+        // fails (no solution, or a solution that still conflicts) caps
+        // for the layout-level retry and, failing that, is owned by the
         // unresolved-junction reporter + the fail-sever pass.
-        let Some(sol) = junction_solver::solve_crossing(
+        let Some(mut sol) = junction_solver::solve_crossing(
             cluster.as_slice(),
             &keys_at_tile,
             &routed_paths,
@@ -3049,6 +3048,7 @@ pub fn route_bus_ghost(
             &entities,
             strategies,
             &pending_crossings,
+            &FxHashSet::default(),
         ) else {
             // Capped: `solve_crossing` returned `None`, matching the
             // `JunctionGrowthCapped` event it emitted at this cluster's seed.
@@ -3080,49 +3080,161 @@ pub fn route_bus_ghost(
             }
             continue;
         };
-        let conflicts: Vec<(i32, i32)> = sol
-            .entities
-            .iter()
-            .filter(|ent| {
-                let tile = (ent.x, ent.y);
-                let claimed = matches!(
-                    occupancy.claim_at(tile),
-                    Some(crate::bus::ghost_occupancy::Claim::Template { .. })
-                        | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
-                );
-                claimed
-                    && occupancy.entity_at(tile).is_some_and(|existing| {
-                        existing.name != ent.name
-                            || existing.direction != ent.direction
-                            || existing.io_type != ent.io_type
-                            || existing.carries != ent.carries
-                    })
-            })
-            .map(|ent| (ent.x, ent.y))
-            .collect();
+        let conflicts_of = |sol_entities: &[PlacedEntity]| -> Vec<(i32, i32)> {
+            sol_entities
+                .iter()
+                .filter(|ent| {
+                    let tile = (ent.x, ent.y);
+                    let claimed = matches!(
+                        occupancy.claim_at(tile),
+                        Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                            | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
+                    );
+                    claimed
+                        && occupancy.entity_at(tile).is_some_and(|existing| {
+                            existing.name != ent.name
+                                || existing.direction != ent.direction
+                                || existing.io_type != ent.io_type
+                                || existing.carries != ent.carries
+                        })
+                })
+                .map(|ent| (ent.x, ent.y))
+                .collect()
+        };
+        let mut conflicts = conflicts_of(&sol.entities);
         if !conflicts.is_empty() {
-            let mut sample = conflicts.clone();
-            sample.truncate(4);
-            trace::emit(trace::TraceEvent::CrossingZoneSkipped {
-                tap_item: String::new(),
-                tap_x: sol.footprint.x,
-                tap_y: sol.footprint.y,
-                reason: format!(
-                    "context-conflict at commit ({} tiles, {:?}): solution collides \
-                     with differing committed entities; cluster capped for retry",
-                    conflicts.len(),
-                    sample
-                ),
-            });
-            cap_coords.push(cluster[0]);
-            // The cluster's tiles stay in remaining_crossings so the
-            // retry pass (or, failing that, the unresolved-junction
-            // reporter + the fail-sever pass) owns them — without this a
-            // conflicting crossing would ship silently dropped.
-            for &t in cluster {
-                remaining_crossings.insert(t);
+            if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
+                for ent in &sol.entities {
+                    if conflicts.contains(&(ent.x, ent.y)) {
+                        let existing = occupancy.entity_at((ent.x, ent.y));
+                        eprintln!(
+                            "PRIMARY-CONFLICT ({},{}): wants {} {:?} io={:?} carries={:?} | committed {:?}",
+                            ent.x,
+                            ent.y,
+                            ent.name,
+                            ent.direction,
+                            ent.io_type,
+                            ent.carries,
+                            existing.map(|e| format!(
+                                "{} {:?} io={:?} carries={:?}",
+                                e.name, e.direction, e.io_type, e.carries
+                            )),
+                        );
+                    }
+                }
             }
-            continue;
+            // Retry with teeth (#652): one re-solve with exactly the
+            // conflicting tiles as the forbidden-override. Bounded and
+            // deterministic — a retry that solves cleanly commits; one
+            // that conflicts again (same tiles or new ones) caps rather
+            // than iterating. If a fixture ever shows a
+            // resolves-on-second-retry shape, widen this to an
+            // accumulate-and-retry loop with a small cap.
+            //
+            // Measured on ac7-HS duty 0.6 (2026-08-16, the fixture the
+            // retry was built for): the override mechanism engages
+            // end-to-end — the forced tiles reach the zone's
+            // `forced_empty`, `topology_boundaries` re-expresses the
+            // ports on them as INTERIOR boundaries, and a direct
+            // encoder call proves the retry zone SAT — but the retry
+            // still returns None there, because the SAT solution
+            // reassigns which same-channel column carries which flow
+            // (channel flow is fungible; routed paths are not), the
+            // walker veto correctly rejects the broken path, and the
+            // veto's remedy (growth) pushes the zone over
+            // MAX_ZONE_SAT_VARS. The recorded next lever (#652) is a
+            // veto→pin re-solve: `sat::solve_crossing_zone_with_pins`
+            // exists, tested and unwired — pin the vetoed path's
+            // committed in-zone tiles and re-solve the SAME zone
+            // instead of growing. Diagnostics for all of this are
+            // env-gated under SPAGHETTIO_DEBUG_CONFLICT_RETRY.
+            let override_set: FxHashSet<(i32, i32)> =
+                conflicts.iter().copied().collect();
+            let retry = junction_solver::solve_crossing(
+                cluster.as_slice(),
+                &keys_at_tile,
+                &routed_paths,
+                &hard_for_junction,
+                &junction_hard,
+                &unreleasable_obstacles,
+                &spec_belt_tiers,
+                &spec_items,
+                &spec_exit_dirs,
+                &spec_kinds,
+                &entities,
+                strategies,
+                &pending_crossings,
+                &override_set,
+            );
+            let resolved = match retry {
+                Some(retry_sol) => {
+                    let retry_conflicts = conflicts_of(&retry_sol.entities);
+                    if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
+                        eprintln!(
+                            "CONFLICT-RETRY seed {:?}: primary footprint {:?}, \
+                             retry footprint {:?}, retry conflicts {:?}",
+                            cluster[0], sol.footprint, retry_sol.footprint, retry_conflicts
+                        );
+                        for ent in &retry_sol.entities {
+                            if override_set.contains(&(ent.x, ent.y)) {
+                                eprintln!(
+                                    "  retry entity ON override tile ({},{}): {} dir {:?} carries {:?}",
+                                    ent.x, ent.y, ent.name, ent.direction, ent.carries
+                                );
+                            }
+                        }
+                    }
+                    if retry_conflicts.is_empty() {
+                        sol = retry_sol;
+                        true
+                    } else {
+                        conflicts = retry_conflicts;
+                        false
+                    }
+                }
+                None => {
+                    if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
+                        eprintln!(
+                            "CONFLICT-RETRY seed {:?}: primary footprint {:?}, \
+                             retry returned None (capped)",
+                            cluster[0], sol.footprint
+                        );
+                    }
+                    false
+                }
+            };
+            trace::emit(trace::TraceEvent::CrossingConflictRetried {
+                x: cluster[0].0,
+                y: cluster[0].1,
+                conflict_tiles: override_set.len(),
+                resolved,
+            });
+            if !resolved {
+                let mut sample = conflicts.clone();
+                sample.truncate(4);
+                trace::emit(trace::TraceEvent::CrossingZoneSkipped {
+                    tap_item: String::new(),
+                    tap_x: sol.footprint.x,
+                    tap_y: sol.footprint.y,
+                    reason: format!(
+                        "context-conflict at commit ({} tiles, {:?}): solution \
+                         collides with differing committed entities and the \
+                         forbidden-override retry did not clear it; cluster \
+                         capped for retry",
+                        conflicts.len(),
+                        sample
+                    ),
+                });
+                cap_coords.push(cluster[0]);
+                // The cluster's tiles stay in remaining_crossings so the
+                // retry pass (or, failing that, the unresolved-junction
+                // reporter + the fail-sever pass) owns them — without this a
+                // conflicting crossing would ship silently dropped.
+                for &t in cluster {
+                    remaining_crossings.insert(t);
+                }
+                continue;
+            }
         }
         // Every cluster member is now handled, regardless of whether
         // it sits inside the solution footprint.
@@ -4765,6 +4877,7 @@ fn blame_unsolvable_cluster(
                 entities,
                 strategies,
                 pending_crossings,
+                &FxHashSet::default(),
             )
             .is_some()
         });

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3161,6 +3161,17 @@ pub fn route_bus_ghost(
             // observability is the CrossingConflictRetried summary
             // event below plus the SPAGHETTIO_DEBUG_CONFLICT_RETRY
             // diagnostics (eprintln, unaffected by trace muting).
+            //
+            // Trace reconciliation on a RESOLVED retry: the primary's
+            // solve series (including its terminal solved event)
+            // describes the DISCARDED conflicting geometry — the
+            // committed geometry is recorded by JunctionCommitted at
+            // stamping (which carries the actual entity list, i.e. the
+            // retry's), and CrossingConflictRetried{resolved: true}
+            // marks the provenance switch. Per-strategy/veto breakdown
+            // of the retry itself lives only in the env-gated
+            // diagnostics — deliberate until the #652 veto→pin unit
+            // gives retries a success path worth first-class tracing.
             let retry = trace::with_muted(|| {
                 junction_solver::solve_crossing(
                     cluster.as_slice(),

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3150,6 +3150,14 @@ pub fn route_bus_ghost(
             // env-gated under SPAGHETTIO_DEBUG_CONFLICT_RETRY.
             let override_set: FxHashSet<(i32, i32)> =
                 conflicts.iter().copied().collect();
+            // Trace-stream accounting: this second solve emits its own
+            // JunctionGrowthStarted / SatInvocation / (on failure)
+            // JunctionGrowthCapped series for the same seed — one extra
+            // growth series per conflicted cluster. Deliberately NOT
+            // muted: those events are the primary forensic record of
+            // WHY a retry failed. Consumers that count events per seed
+            // (stress scoreboards, replay tooling) can bracket retry
+            // series via the CrossingConflictRetried event below.
             let retry = junction_solver::solve_crossing(
                 cluster.as_slice(),
                 &keys_at_tile,
@@ -3166,6 +3174,7 @@ pub fn route_bus_ghost(
                 &pending_crossings,
                 &override_set,
             );
+            let mut retry_footprint = None;
             let resolved = match retry {
                 Some(retry_sol) => {
                     let retry_conflicts = conflicts_of(&retry_sol.entities);
@@ -3188,6 +3197,7 @@ pub fn route_bus_ghost(
                         sol = retry_sol;
                         true
                     } else {
+                        retry_footprint = Some(retry_sol.footprint);
                         conflicts = retry_conflicts;
                         false
                     }
@@ -3212,6 +3222,22 @@ pub fn route_bus_ghost(
             if !resolved {
                 let mut sample = conflicts.clone();
                 sample.truncate(4);
+                // Provenance: on a still-conflicting retry the sampled
+                // tiles are the RETRY solution's conflicts (its
+                // footprint is named in the reason); on a retry that
+                // returned no solution they are the PRIMARY's. tap_x/y
+                // always report the primary footprint — the committed
+                // geometry the forensics will find in the snapshot.
+                let retry_note = match retry_footprint {
+                    Some(r) => format!(
+                        "retry solution (footprint {},{} {}x{}) still \
+                         conflicted at the sampled tiles",
+                        r.x, r.y, r.w, r.h
+                    ),
+                    None => "retry returned no solution; sampled tiles \
+                             are the primary's"
+                        .to_string(),
+                };
                 trace::emit(trace::TraceEvent::CrossingZoneSkipped {
                     tap_item: String::new(),
                     tap_x: sol.footprint.x,
@@ -3219,8 +3245,8 @@ pub fn route_bus_ghost(
                     reason: format!(
                         "context-conflict at commit ({} tiles, {:?}): solution \
                          collides with differing committed entities and the \
-                         forbidden-override retry did not clear it; cluster \
-                         capped for retry",
+                         forbidden-override retry did not clear it ({retry_note}); \
+                         cluster capped for retry",
                         conflicts.len(),
                         sample
                     ),

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3150,30 +3150,35 @@ pub fn route_bus_ghost(
             // env-gated under SPAGHETTIO_DEBUG_CONFLICT_RETRY.
             let override_set: FxHashSet<(i32, i32)> =
                 conflicts.iter().copied().collect();
-            // Trace-stream accounting: this second solve emits its own
-            // JunctionGrowthStarted / SatInvocation / (on failure)
-            // JunctionGrowthCapped series for the same seed — one extra
-            // growth series per conflicted cluster. Deliberately NOT
-            // muted: those events are the primary forensic record of
-            // WHY a retry failed. Consumers that count events per seed
-            // (stress scoreboards, replay tooling) can bracket retry
-            // series via the CrossingConflictRetried event below.
-            let retry = junction_solver::solve_crossing(
-                cluster.as_slice(),
-                &keys_at_tile,
-                &routed_paths,
-                &hard_for_junction,
-                &junction_hard,
-                &unreleasable_obstacles,
-                &spec_belt_tiers,
-                &spec_items,
-                &spec_exit_dirs,
-                &spec_kinds,
-                &entities,
-                strategies,
-                &pending_crossings,
-                &override_set,
-            );
+            // MUTED, per the blame_unsolvable_cluster precedent: the
+            // junction debugger (web/src/ui/junctionTrace.ts) groups
+            // growth series purely by seed tile, so an unmuted retry
+            // would OVERWRITE the primary's bbox/sat/veto records in
+            // place and the cluster's outcome would be whichever
+            // terminal event landed last — corrupting the primary's
+            // forensic record rather than adding to it (session-side
+            // adversary finding on this PR). The retry's own
+            // observability is the CrossingConflictRetried summary
+            // event below plus the SPAGHETTIO_DEBUG_CONFLICT_RETRY
+            // diagnostics (eprintln, unaffected by trace muting).
+            let retry = trace::with_muted(|| {
+                junction_solver::solve_crossing(
+                    cluster.as_slice(),
+                    &keys_at_tile,
+                    &routed_paths,
+                    &hard_for_junction,
+                    &junction_hard,
+                    &unreleasable_obstacles,
+                    &spec_belt_tiers,
+                    &spec_items,
+                    &spec_exit_dirs,
+                    &spec_kinds,
+                    &entities,
+                    strategies,
+                    &pending_crossings,
+                    &override_set,
+                )
+            });
             let mut retry_footprint = None;
             let resolved = match retry {
                 Some(retry_sol) => {

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1153,6 +1153,40 @@ impl JunctionStrategy for SatStrategy {
             ctx.sat_ceiling_refusals
                 .set(ctx.sat_ceiling_refusals.get() + 1);
         }
+        if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
+            let interior_n = zone.boundaries.iter().filter(|b| b.interior).count();
+            eprintln!(
+                "SAT-PREPASS seed {:?} iter {} strat {} zone {}x{}@({},{}) vars {} \
+                 forced_empty {} boundaries {} ({} interior)",
+                ctx.region.initial_tile,
+                ctx.growth_iter,
+                self.name(),
+                zone.width,
+                zone.height,
+                zone.x,
+                zone.y,
+                sat_var_count,
+                zone.forced_empty.len(),
+                zone.boundaries.len(),
+                interior_n,
+            );
+            if !zone.forced_empty.is_empty() {
+                for b in &zone.boundaries {
+                    eprintln!(
+                        "  B ({},{}) {:?} {} {} interior={} ch={} tier={:?}",
+                        b.x,
+                        b.y,
+                        b.direction,
+                        if b.is_input { "IN" } else { "OUT" },
+                        b.item,
+                        b.interior,
+                        b.channel_id,
+                        b.belt_tier,
+                    );
+                }
+                eprintln!("  forced_empty: {:?}", zone.forced_empty);
+            }
+        }
 
         let cache_result = crate::zone_cache::lookup_zone_result(
             &zone,

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -78,6 +78,22 @@ pub struct GrowingRegion {
     /// either non-participating spec paths or hard obstacles (machines,
     /// poles, row template belts, etc.) that the caller passed in.
     pub forbidden_tiles: FxHashSet<(i32, i32)>,
+    /// #652 retry-with-teeth: tiles forbidden REGARDLESS of entity
+    /// kind. `refresh_forbidden` filters obstacle tiles through the
+    /// surface-belt exemption (SAT may lift and re-stamp simple
+    /// surface belts) and the port exemption — both of which made the
+    /// obvious conflict-retry a measured no-op (see the context-
+    /// conflict branch in `ghost_router.rs`). Tiles in this set skip
+    /// both exemptions: they are inserted into `forbidden_tiles`
+    /// unconditionally on every refresh, so they reach the SAT zone's
+    /// `forced_empty` and thereby the cache signature's `|F:` section
+    /// (no cache aliasing — a retried zone is a DIFFERENT cached
+    /// problem). If an override tile coincides with a boundary port,
+    /// the encoder treats a non-interior boundary on a `forced_empty`
+    /// tile as perimeter and returns UNSAT, which forces the region to
+    /// grow past the tile (`sat.rs`, `ZoneBoundary::interior` docs) —
+    /// the "grow instead" fallback the retry needs for ports.
+    pub forbidden_override: FxHashSet<(i32, i32)>,
     /// Tight enclosing rectangle around `tiles`.
     pub bbox: Rect,
     /// Per-spec path-index range currently included. Inclusive on both
@@ -106,6 +122,7 @@ impl GrowingRegion {
         strict_obstacles: &FxHashSet<(i32, i32)>,
         placed_entities: &[PlacedEntity],
         spec_kinds: &FxHashMap<String, SpecKind>,
+        forbidden_override: &FxHashSet<(i32, i32)>,
     ) -> Self {
         assert!(!seeds.is_empty(), "from_crossings: seeds must be non-empty");
         let min_x = seeds.iter().map(|(x, _)| *x).min().unwrap();
@@ -144,6 +161,7 @@ impl GrowingRegion {
             encountered: Vec::new(),
             tiles,
             forbidden_tiles: FxHashSet::default(),
+            forbidden_override: forbidden_override.clone(),
             bbox,
             frontiers,
         };
@@ -570,6 +588,18 @@ impl GrowingRegion {
                 if forbidden_kind {
                     self.forbidden_tiles.insert(t);
                 }
+            }
+        }
+
+        // Retry-with-teeth override: forbidden regardless of entity
+        // kind, and regardless of the port exemption — see the field's
+        // docs for why both exemptions must lose here (the conflict
+        // tiles hold committed entities this zone must not re-stamp,
+        // and a port-coincident override resolves via encoder UNSAT +
+        // growth, not via placement).
+        for &t in &self.forbidden_override {
+            if self.bbox.contains(t.0, t.1) {
+                self.forbidden_tiles.insert(t);
             }
         }
     }
@@ -1101,6 +1131,11 @@ pub fn solve_crossing(
     // real entities; treating them as still-pending causes spurious
     // deferrals for zones whose exits happen to land on them.
     pending_crossings: &FxHashSet<(i32, i32)>,
+    // #652 retry-with-teeth: tiles forbidden regardless of entity kind
+    // (see `GrowingRegion::forbidden_override`). Empty on the primary
+    // attempt; the ghost router's context-conflict branch retries a
+    // conflicted cluster once with the conflict tiles here.
+    forbidden_override: &FxHashSet<(i32, i32)>,
 ) -> Option<JunctionSolution> {
     assert!(!seeds.is_empty(), "solve_crossing: seeds must be non-empty");
     let initial_tile = seeds[0];
@@ -1112,6 +1147,7 @@ pub fn solve_crossing(
         strict_obstacles,
         placed_entities,
         spec_kinds,
+        forbidden_override,
     );
 
     // Emit start-of-solve snapshot: seed, participating specs, and

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -2560,6 +2560,91 @@ mod tests {
         );
     }
 
+    /// #652 retry-with-teeth: the `forbidden_override` must defeat BOTH
+    /// exemptions in `refresh_forbidden` — the surface-belt exemption
+    /// (SAT may normally lift/re-stamp plain belts) and the port
+    /// exemption (frontier endpoints are normally never forbidden).
+    /// It must also be bbox-scoped: an override tile outside the
+    /// current bbox contributes nothing until growth expands the bbox
+    /// over it, at which point the refresh re-inserts it.
+    #[test]
+    fn forbidden_override_defeats_exemptions_and_tracks_growth() {
+        let mut routed_paths: FxHashMap<String, Vec<(i32, i32)>> = FxHashMap::default();
+        routed_paths.insert("a".into(), (9..=13).map(|x| (x, 10)).collect());
+        let placed: Vec<PlacedEntity> = (9..=13)
+            .map(|x| belt(x, 10, EntityDirection::East, "iron-plate"))
+            .collect();
+        // Both tiles sit in an obstacle set, but both hold plain surface
+        // belts — and (11,10) is the spec's frontier seed, i.e. a port.
+        let strict: FxHashSet<(i32, i32)> = [(11, 10), (12, 10)].into_iter().collect();
+        let hard = FxHashSet::default();
+        let spec_kinds: FxHashMap<String, SpecKind> = FxHashMap::default();
+
+        // Control: without an override, the exemptions win.
+        let region = GrowingRegion::from_crossings(
+            &[(11, 10)],
+            &["a"],
+            &routed_paths,
+            &hard,
+            &strict,
+            &placed,
+            &spec_kinds,
+            &FxHashSet::default(),
+        );
+        assert!(
+            !region.forbidden_tiles.contains(&(11, 10)),
+            "control: port + surface-belt exemptions must keep (11,10) free"
+        );
+
+        // Override: (11,10) in-bbox (port + surface belt) → forbidden;
+        // (12,10) and (99,99) outside the 1x1 bbox → not yet.
+        let override_set: FxHashSet<(i32, i32)> =
+            [(11, 10), (12, 10), (99, 99)].into_iter().collect();
+        let mut region = GrowingRegion::from_crossings(
+            &[(11, 10)],
+            &["a"],
+            &routed_paths,
+            &hard,
+            &strict,
+            &placed,
+            &spec_kinds,
+            &override_set,
+        );
+        assert!(
+            region.forbidden_tiles.contains(&(11, 10)),
+            "override must defeat both the port and surface-belt exemptions"
+        );
+        assert!(
+            !region.forbidden_tiles.contains(&(12, 10)),
+            "override tile outside the bbox must not be forbidden yet"
+        );
+        assert!(!region.forbidden_tiles.contains(&(99, 99)));
+
+        // Growth: expand right so (12,10) enters the bbox — the refresh
+        // must re-insert it from the persisted override.
+        let grew = region.expand_bbox(
+            0,
+            0,
+            1,
+            0,
+            &routed_paths,
+            &hard,
+            &strict,
+            &placed,
+            &FxHashSet::default(),
+            &spec_kinds,
+        );
+        assert!(grew, "expand_bbox right by 1 must succeed");
+        assert!(
+            region.forbidden_tiles.contains(&(12, 10)),
+            "override tile newly inside the bbox must become forbidden on growth"
+        );
+        assert!(
+            region.forbidden_tiles.contains(&(11, 10)),
+            "original override tile must survive the growth refresh"
+        );
+    }
+
     #[test]
     fn trim_path_keeps_bbox_span_only() {
         // Path runs east across 20 tiles; bbox covers x=10..=12. Trim

--- a/crates/core/src/fixture.rs
+++ b/crates/core/src/fixture.rs
@@ -257,6 +257,7 @@ pub fn replay_region_fixture(fixture: &RegionFixture) -> RegionReplayResult {
         &fixture.placed_entities,
         &strategies,
         &pending_crossings,
+        &FxHashSet::default(),
     );
     let events = trace::drain_events();
     drop(guard);

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -464,6 +464,22 @@ pub enum TraceEvent {
         item: String,
         into_item: String,
     },
+    /// #652 retry-with-teeth: a cluster's solution collided with
+    /// differing committed entities (context-conflict at commit), and
+    /// the cluster was re-solved once with the conflicting tiles as a
+    /// forbidden-override (forbidden regardless of entity kind — the
+    /// surface-belt exemption does not apply). `resolved == true`
+    /// means the retry produced a conflict-free solution that was
+    /// committed; `false` means the retry failed (no solution, or a
+    /// solution that still conflicted) and the cluster fell through to
+    /// the cap/fail-sever machinery. One event per retried cluster,
+    /// tagged with the cluster's seed tile.
+    CrossingConflictRetried {
+        x: i32,
+        y: i32,
+        conflict_tiles: usize,
+        resolved: bool,
+    },
     /// A balancer block was requested for a lane family. `template_found
     /// == false` is not necessarily a bug by itself — it means no direct
     /// template, gcd-decomposition, nor the runtime generator could


### PR DESCRIPTION
## Intent

Implement the retry-with-teeth design recorded on #652: give the ghost router's context-conflict branch a re-solve in which the conflicting committed tiles are forbidden **regardless of entity kind** — the naive strict-obstacles retry was a measured no-op because `refresh_forbidden`'s surface-belt exemption filtered the tiles back out and the zone cache replayed the identical solution.

This PR ships the mechanism plus the diagnosis it enabled. It does **not** yet reduce ac7's error count — the honest outcome and the reason are below, and the next lever is recorded on #652.

## Scope

- `GrowingRegion::forbidden_override` (new field): tiles inserted into `forbidden_tiles` unconditionally at the end of every `refresh_forbidden` — both the surface-belt exemption and the port exemption lose. Threaded through `from_crossings` / `solve_crossing`; empty for all pre-existing callers (fixture replay, blame diagnostics).
- ghost_router context-conflict branch: conflict check extracted into a closure; ONE retry with the conflict tiles as the override; new `CrossingConflictRetried { x, y, conflict_tiles, resolved }` trace event either way; cap-path skip reason now names the retry.
- Env-gated diagnostics under `SPAGHETTIO_DEBUG_CONFLICT_RETRY` (same pattern as `SPAGHETTIO_BLAME_JUNCTIONS`): primary conflicting entities vs committed, retry outcome, and a SAT pre-pass line (zone dims/vars/forced_empty/boundaries) — kept deliberately, they are the instruments for the follow-up unit.

Two pieces of the recorded design turned out **unnecessary**, which shrank the diff:
- **No cache-signature extension**: override tiles reach `CrossingZone::forced_empty`, which is already in the signature's `|F:` section — a retried zone is a distinct cached problem for free.
- **No port-tile special case**: a non-interior boundary on a `forced_empty` tile is documented encoder UNSAT (forces growth), and `topology_boundaries` re-expresses ports on forced tiles as *interior* boundaries when an item-matched entity sits there.

## Measured outcome (ac7-HS duty 0.6, the target fixture)

The retry fires on both conflicted clusters (seeds (15,93)/(15,96)) and engages end-to-end: fresh signature, `forced_empty` populated, 2 interior boundaries emitted, and a direct encoder call (local repro example) proves the retry zone **SAT** — with exactly the needed shape (deliver into the committed belts at (17,96)/(17,97), stamp nothing on them).

It still returns None in the pipeline, by a composition of three individually-correct mechanisms:
1. The conflict is a **flow-compatible identity mismatch**: the primary wants `underground-belt output East copper-cable` on a committed `transport-belt East copper-cable` — same item/direction/tier. Every feasible solution must either re-stamp a committed continuation belt (identity conflict) or deliver into it via the interior-boundary path.
2. On the interior-boundary retry, SAT's channel-fungible solution **reassigns which same-channel drop column carries which flow** (the zone has a 6-column copper fan in one channel); the walker veto correctly rejects the broken routed path (`flow:copper-cable:14 breaks at (14,94)`).
3. The veto's remedy is **growth**, which pushes the zone over `MAX_ZONE_SAT_VARS` → `sat_var_ceiling` cap.

Error population is byte-identical (17: 6 iso + 8 dead-end + 3 unresolved-junction). The recorded next lever (#652 comment): wire the existing, tested, currently-unwired `sat::solve_crossing_zone_with_pins` into the veto path — pin the vetoed path's committed in-zone tiles and re-solve the **same** zone instead of growing.

## Verification actually run

- CI-way full core suite (cache-pin protocol from `docs/test-suite-followups.md`): **CARGO_EXIT=0**. Every layout-hash pin and warning golden holds — this doubles as the corpus receipt that no shipped layout changes anywhere (a successful retry would flip a hash pin).
- Clippy clean on touched files (pre-commit hook + `--all-targets` run).
- ac7 probe (`i652_ac7_error_classify`, local example): error classes byte-identical before/after; retry firing + failure mode confirmed via the new trace event and env-gated diagnostics.
- Direct encoder repro (`i652_retry_zone_repro`, local example): retry zone SAT at cap None (30 entities, ~4ms), UNSAT at caps 0/1/2 — the ladder's lower rungs are legitimately refusing.

## Deviations

- The recorded design said "cache bypass or signature extension" — neither shipped, because the signature already covers `forced_empty` (explained above; the design comment in the conflict branch documents it).
- No new pin test: behavior is corpus-invariant by the suite receipt, and the retry's success case has no exhibiting fixture yet. The follow-up pin-re-solve unit is where a behavioral pin lands (it will have an exhibiting fixture: ac7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n
