### PR TITLE
feat(router): #652 flow-compatible commit upgrade — UG outputs may replace their committed continuation belts

### DIFF
--- a/crates/core/src/bus/ghost_occupancy.rs
+++ b/crates/core/src/bus/ghost_occupancy.rs
@@ -359,6 +359,17 @@ impl Occupancy {
         Ok(idx)
     }
 
+    /// Drop the claim at `tile`, orphaning its entity (see `place`'s
+    /// orphan note — the backing entity stays in `self.entities` for
+    /// index stability but no claim points to it). Returns true if a
+    /// claim was removed. Used by the flow-compatible commit upgrade
+    /// (#652): a crossing-zone solution may replace a committed
+    /// same-item, same-direction, same-tier surface belt with the UG
+    /// output that continues the identical flow.
+    pub fn release_tile(&mut self, tile: (i32, i32)) -> bool {
+        self.claims.remove(&tile).is_some()
+    }
+
     /// Drop every `GhostSurface` claim whose tile lies inside `zone`.
     /// The corresponding entities become orphaned (see `place`'s note).
     /// Used by SAT before claiming tiles for its own solution.

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3080,45 +3080,64 @@ pub fn route_bus_ghost(
             }
             continue;
         };
-        let conflicts_of = |sol_entities: &[PlacedEntity],
-                           footprint: crate::bus::junction::Rect|
-         -> Vec<(i32, i32)> {
-            sol_entities
-                .iter()
-                .filter(|ent| {
-                    let tile = (ent.x, ent.y);
-                    let claimed = matches!(
+        // Classify each solution entity landing on a committed
+        // Template/RowEntity tile: identical → benign dedupe (neither
+        // list), flow-compatible UG-output-over-continuation-belt on a
+        // Template claim → upgrade (see `flow_compatible_ug_upgrade`;
+        // RowEntity targets are never upgrades — row belts live in
+        // `row_entities` with no eviction path), anything else →
+        // conflict. Evaluated ONCE here — the stamping loop consumes
+        // the approved `upgrades` set instead of re-evaluating, because
+        // the release pass mutates occupancy between the two sites and
+        // a re-evaluation can flip (measured: a stamp-time flip dropped
+        // a UG output and shipped unpaired-UG + belt-loop errors).
+        let classify = |s: &junction_solver::JunctionSolution| -> (
+            Vec<(i32, i32)>,
+            FxHashSet<(i32, i32)>,
+        ) {
+            let mut conflicts: Vec<(i32, i32)> = Vec::new();
+            let mut upgrades: FxHashSet<(i32, i32)> = FxHashSet::default();
+            for ent in &s.entities {
+                let tile = (ent.x, ent.y);
+                let is_template = matches!(
+                    occupancy.claim_at(tile),
+                    Some(crate::bus::ghost_occupancy::Claim::Template { .. })
+                );
+                let claimed = is_template
+                    || matches!(
                         occupancy.claim_at(tile),
-                        Some(crate::bus::ghost_occupancy::Claim::Template { .. })
-                            | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
+                        Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
                     );
-                    claimed
-                        && occupancy.entity_at(tile).is_some_and(|existing| {
-                            let differs = existing.name != ent.name
-                                || existing.direction != ent.direction
-                                || existing.io_type != ent.io_type
-                                || existing.carries != ent.carries;
-                            // #652 flow-compatible carve-out: a UG output
-                            // continuing a committed belt's identical flow
-                            // is an upgrade, not a conflict (see
-                            // `flow_compatible_ug_upgrade`). ac7 proof: the
-                            // walker-clean topology REQUIRES the UG to
-                            // surface exactly on the committed continuation
-                            // belt, and the pin/retry alternatives are
-                            // measured structurally unsolvable there.
-                            differs
-                                && !flow_compatible_ug_upgrade(
-                                    &occupancy,
-                                    existing,
-                                    ent,
-                                    footprint,
-                                )
-                        })
-                })
-                .map(|ent| (ent.x, ent.y))
-                .collect()
+                if !claimed {
+                    continue;
+                }
+                let Some(existing) = occupancy.entity_at(tile) else {
+                    continue;
+                };
+                let differs = existing.name != ent.name
+                    || existing.direction != ent.direction
+                    || existing.io_type != ent.io_type
+                    || existing.carries != ent.carries;
+                if !differs {
+                    continue;
+                }
+                if is_template
+                    && flow_compatible_ug_upgrade(
+                        &occupancy,
+                        existing,
+                        ent,
+                        s.footprint,
+                        &s.participating,
+                    )
+                {
+                    upgrades.insert(tile);
+                } else {
+                    conflicts.push(tile);
+                }
+            }
+            (conflicts, upgrades)
         };
-        let mut conflicts = conflicts_of(&sol.entities, sol.footprint);
+        let (mut conflicts, mut upgrades) = classify(&sol);
         if !conflicts.is_empty() {
             if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
                 for ent in &sol.entities {
@@ -3210,8 +3229,7 @@ pub fn route_bus_ghost(
             let mut retry_footprint = None;
             let resolved = match retry {
                 Some(retry_sol) => {
-                    let retry_conflicts =
-                        conflicts_of(&retry_sol.entities, retry_sol.footprint);
+                    let (retry_conflicts, retry_upgrades) = classify(&retry_sol);
                     if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
                         eprintln!(
                             "CONFLICT-RETRY seed {:?}: primary footprint {:?}, \
@@ -3229,6 +3247,7 @@ pub fn route_bus_ghost(
                     }
                     if retry_conflicts.is_empty() {
                         sol = retry_sol;
+                        upgrades = retry_upgrades;
                         true
                     } else {
                         retry_footprint = Some(retry_sol.footprint);
@@ -3551,28 +3570,21 @@ pub fn route_bus_ghost(
             //
             // EXCEPTION (#652 flow-compatible upgrade): a solution UG
             // output continuing a committed belt's identical flow
-            // replaces it — the conflict check accepted the tile via
-            // `flow_compatible_ug_upgrade`, so skipping here would
-            // strand the solution's flow underground (the UG-in would
-            // keep its half of the pair while the output vanished).
-            // Release the committed claim and purge the superseded
-            // belt from the entity list, then stamp normally.
+            // replaces it — the conflict check approved the tile into
+            // `upgrades` (evaluated ONCE, pre-release; re-evaluating
+            // here against post-release occupancy can flip and
+            // silently drop the UG output, stranding the solution's
+            // flow underground with an unpaired UG-in — measured on
+            // this PR's review round). Release the committed claim
+            // and purge the superseded entities at the tile from the
+            // entity list (the crossing belt plus any stale ghost
+            // orphan sharing the tile), then stamp normally.
             if matches!(
                 occupancy.claim_at(tile),
                 Some(crate::bus::ghost_occupancy::Claim::Template { .. })
                     | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
             ) {
-                let upgrade = occupancy.entity_at(tile).is_some_and(|existing| {
-                    let differs = existing.name != ent.name
-                        || existing.direction != ent.direction
-                        || existing.io_type != ent.io_type
-                        || existing.carries != ent.carries;
-                    differs
-                        && flow_compatible_ug_upgrade(
-                            &occupancy, existing, &ent, footprint,
-                        )
-                });
-                if !upgrade {
+                if !upgrades.contains(&tile) {
                     continue;
                 }
                 occupancy.release_tile(tile);
@@ -5174,49 +5186,56 @@ fn any_spec_turns_at(tile: (i32, i32), routed_paths: &FxHashMap<String, Vec<(i32
     false
 }
 
-/// Returns true if a UG-in/out at `tile` facing `bridge_dir` would receive
-/// a sideload from a perpendicular spec — either because the tile itself has
-/// a perpendicular spec passing through, or because an adjacent SIDE tile
-/// (perpendicular to the bridge axis) has a belt flowing INTO this tile.
-///
-/// In Factorio, sideloads onto UG-input belts only fill the far lane and
-/// can dump items wrong; we reject any template that would create one.
-///
-/// The check considers both (a) in-flight routed ghost specs and (b) already-
-/// placed physical entities (splitters, row belts, trunks placed in Step 2-3).
-/// Without (b), a splitter whose output drops straight into this tile from a
-/// perpendicular direction slips through — the splitter is stamped before
-/// ghost routing and never enters `routed_paths`.
-///
 /// #652 flow-compatible commit upgrade: is `wanted` (a crossing-zone
 /// solution entity) a legal REPLACEMENT for `existing` (a committed
-/// Template/RowEntity-claimed entity at the same tile)?
+/// `Claim::Template` entity at the same tile)? `RowEntity` targets are
+/// excluded by the caller — row-template belts live in `row_entities`,
+/// not the bus `entities` vec, so there is no eviction path for them
+/// (session-side review on this PR).
 ///
 /// The one shape accepted: a UG **output** replacing a plain surface
 /// belt of the same tier, same direction, same item. Flow topology is
 /// preserved exactly — the UG output expels the identical item stream
 /// onto the same downstream tile the belt fed; only the upstream
 /// delivery switches from surface to underground, which is the zone
-/// solution's job. This is the unique walker-clean topology for the
-/// ac7 conflict class: the crossing's UG must surface exactly ON the
-/// committed continuation belt (measured on #652 — the forbid-and-grow
-/// retry and the veto→pin re-solve are both structurally unsolvable
-/// for this shape).
+/// solution's job. On the ac7 conflict class this is the only
+/// walker-clean topology found (argued from dive-column occupancy on
+/// #652, not enumerated): the crossing's UG surfaces exactly ON the
+/// committed continuation belt, and the forbid-and-grow retry and the
+/// veto→pin re-solve were both measured unsolvable for the shape.
 ///
-/// Guards, both conservative (false ⇒ the caller keeps the conflict):
-/// - The tile directly behind the UG output must lie inside the
-///   solution footprint: the zone re-derives that upstream, so no
-///   committed surface flow can jam against the output's back (a UG
-///   exit cannot accept surface items from behind).
-/// - No committed entity outside the footprint may output INTO the
-///   tile from a side: sideloads onto a UG exit lose the near-side
-///   lane (docs/factorio-mechanics.md), so a side-fed continuation
-///   belt must not be silently downgraded.
+/// EVALUATED ONCE, AT CONFLICT-CHECK TIME. The caller carries the
+/// approved tile set to the stamping loop rather than re-evaluating
+/// there: between the two sites the commit's release pass mutates
+/// occupancy, and a re-evaluation can flip (measured on this PR's
+/// review round — a stamp-time flip silently dropped a UG output and
+/// shipped an unpaired-UG + belt-loop error pair).
+///
+/// Guards, all conservative (false ⇒ the caller keeps the conflict).
+/// `released_at` mirrors what the commit's release pass will drop
+/// (`release_for_pertile_template` + `releasable_ghost_tiles`):
+/// GhostSurface claims on PARTICIPATING specs' paths and trunk
+/// Permanents; Template/RowEntity/SatSolved claims persist even
+/// inside the footprint, and balancer/tapoff Permanents may be
+/// preserved — all counted persistent here (a false "persistent"
+/// keeps the conflict, never mints an unsound upgrade).
+/// - Behind tile (the UG exit's back — surface items cannot enter
+///   it): must be inside the footprint and hold nothing persistent,
+///   so no surviving committed flow can jam against it.
+/// - Side neighbors: no persistent entity may feed the tile — a
+///   belt-like entity outputting into it (conservative by analogy
+///   with U7 in docs/factorio-mechanics.md: sideloads interact with
+///   UG endpoints lane-asymmetrically; the exit case is not
+///   documented, so it is refused outright), nor any adjacent
+///   inserter (drop-side conventions are not modeled here). Splitter
+///   second tiles are resolved via `splitter_second_tile` — occupancy
+///   claims key on anchor tiles only.
 fn flow_compatible_ug_upgrade(
     occupancy: &crate::bus::ghost_occupancy::Occupancy,
     existing: &PlacedEntity,
     wanted: &PlacedEntity,
     footprint: crate::bus::junction::Rect,
+    participating: &[String],
 ) -> bool {
     if wanted.io_type.as_deref() != Some("output") {
         return false;
@@ -5240,6 +5259,49 @@ fn flow_compatible_ug_upgrade(
     if existing.carries.is_none() || existing.carries != wanted.carries {
         return false;
     }
+
+    let released_at = |tile: (i32, i32)| -> bool {
+        if !footprint.contains(tile.0, tile.1) {
+            return false;
+        }
+        match occupancy.claim_at(tile) {
+            Some(crate::bus::ghost_occupancy::Claim::GhostSurface { .. }) => occupancy
+                .entity_at(tile)
+                .and_then(|e| e.segment_id.as_deref())
+                .and_then(|s| s.strip_prefix("ghost:"))
+                .is_some_and(|key| participating.iter().any(|p| p == key)),
+            Some(crate::bus::ghost_occupancy::Claim::Permanent { .. }) => occupancy
+                .entity_at(tile)
+                .and_then(|e| e.segment_id.as_deref())
+                .is_some_and(|s| s.starts_with("trunk:")),
+            Some(_) => false,
+            None => true,
+        }
+    };
+    // Anchor-or-splitter-second-tile lookup: a splitter is 2 wide and
+    // only its anchor carries a claim, so a covering splitter must be
+    // found via its possible anchor positions.
+    let entity_covering = |tile: (i32, i32)| -> Option<&PlacedEntity> {
+        if let Some(e) = occupancy.entity_at(tile) {
+            return Some(e);
+        }
+        for (ax, ay) in [
+            (tile.0 - 1, tile.1),
+            (tile.0 + 1, tile.1),
+            (tile.0, tile.1 - 1),
+            (tile.0, tile.1 + 1),
+        ] {
+            if let Some(e) = occupancy.entity_at((ax, ay)) {
+                if crate::common::is_splitter(&e.name)
+                    && crate::common::splitter_second_tile(e) == tile
+                {
+                    return Some(e);
+                }
+            }
+        }
+        None
+    };
+
     let (dx, dy) = match wanted.direction {
         EntityDirection::North => (0, -1),
         EntityDirection::South => (0, 1),
@@ -5250,23 +5312,36 @@ fn flow_compatible_ug_upgrade(
     if !footprint.contains(behind.0, behind.1) {
         return false;
     }
-    // Side neighbors (not behind, not ahead): reject if a committed
-    // belt-like entity outside the footprint outputs into this tile.
+    if entity_covering(behind).is_some() && !released_at(behind) {
+        return false;
+    }
     for (nx, ny) in [
         (wanted.x + dy, wanted.y + dx),
         (wanted.x - dy, wanted.y - dx),
     ] {
-        if footprint.contains(nx, ny) {
+        if released_at((nx, ny)) {
             continue;
         }
-        if let Some(n) = occupancy.entity_at((nx, ny)) {
+        if let Some(n) = entity_covering((nx, ny)) {
+            if n.name.contains("inserter") {
+                return false;
+            }
             let (ndx, ndy) = match n.direction {
                 EntityDirection::North => (0, -1),
                 EntityDirection::South => (0, 1),
                 EntityDirection::East => (1, 0),
                 EntityDirection::West => (-1, 0),
             };
-            let outputs_into_tile = (nx + ndx, ny + ndy) == (wanted.x, wanted.y);
+            // For a splitter the flow crosses its whole 2-wide body in
+            // its facing direction, so anchor-based delta still answers
+            // "does it output into our tile" for the covering tile.
+            let outputs_into_tile = if crate::common::is_splitter(&n.name) {
+                let second = crate::common::splitter_second_tile(n);
+                (n.x + ndx, n.y + ndy) == (wanted.x, wanted.y)
+                    || (second.0 + ndx, second.1 + ndy) == (wanted.x, wanted.y)
+            } else {
+                (nx + ndx, ny + ndy) == (wanted.x, wanted.y)
+            };
             let belt_like = n.name.contains("transport-belt")
                 || n.name.contains("underground-belt")
                 || n.name.contains("splitter");
@@ -5278,6 +5353,20 @@ fn flow_compatible_ug_upgrade(
     true
 }
 
+/// Returns true if a UG-in/out at `tile` facing `bridge_dir` would receive
+/// a sideload from a perpendicular spec — either because the tile itself has
+/// a perpendicular spec passing through, or because an adjacent SIDE tile
+/// (perpendicular to the bridge axis) has a belt flowing INTO this tile.
+///
+/// In Factorio, sideloads onto UG-input belts only fill the far lane and
+/// can dump items wrong; we reject any template that would create one.
+///
+/// The check considers both (a) in-flight routed ghost specs and (b) already-
+/// placed physical entities (splitters, row belts, trunks placed in Step 2-3).
+/// Without (b), a splitter whose output drops straight into this tile from a
+/// perpendicular direction slips through — the splitter is stamped before
+/// ghost routing and never enters `routed_paths`.
+///
 /// Returns `None` if the tile is fine, or `Some(reason)` identifying the
 /// first conflict found. The caller tags the reason with the endpoint
 /// it was checking (UG-in vs UG-out).

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3080,7 +3080,9 @@ pub fn route_bus_ghost(
             }
             continue;
         };
-        let conflicts_of = |sol_entities: &[PlacedEntity]| -> Vec<(i32, i32)> {
+        let conflicts_of = |sol_entities: &[PlacedEntity],
+                           footprint: crate::bus::junction::Rect|
+         -> Vec<(i32, i32)> {
             sol_entities
                 .iter()
                 .filter(|ent| {
@@ -3092,16 +3094,31 @@ pub fn route_bus_ghost(
                     );
                     claimed
                         && occupancy.entity_at(tile).is_some_and(|existing| {
-                            existing.name != ent.name
+                            let differs = existing.name != ent.name
                                 || existing.direction != ent.direction
                                 || existing.io_type != ent.io_type
-                                || existing.carries != ent.carries
+                                || existing.carries != ent.carries;
+                            // #652 flow-compatible carve-out: a UG output
+                            // continuing a committed belt's identical flow
+                            // is an upgrade, not a conflict (see
+                            // `flow_compatible_ug_upgrade`). ac7 proof: the
+                            // walker-clean topology REQUIRES the UG to
+                            // surface exactly on the committed continuation
+                            // belt, and the pin/retry alternatives are
+                            // measured structurally unsolvable there.
+                            differs
+                                && !flow_compatible_ug_upgrade(
+                                    &occupancy,
+                                    existing,
+                                    ent,
+                                    footprint,
+                                )
                         })
                 })
                 .map(|ent| (ent.x, ent.y))
                 .collect()
         };
-        let mut conflicts = conflicts_of(&sol.entities);
+        let mut conflicts = conflicts_of(&sol.entities, sol.footprint);
         if !conflicts.is_empty() {
             if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
                 for ent in &sol.entities {
@@ -3193,7 +3210,8 @@ pub fn route_bus_ghost(
             let mut retry_footprint = None;
             let resolved = match retry {
                 Some(retry_sol) => {
-                    let retry_conflicts = conflicts_of(&retry_sol.entities);
+                    let retry_conflicts =
+                        conflicts_of(&retry_sol.entities, retry_sol.footprint);
                     if std::env::var("SPAGHETTIO_DEBUG_CONFLICT_RETRY").is_ok() {
                         eprintln!(
                             "CONFLICT-RETRY seed {:?}: primary footprint {:?}, \
@@ -3530,12 +3548,35 @@ pub fn route_bus_ghost(
             // it leaks an orphan belt at a tile that's already claimed
             // by an earlier template, and the validator flags it as
             // an entity-overlap with the earlier entity.
+            //
+            // EXCEPTION (#652 flow-compatible upgrade): a solution UG
+            // output continuing a committed belt's identical flow
+            // replaces it — the conflict check accepted the tile via
+            // `flow_compatible_ug_upgrade`, so skipping here would
+            // strand the solution's flow underground (the UG-in would
+            // keep its half of the pair while the output vanished).
+            // Release the committed claim and purge the superseded
+            // belt from the entity list, then stamp normally.
             if matches!(
                 occupancy.claim_at(tile),
                 Some(crate::bus::ghost_occupancy::Claim::Template { .. })
                     | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
             ) {
-                continue;
+                let upgrade = occupancy.entity_at(tile).is_some_and(|existing| {
+                    let differs = existing.name != ent.name
+                        || existing.direction != ent.direction
+                        || existing.io_type != ent.io_type
+                        || existing.carries != ent.carries;
+                    differs
+                        && flow_compatible_ug_upgrade(
+                            &occupancy, existing, &ent, footprint,
+                        )
+                });
+                if !upgrade {
+                    continue;
+                }
+                occupancy.release_tile(tile);
+                entities.retain(|e| (e.x, e.y) != tile);
             }
             occupancy
                 .place(
@@ -5147,6 +5188,96 @@ fn any_spec_turns_at(tile: (i32, i32), routed_paths: &FxHashMap<String, Vec<(i32
 /// perpendicular direction slips through — the splitter is stamped before
 /// ghost routing and never enters `routed_paths`.
 ///
+/// #652 flow-compatible commit upgrade: is `wanted` (a crossing-zone
+/// solution entity) a legal REPLACEMENT for `existing` (a committed
+/// Template/RowEntity-claimed entity at the same tile)?
+///
+/// The one shape accepted: a UG **output** replacing a plain surface
+/// belt of the same tier, same direction, same item. Flow topology is
+/// preserved exactly — the UG output expels the identical item stream
+/// onto the same downstream tile the belt fed; only the upstream
+/// delivery switches from surface to underground, which is the zone
+/// solution's job. This is the unique walker-clean topology for the
+/// ac7 conflict class: the crossing's UG must surface exactly ON the
+/// committed continuation belt (measured on #652 — the forbid-and-grow
+/// retry and the veto→pin re-solve are both structurally unsolvable
+/// for this shape).
+///
+/// Guards, both conservative (false ⇒ the caller keeps the conflict):
+/// - The tile directly behind the UG output must lie inside the
+///   solution footprint: the zone re-derives that upstream, so no
+///   committed surface flow can jam against the output's back (a UG
+///   exit cannot accept surface items from behind).
+/// - No committed entity outside the footprint may output INTO the
+///   tile from a side: sideloads onto a UG exit lose the near-side
+///   lane (docs/factorio-mechanics.md), so a side-fed continuation
+///   belt must not be silently downgraded.
+fn flow_compatible_ug_upgrade(
+    occupancy: &crate::bus::ghost_occupancy::Occupancy,
+    existing: &PlacedEntity,
+    wanted: &PlacedEntity,
+    footprint: crate::bus::junction::Rect,
+) -> bool {
+    if wanted.io_type.as_deref() != Some("output") {
+        return false;
+    }
+    // Same-tier check via name prefixes: "" / "fast-" / "express-".
+    let (Some(tier_e), Some(tier_w)) = (
+        existing.name.strip_suffix("transport-belt"),
+        wanted.name.strip_suffix("underground-belt"),
+    ) else {
+        return false;
+    };
+    if tier_e != tier_w {
+        return false;
+    }
+    if existing.io_type.is_some() {
+        return false;
+    }
+    if existing.direction != wanted.direction {
+        return false;
+    }
+    if existing.carries.is_none() || existing.carries != wanted.carries {
+        return false;
+    }
+    let (dx, dy) = match wanted.direction {
+        EntityDirection::North => (0, -1),
+        EntityDirection::South => (0, 1),
+        EntityDirection::East => (1, 0),
+        EntityDirection::West => (-1, 0),
+    };
+    let behind = (wanted.x - dx, wanted.y - dy);
+    if !footprint.contains(behind.0, behind.1) {
+        return false;
+    }
+    // Side neighbors (not behind, not ahead): reject if a committed
+    // belt-like entity outside the footprint outputs into this tile.
+    for (nx, ny) in [
+        (wanted.x + dy, wanted.y + dx),
+        (wanted.x - dy, wanted.y - dx),
+    ] {
+        if footprint.contains(nx, ny) {
+            continue;
+        }
+        if let Some(n) = occupancy.entity_at((nx, ny)) {
+            let (ndx, ndy) = match n.direction {
+                EntityDirection::North => (0, -1),
+                EntityDirection::South => (0, 1),
+                EntityDirection::East => (1, 0),
+                EntityDirection::West => (-1, 0),
+            };
+            let outputs_into_tile = (nx + ndx, ny + ndy) == (wanted.x, wanted.y);
+            let belt_like = n.name.contains("transport-belt")
+                || n.name.contains("underground-belt")
+                || n.name.contains("splitter");
+            if outputs_into_tile && belt_like {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 /// Returns `None` if the tile is fine, or `Some(reason)` identifying the
 /// first conflict found. The caller tags the reason with the endpoint
 /// it was checking (UG-in vs UG-out).

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3584,7 +3584,12 @@ pub fn route_bus_ghost(
                 Some(crate::bus::ghost_occupancy::Claim::Template { .. })
                     | Some(crate::bus::ghost_occupancy::Claim::RowEntity { .. })
             ) {
-                if !upgrades.contains(&tile) {
+                // Consume (remove, not test): a second solution entity
+                // at the same tile must NOT re-apply the release —
+                // it would clobber the just-stamped upgrade (bot
+                // round 2, defence-in-depth; the solver never emits
+                // overlapping entities today, `place` would panic).
+                if !upgrades.remove(&tile) {
                     continue;
                 }
                 occupancy.release_tile(tile);
@@ -5230,6 +5235,17 @@ fn any_spec_turns_at(tile: (i32, i32), routed_paths: &FxHashMap<String, Vec<(i32
 ///   inserter (drop-side conventions are not modeled here). Splitter
 ///   second tiles are resolved via `splitter_second_tile` — occupancy
 ///   claims key on anchor tiles only.
+///
+/// Two adjacencies are deliberately NOT guarded here because other
+/// layers own them: (a) the FORWARD tile the output expels onto — a
+/// solution UG-out's downstream flow is part of SAT's own model
+/// (in-zone: the adjacency rules require a receiving entity or an
+/// interior sink; zone-edge: off-grid output is only legal at
+/// boundary ports, where the committed continuation persists), and
+/// the walker re-walks the composite before any candidate reaches
+/// the conflict check; (b) SOLUTION entities beside/behind the tile —
+/// this predicate reads committed occupancy only, and solution-
+/// internal shapes are the encoder's + walker's jurisdiction.
 fn flow_compatible_ug_upgrade(
     occupancy: &crate::bus::ghost_occupancy::Occupancy,
     existing: &PlacedEntity,
@@ -5272,8 +5288,17 @@ fn flow_compatible_ug_upgrade(
                 .is_some_and(|key| participating.iter().any(|p| p == key)),
             Some(crate::bus::ghost_occupancy::Claim::Permanent { .. }) => occupancy
                 .entity_at(tile)
-                .and_then(|e| e.segment_id.as_deref())
-                .is_some_and(|s| s.starts_with("trunk:")),
+                .is_some_and(|e| {
+                    // Pipes are refused by the release pass regardless
+                    // of segment (`release_for_pertile_template` —
+                    // fluid trunks are inviolable), so a trunk: pipe
+                    // PERSISTS and must not count as released here
+                    // (bot round 2 on this PR).
+                    !matches!(e.name.as_str(), "pipe" | "pipe-to-ground")
+                        && e.segment_id
+                            .as_deref()
+                            .is_some_and(|s| s.starts_with("trunk:"))
+                }),
             Some(_) => false,
             None => true,
         }

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3589,6 +3589,16 @@ pub fn route_bus_ghost(
                 // it would clobber the just-stamped upgrade (bot
                 // round 2, defence-in-depth; the solver never emits
                 // overlapping entities today, `place` would panic).
+                //
+                // LOAD-BEARING INVARIANT (bot round 3): this guard's
+                // `matches!` runs against POST-release occupancy while
+                // `upgrades` was approved PRE-release — they agree
+                // only because `release_for_pertile_template` never
+                // drops Template/RowEntity claims. If the release pass
+                // is ever widened to drop Template claims, approved
+                // tiles stop matching here, the upgrade silently
+                // reverts to a skip, and the solution's UG output is
+                // stranded — re-derive this pairing before widening.
                 if !upgrades.remove(&tile) {
                     continue;
                 }
@@ -5217,13 +5227,17 @@ fn any_spec_turns_at(tile: (i32, i32), routed_paths: &FxHashMap<String, Vec<(i32
 /// shipped an unpaired-UG + belt-loop error pair).
 ///
 /// Guards, all conservative (false ⇒ the caller keeps the conflict).
-/// `released_at` mirrors what the commit's release pass will drop
-/// (`release_for_pertile_template` + `releasable_ghost_tiles`):
-/// GhostSurface claims on PARTICIPATING specs' paths and trunk
-/// Permanents; Template/RowEntity/SatSolved claims persist even
-/// inside the footprint, and balancer/tapoff Permanents may be
-/// preserved — all counted persistent here (a false "persistent"
-/// keeps the conflict, never mints an unsound upgrade).
+/// `released_at` under-approximates what the commit's release pass
+/// will drop: the actual release
+/// (`release_for_pertile_template(&release_rect, None, ..)`) clears
+/// ALL in-zone GhostSurface claims, while this mirror counts only
+/// PARTICIPATING specs' ghosts — deliberately stricter (bot round 3;
+/// relaxing to match is a recorded #652 nicety with no exhibiting
+/// fixture). Trunk Permanents (non-pipe) are released;
+/// Template/RowEntity/SatSolved claims persist even inside the
+/// footprint, and balancer/tapoff Permanents may be preserved — all
+/// counted persistent here (a false "persistent" keeps the conflict,
+/// never mints an unsound upgrade).
 /// - Behind tile (the UG exit's back — surface items cannot enter
 ///   it): must be inside the footprint and hold nothing persistent,
 ///   so no surviving committed flow can jam against it.

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2250,6 +2250,12 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
 /// pinned here: a residual balancer-over-trunk overlap (recorded on
 /// #652) still ships a handful, and that mechanism is out of this
 /// pin's scope.
+///
+/// 2026-08-16 update: the context-conflict half of the fixture IS now
+/// resolved (flow-compatible commit upgrade — see the
+/// `context_conflicts == 0` assertion below); the sever/unresolved
+/// liveness path stays exercised by the remaining 21-tile iter-capped
+/// cluster near (15,123), the mega-zone class tracked on #652/#644.
 #[test]
 #[ntest::timeout(300000)]
 fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
@@ -2272,10 +2278,34 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
         },
     )
     .expect("ac7 duty-0.6 lays out");
-    let severed = spaghettio_core::trace::drain_events()
+    let events = spaghettio_core::trace::drain_events();
+    let severed = events
         .iter()
         .filter(|e| matches!(e, spaghettio_core::trace::TraceEvent::CrossingSevered { .. }))
         .count();
+    // #652 flow-compatible upgrade pin: the context-conflict class is
+    // RESOLVED on this fixture — both formerly-conflicted clusters
+    // (seeds (15,93)/(15,96), UG outputs surfacing onto committed
+    // same-item continuation belts) now commit via
+    // `flow_compatible_ug_upgrade`. A context-conflict skip reappearing
+    // here means the carve-out regressed (or a new, genuinely
+    // incompatible conflict shape arrived — either way, look).
+    let context_conflicts = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                spaghettio_core::trace::TraceEvent::CrossingZoneSkipped { reason, .. }
+                    if reason.starts_with("context-conflict")
+            )
+        })
+        .count();
+    assert_eq!(
+        context_conflicts, 0,
+        "ac7-HS duty-0.6 shipped {context_conflicts} context-conflict \
+         cluster skips — the #652 flow-compatible commit upgrade stopped \
+         clearing the UG-onto-continuation-belt conflict class"
+    );
     let issues = match validate::validate(&layout, Some(&sr), LayoutStyle::Bus) {
         Ok(v) => v,
         Err(e) => e.issues,

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2354,6 +2354,18 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
          fail-sever pass dropped nothing — the zero-lane-error result is \
          vacuous (sever scope regressed?)"
     );
+    // Positive half of the context_conflicts == 0 pin above (review:
+    // that zero is an absence). Pre-upgrade this fixture shipped 3
+    // unresolved-junction errors (two conflict-capped clusters + the
+    // iter-capped 21-tile mega-cluster); the flow-compatible upgrade
+    // commits the two conflicted ones. If the carve-out silently stops
+    // firing, the conflicted clusters cap again and this returns to 3.
+    assert!(
+        unresolved <= 1,
+        "ac7-HS duty-0.6 shipped {unresolved} unresolved-junction errors \
+         (expected <= 1) — formerly-upgradeable conflict clusters are \
+         capping again; check the flow-compatible upgrade path"
+    );
     // LIVENESS (session-side review): if this trips, the pin has stopped
     // exercising the fail-safe path at all (duty stopped reaching the
     // engine, or every crossing now resolves — ac7-HS at duty 1.0 has

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2279,6 +2279,26 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
     )
     .expect("ac7 duty-0.6 lays out");
     let events = spaghettio_core::trace::drain_events();
+    // Vacuity guard for the trace-derived assertions below (session-side
+    // review on #658): if trace collection breaks, `events` is empty and
+    // `context_conflicts == 0` passes for the wrong reason while the
+    // liveness assert is still satisfied by validator-derived
+    // `unresolved`. Pin a positive trace signal: zone commits always
+    // happen on this fixture (25 at the time of writing).
+    let committed = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                spaghettio_core::trace::TraceEvent::JunctionCommitted { .. }
+            )
+        })
+        .count();
+    assert!(
+        committed > 0,
+        "no JunctionCommitted events collected — trace stream is broken, \
+         every trace-derived assertion in this test is vacuous"
+    );
     let severed = events
         .iter()
         .filter(|e| matches!(e, spaghettio_core::trace::TraceEvent::CrossingSevered { .. }))


### PR DESCRIPTION
## Intent

Eliminate the ac7 context-conflict class — the flip-gating defect where two crossing clusters could never commit. The #653 identity-based conflict check made the shape structurally uncommittable: every feasible solution must place a UG **output** exactly ON a committed surface belt that already carries the identical flow (same item, direction, tier) — the committed belt IS the flow's continuation into the neighboring, earlier-committed crossing zone.

Both alternatives were implemented and **measured structurally unsolvable** before this carve-out was chosen (receipts on #652):
- The forbid-and-grow retry (#657) engages end-to-end but the override makes the zone grow into the var ceiling.
- The recorded veto→pin re-solve was prototyped this session and falsified by encoder bisect: pinning any committed east-row belt UNSATs the zone (the EC crossing then has no dive column under the straight-feed UG rules), and the walker-clean topology provably requires the UG to surface on the committed tile. The prototype is not in this diff; design + falsification are recorded on #652.

## Scope

- `flow_compatible_ug_upgrade` (ghost_router.rs): the one accepted shape — solution UG output over committed plain surface belt, matching direction/item/tier (name-prefix compare). Conservative guards, each `false` ⇒ keep the conflict: behind-tile must be inside the solution footprint (nothing can jam against the UG exit's back — the zone re-derives that upstream); no committed belt-like entity outside the footprint may output into the tile from a side (sideloads onto a UG exit lose the near-side lane).
- `conflicts_of` carve-out: flow-compatible tiles are not conflicts (closure now takes the footprint as an argument so the retry path evaluates against its own footprint).
- Stamping upgrade path: `Occupancy::release_tile` (new; orphan semantics per `place()`'s existing note) + purge of the superseded belt from the entity list, then normal placement. The old Template/RowEntity skip would have stranded the solution's flow underground (kept UG-in, vanished UG-out).
- e2e: the ac7 fail-safe pin gains a `context_conflicts == 0` assertion; doc comment updated (liveness now carried by the remaining mega-cluster).

## Measured outcome (ac7-HS duty 0.6)

| | before | after |
|---|---|---|
| total errors | 17 | **14** |
| unresolved-junction | 3 | **1** |
| context-conflict skips | 2 | **0** |
| zones committed | 24 | **25** |
| severed feeders | 9 | 7 |

Remaining on the fixture: 6 balancer-over-trunk isolation errors + the 21-tile iter-capped mega-cluster near (15,123) (owns the 7 dead-ends) — both pre-existing classes tracked on #652/#644.

## Verification actually run

- CI-way full core suite (cache-pin protocol): **CARGO_EXIT=0**, twice (pre- and post-pin-extension). Corpus exactness argument: the #657 session-side adversary independently proved zero context-conflicts fire anywhere in the CI corpus, so the carve-out has nothing to change there — and every layout-hash pin and warning golden held.
- Extended ac7 pin test green in isolation (CI-way).
- Probe receipts (`i652_ac7_error_classify`, local): the table above; both formerly-conflicted clusters commit; layout shrinks slightly (3407 → 3397 entities) because the layout-level conflict retry no longer fires.
- Encoder bisect receipts (`i652_retry_zone_repro`, local): pin-UNSAT localization that falsified the pin design.
- Clippy clean on touched files.

## Deviations

- The unit this branch set out to build (veto→pin re-solve, recorded on #652) is deliberately absent: its target shape was falsified mid-implementation and it would have shipped with zero exhibiting fixtures. Falsification receipts and the code sketch are on #652 for the day a pinnable shape appears.
- No standalone unit test for the predicate: the load-bearing receipt is the e2e assertion on the exhibiting fixture plus the corpus invariance; a synthetic `Occupancy` harness would restate the predicate's own arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpaH63paEaqPsCUtLJ2h3n
