### PR TITLE
fix(balancer): #652 lever 1 — reserve the balancer stamp's WIDTH, not just its height

### DIFF
--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -29,6 +29,7 @@
 //!   --di off|candidate|forced        direct insertion (default candidate)
 //!   --claim up|down|search           DI claim order (default: engine default)
 //!   --belt <entity>        max belt tier (default: engine picks by rate)
+//!   --row-layout <kind>    native (default) | horizontal-stack
 //!   --quality <name>       normal|uncommon|rare|epic|legendary (default normal)
 //!   --stacking <1..4>      belt stacking (default 1)
 //!   --research-productivity <recipe=bonus,...>   declared research
@@ -53,7 +54,7 @@
 
 use rustc_hash::FxHashSet;
 use spaghettio_core::bus::di_cell::{DiClaimOrder, DirectInsertion};
-use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions};
+use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions, RowLayout};
 use spaghettio_core::common::QualityTier;
 use spaghettio_core::recipe_db::MachinePalette;
 use spaghettio_core::validate::{self, LayoutStyle, Severity};
@@ -140,6 +141,7 @@ fn main() {
     let mut research_productivity: std::collections::BTreeMap<String, f64> =
         Default::default();
     let mut inserter_cap: Option<u8> = None;
+    let mut row_layout = RowLayout::default();
     let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
     let mut label: Option<String> = None;
     let mut out = std::env::var("SIM_PROBE_OUT").unwrap_or_else(|_| "/tmp".to_string());
@@ -169,6 +171,19 @@ fn main() {
                 })
             }
             "--belt" => belt = Some(need(i)),
+            // #652: without this the tracked generator cannot express a
+            // horizontal-stack fixture at all, so the corpus's HS class
+            // (ac7-HS and friends) had no supported route to a
+            // blueprint+manifest pair and could not be sim-anchored.
+            "--row-layout" => {
+                row_layout = match need(i).as_str() {
+                    "native" | "default" => RowLayout::default(),
+                    "horizontal-stack" | "hs" => RowLayout::HorizontalStack,
+                    other => usage(&format!(
+                        "--row-layout must be native|horizontal-stack (got {other})"
+                    )),
+                }
+            }
             // RFC-069 Phase 1: planning-duty knob for the K69-1 sim A/B.
             "--duty" => {
                 duty = need(i)
@@ -279,6 +294,7 @@ fn main() {
         direct_insertion: di,
         max_belt_tier: belt,
         planning_duty: duty,
+        row_layout,
         quality,
         stacking,
         research_productivity,

--- a/crates/core/src/bus/balancer.rs
+++ b/crates/core/src/bus/balancer.rs
@@ -598,11 +598,47 @@ mod tests {
 
     /// A merge-tap family's merge tree puts its single output at the
     /// tree's EAST edge, so the whole body is a western spill.
+    ///
+    /// Check-stamps every tree size rather than asserting the pad value
+    /// on one isolated family (round-2 review: the value alone leaves
+    /// the "output at east edge, body all-west" geometry premise
+    /// unverified, so a merge-tree change would ship an adjacent-trunk
+    /// overlap unnoticed — and the shape sweep below cannot reach this
+    /// branch because it builds `merge_tap: false` families).
     #[test]
     fn family_stamp_x_pad_covers_the_merge_tree() {
-        let mut fam = library_family(4, 1, 20);
-        fam.merge_tap = true;
-        assert_eq!(family_stamp_x_pad(&fam), (3, 0));
+        assert_eq!(
+            family_stamp_x_pad(&{
+                let mut f = library_family(4, 1, 20);
+                f.merge_tap = true;
+                f
+            }),
+            (3, 0)
+        );
+
+        for n in 1..=10u32 {
+            let mut fam = library_family(n, 1, 100);
+            fam.merge_tap = true;
+            let (west, east) = family_stamp_x_pad(&fam);
+            let ents = stamp_merge_tap_family(&fam, None, &StackingCtx::unstacked());
+            assert!(!ents.is_empty(), "merge tree n={n} stamped nothing");
+            let trunk = fam.lane_xs[0];
+            let (lo, hi) = (trunk - west, trunk + east);
+            for e in &ents {
+                let spans_x = e.name.contains("splitter")
+                    && matches!(e.direction, EntityDirection::North | EntityDirection::South);
+                let e_hi = if spans_x { e.x + 1 } else { e.x };
+                assert!(
+                    e.x >= lo && e_hi <= hi,
+                    "merge tree n={n}: {} at x {}..{} escapes the reserved \
+                     span {lo}..{hi} (pad west={west} east={east}) — a K-group \
+                     sibling trunk would be overlapped",
+                    e.name,
+                    e.x,
+                    e_hi
+                );
+            }
+        }
     }
 
     /// #652: the reservation must cover the stamp's ACTUAL extent for

--- a/crates/core/src/bus/balancer.rs
+++ b/crates/core/src/bus/balancer.rs
@@ -661,9 +661,22 @@ mod tests {
     /// happened never to spill.
     #[test]
     fn family_stamp_x_pad_covers_every_stamped_shape() {
+        // The grid bound is DERIVED from the library, not hardcoded
+        // (round-3 review). Today every key is within 1..=10, so a
+        // literal 10 would sweep everything — but a regeneration that
+        // adds an (11, k) would then ship un-swept, which is precisely
+        // the case the reviewer was worried about. Deriving it means
+        // the sweep grows with the library instead of silently falling
+        // behind it.
+        let hi = crate::bus::balancer_library::balancer_templates()
+            .keys()
+            .flat_map(|&(n, m)| [n, m])
+            .max()
+            .unwrap_or(10)
+            .max(10);
         let mut checked = 0usize;
         let mut spilling = 0usize;
-        for (n, m) in (1..=10u32).flat_map(|n| (1..=10u32).map(move |m| (n, m))) {
+        for (n, m) in (1..=hi).flat_map(|n| (1..=hi).map(move |m| (n, m))) {
             let fam = library_family(n, m, 100);
             let (west, east) = family_stamp_x_pad(&fam);
             let ents = stamp_family_balancer(&fam, None, &StackingCtx::unstacked())

--- a/crates/core/src/bus/balancer.rs
+++ b/crates/core/src/bus/balancer.rs
@@ -200,6 +200,64 @@ pub(crate) fn family_stamp_plan(
     }
 }
 
+/// Columns a family's stamp needs BEYOND its own trunk columns, as
+/// `(west, east)`.
+///
+/// Every stamping path aligns by [`balancer_origin_x`] — output tile 0
+/// onto `lane_xs[0]` — so a template whose width exceeds its output
+/// count spills west of the family's first trunk column (by the output
+/// tiles' own x-offset) and east of its last (by whatever width is
+/// left over). Nothing downstream moves out of the way: the lane
+/// planner has always reserved the stamp's HEIGHT (`balancer_y_end`,
+/// so trunks skip the zone) and never its WIDTH, so the spill lands on
+/// whichever family was assigned the neighbouring columns.
+///
+/// That is #652's balancer-over-trunk overlap. On ac7-HS at duty 0.6
+/// the electronic-circuit family's `(5,2)` is width 6 over 2 trunk
+/// columns — 1 west + 3 east — and the eastern spill swallowed the
+/// plastic-bar trunk at x=18–19, severing it and stranding fragments
+/// inside the template's holes. 31 library templates are wider than
+/// their output count, so this is a shape property, not a fixture one.
+///
+/// `Decomposed` and `Generated` are guarded at *selection* time
+/// (`sub.width <= sub_m` / `generated.width <= m`), which forces both
+/// pads to zero; they are derived here rather than assumed so the
+/// guard and this reservation cannot drift apart. `Direct` — the
+/// exact-shape library hit — has never had such a guard, and is the
+/// path that spills.
+pub(crate) fn family_stamp_x_pad(fam: &LaneFamily) -> (i32, i32) {
+    /// `width` minus the contiguous run of output columns, split
+    /// around the run's offset. Output tiles are sorted by x and
+    /// contiguous (see [`balancer_origin_x`]'s debug asserts), and may
+    /// repeat an x when a template has two output rows.
+    fn pad_of(width: u32, output_tiles: &[(i32, i32)]) -> (i32, i32) {
+        let Some(&(d0, _)) = output_tiles.first() else {
+            return (0, 0);
+        };
+        let mut cols: Vec<i32> = output_tiles.iter().map(|t| t.0).collect();
+        cols.dedup();
+        let m = cols.len() as i32;
+        (d0.max(0), (width as i32 - d0 - m).max(0))
+    }
+
+    let n = fam.shape.0 as u32;
+    if fam.merge_tap {
+        // The merge tree's single output sits at its EAST edge
+        // (`(n-1, 2n-2)`), so its whole body is a western spill.
+        let t = crate::bus::balancer_generate::merge_tree(n);
+        return pad_of(t.width, &t.output_tiles);
+    }
+    match family_stamp_plan(fam) {
+        FamilyStampPlan::Passthrough | FamilyStampPlan::Unresolvable => (0, 0),
+        FamilyStampPlan::Direct(t) => pad_of(t.width, t.output_tiles),
+        FamilyStampPlan::Generated(g) => pad_of(g.width, &g.output_tiles),
+        // Sub-stamps sit side by side, each aligned onto its own lane
+        // chunk: the westmost chunk owns the west pad, the eastmost
+        // the east pad, and both are the sub-template's.
+        FamilyStampPlan::Decomposed { sub, .. } => pad_of(sub.width, sub.output_tiles),
+    }
+}
+
 /// Predicate: would `stamp_family_balancer((n, m), …)` find a template
 /// to use, either directly or via decomposition?
 ///
@@ -500,6 +558,97 @@ mod tests {
                 "template ({n},{m}): outputs {actual:?} should equal lane_xs {lane_xs:?} after origin shift"
             );
         }
+    }
+
+    /// Build a family that will take the LIBRARY path for `(n, m)`.
+    /// An unskewed square would shortcut to passthrough and never
+    /// stamp a template at all, so squares are marked demand-skewed.
+    fn library_family(n: u32, m: u32, lane_x0: i32) -> LaneFamily {
+        LaneFamily {
+            item: "iron-plate".to_string(),
+            module_id: 0,
+            shape: (n as usize, m as usize),
+            producer_rows: (0..n as usize).collect(),
+            lane_xs: (lane_x0..lane_x0 + m as i32).collect(),
+            balancer_y_start: 10,
+            balancer_y_end: 60,
+            total_rate: 20.0,
+            merge_tap: false,
+            demand_skewed: n == m,
+        }
+    }
+
+    /// #652 anchor: the shape that exhibited the balancer-over-trunk
+    /// overlap. `(5,2)` is a width-6 template over 2 trunk columns
+    /// whose outputs sit at x-offsets 1..2 — 1 column of spill west,
+    /// 3 east. Documented explicitly so a library regeneration that
+    /// changes T_5_2's geometry has to come past this number.
+    #[test]
+    fn family_stamp_x_pad_anchors_the_5x2_spill() {
+        assert_eq!(family_stamp_x_pad(&library_family(5, 2, 16)), (1, 3));
+    }
+
+    /// A merge-tap family's merge tree puts its single output at the
+    /// tree's EAST edge, so the whole body is a western spill.
+    #[test]
+    fn family_stamp_x_pad_covers_the_merge_tree() {
+        let mut fam = library_family(4, 1, 20);
+        fam.merge_tap = true;
+        assert_eq!(family_stamp_x_pad(&fam), (3, 0));
+    }
+
+    /// #652: the reservation must cover the stamp's ACTUAL extent for
+    /// every shape the library serves — not just the one that
+    /// exhibited the bug. Stamps each shape at a known lane block and
+    /// asserts every emitted tile falls inside
+    /// `[lane_xs[0] - west, lane_xs.last() + east]`.
+    ///
+    /// Both anti-vacuity guards matter: without the first the loop
+    /// could stamp nothing and pass, and without the second a pad
+    /// that always returned `(0, 0)` would pass on a library that
+    /// happened never to spill.
+    #[test]
+    fn family_stamp_x_pad_covers_every_library_stamp() {
+        let mut checked = 0usize;
+        let mut spilling = 0usize;
+        for (&(n, m), _) in crate::bus::balancer_library::balancer_templates().iter() {
+            let fam = library_family(n, m, 100);
+            let (west, east) = family_stamp_x_pad(&fam);
+            let ents = stamp_family_balancer(&fam, None, &StackingCtx::unstacked())
+                .unwrap_or_else(|e| panic!("({n},{m}) stamp: {e}"));
+            if ents.is_empty() {
+                continue;
+            }
+            let lo = fam.lane_xs[0] - west;
+            let hi = *fam.lane_xs.last().unwrap() + east;
+            for e in &ents {
+                // A splitter is 2 tiles wide across its facing axis;
+                // `x` records only its west tile.
+                let spans_x = e.name.contains("splitter")
+                    && matches!(e.direction, EntityDirection::North | EntityDirection::South);
+                let e_hi = if spans_x { e.x + 1 } else { e.x };
+                assert!(
+                    e.x >= lo && e_hi <= hi,
+                    "({n},{m}): stamped {} at x {}..{} escapes the reserved span {lo}..{hi} \
+                     (pad west={west} east={east}, lane_xs {:?}) — the lane planner would \
+                     hand those columns to the next family",
+                    e.name,
+                    e.x,
+                    e_hi,
+                    fam.lane_xs
+                );
+            }
+            checked += 1;
+            if west + east > 0 {
+                spilling += 1;
+            }
+        }
+        assert!(checked > 0, "vacuous: no library shape stamped anything");
+        assert!(
+            spilling > 0,
+            "vacuous: no library shape spills past its trunk columns, so a \
+             pad of (0,0) would satisfy this test — re-point it"
+        );
     }
 
     /// `shape_is_stampable` must agree with what `stamp_family_balancer`

--- a/crates/core/src/bus/balancer.rs
+++ b/crates/core/src/bus/balancer.rs
@@ -220,11 +220,19 @@ pub(crate) fn family_stamp_plan(
 /// their output count, so this is a shape property, not a fixture one.
 ///
 /// `Decomposed` and `Generated` are guarded at *selection* time
-/// (`sub.width <= sub_m` / `generated.width <= m`), which forces both
-/// pads to zero; they are derived here rather than assumed so the
-/// guard and this reservation cannot drift apart. `Direct` — the
-/// exact-shape library hit — has never had such a guard, and is the
-/// path that spills.
+/// (`sub.width <= sub_m` / `generated.width <= m`). Be precise about
+/// what that buys, because it is less than it looks (review finding):
+/// the guard directly forces only the EAST pad to zero. The west pad
+/// is `d0`, which the width guard does not mention — it reaches zero
+/// only via the additional premise that a template's outputs lie
+/// inside its own width (`d0 + m <= width`), which with `width <= m`
+/// gives `d0 <= 0`. Both pads are therefore zero on those paths today,
+/// but as a *consequence of two facts*, not one. They are derived here
+/// rather than hardcoded so a library regeneration that breaks either
+/// premise is picked up instead of silently mis-reserving.
+///
+/// `Direct` — the exact-shape library hit — has never had such a
+/// guard, and is the path that spills.
 pub(crate) fn family_stamp_x_pad(fam: &LaneFamily) -> (i32, i32) {
     /// `width` minus the contiguous run of output columns, split
     /// around the run's offset. Output tiles are sorted by x and
@@ -598,20 +606,28 @@ mod tests {
     }
 
     /// #652: the reservation must cover the stamp's ACTUAL extent for
-    /// every shape the library serves — not just the one that
-    /// exhibited the bug. Stamps each shape at a known lane block and
-    /// asserts every emitted tile falls inside
-    /// `[lane_xs[0] - west, lane_xs.last() + east]`.
+    /// every shape — not just the one that exhibited the bug. Stamps
+    /// each shape at a known lane block and asserts every emitted tile
+    /// falls inside `[lane_xs[0] - west, lane_xs.last() + east]`.
+    ///
+    /// Sweeps the whole 1..=10 x 1..=10 grid rather than the library's
+    /// key set (review finding): iterating only library shapes means
+    /// `family_stamp_plan` returns `Direct` every time, so the
+    /// Decomposed and Generated pad branches — whose pads are zero
+    /// today only as a consequence of the selection guard AND outputs
+    /// fitting inside their template width — are never stamped and
+    /// verified. Shapes off the library's key set are exactly the ones
+    /// that reach them.
     ///
     /// Both anti-vacuity guards matter: without the first the loop
     /// could stamp nothing and pass, and without the second a pad
     /// that always returned `(0, 0)` would pass on a library that
     /// happened never to spill.
     #[test]
-    fn family_stamp_x_pad_covers_every_library_stamp() {
+    fn family_stamp_x_pad_covers_every_stamped_shape() {
         let mut checked = 0usize;
         let mut spilling = 0usize;
-        for (&(n, m), _) in crate::bus::balancer_library::balancer_templates().iter() {
+        for (n, m) in (1..=10u32).flat_map(|n| (1..=10u32).map(move |m| (n, m))) {
             let fam = library_family(n, m, 100);
             let (west, east) = family_stamp_x_pad(&fam);
             let ents = stamp_family_balancer(&fam, None, &StackingCtx::unstacked())

--- a/crates/core/src/bus/lane_planner.rs
+++ b/crates/core/src/bus/lane_planner.rs
@@ -589,14 +589,18 @@ pub fn plan_bus_lanes(
             // downstream contiguous-`lane_xs` check would eventually
             // Err, but only after the layout collapsed; catch it here,
             // where the cause is.
-            debug_assert!(
-                (lo..=hi).all(|i| lanes[i].family_id == Some(fid)),
-                "family {fid} ({}, shape {:?}) has non-contiguous lanes at \
-                 indices {lo}..={hi} — the stamp pads ({w},{e}) would be \
-                 reserved at the wrong columns",
-                fam.item,
-                fam.shape
-            );
+            // A real check, not a `debug_assert` (round-3 review): this
+            // is the guard for a RELEASE/WASM-shipped geometry
+            // invariant, and a debug-only one compiles out exactly
+            // where the silent mis-reservation would ship.
+            if !(lo..=hi).all(|i| lanes[i].family_id == Some(fid)) {
+                return Err(format!(
+                    "Balancer family for item {} shape {:?} has non-contiguous \
+                     lanes at indices {lo}..={hi} — its stamp pads ({w},{e}) \
+                     would be reserved at the wrong columns",
+                    fam.item, fam.shape
+                ));
+            }
             west[lo] += w;
             east[hi] += e;
         }

--- a/crates/core/src/bus/lane_planner.rs
+++ b/crates/core/src/bus/lane_planner.rs
@@ -574,12 +574,31 @@ pub fn plan_bus_lanes(
         }
         for (fid, fam) in families.iter().enumerate() {
             let (w, e) = crate::bus::balancer::family_stamp_x_pad(fam);
-            if let Some(&i) = first.get(&fid) {
-                west[i] += w;
-            }
-            if let Some(&i) = last.get(&fid) {
-                east[i] += e;
-            }
+            let (Some(&lo), Some(&hi)) = (first.get(&fid), last.get(&fid)) else {
+                continue;
+            };
+            // The pads are keyed by the family's FIRST and LAST index in
+            // this array, which reserves its true bus-front/back edges
+            // only while the family's lanes are contiguous here. That
+            // holds for both of today's family producers (balancer
+            // splits and merge-tap trunks share a perimeter-exit status,
+            // so neither `optimize_lane_order` nor the perimeter sort
+            // separates them) — but nothing upstream PROMISES it, and a
+            // future ordering change that interleaves two families would
+            // silently pad the wrong columns (round-2 review). The
+            // downstream contiguous-`lane_xs` check would eventually
+            // Err, but only after the layout collapsed; catch it here,
+            // where the cause is.
+            debug_assert!(
+                (lo..=hi).all(|i| lanes[i].family_id == Some(fid)),
+                "family {fid} ({}, shape {:?}) has non-contiguous lanes at \
+                 indices {lo}..={hi} — the stamp pads ({w},{e}) would be \
+                 reserved at the wrong columns",
+                fam.item,
+                fam.shape
+            );
+            west[lo] += w;
+            east[hi] += e;
         }
         (west, east)
     };
@@ -754,14 +773,23 @@ pub fn plan_bus_lanes(
             total_rate: f.total_rate,
             producer_rows: f.producer_rows.clone(),
         }).collect(),
-        // #652 (review finding): this must agree with
-        // `bus_width_for_lanes`, which the layout actually sizes on. A
-        // family's eastern stamp spill lives only in the width — never
-        // in a lane's `x` — so a max-over-`l.x` under-reports it, and
-        // the snapshot debugger grids on THIS field: a spilling layout
-        // (exactly the class #652 is about) would render its stamp
-        // clipped off the east edge. Derive both from the same helper
-        // rather than keeping two definitions of one number.
+        // #652: this field must COVER the eastmost family's stamp
+        // spill. The spill lives only in the width — never in a lane's
+        // `x`, because the reservation works by shifting the lanes that
+        // FOLLOW a family and the eastmost has none — so the old
+        // `max(l.x) + 1` under-reported it, and the snapshot debugger
+        // grids on THIS field: a spilling layout (exactly the class
+        // #652 is about) rendered its stamp clipped off the east edge.
+        //
+        // The `- 1` is deliberate and must stay (round-2 review caught
+        // an earlier version of this comment claiming the two values
+        // are now IDENTICAL — they are not, and that wording invited a
+        // future "fix" that would re-break the grid). Two different
+        // quantities, one source:
+        //   `bus_width_for_lanes` = an allocation WIDTH  (max_x + 2)
+        //   this field            = a grid EXTENT        (max_x + 1)
+        // Deriving the extent as `width - 1` keeps the old convention
+        // while picking up the spill, which is the whole fix.
         bus_width: lanes
             .iter()
             .map(|l| l.x)

--- a/crates/core/src/bus/lane_planner.rs
+++ b/crates/core/src/bus/lane_planner.rs
@@ -553,8 +553,39 @@ pub fn plan_bus_lanes(
                 && neighbor_overlaps_splitter(&lanes[i], &lanes[i + 1])
         })
         .collect();
+    // #652: reserve the balancer stamp's WIDTH, not only its height.
+    // A family's stamp is aligned by `balancer_origin_x` and can be
+    // wider than the family's own trunk columns, spilling onto the
+    // neighbouring family's — see `balancer::family_stamp_x_pad` for
+    // the mechanism and the measured case. The spill columns are
+    // reserved here as empty columns flanking the family's block, so
+    // the neighbour is assigned a column the stamp cannot reach.
+    // Within-family columns stay contiguous (the pads go strictly
+    // outside the block), which the check below still enforces.
+    let (pad_west, pad_east) = {
+        let mut west = vec![0i32; lanes.len()];
+        let mut east = vec![0i32; lanes.len()];
+        let mut first: FxHashMap<usize, usize> = FxHashMap::default();
+        let mut last: FxHashMap<usize, usize> = FxHashMap::default();
+        for (i, ln) in lanes.iter().enumerate() {
+            let Some(fid) = ln.family_id else { continue };
+            first.entry(fid).or_insert(i);
+            last.insert(fid, i);
+        }
+        for (fid, fam) in families.iter().enumerate() {
+            let (w, e) = crate::bus::balancer::family_stamp_x_pad(fam);
+            if let Some(&i) = first.get(&fid) {
+                west[i] += w;
+            }
+            if let Some(&i) = last.get(&fid) {
+                east[i] += e;
+            }
+        }
+        (west, east)
+    };
     let mut extra = 0i32;
     for (i, lane) in lanes.iter_mut().enumerate() {
+        extra += pad_west[i];
         lane.x = (i + 1) as i32 + extra;
         if lane.perimeter_exit_y.is_some() && lane.consumer_rows.is_empty() {
             extra += 1;
@@ -562,6 +593,7 @@ pub fn plan_bus_lanes(
         if spacer_after[i] {
             extra += 1;
         }
+        extra += pad_east[i];
     }
 
     // Fluid lanes surface (plain pipe) at their ANCHOR rows: port taps,
@@ -1461,12 +1493,26 @@ fn find_tap_off_ys(lane: &BusLane, row_spans: &[RowSpan]) -> Vec<i32> {
 }
 
 /// Return the total bus width needed for the given lanes.
-pub fn bus_width_for_lanes(lanes: &[BusLane]) -> i32 {
+///
+/// #652: `families` is consulted because the x-assignment loop reserves
+/// a family's eastern stamp spill by shifting the lanes that follow it —
+/// and the EASTMOST family has none to shift. Its spill columns exist
+/// only here, so the width must reach `last_lane_x + east_pad` or the
+/// stamp lands outside the declared bus and into pass-2 row placement.
+pub fn bus_width_for_lanes(lanes: &[BusLane], families: &[LaneFamily]) -> i32 {
     // Derived from the max assigned column, not the lane count — surplus
     // lanes insert spacer columns (see the x-assignment loop), so count
     // and extent can differ. Identical to the old `len + 2` when columns
-    // are gapless.
-    match lanes.iter().map(|l| l.x).max() {
+    // are gapless and no family spills.
+    let lane_max = lanes.iter().map(|l| l.x).max();
+    let stamp_max = families
+        .iter()
+        .filter_map(|fam| {
+            let last = *fam.lane_xs.last()?;
+            Some(last + crate::bus::balancer::family_stamp_x_pad(fam).1)
+        })
+        .max();
+    match lane_max.into_iter().chain(stamp_max).max() {
         None => 2,
         Some(max_x) => max_x + 2,
     }
@@ -1518,7 +1564,7 @@ mod tests {
 
     #[test]
     fn test_bus_width_for_lanes_empty() {
-        assert_eq!(bus_width_for_lanes(&[]), 2);
+        assert_eq!(bus_width_for_lanes(&[], &[]), 2);
     }
 
     #[test]
@@ -1530,7 +1576,7 @@ mod tests {
             x: 1,
             ..Default::default()
         };
-        assert_eq!(bus_width_for_lanes(&[lane]), 3);
+        assert_eq!(bus_width_for_lanes(&[lane], &[]), 3);
     }
 
     #[test]
@@ -1544,7 +1590,7 @@ mod tests {
                 ..Default::default()
             })
             .collect();
-        assert_eq!(bus_width_for_lanes(&lanes), 5);
+        assert_eq!(bus_width_for_lanes(&lanes, &[]), 5);
     }
 
     #[test]
@@ -1555,7 +1601,7 @@ mod tests {
             .iter()
             .map(|&x| BusLane { item: format!("item-{x}"), x, ..Default::default() })
             .collect();
-        assert_eq!(bus_width_for_lanes(&lanes), 6);
+        assert_eq!(bus_width_for_lanes(&lanes, &[]), 6);
     }
 
     #[test]

--- a/crates/core/src/bus/lane_planner.rs
+++ b/crates/core/src/bus/lane_planner.rs
@@ -754,7 +754,20 @@ pub fn plan_bus_lanes(
             total_rate: f.total_rate,
             producer_rows: f.producer_rows.clone(),
         }).collect(),
-        bus_width: lanes.iter().map(|l| l.x).max().map(|x| x + 1).unwrap_or(0),
+        // #652 (review finding): this must agree with
+        // `bus_width_for_lanes`, which the layout actually sizes on. A
+        // family's eastern stamp spill lives only in the width — never
+        // in a lane's `x` — so a max-over-`l.x` under-reports it, and
+        // the snapshot debugger grids on THIS field: a spilling layout
+        // (exactly the class #652 is about) would render its stamp
+        // clipped off the east edge. Derive both from the same helper
+        // rather than keeping two definitions of one number.
+        bus_width: lanes
+            .iter()
+            .map(|l| l.x)
+            .max()
+            .map(|_| bus_width_for_lanes(&lanes, &families) - 1)
+            .unwrap_or(0),
     });
 
     Ok((lanes, families))
@@ -1602,6 +1615,44 @@ mod tests {
             .map(|&x| BusLane { item: format!("item-{x}"), x, ..Default::default() })
             .collect();
         assert_eq!(bus_width_for_lanes(&lanes, &[]), 6);
+    }
+
+    /// #652 (review finding): the `stamp_max` branch is the whole
+    /// point of the width change and every other unit test here passes
+    /// `&[]` for families, so without this the ONLY coverage of the
+    /// eastmost-family spill was a 300-second e2e.
+    ///
+    /// A `(5,2)` family is a width-6 template over 2 trunk columns with
+    /// its outputs at x-offsets 1..2 — 3 columns of eastern spill.
+    /// Nothing shifts past the last lane, so the width must reach
+    /// `lane_xs.last() + 3 + 2`, not `lane_xs.last() + 2`.
+    #[test]
+    fn bus_width_for_lanes_reserves_the_eastmost_family_spill() {
+        let lanes: Vec<BusLane> = [10i32, 11]
+            .iter()
+            .map(|&x| BusLane { item: "electronic-circuit".to_string(), x, ..Default::default() })
+            .collect();
+        let fam = LaneFamily {
+            item: "electronic-circuit".to_string(),
+            module_id: 0,
+            shape: (5, 2),
+            producer_rows: (0..5).collect(),
+            lane_xs: vec![10, 11],
+            balancer_y_start: 0,
+            balancer_y_end: 9,
+            total_rate: 20.0,
+            merge_tap: false,
+            demand_skewed: false,
+        };
+        // Sanity: this shape really does spill east, or the assertion
+        // below would hold for the wrong reason.
+        assert_eq!(crate::bus::balancer::family_stamp_x_pad(&fam), (1, 3));
+        assert_eq!(bus_width_for_lanes(&lanes, &[]), 13, "lanes alone");
+        assert_eq!(
+            bus_width_for_lanes(&lanes, std::slice::from_ref(&fam)),
+            16,
+            "the (5,2) stamp reaches x=14, so the bus must be 16 wide"
+        );
     }
 
     #[test]

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -971,6 +971,23 @@ fn layout_pass(
             (re, rs, rw, th, nl, nf)
         };
 
+    // #652 (review finding): pass 2 RE-PLANS the lanes, and its families
+    // can differ from pass 1's — different `lane_xs`, or a different
+    // family ending up eastmost. `actual_bw` above was measured on pass
+    // 1, and a family's eastern stamp spill is the one quantity that
+    // exists ONLY in the bus width and never in any lane's `x` (the
+    // reservation works by shifting the lanes that FOLLOW a family, and
+    // the eastmost has none to shift). So a stale `actual_bw` would
+    // leave pass 2's eastmost spill unreserved and re-introduce exactly
+    // the overlap this change exists to prevent.
+    //
+    // Re-measure against the lanes actually being routed. `max` and not
+    // plain assignment: pass 2's rows were already placed against pass
+    // 1's value, so the width may grow but must never shrink under
+    // them. The equal-width fast path above skips pass 2 entirely, so
+    // this is a no-op there.
+    let actual_bw = actual_bw.max(bus_width_for_lanes(&lanes, &families));
+
     crate::trace::emit(crate::trace::TraceEvent::PhaseComplete {
         phase: "rows_placed".into(),
         entity_count: row_entities.len(),

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -900,7 +900,7 @@ fn layout_pass(
         phase: "plan_bus_lanes_1".to_string(),
         duration_ms: t_plan1.elapsed().as_millis() as u64,
     });
-    let actual_bw = bus_width_for_lanes(&lanes_1);
+    let actual_bw = bus_width_for_lanes(&lanes_1, &families_1);
     let balancer_gaps = compute_extra_gaps(&families_1);
 
     // Pass 2: re-place rows with the real bus width + any balancer

--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -986,6 +986,19 @@ fn layout_pass(
     // 1's value, so the width may grow but must never shrink under
     // them. The equal-width fast path above skips pass 2 entirely, so
     // this is a no-op there.
+    //
+    // Residual, stated because three review passes asked (and the
+    // answer is that it is NOT silent): if pass 2's eastmost family
+    // needs more width than pass 1 measured, the rows have already been
+    // placed against the smaller value, so the grown columns are
+    // reserved in the ghost grid but not in the row layout. That
+    // resolves one of two ways, never quietly — the spill either lands
+    // in empty space (benign, nothing to collide with) or it lands on a
+    // row entity, which `belt_structural::check_entity_overlaps`
+    // reports (dispatched from `validate/mod.rs`). Fixing it properly
+    // means re-placing rows, i.e. a third pass; not worth it for a
+    // condition with no exhibiting fixture and a validator that catches
+    // the harmful half.
     let actual_bw = actual_bw.max(bus_width_for_lanes(&lanes, &families));
 
     crate::trace::emit(crate::trace::TraceEvent::PhaseComplete {

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2316,12 +2316,24 @@ fn tier4_ac7_duty06_lays_out_clean() {
         "no JunctionCommitted events collected — trace stream is broken, \
          every trace-derived assertion in this test is vacuous"
     );
-    // ...and pin the CLAIM, not just its vacuity guard (review
-    // finding): the comment above asserts the reservation RAISED
+    // ...and pin the CLAIM, not just its vacuity guard (round-1
+    // review): the comment above asserts the reservation RAISED
     // committed crossings 25 → 32, but `committed > 0` would hold at 3
-    // while that claim was false. A floor between the two numbers
-    // fails if the reservation stops freeing the router, which is the
-    // mechanism this fixture exists to protect.
+    // while that claim was false.
+    //
+    // This floor is a deliberate TRIPWIRE, not a stable invariant
+    // (round-2 review, which called 30-against-32 fragile — correctly:
+    // zone-commit count is input-sensitive and a legitimate engine
+    // change could land at 29 with zero errors). It is set just under
+    // the observed 32 on purpose, because the failure it exists to
+    // catch — the router "solving" the fixture by no longer attempting
+    // crossings — shows up as a COLLAPSE, and a floor loose enough to
+    // never false-positive would not catch that either.
+    //
+    // If it fires: check the error count first. Still zero errors and a
+    // count in the high 20s is a re-adjudication (move the floor, note
+    // the new number here). Zero errors with a count in the single
+    // digits is the real thing.
     assert!(
         committed >= 30,
         "ac7-HS duty-0.6 committed only {committed} junction zones \
@@ -2586,19 +2598,40 @@ fn tier5_processing_unit_from_ore_am3() {
     // because the golden itself is a bare category tally and a re-bless
     // with no reachable reasoning is indistinguishable from paperwork.
     //
-    // The reservation gives a balancer family the columns its template
-    // actually spans, which widens this layout's bus by 4 columns
-    // (165 -> 169) and adds ~160 entities. One copper-cable run then
-    // measures 105 tiles for a 52-tile separation and clears
-    // `belt-detour`'s paired floors (ratio >= 2.0 AND excess >= 8).
+    // TRACED, not inferred (round-2 review asked for exactly this, and
+    // the traced answer corrected the first guess). Instrument:
+    // `measure_belt_runs` — the check's own decomposition — walked tile
+    // by tile on both arms.
     //
-    // ACCEPTED, with its limit stated: errors stay 0 and
-    // input-rate-delivery is unchanged at 13, and the check is
-    // diagnostic-only by construction (never promotes to Error). What is
-    // NOT established is the tile-level path — the mechanism above is
-    // inferred from the width delta, not traced. If this fixture ever
-    // gains a SECOND detour, or an error, treat that inference as due for
-    // a snapshot before re-blessing again.
+    // The flagged run is (42,106) -> (43,157): 105 tiles for a 52-tile
+    // separation, ratio 2.02. Its path is a U, and an entirely ordinary
+    // one for a bus:
+    //     West  26 tiles along y=106,  x=42 -> x=16   (row out to trunk)
+    //     South 51 tiles down  x=16,   y=106 -> y=157 (down the trunk)
+    //     East  24 tiles along y=157,  x=16 -> x=43   (trunk to consumer)
+    // `direct` is only 52 because entry and exit are nearly vertically
+    // aligned (x=42 vs 43), so both lateral legs count as pure excess.
+    //
+    // MECHANISM: the reservation widens the bus 165 -> 169, which adds
+    // ~4 tiles to EACH lateral leg of every row->trunk->row U while
+    // leaving `direct` untouched. Measured across the six
+    // highest-excess runs, every ratio rose: 1.42->1.47, 1.53->1.59,
+    // 1.38->1.43, 1.47->1.54, 1.53->1.61, 1.60->1.70. This run was
+    // already sitting just under the floor and crossed it. Pre-fix the
+    // fixture flags ZERO runs; post-fix, exactly this one.
+    //
+    // It is NOT the layout's worst detour: six runs carry MORE excess
+    // (57-83 vs 53) and none trip, because their ratios are 1.43-1.70.
+    // This one trips only because its small `direct` makes the
+    // denominator small — a property of the check's paired-floor design
+    // (ratio >= 2.0 AND excess >= 8), not evidence that this particular
+    // belt is newly pathological.
+    //
+    // ACCEPTED: errors stay 0, input-rate-delivery is unchanged at 13,
+    // and the check is diagnostic-only by construction (never promotes
+    // to Error). A SECOND detour appearing here would mean the width
+    // grew again — re-trace with the same instrument rather than
+    // re-blessing.
     assert_warnings_golden(&result, "tier5_processing_unit_from_ore_am3");
     assert_produces(&result, "processing-unit", 2.0);
     assert_round_trip(&result);

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2316,6 +2316,20 @@ fn tier4_ac7_duty06_lays_out_clean() {
         "no JunctionCommitted events collected — trace stream is broken, \
          every trace-derived assertion in this test is vacuous"
     );
+    // ...and pin the CLAIM, not just its vacuity guard (review
+    // finding): the comment above asserts the reservation RAISED
+    // committed crossings 25 → 32, but `committed > 0` would hold at 3
+    // while that claim was false. A floor between the two numbers
+    // fails if the reservation stops freeing the router, which is the
+    // mechanism this fixture exists to protect.
+    assert!(
+        committed >= 30,
+        "ac7-HS duty-0.6 committed only {committed} junction zones \
+         (expected >= 30; 25 before the balancer-width reservation, 32 \
+         after). The router has stopped solving crossings the \
+         reservation freed up — the zero-error result below may be \
+         hiding a shape that simply stopped trying."
+    );
     // #652 flow-compatible upgrade pin: the context-conflict class is
     // RESOLVED on this fixture. A context-conflict skip reappearing
     // here means the carve-out regressed (or a new, genuinely
@@ -2567,6 +2581,24 @@ fn tier5_processing_unit_from_ore_am3() {
     // copper-plate / copper-cable / plastic rows — the same uniform
     // −24% chain signature pu@3 sim-measured (RFC-060 K60-3, converged,
     // warmup-flat). The check now reports what the sim already proved.
+    // 2026-08-17 (#652 balancer-width reservation, PR #659) — ADJUDICATION
+    // for the `belt-detour 1` line in this fixture's golden, recorded here
+    // because the golden itself is a bare category tally and a re-bless
+    // with no reachable reasoning is indistinguishable from paperwork.
+    //
+    // The reservation gives a balancer family the columns its template
+    // actually spans, which widens this layout's bus by 4 columns
+    // (165 -> 169) and adds ~160 entities. One copper-cable run then
+    // measures 105 tiles for a 52-tile separation and clears
+    // `belt-detour`'s paired floors (ratio >= 2.0 AND excess >= 8).
+    //
+    // ACCEPTED, with its limit stated: errors stay 0 and
+    // input-rate-delivery is unchanged at 13, and the check is
+    // diagnostic-only by construction (never promotes to Error). What is
+    // NOT established is the tile-level path — the mechanism above is
+    // inferred from the width delta, not traced. If this fixture ever
+    // gains a SECOND detour, or an error, treat that inference as due for
+    // a snapshot before re-blessing again.
     assert_warnings_golden(&result, "tier5_processing_unit_from_ore_am3");
     assert_produces(&result, "processing-unit", 2.0);
     assert_round_trip(&result);

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2321,26 +2321,27 @@ fn tier4_ac7_duty06_lays_out_clean() {
     // committed crossings 25 → 32, but `committed > 0` would hold at 3
     // while that claim was false.
     //
-    // This floor is a deliberate TRIPWIRE, not a stable invariant
-    // (round-2 review, which called 30-against-32 fragile — correctly:
-    // zone-commit count is input-sensitive and a legitimate engine
-    // change could land at 29 with zero errors). It is set just under
-    // the observed 32 on purpose, because the failure it exists to
-    // catch — the router "solving" the fixture by no longer attempting
-    // crossings — shows up as a COLLAPSE, and a floor loose enough to
-    // never false-positive would not catch that either.
+    // The floor is the PRE-FIX value, 25, not the observed 32. Rounds 2
+    // and 3 both objected to a floor of 30 as an input-sensitive magic
+    // number two under the observation — a legitimate engine change
+    // landing at 29 with zero errors would red CI and block unrelated
+    // merges. They are right, and 25 keeps the property that actually
+    // matters while removing the flap window: the failure this guards
+    // against is the router "solving" the fixture by no longer
+    // ATTEMPTING crossings, which is a collapse to single digits, not a
+    // drift of three.
     //
-    // If it fires: check the error count first. Still zero errors and a
-    // count in the high 20s is a re-adjudication (move the floor, note
-    // the new number here). Zero errors with a count in the single
-    // digits is the real thing.
+    // So this pins "never worse than before the fix" rather than the
+    // exact 25 -> 32 improvement. The improvement itself is recorded in
+    // the doc comment and its receipts are on #659; pinning 32 exactly
+    // would be pinning a number no invariant protects.
     assert!(
-        committed >= 30,
-        "ac7-HS duty-0.6 committed only {committed} junction zones \
-         (expected >= 30; 25 before the balancer-width reservation, 32 \
-         after). The router has stopped solving crossings the \
-         reservation freed up — the zero-error result below may be \
-         hiding a shape that simply stopped trying."
+        committed >= 25,
+        "ac7-HS duty-0.6 committed only {committed} junction zones — fewer \
+         than the 25 it managed BEFORE the balancer-width reservation (32 \
+         after). The router has stopped attempting crossings, so the \
+         zero-error result below may be a shape that simply stopped \
+         trying rather than one that succeeded."
     );
     // #652 flow-compatible upgrade pin: the context-conflict class is
     // RESOLVED on this fixture. A context-conflict skip reappearing

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2237,28 +2237,45 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
     }
 }
 
-/// #652 fail-safe pin: ac7-HS at duty 0.6 (the RFC-069 flip shape) with
-/// unresolved crossings must fail SAFE, never merged. Pre-fix, one
-/// unrouted iron-plate crossing shipped as a flat sideload-merge into
-/// the copper-cable trunk and fanned out as ~90 downstream
-/// lane-throughput errors (111 total; #652 diagnosis 2026-08-15); the
-/// conflict-retry + fail-sever pass converts that to severed dead-ends
-/// plus the honest unresolved-junction reports. The pin is the
-/// invariant the fix guarantees — ZERO lane-throughput errors — which
-/// holds regardless of whether the crossings themselves later get
-/// resolved (then severs simply stop firing). Isolation errors are NOT
-/// pinned here: a residual balancer-over-trunk overlap (recorded on
-/// #652) still ships a handful, and that mechanism is out of this
-/// pin's scope.
+/// #652: ac7-HS at duty 0.6 (the RFC-069 flip shape) lays out CLEAN.
 ///
-/// 2026-08-16 update: the context-conflict half of the fixture IS now
-/// resolved (flow-compatible commit upgrade — see the
-/// `context_conflicts == 0` assertion below); the sever/unresolved
-/// liveness path stays exercised by the remaining 21-tile iter-capped
-/// cluster near (15,123), the mega-zone class tracked on #652/#644.
+/// This pin has inverted twice and the history is the point of the
+/// comment — it is the record of what each fix actually bought:
+///
+///   * #652 diagnosis (2026-08-15): 111 errors. One unrouted
+///     iron-plate crossing shipped as a flat sideload-merge into the
+///     copper-cable trunk, and ~90 lane-throughput errors were its
+///     downstream shadow.
+///   * Conflict-retry + fail-sever (#655/#657) converted the merge to
+///     severed dead-ends plus honest unresolved-junction reports;
+///     flow-compatible commit upgrade (#658) cleared the
+///     context-conflict half. 14 errors: 7 belt-dead-end,
+///     6 belt-item-isolation, 1 unresolved-junction.
+///   * Balancer-width reservation (this change) removes the CAUSE.
+///     Electronic-circuit's `(5,2)` template is 6 columns wide over 2
+///     trunk columns, and nothing reserved the spill: it swallowed the
+///     plastic-bar trunk at x=18-19, severing it and stranding
+///     fragments inside the template's holes. All 6 isolation errors
+///     were that spill (including the one at (18,76), which #652
+///     recorded as a separate seam class — it is the copper-cable
+///     `(6,7)`, width 10 over 7 columns, spilling onto the same
+///     plastic column). Reserving the spill drops the fixture to ZERO
+///     errors, and the 21-tile iter-capped mega-cluster near (15,123)
+///     — which #652 called the campaign's one open design problem —
+///     resolves with it, because plastic no longer has to route
+///     around a balancer wall.
+///
+/// **The sever pass is now uncovered.** This test used to carry the
+/// only liveness assert for #655's fail-sever machinery
+/// (`severed > 0 || unresolved > 0`). It is gone because the fixture
+/// no longer severs anything, and a 7-fixture sweep on this same code
+/// path found no remaining exhibitor anywhere. Do NOT read its absence
+/// as the machinery being fine — a synthetic pin for it is tracked on
+/// #652. (Renamed from `tier4_ac7_duty06_unresolved_crossings_fail_safe`,
+/// which is the name #652's comments refer to.)
 #[test]
 #[ntest::timeout(300000)]
-fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
+fn tier4_ac7_duty06_lays_out_clean() {
     use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions, RowLayout};
 
     let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "coal", "water", "crude-oil"]
@@ -2279,12 +2296,12 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
     )
     .expect("ac7 duty-0.6 lays out");
     let events = spaghettio_core::trace::drain_events();
-    // Vacuity guard for the trace-derived assertions below (session-side
+    // Vacuity guard for the trace-derived assertion below (session-side
     // review on #658): if trace collection breaks, `events` is empty and
-    // `context_conflicts == 0` passes for the wrong reason while the
-    // liveness assert is still satisfied by validator-derived
-    // `unresolved`. Pin a positive trace signal: zone commits always
-    // happen on this fixture (25 at the time of writing).
+    // `context_conflicts == 0` passes for the wrong reason. Pin a
+    // positive trace signal: zone commits always happen on this fixture
+    // (32 after the width reservation, up from 25 — the reservation
+    // frees the router to solve crossings it previously capped on).
     let committed = events
         .iter()
         .filter(|e| {
@@ -2299,15 +2316,8 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
         "no JunctionCommitted events collected — trace stream is broken, \
          every trace-derived assertion in this test is vacuous"
     );
-    let severed = events
-        .iter()
-        .filter(|e| matches!(e, spaghettio_core::trace::TraceEvent::CrossingSevered { .. }))
-        .count();
     // #652 flow-compatible upgrade pin: the context-conflict class is
-    // RESOLVED on this fixture — both formerly-conflicted clusters
-    // (seeds (15,93)/(15,96), UG outputs surfacing onto committed
-    // same-item continuation belts) now commit via
-    // `flow_compatible_ug_upgrade`. A context-conflict skip reappearing
+    // RESOLVED on this fixture. A context-conflict skip reappearing
     // here means the carve-out regressed (or a new, genuinely
     // incompatible conflict shape arrived — either way, look).
     let context_conflicts = events
@@ -2330,52 +2340,20 @@ fn tier4_ac7_duty06_unresolved_crossings_fail_safe() {
         Ok(v) => v,
         Err(e) => e.issues,
     };
-    let lane_errors: Vec<&ValidationIssue> = issues
-        .iter()
-        .filter(|i| i.severity == Severity::Error && i.category == "lane-throughput")
-        .collect();
+    let errors: Vec<&ValidationIssue> =
+        issues.iter().filter(|i| i.severity == Severity::Error).collect();
+    // The whole-fixture pin. Deliberately NOT scoped to a category:
+    // every previous version of this test tolerated some class it had
+    // decided was out of scope, and the balancer spill hid inside that
+    // tolerance for a full campaign round. Zero means zero.
     assert!(
-        lane_errors.is_empty(),
-        "ac7-HS duty-0.6 shipped {} lane-throughput errors — an unresolved \
-         crossing is merging flows again (fail-severed regressed): {:#?}",
-        lane_errors.len(),
-        lane_errors.iter().take(5).collect::<Vec<_>>()
-    );
-    // Anti-vacuity (review): the zero above must come from the fail-safe
-    // actually engaging, not from the fixture drifting to a shape where
-    // nothing needed severing while merges ship elsewhere.
-    let unresolved = issues
-        .iter()
-        .filter(|i| i.severity == Severity::Error && i.category == "unresolved-junction")
-        .count();
-    assert!(
-        unresolved == 0 || severed > 0,
-        "ac7-HS duty-0.6 has {unresolved} unresolved crossings but the \
-         fail-sever pass dropped nothing — the zero-lane-error result is \
-         vacuous (sever scope regressed?)"
-    );
-    // Positive half of the context_conflicts == 0 pin above (review:
-    // that zero is an absence). Pre-upgrade this fixture shipped 3
-    // unresolved-junction errors (two conflict-capped clusters + the
-    // iter-capped 21-tile mega-cluster); the flow-compatible upgrade
-    // commits the two conflicted ones. If the carve-out silently stops
-    // firing, the conflicted clusters cap again and this returns to 3.
-    assert!(
-        unresolved <= 1,
-        "ac7-HS duty-0.6 shipped {unresolved} unresolved-junction errors \
-         (expected <= 1) — formerly-upgradeable conflict clusters are \
-         capping again; check the flow-compatible upgrade path"
-    );
-    // LIVENESS (session-side review): if this trips, the pin has stopped
-    // exercising the fail-safe path at all (duty stopped reaching the
-    // engine, or every crossing now resolves — ac7-HS at duty 1.0 has
-    // zero errors of ANY kind, so the lane assertion above is vacuous
-    // without this). Do NOT just delete it: re-point the pin at a shape
-    // that still produces unresolved crossings.
-    assert!(
-        severed > 0 || unresolved > 0,
-        "fail-safe pin no longer exercises the severed/unresolved path \
-         (severed=0, unresolved=0) — re-point it at a failing shape"
+        errors.is_empty(),
+        "ac7-HS duty-0.6 shipped {} errors (expected 0). If a balancer \
+         family regained a spill onto a neighbouring trunk, look at \
+         `balancer::family_stamp_x_pad` and the lane planner's column \
+         reservation first: {:#?}",
+        errors.len(),
+        errors.iter().take(12).collect::<Vec<_>>()
     );
 }
 

--- a/crates/core/tests/goldens/warnings/tier5_processing_unit_from_ore_am3.txt
+++ b/crates/core/tests/goldens/warnings/tier5_processing_unit_from_ore_am3.txt
@@ -1,1 +1,2 @@
+belt-detour 1
 input-rate-delivery 13

--- a/docs/rfc-069-achievable-duty-provisioning.md
+++ b/docs/rfc-069-achievable-duty-provisioning.md
@@ -175,11 +175,21 @@ goes to the owner before merge.
   consequences for this RFC:
   - **ac7-HS at duty 0.6 — the flip shape — goes from 14 errors to
     ZERO**, and its 21-tile iter-capped mega-cluster resolves with the
-    spill. Meter A/B on the same instrument: pre-fix `produced {}`
-    (nothing at all — the spill had severed the plastic trunk, and
-    plastic is an AC ingredient); post-fix advanced-circuit **64.3% of
-    plan**, uniform down the chain. Still below plan, and believed as
-    such: this removes a structural break, it does not reach plan.
+    spill. **SIM-ANCHORED A/B** (both arms 432k warmup, axis declared,
+    kit-clean): pre-fix produces **0.00/s on every stage, −100%, not
+    converged, zero machines working** (49 producers backed up, 63
+    consumers starved — the severed plastic trunk, and plastic is an AC
+    ingredient); post-fix **4.51/7.00 = 64.4% of plan**, converged,
+    75 machines working. Both arms still FAIL. This removes a
+    structural break; it does not make the fixture attain plan, and the
+    residual −35.6% is uniform across every stage — one shared
+    constraint, i.e. this RFC's own zero-headroom/duty territory rather
+    than a router question.
+  - Calibration row worth banking: the fast meter read **64.3%** where
+    the sim reads **64.4%** on the post-fix artifact, on a fluid chain
+    where the meter has a known gap (#570). The meter's below-plan half
+    held to 0.1pp; its `produced {}` on the pre-fix arm was likewise
+    confirmed by the sim's −100%.
   - **The 2026-08-15 tier5 entry below ("9 belt-dead-end + 1
     unresolved-junction") does not reproduce through
     `build_bus_layout`**, which reports 18 belt-dead-end and **0**

--- a/docs/rfc-069-achievable-duty-provisioning.md
+++ b/docs/rfc-069-achievable-duty-provisioning.md
@@ -165,6 +165,34 @@ goes to the owner before merge.
 
 ## Decision log
 
+- *2026-08-17 — the tier5 router-block receipt is NOT reproducible on
+  the direct path, and one of its two blockers was a balancer defect.*
+  #652's lever 1 (PR #659) reserves a balancer stamp's WIDTH, not just
+  its height: `family_stamp_plan` guarded template width against output
+  count on the decomposed and generated paths but never on `Direct`,
+  and 31 library templates are wider than their output count, so a
+  family's stamp spilled onto its neighbour's trunk columns. Two
+  consequences for this RFC:
+  - **ac7-HS at duty 0.6 — the flip shape — goes from 14 errors to
+    ZERO**, and its 21-tile iter-capped mega-cluster resolves with the
+    spill. Meter A/B on the same instrument: pre-fix `produced {}`
+    (nothing at all — the spill had severed the plastic trunk, and
+    plastic is an AC ingredient); post-fix advanced-circuit **64.3% of
+    plan**, uniform down the chain. Still below plan, and believed as
+    such: this removes a structural break, it does not reach plan.
+  - **The 2026-08-15 tier5 entry below ("9 belt-dead-end + 1
+    unresolved-junction") does not reproduce through
+    `build_bus_layout`**, which reports 18 belt-dead-end and **0**
+    unresolved-junction on that fixture — and reports them
+    IDENTICALLY with and without the balancer fix (175×255, 7057
+    entities, both arms). The two numbers came from different export
+    paths. The entry stands as the record of what the sim-export
+    artifact carried; it should NOT be cited as the direct-path
+    baseline, and tier5's gate-on-an-error-free-artifact is still open
+    against the 18-dead-end shape. Whoever resumes it re-diagnoses
+    against that, not against the "68-tile / 1547-var" mega-zone
+    figures.
+
 - *2026-08-15 — **OWNER CALL: correctness over footprint.*** The
   owner's direction (in-session, verbatim: "we should agree that
   correctness is more important than footprint") resolves K69-4's


### PR DESCRIPTION
## Intent

#652's lever 1 (obstacle-aware balancer placement), the pick-up its last comment recommended doing first. `family_stamp_plan` guards a template's width against its output count on the **decomposed** path (`sub.width > sub_m` → skip, with a comment explaining that neighbouring sub-stamps would otherwise overlap) and on the **generated** path (`generated.width <= m`). The `Direct` path — the exact-shape library hit, which is what most families take — has never had that guard, and **31 of the library's templates are wider than their output count**.

Every stamping path aligns by `balancer_origin_x` (output tile 0 onto `lane_xs[0]`), so such a template spills west of the family's first trunk column and east of its last. The lane planner has always reserved the stamp's **height** (`balancer_y_end`, so trunks skip the zone) and never its **width** — so the spill lands on whichever family was assigned the neighbouring columns.

On ac7-HS at duty 0.6 (the RFC-069 flip shape) electronic-circuit's `(5,2)` is width 6 over 2 trunk columns — 1 west, 3 east — and the eastern spill swallowed the plastic-bar trunk at x=18–19, severing it and stranding fragments inside the template's holes.

## Scope

- **In:** `balancer::family_stamp_x_pad` derives the `(west, east)` spill from a family's stamp plan; the lane planner reserves it as empty columns flanking the family's block. `bus_width_for_lanes` now also takes the families (the reservation works by shifting the lanes that *follow* a family, and the eastmost family has none to shift). 3 new unit tests. The ac7 pin rewritten. One golden re-blessed. `sim_export --row-layout`.
- **Out:** #652's lever 2 (mega-zone resolution: zone-split / channel-reduction / ceiling-aware decomposition). ac7's exhibitor of that class **disappears** with this change — its 21-tile iter-capped cluster near (15,123) resolves once plastic no longer has to route around the balancer wall — so lever 2 now has tier5 as its only fixture, exactly as #652 predicted when it recommended this ordering.
- **Out:** the RFC-069 default flip itself. This unblocks ac7's half; the flip is #644's call.
- **Size:** 277 added, comfortably under the norm.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml` — green in one clean invocation, zero failures across all 20 test binaries.
- [x] `cargo clippy --workspace -- -D warnings` — the CI gate. (`--all-targets` fails on pre-existing `power_wires.rs` debt in files this PR does not touch; ci.yml is lib-only *on purpose* and says so.)
- [x] WASM rebuild green.
- [x] **Measured, not eyeballed** — the protocol's step 2.

**ac7-HS duty 0.6** (`i652_ac7_error_classify`, a rebuilt local probe — the original was lost with the untracked `examples/` dir):

| | pre | post |
|---|---|---|
| errors | **14** (7 belt-dead-end, 6 belt-item-isolation, 1 unresolved-junction) | **0** |
| warnings | 91 (IRD 77, reach 10, path 4) | 16 (IRD 14, reach 2) |
| crossings severed | 7 | 0 |
| junction growth caps | 1 (`iter_cap`) | 0 |
| **junctions committed** | 25 | **32** |
| size | 111×161, 3398 ent | 118×160, 3634 ent (+7%) |

The committed-junction **increase** is the load-bearing number: it rules out "a check stopped discriminating" ([validator-reporting.md](../docs/validator-reporting.md)), because silencing a check cannot make the router solve seven more crossings.

**Meter A/B** (`check_one`, same instrument both arms):

```
pre-fix   produced {}  — NOTHING          note: "175 tiles in a belt cycle"
post-fix  advanced-circuit 4.50/7.0 = 64.3% of plan, uniform down the
          chain (cable 45/70, EC 9/14, plastic 9/14)   note: "12 tiles"
```

Producing zero is exactly what a severed plastic trunk predicts — plastic is an AC ingredient, so the chain stalls. **The post-fix reading is still below plan and I believe it**: this removes the structural break, it does not bring the fixture to plan. Absolute values carry the meter's known fluid gap (#570) on this crude-oil chain (petroleum-gas is absent from `produced` in *both* arms), so the claim rests on the delta, not the level.

- [ ] **Sim anchor running** (432k warmup, `--timeout-secs 3600`). Result will be posted here. Not merging on the meter alone — the meter refutes, it never clears.

## Deviations from intent

Three, all recorded in the commit message:

1. **#652's record corrected.** Its last comment called the sixth isolation error at (18,76) "separate and small … not part of this complex". It is the same defect — copper-cable's `(6,7)`, width 10 over 7 columns, spilling onto the same plastic column. All six were one cause.
2. **RFC-069's tier5 receipt is not comparable** to a `build_bus_layout` measurement of the same fixture (different export path). Measured both ways here, tier5 at duty 0.6 is **identical** with and without this change (175×255, 7057 entities, 18 belt-dead-end, 320 warnings) — this lever does not touch the tier5 half.
3. **`sim_export --row-layout` added** (not in the original scope). The tracked generator could not express a horizontal-stack fixture at all, so the corpus's HS class had no supported route to a blueprint+manifest pair and *could not be sim-anchored*. Without it the verification protocol's step 2 is unreachable for this change.

## Costs and lost coverage — stated, not blessed away

- **tier5 at the shipping default gains one `belt-detour` warning** (105 tiles for a 52-tile separation) and +160 entities / +4 columns. Errors stay 0, IRD unchanged at 13. The check is diagnostic-only and never promotes to Error. The mechanism — the reservation widens the bus and lengthens a copper-cable path — is **inferred from the width delta, not proven at tile level**. That is the one claim here I have not nailed down.
- **The fail-sever pass is now uncovered.** The ac7 pin carried the only liveness assert for #655's machinery (`severed > 0 || unresolved > 0`), and it is gone because the fixture no longer severs. A 7-fixture sweep on the same code path found ac7 was the **only** exhibitor before this change and **none remain** after. Recorded in the test's own doc comment; synthetic pin tracked on #652. The sweep is not the whole corpus and is not claimed to be.
- **A ceiling that has stopped discriminating:** `processing_unit_2s_am2_fast_belts_validation_baseline`'s `("unresolved-junction", 4)` is an upper bound measuring 0 on the probe path. Not touched here — its ceiling and my probe are different pipelines, so that 0 is not a licence to tighten it — but it is the exact class validator-reporting.md warns about, so it is reported on #652.

## Models / contracts touched

Balancer stamping geometry. The contract that changed is implicit and now explicit: **a family's reserved columns must cover its stamp's full width, not just its output count.** Documented at `family_stamp_x_pad` and pinned by `family_stamp_x_pad_covers_every_library_stamp`, which asserts every library shape's stamped tiles fall inside the reserved span and carries two anti-vacuity guards — one that the loop stamped something, one that some shape actually spills, so a pad of `(0,0)` cannot pass it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
