### PR TITLE
feat(sim): sim_export --strategy, so PartitionedDecomposed is reachable

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,3 +32,12 @@ web-time = "1"
 [dev-dependencies]
 ntest = "0.9"
 sha2 = "0.10"
+
+# sim_export is the tracked fixture generator; its label logic decides the
+# OUTPUT DIRECTORY, so a regression there silently re-collides A/B fixtures
+# (#661). Declared explicitly with `test = true` so its unit tests actually
+# RUN — `cargo test` builds examples but does not run their tests by default.
+[[example]]
+name = "sim_export"
+path = "examples/sim_export.rs"
+test = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -36,7 +36,15 @@ sha2 = "0.10"
 # sim_export is the tracked fixture generator; its label logic decides the
 # OUTPUT DIRECTORY, so a regression there silently re-collides A/B fixtures
 # (#661). Declared explicitly with `test = true` so its unit tests actually
-# RUN — `cargo test` builds examples but does not run their tests by default.
+# RUN: `cargo test` BUILDS examples but does not RUN their tests by default.
+#
+# Measured, because a review disputed it (#661 round 5) — plain
+# `cargo test`, grepping for two of the label tests by name:
+#   stanza removed  -> 0 matches
+#   stanza present  -> 2 matches
+# Not a no-op. Note the distinction that makes it easy to get wrong:
+# `cargo test --example sim_export` runs them either way, because naming a
+# target selects it; the default target set is what the stanza changes.
 [[example]]
 name = "sim_export"
 path = "examples/sim_export.rs"

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -38,6 +38,7 @@
 //!   --inserter-cap <n>     inserter capacity level (default: engine default)
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
+//!                          REQUIRED whenever any layout-changing flag is used
 //!   --out <dir>            parent output dir (default $SIM_PROBE_OUT or /tmp)
 //! ```
 //!
@@ -60,9 +61,41 @@ use spaghettio_core::common::QualityTier;
 use spaghettio_core::recipe_db::MachinePalette;
 use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
-/// Default crafting machine — the one `--tier` overrides. Named so the
-/// label logic and the parser default cannot drift apart.
+/// Default crafting machine — the one `--tier` overrides.
 const DEFAULT_TIER: &str = "assembling-machine-3";
+
+/// Flags that change the exported artifact, and therefore make the default
+/// `{item}-{rate}` label ambiguous.
+///
+/// The label IS the output directory (`<out>/<label>/`), so two runs that
+/// differ by any of these must not share it. The original bug (#661) was that
+/// the label encoded none of them and the second run silently overwrote the
+/// first's `bp.txt` and `manifest-real.json` — a wrong-A/B generator, in the
+/// tool whose whole purpose is A/B.
+///
+/// Rather than encode each axis into the name — which needs every axis
+/// enumerated and every engine default stated correctly, and which took five
+/// review rounds without converging — passing any of these simply REQUIRES an
+/// explicit `--label`. Collisions become impossible by construction, and the
+/// check consults no defaults, so a future default flip cannot invert it.
+///
+/// Slightly over-strict on purpose: `--strategy pooled` is the default value
+/// and still demands a label. Erring toward "be explicit" costs a flag; erring
+/// the other way silently corrupts a measurement.
+const AXIS_FLAGS: &[&str] = &[
+    "--tier",
+    "--di",
+    "--claim",
+    "--belt",
+    "--row-layout",
+    "--strategy",
+    "--duty",
+    "--quality",
+    "--stacking",
+    "--research-productivity",
+    "--inserter-cap",
+    "--inputs",
+];
 
 const DEFAULT_INPUTS: &[&str] = &[
     "iron-ore",
@@ -96,138 +129,17 @@ fn parse_target_token(tok: &str) -> (String, f64) {
 }
 
 
-/// Every axis that changes the exported artifact, as one value — so the
-/// label logic is a pure function and can be tested (#661 round 3: it was
-/// the PR's entire purpose and had no coverage, which is the same class of
-/// gap that produced the collision in the first place).
-struct LabelAxes<'a> {
-    strategy: LayoutStrategy,
-    row_layout: RowLayout,
-    duty: f64,
-    tier: &'a str,
-    belt: Option<&'a str>,
-    quality: QualityTier,
-    stacking: u8,
-    di: DirectInsertion,
-    claim: Option<&'a DiClaimOrder>,
-    inserter_cap: Option<u8>,
-    inputs: &'a [String],
-    research_productivity: &'a std::collections::BTreeMap<String, f64>,
-}
-
-/// The auto label, which is also the OUTPUT DIRECTORY (`<out>/<label>/`).
+/// Does this invocation need an explicit `--label`?
 ///
-/// Two runs whose artifacts differ must not share it. They did: the label
-/// was `{item}-{rate}` and encoded no configuration at all, so
-/// `--strategy pooled X 5` and `--strategy partitioned-decomposed X 5`
-/// both wrote `<out>/X-5/` and the second silently overwrote the first
-/// (#661). That is a wrong-A/B generator, and A/B is why this binary takes
-/// these flags.
+/// True when any artifact-changing flag was passed. Kept as a pure function
+/// so the rule is testable — the previous design put per-axis default
+/// comparisons inline in `main()`, where nothing exercised them and five
+/// review rounds each found another axis compared against the wrong default.
 ///
-/// Suffixes are emitted only where the value differs from the ENGINE
-/// default — not merely where a flag was passed (#661 round 3) — so
-/// `--inserter-cap 2` and a default run share a directory, because they
-/// produce the same artifact. Default paths stay byte-identical to
-/// pre-#661.
-fn auto_label(base: &str, ax: &LabelAxes<'_>) -> String {
-    // Every "is this at default?" test compares against the ENGINE's own
-    // default, never a literal (#661 round 5). Round 4 fixed only `claim`
-    // this way, after hardcoding `Upstream` inverted the contract when the
-    // real default turned out to be `Downstream`. Every other axis had the
-    // same latent bug: this repo flips defaults on measurement (RFC-051,
-    // RFC-053, RFC-059, RFC-060 all did), and a flip would silently
-    // reintroduce the collision this whole function exists to prevent.
-    //
-    // `LayoutOptions::default()` IS the reference, so the comparison cannot
-    // drift from the thing it is describing.
-    let d = LayoutOptions::default();
-    let mut tags: Vec<String> = Vec::new();
-
-    if ax.strategy != d.strategy {
-        tags.push("pd".to_string());
-    }
-    if ax.row_layout != d.row_layout {
-        tags.push(format!("{:?}", ax.row_layout).to_lowercase());
-    }
-    // Exact float comparison, not epsilon (#661 round 2) and not a formatted
-    // string (round 3): `1.0` never tags, `0.9999999999999999` does.
-    if ax.duty != d.planning_duty {
-        tags.push(format!("duty{}", format!("{}", ax.duty).replace('.', "_")));
-    }
-    if ax.tier != DEFAULT_TIER {
-        tags.push(ax.tier.replace("assembling-machine-", "am").replace('-', ""));
-    }
-    // NOTE the asymmetry, stated because it breaks the "only non-default"
-    // rule on purpose: `max_belt_tier: None` means "engine picks by rate", so
-    // an explicit `--belt` matching what the engine would have picked yields a
-    // byte-identical artifact in a separate directory. That over-forks, which
-    // is the SAFE direction (a redundant dir, never a shared one); resolving
-    // it properly needs the rate-dependent `belt_entity_for_rate`, which the
-    // label does not have. Documented rather than silently tolerated.
-    if ax.belt != d.max_belt_tier.as_deref() {
-        if let Some(b) = ax.belt {
-            tags.push(b.replace("-transport-belt", "").replace("transport-belt", "yellow"));
-        }
-    }
-    if ax.quality != d.quality {
-        tags.push(format!("{:?}", ax.quality).to_lowercase());
-    }
-    if ax.stacking != d.stacking {
-        tags.push(format!("stack{}", ax.stacking));
-    }
-    if ax.di != d.direct_insertion {
-        tags.push(format!("di{:?}", ax.di).to_lowercase());
-    }
-    if let Some(c) = ax.claim {
-        if *c != d.di_claim_order {
-            tags.push(format!("claim{c:?}").to_lowercase());
-        }
-    }
-    if let Some(ic) = ax.inserter_cap {
-        if ic != d.inserter_capacity {
-            tags.push(format!("icap{ic}"));
-        }
-    }
-
-    // List-valued axes, compared and digested as SETS because the solve
-    // consumes `--inputs` as an `FxHashSet` (#661 round 4).
-    let mut listy = String::new();
-    let mut given: Vec<&str> = ax.inputs.iter().map(|s| s.as_str()).collect();
-    given.sort_unstable();
-    given.dedup();
-    let mut default_inputs: Vec<&str> = DEFAULT_INPUTS.to_vec();
-    default_inputs.sort_unstable();
-    let inputs_differ = given != default_inputs;
-    if inputs_differ {
-        listy.push_str(&given.join(","));
-    }
-    for (k, v) in ax.research_productivity {
-        listy.push_str(&format!(";{k}={v}"));
-    }
-    // Keyed on "does it DIFFER", not on "is the digest string non-empty"
-    // (#661 round 5): `--inputs ""` parses to `[""]`, which differs from the
-    // default set but joins to the empty string, so the old test skipped the
-    // tag and dropped the run into the DEFAULT directory — the exact
-    // collision, at the empty edge.
-    if inputs_differ || !ax.research_productivity.is_empty() {
-        // FNV-1a 64-bit (#661 round 5). The 32-bit version could alias two
-        // distinct sets onto one directory, which made the "cannot collide"
-        // claim false; 64 bits makes it true for any realistic number of
-        // fixture configs. Deterministic across runs and platforms, which
-        // `DefaultHasher` explicitly is not.
-        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-        for byte in listy.as_bytes() {
-            h ^= *byte as u64;
-            h = h.wrapping_mul(0x0000_0100_0000_01b3);
-        }
-        tags.push(format!("cfg{h:016x}"));
-    }
-
-    if tags.is_empty() {
-        base.to_string()
-    } else {
-        format!("{base}-{}", tags.join("-"))
-    }
+/// Note what it does NOT take: any value, and any default. It is a question
+/// about the command line, not about the configuration.
+fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
+    !axis_flags_seen.is_empty() && label.is_none()
 }
 
 fn main() {
@@ -284,6 +196,7 @@ fn main() {
     let mut strategy = LayoutStrategy::default();
     let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
     let mut label: Option<String> = None;
+    let mut axis_flags_seen: Vec<String> = Vec::new();
     let mut out = std::env::var("SIM_PROBE_OUT").unwrap_or_else(|_| "/tmp".to_string());
 
     while i < args.len() {
@@ -292,6 +205,14 @@ fn main() {
                 .cloned()
                 .unwrap_or_else(|| usage(&format!("{} needs a value", args[i])))
         };
+        // Purely SYNTACTIC: was the flag passed? This deliberately does not
+        // look at the VALUE or compare it to any default — see
+        // `AXIS_FLAGS`. Five review rounds went into getting per-axis
+        // default comparisons right and each one found another axis I had
+        // wrong; not consulting a default at all is the fix.
+        if AXIS_FLAGS.contains(&args[i].as_str()) {
+            axis_flags_seen.push(args[i].clone());
+        }
         match args[i].as_str() {
             "--tier" => tier = need(i),
             "--di" => {
@@ -399,30 +320,23 @@ fn main() {
             .collect::<Vec<_>>()
             .join(" + ")
     };
+    // Any axis flag without an explicit label is refused, because the label
+    // is the output directory and `{item}-{rate}` cannot distinguish the runs.
+    if label_required(&axis_flags_seen, &label) {
+        usage(&format!(
+            "{} changes the exported layout, so `--label <name>` is required: \
+             without it this run writes to <out>/{{item}}-{{rate}}/ and silently \
+             overwrites any other run of the same target",
+            axis_flags_seen.join(", ")
+        ));
+    }
     let label = label.unwrap_or_else(|| {
-        let base = targets
+        targets
             .iter()
             .map(|(item, rate)| format!("{item}-{rate}"))
             .collect::<Vec<_>>()
             .join("_")
-            .replace('.', "_");
-        auto_label(
-            &base,
-            &LabelAxes {
-                strategy,
-                row_layout,
-                duty,
-                tier: &tier,
-                belt: belt.as_deref(),
-                quality,
-                stacking,
-                di,
-                claim: claim.as_ref(),
-                inserter_cap,
-                inputs: &inputs,
-                research_productivity: &research_productivity,
-            },
-        )
+            .replace('.', "_")
     });
 
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
@@ -553,183 +467,54 @@ fn main() {
 mod tests {
     use super::*;
 
-    fn axes<'a>() -> LabelAxes<'a> {
-        // Every field taken FROM `LayoutOptions::default()` rather than named
-        // (#661 round 5) — a fixture that hardcodes defaults goes stale the
-        // same way the production code did, and then passes anyway.
-        let d = LayoutOptions::default();
-        LabelAxes {
-            strategy: d.strategy,
-            row_layout: d.row_layout,
-            duty: d.planning_duty,
-            tier: DEFAULT_TIER,
-            belt: None,
-            quality: d.quality,
-            stacking: d.stacking,
-            di: d.direct_insertion,
-            claim: None,
-            inserter_cap: None,
-            inputs: &[],
-            research_productivity: &EMPTY_RP,
+    /// The rule: any artifact-changing flag demands an explicit `--label`.
+    #[test]
+    fn axis_flags_require_a_label() {
+        let none: Option<String> = None;
+        let some = Some("ac7hs-duty06-pd".to_string());
+
+        // No axis flags: the `{item}-{rate}` default is unambiguous.
+        assert!(!label_required(&[], &none));
+        assert!(!label_required(&[], &some));
+
+        // Any axis flag without a label is refused...
+        for f in AXIS_FLAGS {
+            assert!(
+                label_required(&[f.to_string()], &none),
+                "{f} changes the artifact and must demand a label"
+            );
+            // ...and is fine with one.
+            assert!(!label_required(&[f.to_string()], &some), "{f} with a label");
         }
     }
 
-    static EMPTY_RP: std::sync::LazyLock<std::collections::BTreeMap<String, f64>> =
-        std::sync::LazyLock::new(std::collections::BTreeMap::new);
-    static DEFAULT_CLAIM: std::sync::LazyLock<DiClaimOrder> =
-        std::sync::LazyLock::new(DiClaimOrder::default);
-    static NON_DEFAULT_CLAIM: std::sync::LazyLock<DiClaimOrder> =
-        std::sync::LazyLock::new(|| {
-            // Whichever arm is NOT the default, derived rather than named, so
-            // a default flip does not silently make this test vacuous.
-            if DiClaimOrder::default() == DiClaimOrder::Upstream {
-                DiClaimOrder::Downstream
-            } else {
-                DiClaimOrder::Upstream
+    /// Every flag that reaches `LayoutOptions` or the solve must be in
+    /// `AXIS_FLAGS`. This is the one place the list can go stale, so it is
+    /// pinned against the usage text rather than left to review.
+    ///
+    /// `--label` and `--out` are excluded deliberately: they name the output,
+    /// they do not change it.
+    #[test]
+    fn axis_flag_list_covers_every_documented_flag() {
+        let doc = include_str!("sim_export.rs");
+        let documented: Vec<String> = doc
+            .lines()
+            .filter(|l| l.trim_start().starts_with("//!   --"))
+            .filter_map(|l| l.split_whitespace().nth(1).map(str::to_string))
+            .filter(|f| f.starts_with("--"))
+            .collect();
+        assert!(!documented.is_empty(), "usage block not found");
+
+        const NOT_AXES: &[&str] = &["--label", "--out", "--multi"];
+        for f in &documented {
+            if NOT_AXES.contains(&f.as_str()) {
+                continue;
             }
-        });
-
-    /// The blocker from round 4: the default arm must not tag, and the
-    /// non-default arm MUST — checked against `DiClaimOrder::default()` so
-    /// neither direction can silently invert if the default changes.
-    #[test]
-    fn claim_tags_track_the_real_default() {
-        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        let mk = |c| {
-            let mut ax = axes();
-            ax.inputs = &default_inputs;
-            ax.claim = Some(c);
-            auto_label("ec-5", &ax)
-        };
-        assert_eq!(mk(&DEFAULT_CLAIM), "ec-5", "the default claim order must not fork the path");
-        assert_ne!(
-            mk(&NON_DEFAULT_CLAIM),
-            "ec-5",
-            "a non-default claim order changes the artifact and must tag"
-        );
-    }
-
-    /// `--inputs` is consumed as an unordered set, so a reordering of the
-    /// same items is the same artifact and must share a directory.
-    #[test]
-    fn input_order_does_not_fork_the_path() {
-        let fwd: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        let mut rev = fwd.clone();
-        rev.reverse();
-        let mut a = axes();
-        a.inputs = &fwd;
-        let mut b = axes();
-        b.inputs = &rev;
-        assert_eq!(auto_label("ec-5", &a), auto_label("ec-5", &b));
-        assert_eq!(auto_label("ec-5", &a), "ec-5", "the default set must not tag at all");
-    }
-
-    /// The contract: default config keeps the pre-#661 path byte-identical.
-    #[test]
-    fn defaults_produce_the_bare_base() {
-        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        let mut ax = axes();
-        ax.inputs = &default_inputs;
-        assert_eq!(auto_label("electronic-circuit-5", &ax), "electronic-circuit-5");
-    }
-
-    /// The bug this PR exists to fix: two strategies must not share a path.
-    #[test]
-    fn strategy_separates_the_two_arms() {
-        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        let mut pooled = axes();
-        pooled.inputs = &default_inputs;
-        let mut pd = axes();
-        pd.inputs = &default_inputs;
-        pd.strategy = LayoutStrategy::PartitionedDecomposed;
-
-        let a = auto_label("ec-5", &pooled);
-        let b = auto_label("ec-5", &pd);
-        assert_ne!(a, b, "pooled and partitioned-decomposed collided: {a}");
-        assert_eq!(b, "ec-5-pd");
-    }
-
-    /// The cross-comparison the round-2 review named: `--duty < 1` requires an
-    /// explicit `--belt`, so duty fixtures always pin a belt tier and the two
-    /// belt tiers must still separate.
-    #[test]
-    fn duty_and_belt_separate_together() {
-        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        let mk = |belt| {
-            let mut ax = axes();
-            ax.inputs = &default_inputs;
-            ax.duty = 0.6;
-            ax.belt = Some(belt);
-            auto_label("ec-5", &ax)
-        };
-        let yellow = mk("transport-belt");
-        let fast = mk("fast-transport-belt");
-        assert_ne!(yellow, fast, "duty/belt cross-comparison collided");
-        assert_eq!(yellow, "ec-5-duty0_6-yellow");
-    }
-
-    /// Exact float comparison, not epsilon: a duty a hair under 1.0 lays out
-    /// differently and must not share the default's directory.
-    #[test]
-    fn near_one_duty_still_tags() {
-        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        let mut ax = axes();
-        ax.inputs = &default_inputs;
-        ax.duty = 0.9999999999999999;
-        assert_ne!(
-            auto_label("ec-5", &ax),
-            "ec-5",
-            "a duty within f64::EPSILON of 1.0 collided with the default"
-        );
-    }
-
-    /// Passing a flag whose value IS the engine default must not fork the
-    /// directory — the artifact is identical, so the path should be too.
-    #[test]
-    fn explicit_default_values_do_not_fork_the_path() {
-        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        let mut ax = axes();
-        ax.inputs = &default_inputs;
-        ax.inserter_cap = Some(spaghettio_core::common::DEFAULT_INSERTER_CAPACITY);
-        ax.claim = Some(&DEFAULT_CLAIM);
-        assert_eq!(
-            auto_label("ec-5", &ax),
-            "ec-5",
-            "explicitly passing the DEFAULT inserter-cap and claim order \
-             produces the default artifact and must not create a second \
-             directory for it"
-        );
-    }
-
-    /// `--inputs ""` parses to `[""]` — a NON-default set that joins to the
-    /// empty string. Keying the tag on "digest string is non-empty" dropped
-    /// it into the default directory; keying on "does the set differ" does
-    /// not (#661 round 5).
-    #[test]
-    fn empty_input_string_does_not_collapse_onto_the_default() {
-        let empty: Vec<String> = vec![String::new()];
-        let mut ax = axes();
-        ax.inputs = &empty;
-        assert_ne!(
-            auto_label("ec-5", &ax),
-            "ec-5",
-            "an empty-string input set differs from the default and must tag"
-        );
-    }
-
-    /// Non-default list-valued axes are digested rather than spelled out, but
-    /// must still separate.
-    #[test]
-    fn custom_inputs_digest_and_separate() {
-        let a_in: Vec<String> = vec!["iron-plate".into()];
-        let b_in: Vec<String> = vec!["copper-plate".into()];
-        let mut a = axes();
-        a.inputs = &a_in;
-        let mut b = axes();
-        b.inputs = &b_in;
-        let la = auto_label("ec-5", &a);
-        let lb = auto_label("ec-5", &b);
-        assert_ne!(la, lb, "different input sets collided");
-        assert!(la.contains("-cfg"), "expected a digest tag, got {la}");
+            assert!(
+                AXIS_FLAGS.contains(&f.as_str()),
+                "{f} is documented but missing from AXIS_FLAGS, so passing it \
+                 would not demand a label and two runs could collide"
+            );
+        }
     }
 }

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -40,8 +40,6 @@
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
 //!                          REQUIRED whenever any layout-changing flag is used
-//!   --force                replace a fixture built from a DIFFERENT config
-//!                          (re-running the SAME config never needs it)
 //!   --out <dir>            parent output dir (default $SIM_PROBE_OUT or /tmp)
 //! ```
 //!
@@ -148,76 +146,18 @@ fn default_label(targets: &[(String, f64)]) -> String {
         .replace('.', "_")
 }
 
-/// The name of the provenance file written beside each fixture.
-const CONFIG_FILE: &str = ".sim-export-config";
-
-/// A canonical description of everything about this invocation that changes
-/// the exported artifact.
+/// Does this invocation need an explicit `--label`?
 ///
-/// Sorted, so flag order does not matter, and built from the axis flags and
-/// their VALUES — which is the part every previous version of this guard
-/// could not see.
-fn config_fingerprint(targets: &[(String, f64)], axis_args: &[(String, String)]) -> String {
-    // The TARGETS are configuration too (#661 round 11, 3/3). Leaving them
-    // out meant `ec 5 --strategy pd --label x` and `copper-cable 20
-    // --strategy pd --label x` fingerprinted identically, so the second
-    // silently overwrote the first — the same wrong-A/B, in the fourth
-    // direction this guard has been caught from. The artifact depends on
-    // what is being built, not only on how.
-    let mut pairs: Vec<String> = targets
-        .iter()
-        .map(|(item, rate)| format!("target:{item}={rate}"))
-        .collect();
-    pairs.extend(axis_args.iter().map(|(f, v)| format!("{f}={v}")));
-    pairs.sort();
-    pairs.join("\n")
-}
-
-/// Should this run refuse rather than overwrite what is already there?
+/// True when any artifact-changing flag was passed. Kept as a pure function
+/// so the rule is testable — the previous design put per-axis default
+/// comparisons inline in `main()`, where nothing exercised them and five
+/// review rounds each found another axis compared against the wrong default.
 ///
-/// Compares the stored fingerprint of the existing artifact against this
-/// run's. Same configuration means a re-run producing the same bytes, which
-/// is idempotent and allowed; a different one means the two fixtures would
-/// silently become one, which is the wrong-A/B this tool exists to prevent.
-///
-/// This replaces three rounds of flag-shaped heuristics, each of which was a
-/// proxy for artifact identity and each of which leaked:
-///
-///   round 7  refuse whenever anything exists
-///            -> broke plain re-runs, which are idempotent
-///   round 8  refuse only when THIS run passed an axis flag
-///            -> `--strategy pd --label x` then `--label x` overwrote it
-///   round 9  refuse only when the label was EXPLICIT
-///            -> `--strategy pd --label ec-5` then a plain `ec 5` (whose
-///               derived label is also `ec-5`) overwrote it
-///
-/// Every one of those asks a question about the COMMAND LINE. The question
-/// that actually matters is about the ARTIFACT, and it cannot be answered
-/// from flags alone — which is what the #661 reviews kept demonstrating,
-/// from a different direction each time. So it is answered from the
-/// artifact.
-///
-/// `Unknown` provenance (files present, no fingerprint) is refused too: it
-/// means a fixture written before this existed, or by hand, and assuming it
-/// matches is the same guess in a new place.
-fn overwrite_verdict(stored: Option<&str>, current: &str, force: bool, any_artifact: bool) -> OverwriteVerdict {
-    if force || !any_artifact {
-        return OverwriteVerdict::Proceed;
-    }
-    match stored {
-        Some(prev) if prev == current => OverwriteVerdict::Proceed,
-        Some(_) => OverwriteVerdict::DifferentConfig,
-        None => OverwriteVerdict::UnknownProvenance,
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum OverwriteVerdict {
-    Proceed,
-    DifferentConfig,
-    UnknownProvenance,
-}
-
+/// Note what it does NOT take: any value, and any default. It is a question
+/// about the command line, not about the configuration — which is also its
+/// limit: it cannot separate two runs that pass the SAME axis with DIFFERENT
+/// values under one `--label`. Closing that needs artifact provenance, which
+/// is a separate change (branch `feat/sim-export-overwrite-provenance`).
 fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
     !axis_flags_seen.is_empty() && label.is_none()
 }
@@ -276,9 +216,7 @@ fn main() {
     let mut strategy = LayoutStrategy::default();
     let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
     let mut label: Option<String> = None;
-    let mut force = false;
     let mut axis_flags_seen: Vec<String> = Vec::new();
-    let mut axis_args: Vec<(String, String)> = Vec::new();
     let mut out = std::env::var("SIM_PROBE_OUT").unwrap_or_else(|_| "/tmp".to_string());
 
     while i < args.len() {
@@ -294,20 +232,6 @@ fn main() {
         // wrong; not consulting a default at all is the fix.
         if AXIS_FLAGS.contains(&args[i].as_str()) {
             axis_flags_seen.push(args[i].clone());
-            // The VALUE too, for the artifact fingerprint. The label guard
-            // deliberately ignores values (see `label_required`); the
-            // overwrite guard deliberately does not.
-            axis_args.push((
-                args[i].clone(),
-                args.get(i + 1).cloned().unwrap_or_default(),
-            ));
-        }
-        // The one valueless flag, so it advances by 1 rather than the 2
-        // every other branch assumes.
-        if args[i] == "--force" {
-            force = true;
-            i += 1;
-            continue;
         }
         match args[i].as_str() {
             "--tier" => tier = need(i),
@@ -447,73 +371,6 @@ fn main() {
         ));
     }
     let label = label.unwrap_or_else(|| default_label(&targets));
-
-    // The label guard is necessary but NOT sufficient (#661 review, major).
-    // It reasons about flag PRESENCE, so it cannot separate two runs that
-    // pass the same axis with different VALUES under one `--label` —
-    // `--strategy pd --label x` then `--strategy pooled --label x` both
-    // satisfy it, and the second silently overwrote the first. That is the
-    // original wrong-A/B bug, reachable through the guard added to prevent
-    // it. Presence is knowable at parse time; artifact identity is not, so
-    // the second half of the invariant is enforced against the filesystem.
-    //
-    // Checked HERE, before the solve, and not at the write (#661 round 7,
-    // 3/3): everything between is minutes of layout and validation, and a
-    // refusal the user could have been given immediately is a bad trade for
-    // a `Path::exists` call. Nothing between here and the write can change
-    // the answer — the paths depend only on `out` and `label`, both already
-    // final.
-    //
-    // Either artifact present means the directory is claimed. Which one
-    // arrives first is deliberately not load-bearing: this diff put the
-    // config file ahead of both, so an interrupted run leaves its
-    // provenance readable rather than a fixture nobody can attribute.
-    //
-    // Applies to EVERY run, explicit label or not. Earlier rounds scoped
-    // this by axis flags and then by label-explicitness; both were proxies
-    // for artifact identity and both leaked. The verdict now comes from
-    // comparing recorded configurations, so no scoping is needed — an
-    // identical re-run is allowed because it IS identical, not because of
-    // how it was invoked.
-    let fingerprint = config_fingerprint(&targets, &axis_args);
-    {
-        let dir = format!("{out}/{label}");
-        let any_artifact = ["bp.txt", "manifest-real.json"]
-            .iter()
-            .any(|f| std::path::Path::new(&format!("{dir}/{f}")).exists());
-        let stored = std::fs::read_to_string(format!("{dir}/{CONFIG_FILE}")).ok();
-        match overwrite_verdict(stored.as_deref(), &fingerprint, force, any_artifact) {
-            OverwriteVerdict::Proceed => {}
-            OverwriteVerdict::DifferentConfig => {
-                eprintln!(
-                    "error: {dir}/ holds a fixture built from a DIFFERENT configuration \
-                     — refusing to overwrite it.\n\
-                     \n\
-                     existing: {}\n\
-                     this run: {}\n\
-                     \n\
-                     Overwriting would silently turn two fixtures into one, which is the \
-                     wrong-A/B this tool exists to prevent. Give this run its own \
-                     --label, or pass --force if you meant to replace it.",
-                    stored.as_deref().unwrap_or("<none>").replace('\n', ", "),
-                    fingerprint.replace('\n', ", "),
-                );
-                std::process::exit(2);
-            }
-            OverwriteVerdict::UnknownProvenance => {
-                eprintln!(
-                    "error: {dir}/ already holds a fixture, and carries no {CONFIG_FILE} \
-                     recording how it was built — refusing to overwrite it.\n\
-                     \n\
-                     It predates this check or was written by hand, so whether it matches \
-                     this run cannot be determined. Give this run its own --label, or \
-                     pass --force if you know it is safe to replace."
-                );
-                std::process::exit(2);
-            }
-        }
-    }
-
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
 
     // RFC-062 Phase 3: always the multi-target entry point, even for N=1
@@ -586,17 +443,9 @@ fn main() {
     let dir = format!("{out}/{label}");
     let bp_path = format!("{dir}/bp.txt");
     let mf_path = format!("{dir}/manifest-real.json");
-    let cfg_path = format!("{dir}/{CONFIG_FILE}");
 
     std::fs::create_dir_all(&dir).unwrap_or_else(|e| {
         eprintln!("cannot create {dir}: {e}");
-        std::process::exit(1);
-    });
-    // Provenance first, so an interrupted run cannot leave artifacts whose
-    // configuration is unrecorded — which the guard would then have to
-    // refuse as unknown.
-    std::fs::write(&cfg_path, &fingerprint).unwrap_or_else(|e| {
-        eprintln!("cannot write {cfg_path}: {e}");
         std::process::exit(1);
     });
     std::fs::write(&bp_path, &bp).unwrap_or_else(|e| {
@@ -683,83 +532,6 @@ mod tests {
             .collect()
     }
 
-    /// The overwrite policy, which the filesystem check only executes.
-    ///
-    /// Keyed on the artifact's recorded configuration, so every case below
-    /// is a statement about what is ON DISK, not about the command line —
-    /// which is what three rounds of flag-shaped heuristics kept getting
-    /// wrong from a different direction each time.
-    #[test]
-    fn overwrite_policy() {
-        let ec = vec![("electronic-circuit".to_string(), 5.0)];
-        let pd = config_fingerprint(&ec, &[("--strategy".into(), "pd".into())]);
-        let pooled = config_fingerprint(&ec, &[("--strategy".into(), "pooled".into())]);
-        let plain = config_fingerprint(&ec, &[]);
-
-        // Same configuration, so the re-run writes the same bytes.
-        assert_eq!(
-            overwrite_verdict(Some(&pd), &pd, false, true),
-            OverwriteVerdict::Proceed,
-            "a re-run of the same configuration is idempotent"
-        );
-
-        // The round-8 hole: an axis fixture, then a run with no axis flags
-        // reusing its directory.
-        assert_eq!(
-            overwrite_verdict(Some(&pd), &plain, false, true),
-            OverwriteVerdict::DifferentConfig,
-            "a plain run must not overwrite an axis run's fixture"
-        );
-
-        // The round-9 hole, the same collision in the other direction: an
-        // explicit --label that happens to equal the derived name.
-        assert_eq!(
-            overwrite_verdict(Some(&pd), &pooled, false, true),
-            OverwriteVerdict::DifferentConfig,
-            "two different axis VALUES are two different fixtures"
-        );
-
-        // Flag ORDER is not configuration.
-        let a = config_fingerprint(&ec, &[
-            ("--strategy".into(), "pd".into()),
-            ("--belt".into(), "fast".into()),
-        ]);
-        let b = config_fingerprint(&ec, &[
-            ("--belt".into(), "fast".into()),
-            ("--strategy".into(), "pd".into()),
-        ]);
-        assert_eq!(a, b, "the same run written two ways is one configuration");
-        assert_eq!(overwrite_verdict(Some(&a), &b, false, true), OverwriteVerdict::Proceed);
-
-        // Escape hatch, empty directory, and unrecorded provenance.
-        assert_eq!(overwrite_verdict(Some(&pd), &pooled, true, true), OverwriteVerdict::Proceed);
-        assert_eq!(overwrite_verdict(None, &pd, false, false), OverwriteVerdict::Proceed);
-        assert_eq!(
-            overwrite_verdict(None, &pd, false, true),
-            OverwriteVerdict::UnknownProvenance,
-            "a fixture with no recorded config cannot be assumed to match"
-        );
-
-        // The TARGETS are configuration too (#661 round 11, 3/3). Same
-        // flags, same label, different thing being built.
-        let cable = vec![("copper-cable".to_string(), 20.0)];
-        let cable_pd = config_fingerprint(&cable, &[("--strategy".into(), "pd".into())]);
-        assert_ne!(cable_pd, pd, "different targets are different configurations");
-        assert_eq!(
-            overwrite_verdict(Some(&pd), &cable_pd, false, true),
-            OverwriteVerdict::DifferentConfig,
-            "a different target must not overwrite an earlier fixture's directory"
-        );
-
-        // ...including a differing RATE for the same item.
-        let ec_faster = vec![("electronic-circuit".to_string(), 30.0)];
-        let faster_pd = config_fingerprint(&ec_faster, &[("--strategy".into(), "pd".into())]);
-        assert_eq!(
-            overwrite_verdict(Some(&pd), &faster_pd, false, true),
-            OverwriteVerdict::DifferentConfig,
-            "the rate changes the artifact, so it changes the fingerprint"
-        );
-    }
 
     /// Every flag the PARSER accepts must be documented.
     ///
@@ -813,10 +585,8 @@ mod tests {
     #[test]
     fn axis_flag_list_and_docs_agree_both_ways() {
         // Not axes: these change WHERE a run writes, or WHETHER it may,
-        // never WHAT it exports. `--force` joined them when the overwrite
-        // guard landed — and this test caught the omission on its first
-        // run, which is the whole reason it is bidirectional.
-        const NOT_AXES: &[&str] = &["--label", "--out", "--multi", "--force"];
+        // never WHAT it exports.
+        const NOT_AXES: &[&str] = &["--label", "--out", "--multi"];
         let doc = include_str!("sim_export.rs");
         let documented: Vec<String> = doc
             .lines()

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -77,7 +77,9 @@ const DEFAULT_TIER: &str = "assembling-machine-3";
 /// Rather than encode each axis into the name — which needs every axis
 /// enumerated and every engine default stated correctly, and which took five
 /// review rounds without converging — passing any of these simply REQUIRES an
-/// explicit `--label`. Collisions become impossible by construction, and the
+/// explicit `--label`. Collisions between runs that differ only by an axis
+/// become impossible by construction — reusing the same `--label` twice
+/// still collides, and deliberately so — and the
 /// check consults no defaults, so a future default flip cannot invert it.
 ///
 /// Slightly over-strict on purpose: `--strategy pooled` is the default value
@@ -139,6 +141,20 @@ fn parse_target_token(tok: &str) -> (String, f64) {
 ///
 /// Note what it does NOT take: any value, and any default. It is a question
 /// about the command line, not about the configuration.
+/// The label a run falls back to when `--label` is absent.
+///
+/// One definition, because the refusal message quotes it: when these were
+/// two expressions the message described `{item}-{rate}` while a --multi
+/// run actually used the joined list (#661 review).
+fn default_label(targets: &[(String, f64)]) -> String {
+    targets
+        .iter()
+        .map(|(item, rate)| format!("{item}-{rate}"))
+        .collect::<Vec<_>>()
+        .join("_")
+        .replace('.', "_")
+}
+
 fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
     !axis_flags_seen.is_empty() && label.is_none()
 }
@@ -255,7 +271,12 @@ fn main() {
             // from here.
             "--strategy" => {
                 strategy = match need(i).as_str() {
-                    "pooled" | "default" => LayoutStrategy::Pooled,
+                    "pooled" => LayoutStrategy::Pooled,
+                    // Delegate, matching `--row-layout`'s "native"|"default"
+                    // (#661 review). Hardcoding Pooled here meant a change to
+                    // the #[default] would silently stop being what
+                    // `--strategy default` selects.
+                    "default" => LayoutStrategy::default(),
                     "partitioned-decomposed" | "pd" => LayoutStrategy::PartitionedDecomposed,
                     other => usage(&format!(
                         "--strategy must be pooled|default|partitioned-decomposed|pd (got {other})"
@@ -321,24 +342,32 @@ fn main() {
             .collect::<Vec<_>>()
             .join(" + ")
     };
+    // The fitted duty values are TIER-RELATIVE (bot review round 2):
+    // block = floor(in_lane_cap(tier) × 2 × duty / rate), and with no
+    // --belt the cap resolves to the express default (belt_cap 45), so
+    // --duty 0.6 silently computes the measured-DEAD block 6 instead of
+    // the gate-clearing block 2. Require the tier to be explicit.
+    if duty < 1.0 && belt.is_none() {
+        usage("--duty < 1 requires an explicit --belt (the fitted duty is tier-relative; the RFC-069 gate receipts are on transport-belt)");
+    }
+
     // Any axis flag without an explicit label is refused, because the label
     // is the output directory and `{item}-{rate}` cannot distinguish the runs.
     if label_required(&axis_flags_seen, &label) {
+        // Name the directory this run would ACTUALLY have used. The
+        // default label is `{item}-{rate}` only for a single target; under
+        // --multi it is the joined list, so the old hardcoded
+        // `<out>/{item}-{rate}/` described the wrong path back to anyone
+        // hitting this in multi mode (#661 review).
         usage(&format!(
             "{} changes the exported layout, so `--label <name>` is required: \
-             without it this run writes to <out>/{{item}}-{{rate}}/ and silently \
-             overwrites any other run of the same target",
-            axis_flags_seen.join(", ")
+             without it this run writes to <out>/{}/ and silently overwrites \
+             any other run of the same target",
+            axis_flags_seen.join(", "),
+            default_label(&targets)
         ));
     }
-    let label = label.unwrap_or_else(|| {
-        targets
-            .iter()
-            .map(|(item, rate)| format!("{item}-{rate}"))
-            .collect::<Vec<_>>()
-            .join("_")
-            .replace('.', "_")
-    });
+    let label = label.unwrap_or_else(|| default_label(&targets));
 
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
 
@@ -371,14 +400,6 @@ fn main() {
         std::process::exit(1);
     });
 
-    // The fitted duty values are TIER-RELATIVE (bot review round 2):
-    // block = floor(in_lane_cap(tier) × 2 × duty / rate), and with no
-    // --belt the cap resolves to the express default (belt_cap 45), so
-    // --duty 0.6 silently computes the measured-DEAD block 6 instead of
-    // the gate-clearing block 2. Require the tier to be explicit.
-    if duty < 1.0 && belt.is_none() {
-        usage("--duty < 1 requires an explicit --belt (the fitted duty is tier-relative; the RFC-069 gate receipts are on transport-belt)");
-    }
     let mut opts = LayoutOptions {
         direct_insertion: di,
         max_belt_tier: belt,

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -30,7 +30,7 @@
 //!   --claim up|down|search           DI claim order (default: engine default)
 //!   --belt <entity>        max belt tier (default: engine picks by rate)
 //!   --row-layout <kind>    native (default) | horizontal-stack
-//!   --strategy <kind>      pooled (default) | partitioned-decomposed
+//!   --strategy <kind>      pooled (aka default) | partitioned-decomposed (aka pd)
 //!   --duty <0..1>          planning duty (default 1.0; <1 needs --belt)
 //!   --quality <name>       normal|uncommon|rare|epic|legendary (default normal)
 //!   --stacking <1..4>      belt stacking (default 1)
@@ -39,6 +39,7 @@
 //!   --inserter-cap <n>     inserter capacity level (default: engine default)
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
+//!   --force                overwrite an existing <out>/<label>/bp.txt
 //!                          REQUIRED whenever any layout-changing flag is used
 //!   --out <dir>            parent output dir (default $SIM_PROBE_OUT or /tmp)
 //! ```
@@ -132,15 +133,6 @@ fn parse_target_token(tok: &str) -> (String, f64) {
 }
 
 
-/// Does this invocation need an explicit `--label`?
-///
-/// True when any artifact-changing flag was passed. Kept as a pure function
-/// so the rule is testable — the previous design put per-axis default
-/// comparisons inline in `main()`, where nothing exercised them and five
-/// review rounds each found another axis compared against the wrong default.
-///
-/// Note what it does NOT take: any value, and any default. It is a question
-/// about the command line, not about the configuration.
 /// The label a run falls back to when `--label` is absent.
 ///
 /// One definition, because the refusal message quotes it: when these were
@@ -155,6 +147,18 @@ fn default_label(targets: &[(String, f64)]) -> String {
         .replace('.', "_")
 }
 
+/// Does this invocation need an explicit `--label`?
+///
+/// True when any artifact-changing flag was passed. Kept as a pure function
+/// so the rule is testable — the previous design put per-axis default
+/// comparisons inline in `main()`, where nothing exercised them and five
+/// review rounds each found another axis compared against the wrong default.
+///
+/// Note what it does NOT take: any value, and any default. It is a question
+/// about the command line, not about the configuration — which is also its
+/// limit: it cannot tell two runs apart that pass the SAME axis with
+/// DIFFERENT values under one `--label`. That case is caught at the write
+/// instead, where the artifact is.
 fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
     !axis_flags_seen.is_empty() && label.is_none()
 }
@@ -213,6 +217,7 @@ fn main() {
     let mut strategy = LayoutStrategy::default();
     let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
     let mut label: Option<String> = None;
+    let mut force = false;
     let mut axis_flags_seen: Vec<String> = Vec::new();
     let mut out = std::env::var("SIM_PROBE_OUT").unwrap_or_else(|_| "/tmp".to_string());
 
@@ -229,6 +234,13 @@ fn main() {
         // wrong; not consulting a default at all is the fix.
         if AXIS_FLAGS.contains(&args[i].as_str()) {
             axis_flags_seen.push(args[i].clone());
+        }
+        // The one valueless flag, so it advances by 1 rather than the 2
+        // every other branch assumes.
+        if args[i] == "--force" {
+            force = true;
+            i += 1;
+            continue;
         }
         match args[i].as_str() {
             "--tier" => tier = need(i),
@@ -439,12 +451,34 @@ fn main() {
         &layout, &solved, &label, &issues,
     );
     let dir = format!("{out}/{label}");
+    let bp_path = format!("{dir}/bp.txt");
+    let mf_path = format!("{dir}/manifest-real.json");
+
+    // The label guard is necessary but NOT sufficient (#661 review, major).
+    // It reasons about flag PRESENCE, so it cannot separate two runs that
+    // pass the same axis with different values under one `--label` —
+    // `--strategy pd --label x` then `--strategy pooled --label x` both
+    // satisfy it and the second silently overwrote the first. That is the
+    // original wrong-A/B bug, reachable through the guard added to prevent
+    // it. Presence is knowable at parse time; artifact identity is only
+    // knowable here, so the second half of the invariant belongs at the
+    // write.
+    if !force && std::path::Path::new(&bp_path).exists() {
+        eprintln!(
+            "error: {bp_path} already exists — refusing to overwrite it.\n\
+             \n\
+             A previous run wrote this label. If that run used different flags, \
+             overwriting it is the silent wrong-A/B this tool exists to avoid; \
+             give this run its own --label. If you are deliberately \
+             regenerating the same configuration, pass --force."
+        );
+        std::process::exit(1);
+    }
+
     std::fs::create_dir_all(&dir).unwrap_or_else(|e| {
         eprintln!("cannot create {dir}: {e}");
         std::process::exit(1);
     });
-    let bp_path = format!("{dir}/bp.txt");
-    let mf_path = format!("{dir}/manifest-real.json");
     std::fs::write(&bp_path, &bp).unwrap_or_else(|e| {
         eprintln!("cannot write {bp_path}: {e}");
         std::process::exit(1);
@@ -522,7 +556,11 @@ mod tests {
     /// or select the output, they do not change it.
     #[test]
     fn axis_flag_list_and_docs_agree_both_ways() {
-        const NOT_AXES: &[&str] = &["--label", "--out", "--multi"];
+        // Not axes: these change WHERE a run writes, or WHETHER it may,
+        // never WHAT it exports. `--force` joined them when the overwrite
+        // guard landed — and this test caught the omission on its first
+        // run, which is the whole reason it is bidirectional.
+        const NOT_AXES: &[&str] = &["--label", "--out", "--multi", "--force"];
         let doc = include_str!("sim_export.rs");
         let documented: Vec<String> = doc
             .lines()

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -261,13 +261,37 @@ fn main() {
             .collect::<Vec<_>>()
             .join(" + ")
     };
+    // The auto label is also the OUTPUT DIRECTORY (`<out>/<label>/`), so it
+    // has to separate runs that differ only by a layout axis. It did not:
+    // `{item}-{rate}` encoded neither strategy, row layout, nor duty, so
+    // `--strategy pooled X 5` and `--strategy partitioned-decomposed X 5`
+    // both wrote `<out>/X-5/` and the second silently overwrote the first's
+    // `bp.txt` and `manifest-real.json` (#661 review). That is a wrong-A/B
+    // generator, and A/B is the entire reason this binary takes these flags.
+    //
+    // Suffixes are emitted ONLY for non-default values, so every existing
+    // default-axis path is byte-identical to before. An explicit `--label`
+    // still overrides everything, which is how you opt out.
     let label = label.unwrap_or_else(|| {
-        targets
+        let base = targets
             .iter()
             .map(|(item, rate)| format!("{item}-{rate}"))
             .collect::<Vec<_>>()
             .join("_")
-            .replace('.', "_")
+            .replace('.', "_");
+        let mut suffix = String::new();
+        match strategy {
+            LayoutStrategy::Pooled => {}
+            LayoutStrategy::PartitionedDecomposed => suffix.push_str("-pd"),
+        }
+        match row_layout {
+            RowLayout::HorizontalStack => suffix.push_str("-hs"),
+            _ => {}
+        }
+        if (duty - 1.0).abs() > f64::EPSILON {
+            suffix.push_str(&format!("-duty{}", format!("{duty}").replace('.', "_")));
+        }
+        format!("{base}{suffix}")
     });
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
 

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -157,8 +157,18 @@ const CONFIG_FILE: &str = ".sim-export-config";
 /// Sorted, so flag order does not matter, and built from the axis flags and
 /// their VALUES — which is the part every previous version of this guard
 /// could not see.
-fn config_fingerprint(axis_args: &[(String, String)]) -> String {
-    let mut pairs: Vec<String> = axis_args.iter().map(|(f, v)| format!("{f}={v}")).collect();
+fn config_fingerprint(targets: &[(String, f64)], axis_args: &[(String, String)]) -> String {
+    // The TARGETS are configuration too (#661 round 11, 3/3). Leaving them
+    // out meant `ec 5 --strategy pd --label x` and `copper-cable 20
+    // --strategy pd --label x` fingerprinted identically, so the second
+    // silently overwrote the first — the same wrong-A/B, in the fourth
+    // direction this guard has been caught from. The artifact depends on
+    // what is being built, not only on how.
+    let mut pairs: Vec<String> = targets
+        .iter()
+        .map(|(item, rate)| format!("target:{item}={rate}"))
+        .collect();
+    pairs.extend(axis_args.iter().map(|(f, v)| format!("{f}={v}")));
     pairs.sort();
     pairs.join("\n")
 }
@@ -454,20 +464,18 @@ fn main() {
     // the answer — the paths depend only on `out` and `label`, both already
     // final.
     //
-    // Both artifacts count, not just `bp.txt`. The justification given in
-    // round 7 — an interrupted run leaving only the manifest — is NOT
-    // producible, since `bp.txt` is written first (#661 review). The real
-    // reason is narrower and still worth it: either file present means the
-    // directory is claimed, and keying on one of two artifacts invites the
-    // write order becoming load-bearing later.
+    // Either artifact present means the directory is claimed. Which one
+    // arrives first is deliberately not load-bearing: this diff put the
+    // config file ahead of both, so an interrupted run leaves its
+    // provenance readable rather than a fixture nobody can attribute.
     //
-    // Scoped to runs with an EXPLICIT --label (#661 round 9). A plain
-    // `sim_export iron-ore 10` re-run derives its label from the target and
-    // writes the same bytes, so refusing it broke a workflow that was fine.
-    // Keying on the axis flags instead — round 8's attempt at that — let
-    // `--label x` with no axis flag overwrite an axis run's fixture, which
-    // is the wrong-A/B this exists to stop.
-    let fingerprint = config_fingerprint(&axis_args);
+    // Applies to EVERY run, explicit label or not. Earlier rounds scoped
+    // this by axis flags and then by label-explicitness; both were proxies
+    // for artifact identity and both leaked. The verdict now comes from
+    // comparing recorded configurations, so no scoping is needed — an
+    // identical re-run is allowed because it IS identical, not because of
+    // how it was invoked.
+    let fingerprint = config_fingerprint(&targets, &axis_args);
     {
         let dir = format!("{out}/{label}");
         let any_artifact = ["bp.txt", "manifest-real.json"]
@@ -683,9 +691,10 @@ mod tests {
     /// wrong from a different direction each time.
     #[test]
     fn overwrite_policy() {
-        let pd = config_fingerprint(&[("--strategy".into(), "pd".into())]);
-        let pooled = config_fingerprint(&[("--strategy".into(), "pooled".into())]);
-        let plain = config_fingerprint(&[]);
+        let ec = vec![("electronic-circuit".to_string(), 5.0)];
+        let pd = config_fingerprint(&ec, &[("--strategy".into(), "pd".into())]);
+        let pooled = config_fingerprint(&ec, &[("--strategy".into(), "pooled".into())]);
+        let plain = config_fingerprint(&ec, &[]);
 
         // Same configuration, so the re-run writes the same bytes.
         assert_eq!(
@@ -711,11 +720,11 @@ mod tests {
         );
 
         // Flag ORDER is not configuration.
-        let a = config_fingerprint(&[
+        let a = config_fingerprint(&ec, &[
             ("--strategy".into(), "pd".into()),
             ("--belt".into(), "fast".into()),
         ]);
-        let b = config_fingerprint(&[
+        let b = config_fingerprint(&ec, &[
             ("--belt".into(), "fast".into()),
             ("--strategy".into(), "pd".into()),
         ]);
@@ -729,6 +738,26 @@ mod tests {
             overwrite_verdict(None, &pd, false, true),
             OverwriteVerdict::UnknownProvenance,
             "a fixture with no recorded config cannot be assumed to match"
+        );
+
+        // The TARGETS are configuration too (#661 round 11, 3/3). Same
+        // flags, same label, different thing being built.
+        let cable = vec![("copper-cable".to_string(), 20.0)];
+        let cable_pd = config_fingerprint(&cable, &[("--strategy".into(), "pd".into())]);
+        assert_ne!(cable_pd, pd, "different targets are different configurations");
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &cable_pd, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "a different target must not overwrite an earlier fixture's directory"
+        );
+
+        // ...including a differing RATE for the same item.
+        let ec_faster = vec![("electronic-circuit".to_string(), 30.0)];
+        let faster_pd = config_fingerprint(&ec_faster, &[("--strategy".into(), "pd".into())]);
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &faster_pd, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "the rate changes the artifact, so it changes the fingerprint"
         );
     }
 

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -39,9 +39,9 @@
 //!   --inserter-cap <n>     inserter capacity level (default: engine default)
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
+//!                          REQUIRED whenever any layout-changing flag is used
 //!   --force                regenerate over an existing <out>/<label>/
 //!                          (NOT needed for a fresh --label; only for reusing one)
-//!                          REQUIRED whenever any layout-changing flag is used
 //!   --out <dir>            parent output dir (default $SIM_PROBE_OUT or /tmp)
 //! ```
 //!
@@ -160,6 +160,22 @@ fn default_label(targets: &[(String, f64)]) -> String {
 /// limit: it cannot tell two runs apart that pass the SAME axis with
 /// DIFFERENT values under one `--label`. That case is caught at the write
 /// instead, where the artifact is.
+/// Which already-written artifacts should block this run.
+///
+/// Split out from `main` so the overwrite policy is testable (#661 round 8:
+/// "the core overwrite guard has no tests" — the filesystem call is not the
+/// part worth testing, the decision is).
+///
+/// Empty means proceed. Three ways to get there: `--force`, no axis flag
+/// (a re-run with the same configuration writes the same bytes, so there is
+/// no A/B to get wrong), or nothing on disk yet.
+fn overwrite_blocked_by(axis_flags_seen: &[String], force: bool, present: &[String]) -> Vec<String> {
+    if force || axis_flags_seen.is_empty() {
+        return Vec::new();
+    }
+    present.to_vec()
+}
+
 fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
     !axis_flags_seen.is_empty() && label.is_none()
 }
@@ -401,14 +417,22 @@ fn main() {
     // Both artifacts count, not just `bp.txt`: an interrupted earlier run
     // can leave a directory holding only `manifest-real.json`, and
     // overwriting that is the same silent loss (#661 round 7).
+    //
+    // Scoped to runs that passed an axis (#661 round 8). A plain
+    // `sim_export iron-ore 10` re-run produces the SAME artifact — there is
+    // no A/B to get wrong — so refusing it broke a workflow that was fine,
+    // which is a worse outcome than the one being prevented. The guard
+    // exists for the case where two runs under one label can DIFFER, and
+    // that requires an axis flag.
     {
         let dir = format!("{out}/{label}");
-        let existing: Vec<String> = ["bp.txt", "manifest-real.json"]
+        let present: Vec<String> = ["bp.txt", "manifest-real.json"]
             .iter()
             .map(|f| format!("{dir}/{f}"))
             .filter(|p| std::path::Path::new(p).exists())
             .collect();
-        if !force && !existing.is_empty() {
+        let existing = overwrite_blocked_by(&axis_flags_seen, force, &present);
+        if !existing.is_empty() {
             eprintln!(
                 "error: {} already {} — refusing to overwrite.\n\
                  \n\
@@ -575,6 +599,99 @@ mod tests {
     ///
     /// `--label`, `--out` and `--multi` are excluded deliberately: they name
     /// or select the output, they do not change it.
+    /// Every flag named in the module's usage block, axis or not.
+    fn documented_flags(src: &str) -> Vec<String> {
+        src.lines()
+            .filter(|l| l.trim_start().starts_with("//!   --"))
+            .filter_map(|l| l.split_whitespace().nth(1).map(str::to_string))
+            .filter(|f| f.starts_with("--"))
+            .collect()
+    }
+
+    /// The overwrite policy, which the filesystem check only executes.
+    #[test]
+    fn overwrite_policy() {
+        let axis = vec!["--strategy".to_string()];
+        let none: Vec<String> = vec![];
+        let present = vec!["out/x/bp.txt".to_string()];
+
+        assert_eq!(
+            overwrite_blocked_by(&axis, false, &present),
+            present,
+            "an axis run must not silently overwrite a previous run's artifact"
+        );
+        assert!(
+            overwrite_blocked_by(&axis, true, &present).is_empty(),
+            "--force is the escape hatch"
+        );
+        assert!(
+            overwrite_blocked_by(&none, false, &present).is_empty(),
+            "a plain re-run writes the same bytes, so it must stay idempotent \
+             (#661 round 8 — scoping this to axis runs is the fix for that)"
+        );
+        assert!(
+            overwrite_blocked_by(&axis, false, &[]).is_empty(),
+            "nothing on disk, nothing to block"
+        );
+
+        // The interrupted-run case: only the manifest survived.
+        let manifest_only = vec!["out/x/manifest-real.json".to_string()];
+        assert_eq!(
+            overwrite_blocked_by(&axis, false, &manifest_only),
+            manifest_only,
+            "a half-written directory is still a collision"
+        );
+    }
+
+    /// Every flag the PARSER accepts must be documented.
+    ///
+    /// The bidirectional pin below compares `AXIS_FLAGS` against the doc
+    /// block, and both live in this file — so a flag added to the parser and
+    /// omitted from BOTH sails through undetected (#661 round 8, 3/3). This
+    /// one reads the parser's own match arms, which is the source that
+    /// cannot be forgotten: adding a flag means adding an arm.
+    #[test]
+    fn every_parsed_flag_is_documented() {
+        let src = include_str!("sim_export.rs");
+        let documented = documented_flags(src);
+        // Only the real code: this module's own examples mention flag-shaped
+        // strings in comments, and scanning them made the test fail on
+        // `"--flag"` from its own docstring.
+        let code = src.split("\nmod tests {").next().expect("module splits");
+
+        let mut parsed: Vec<String> = Vec::new();
+        for line in code.lines() {
+            let t = line.trim();
+            // `"--flag" => ...` and `if args[i] == "--flag"`.
+            let candidate = t
+                .strip_prefix('"')
+                .and_then(|r| r.split_once('"').map(|(f, _)| f))
+                .filter(|_| t.contains("=>"))
+                .or_else(|| {
+                    t.split_once("args[i] == \"")
+                        .and_then(|(_, r)| r.split_once('"').map(|(f, _)| f))
+                });
+            if let Some(f) = candidate {
+                if f.starts_with("--") && !parsed.contains(&f.to_string()) {
+                    parsed.push(f.to_string());
+                }
+            }
+        }
+
+        assert!(
+            parsed.len() > 10,
+            "flag extraction found only {parsed:?} — the parser's shape changed and \
+             this test stopped reading it, which would make it pass vacuously"
+        );
+
+        let undocumented: Vec<&String> =
+            parsed.iter().filter(|f| !documented.contains(&f.to_string())).collect();
+        assert!(
+            undocumented.is_empty(),
+            "flags accepted by the parser but absent from the usage block: {undocumented:?}"
+        );
+    }
+
     #[test]
     fn axis_flag_list_and_docs_agree_both_ways() {
         // Not axes: these change WHERE a run writes, or WHETHER it may,

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -39,7 +39,8 @@
 //!   --inserter-cap <n>     inserter capacity level (default: engine default)
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
-//!   --force                overwrite an existing <out>/<label>/bp.txt
+//!   --force                regenerate over an existing <out>/<label>/
+//!                          (NOT needed for a fresh --label; only for reusing one)
 //!                          REQUIRED whenever any layout-changing flag is used
 //!   --out <dir>            parent output dir (default $SIM_PROBE_OUT or /tmp)
 //! ```
@@ -381,6 +382,47 @@ fn main() {
     }
     let label = label.unwrap_or_else(|| default_label(&targets));
 
+    // The label guard is necessary but NOT sufficient (#661 review, major).
+    // It reasons about flag PRESENCE, so it cannot separate two runs that
+    // pass the same axis with different VALUES under one `--label` —
+    // `--strategy pd --label x` then `--strategy pooled --label x` both
+    // satisfy it, and the second silently overwrote the first. That is the
+    // original wrong-A/B bug, reachable through the guard added to prevent
+    // it. Presence is knowable at parse time; artifact identity is not, so
+    // the second half of the invariant is enforced against the filesystem.
+    //
+    // Checked HERE, before the solve, and not at the write (#661 round 7,
+    // 3/3): everything between is minutes of layout and validation, and a
+    // refusal the user could have been given immediately is a bad trade for
+    // a `Path::exists` call. Nothing between here and the write can change
+    // the answer — the paths depend only on `out` and `label`, both already
+    // final.
+    //
+    // Both artifacts count, not just `bp.txt`: an interrupted earlier run
+    // can leave a directory holding only `manifest-real.json`, and
+    // overwriting that is the same silent loss (#661 round 7).
+    {
+        let dir = format!("{out}/{label}");
+        let existing: Vec<String> = ["bp.txt", "manifest-real.json"]
+            .iter()
+            .map(|f| format!("{dir}/{f}"))
+            .filter(|p| std::path::Path::new(p).exists())
+            .collect();
+        if !force && !existing.is_empty() {
+            eprintln!(
+                "error: {} already {} — refusing to overwrite.\n\
+                 \n\
+                 A previous run wrote this label. If that run used different \
+                 flags, overwriting it is the silent wrong-A/B this tool exists \
+                 to avoid; give this run its own --label. If you are \
+                 deliberately regenerating the same configuration, pass --force.",
+                existing.join(" and "),
+                if existing.len() == 1 { "exists" } else { "exist" }
+            );
+            std::process::exit(2);
+        }
+    }
+
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
 
     // RFC-062 Phase 3: always the multi-target entry point, even for N=1
@@ -453,27 +495,6 @@ fn main() {
     let dir = format!("{out}/{label}");
     let bp_path = format!("{dir}/bp.txt");
     let mf_path = format!("{dir}/manifest-real.json");
-
-    // The label guard is necessary but NOT sufficient (#661 review, major).
-    // It reasons about flag PRESENCE, so it cannot separate two runs that
-    // pass the same axis with different values under one `--label` —
-    // `--strategy pd --label x` then `--strategy pooled --label x` both
-    // satisfy it and the second silently overwrote the first. That is the
-    // original wrong-A/B bug, reachable through the guard added to prevent
-    // it. Presence is knowable at parse time; artifact identity is only
-    // knowable here, so the second half of the invariant belongs at the
-    // write.
-    if !force && std::path::Path::new(&bp_path).exists() {
-        eprintln!(
-            "error: {bp_path} already exists — refusing to overwrite it.\n\
-             \n\
-             A previous run wrote this label. If that run used different flags, \
-             overwriting it is the silent wrong-A/B this tool exists to avoid; \
-             give this run its own --label. If you are deliberately \
-             regenerating the same configuration, pass --force."
-        );
-        std::process::exit(1);
-    }
 
     std::fs::create_dir_all(&dir).unwrap_or_else(|e| {
         eprintln!("cannot create {dir}: {e}");

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -31,6 +31,7 @@
 //!   --belt <entity>        max belt tier (default: engine picks by rate)
 //!   --row-layout <kind>    native (default) | horizontal-stack
 //!   --strategy <kind>      pooled (default) | partitioned-decomposed
+//!   --duty <0..1>          planning duty (default 1.0; <1 needs --belt)
 //!   --quality <name>       normal|uncommon|rare|epic|legendary (default normal)
 //!   --stacking <1..4>      belt stacking (default 1)
 //!   --research-productivity <recipe=bonus,...>   declared research
@@ -488,32 +489,40 @@ mod tests {
         }
     }
 
-    /// Every flag that reaches `LayoutOptions` or the solve must be in
-    /// `AXIS_FLAGS`. This is the one place the list can go stale, so it is
-    /// pinned against the usage text rather than left to review.
+    /// `AXIS_FLAGS` and the documented flag list must agree, BOTH ways.
     ///
-    /// `--label` and `--out` are excluded deliberately: they name the output,
-    /// they do not change it.
+    /// One direction catches "a new axis was added and forgotten", which is
+    /// the failure that produced five review rounds. The other catches the
+    /// hole this test itself shipped with: `--duty` was in `AXIS_FLAGS` but
+    /// missing from the usage block, so the pin could not see it and would
+    /// have passed while `--duty` silently lost its guard.
+    ///
+    /// `--label`, `--out` and `--multi` are excluded deliberately: they name
+    /// or select the output, they do not change it.
     #[test]
-    fn axis_flag_list_covers_every_documented_flag() {
+    fn axis_flag_list_and_docs_agree_both_ways() {
+        const NOT_AXES: &[&str] = &["--label", "--out", "--multi"];
         let doc = include_str!("sim_export.rs");
         let documented: Vec<String> = doc
             .lines()
             .filter(|l| l.trim_start().starts_with("//!   --"))
             .filter_map(|l| l.split_whitespace().nth(1).map(str::to_string))
-            .filter(|f| f.starts_with("--"))
+            .filter(|f| f.starts_with("--") && !NOT_AXES.contains(&f.as_str()))
             .collect();
         assert!(!documented.is_empty(), "usage block not found");
 
-        const NOT_AXES: &[&str] = &["--label", "--out", "--multi"];
         for f in &documented {
-            if NOT_AXES.contains(&f.as_str()) {
-                continue;
-            }
             assert!(
                 AXIS_FLAGS.contains(&f.as_str()),
                 "{f} is documented but missing from AXIS_FLAGS, so passing it \
                  would not demand a label and two runs could collide"
+            );
+        }
+        for f in AXIS_FLAGS {
+            assert!(
+                documented.iter().any(|d| d == f),
+                "{f} is in AXIS_FLAGS but undocumented, so the check above \
+                 cannot see it — the guard would decay silently"
             );
         }
     }

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -164,8 +164,15 @@ fn auto_label(base: &str, ax: &LabelAxes<'_>) -> String {
     // `--claim` and `--inserter-cap` compare against the ENGINE default, not
     // against "was a flag passed": passing the default value produces a
     // byte-identical artifact and must not fork the directory.
+    // `DiClaimOrder::default()`, never a hardcoded variant (#661 round 4,
+    // BLOCKER): the default is `Downstream` (RFC-059's sim close-out), and
+    // this compared against `Upstream`. That inverted the contract BOTH
+    // ways — `--claim up`, a genuine non-default, produced no tag and
+    // collided with the default artifact, while `--claim down`, the actual
+    // default, forked a redundant directory. Deriving it from the type
+    // means a future default flip cannot desynchronise this again.
     if let Some(c) = ax.claim {
-        if !matches!(c, DiClaimOrder::Upstream) {
+        if *c != DiClaimOrder::default() {
             tags.push(format!("claim{c:?}").to_lowercase());
         }
     }
@@ -177,10 +184,18 @@ fn auto_label(base: &str, ax: &LabelAxes<'_>) -> String {
 
     // List-valued axes: a stable short digest, so they cannot collide without
     // spelling an ingredient list into a path component.
+    // Compared and digested as a SET, sorted, because the solve consumes
+    // `--inputs` as an `FxHashSet` (#661 round 4). Comparing by order forked
+    // the directory for a reordering of the same six ores, whose artifact is
+    // byte-identical.
     let mut listy = String::new();
-    let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-    if ax.inputs != default_inputs.as_slice() {
-        listy.push_str(&ax.inputs.join(","));
+    let mut given: Vec<&str> = ax.inputs.iter().map(|s| s.as_str()).collect();
+    given.sort_unstable();
+    given.dedup();
+    let mut default_inputs: Vec<&str> = DEFAULT_INPUTS.to_vec();
+    default_inputs.sort_unstable();
+    if given != default_inputs {
+        listy.push_str(&given.join(","));
     }
     for (k, v) in ax.research_productivity {
         listy.push_str(&format!(";{k}={v}"));
@@ -546,6 +561,53 @@ mod tests {
 
     static EMPTY_RP: std::sync::LazyLock<std::collections::BTreeMap<String, f64>> =
         std::sync::LazyLock::new(std::collections::BTreeMap::new);
+    static DEFAULT_CLAIM: std::sync::LazyLock<DiClaimOrder> =
+        std::sync::LazyLock::new(DiClaimOrder::default);
+    static NON_DEFAULT_CLAIM: std::sync::LazyLock<DiClaimOrder> =
+        std::sync::LazyLock::new(|| {
+            // Whichever arm is NOT the default, derived rather than named, so
+            // a default flip does not silently make this test vacuous.
+            if DiClaimOrder::default() == DiClaimOrder::Upstream {
+                DiClaimOrder::Downstream
+            } else {
+                DiClaimOrder::Upstream
+            }
+        });
+
+    /// The blocker from round 4: the default arm must not tag, and the
+    /// non-default arm MUST — checked against `DiClaimOrder::default()` so
+    /// neither direction can silently invert if the default changes.
+    #[test]
+    fn claim_tags_track_the_real_default() {
+        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        let mk = |c| {
+            let mut ax = axes();
+            ax.inputs = &default_inputs;
+            ax.claim = Some(c);
+            auto_label("ec-5", &ax)
+        };
+        assert_eq!(mk(&DEFAULT_CLAIM), "ec-5", "the default claim order must not fork the path");
+        assert_ne!(
+            mk(&NON_DEFAULT_CLAIM),
+            "ec-5",
+            "a non-default claim order changes the artifact and must tag"
+        );
+    }
+
+    /// `--inputs` is consumed as an unordered set, so a reordering of the
+    /// same items is the same artifact and must share a directory.
+    #[test]
+    fn input_order_does_not_fork_the_path() {
+        let fwd: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        let mut rev = fwd.clone();
+        rev.reverse();
+        let mut a = axes();
+        a.inputs = &fwd;
+        let mut b = axes();
+        b.inputs = &rev;
+        assert_eq!(auto_label("ec-5", &a), auto_label("ec-5", &b));
+        assert_eq!(auto_label("ec-5", &a), "ec-5", "the default set must not tag at all");
+    }
 
     /// The contract: default config keeps the pre-#661 path byte-identical.
     #[test]
@@ -614,7 +676,7 @@ mod tests {
         let mut ax = axes();
         ax.inputs = &default_inputs;
         ax.inserter_cap = Some(spaghettio_core::common::DEFAULT_INSERTER_CAPACITY);
-        ax.claim = Some(&DiClaimOrder::Upstream);
+        ax.claim = Some(&DEFAULT_CLAIM);
         assert_eq!(
             auto_label("ec-5", &ax),
             "ec-5",

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -60,6 +60,10 @@ use spaghettio_core::common::QualityTier;
 use spaghettio_core::recipe_db::MachinePalette;
 use spaghettio_core::validate::{self, LayoutStyle, Severity};
 
+/// Default crafting machine — the one `--tier` overrides. Named so the
+/// label logic and the parser default cannot drift apart.
+const DEFAULT_TIER: &str = "assembling-machine-3";
+
 const DEFAULT_INPUTS: &[&str] = &[
     "iron-ore",
     "copper-ore",
@@ -132,7 +136,7 @@ fn main() {
     // rather than ignored: a silently-dropped `--belt` would export a
     // layout the caller did not ask for and then be simmed as though it
     // had.
-    let mut tier = "assembling-machine-3".to_string();
+    let mut tier = DEFAULT_TIER.to_string();
     let mut di = DirectInsertion::Candidate;
     let mut claim: Option<DiClaimOrder> = None;
     let mut belt: Option<String> = None;
@@ -198,7 +202,7 @@ fn main() {
                     "pooled" | "default" => LayoutStrategy::Pooled,
                     "partitioned-decomposed" | "pd" => LayoutStrategy::PartitionedDecomposed,
                     other => usage(&format!(
-                        "--strategy must be pooled|partitioned-decomposed (got {other})"
+                        "--strategy must be pooled|default|partitioned-decomposed|pd (got {other})"
                     )),
                 }
             }
@@ -261,17 +265,28 @@ fn main() {
             .collect::<Vec<_>>()
             .join(" + ")
     };
-    // The auto label is also the OUTPUT DIRECTORY (`<out>/<label>/`), so it
-    // has to separate runs that differ only by a layout axis. It did not:
-    // `{item}-{rate}` encoded neither strategy, row layout, nor duty, so
-    // `--strategy pooled X 5` and `--strategy partitioned-decomposed X 5`
-    // both wrote `<out>/X-5/` and the second silently overwrote the first's
-    // `bp.txt` and `manifest-real.json` (#661 review). That is a wrong-A/B
-    // generator, and A/B is the entire reason this binary takes these flags.
+    // The auto label is also the OUTPUT DIRECTORY (`<out>/<label>/`), so two
+    // runs whose artifacts differ must not share it. They did: `{item}-{rate}`
+    // encoded no configuration at all, so `--strategy pooled X 5` and
+    // `--strategy partitioned-decomposed X 5` both wrote `<out>/X-5/` and the
+    // second silently overwrote the first's `bp.txt` and `manifest-real.json`
+    // (#661 review). That is a wrong-A/B generator, and A/B is the entire
+    // reason this binary takes these flags.
+    //
+    // EVERY axis that changes the artifact is encoded, not a hand-picked few
+    // (#661 round 2, 3/3 — the first attempt covered strategy/row-layout/duty
+    // and claimed in docs to cover "any non-default axis", which was an
+    // overclaim: `--belt`, `--quality`, `--stacking`, `--tier`, the DI pair,
+    // `--inserter-cap`, `--inputs` and `--research-productivity` all still
+    // collided). The concrete case that makes this not-hypothetical: `--duty
+    // < 1` REQUIRES an explicit `--belt`, so the K69-1 duty fixtures this
+    // binary exists to produce necessarily pin a belt tier, and a duty/belt
+    // cross-comparison collided.
     //
     // Suffixes are emitted ONLY for non-default values, so every existing
-    // default-axis path is byte-identical to before. An explicit `--label`
-    // still overrides everything, which is how you opt out.
+    // default-axis path is byte-identical to before. List-valued axes are
+    // hashed rather than spelled out, to keep the directory name usable.
+    // An explicit `--label` overrides all of it.
     let label = label.unwrap_or_else(|| {
         let base = targets
             .iter()
@@ -279,20 +294,75 @@ fn main() {
             .collect::<Vec<_>>()
             .join("_")
             .replace('.', "_");
-        let mut suffix = String::new();
+
+        let mut tags: Vec<String> = Vec::new();
         match strategy {
             LayoutStrategy::Pooled => {}
-            LayoutStrategy::PartitionedDecomposed => suffix.push_str("-pd"),
+            LayoutStrategy::PartitionedDecomposed => tags.push("pd".to_string()),
         }
-        match row_layout {
-            RowLayout::HorizontalStack => suffix.push_str("-hs"),
-            _ => {}
+        if !matches!(row_layout, RowLayout::VerticalSplit) {
+            tags.push(format!("{row_layout:?}").to_lowercase());
         }
-        if (duty - 1.0).abs() > f64::EPSILON {
-            suffix.push_str(&format!("-duty{}", format!("{duty}").replace('.', "_")));
+        // Not an epsilon compare (#661 round 2): `--duty 0.9999999999999999`
+        // is within f64::EPSILON of 1.0 and would have collided with a
+        // default run despite producing a different layout. The formatted
+        // value IS the identity — if it renders differently, it tags
+        // differently.
+        let duty_s = format!("{duty}");
+        if duty_s != "1" {
+            tags.push(format!("duty{}", duty_s.replace('.', "_")));
         }
-        format!("{base}{suffix}")
+        if tier != DEFAULT_TIER {
+            tags.push(tier.replace("assembling-machine-", "am").replace('-', ""));
+        }
+        if let Some(b) = &belt {
+            tags.push(b.replace("-transport-belt", "").replace("transport-belt", "yellow"));
+        }
+        if !matches!(quality, QualityTier::Normal) {
+            tags.push(format!("{quality:?}").to_lowercase());
+        }
+        if stacking != 1 {
+            tags.push(format!("stack{stacking}"));
+        }
+        if !matches!(di, DirectInsertion::Candidate) {
+            tags.push(format!("di{:?}", di).to_lowercase());
+        }
+        if let Some(c) = claim.as_ref() {
+            tags.push(format!("claim{c:?}").to_lowercase());
+        }
+        if let Some(ic) = inserter_cap {
+            tags.push(format!("icap{ic}"));
+        }
+        // List-valued axes: a stable short digest, so they cannot collide
+        // without spelling a whole ingredient list into a path component.
+        let mut listy = String::new();
+        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        if inputs != default_inputs {
+            listy.push_str(&inputs.join(","));
+        }
+        if !research_productivity.is_empty() {
+            for (k, v) in &research_productivity {
+                listy.push_str(&format!(";{k}={v}"));
+            }
+        }
+        if !listy.is_empty() {
+            // FNV-1a, 32-bit — deterministic across runs and platforms, which
+            // `DefaultHasher` is explicitly NOT.
+            let mut h: u32 = 0x811c_9dc5;
+            for byte in listy.as_bytes() {
+                h ^= *byte as u32;
+                h = h.wrapping_mul(0x0100_0193);
+            }
+            tags.push(format!("cfg{h:08x}"));
+        }
+
+        if tags.is_empty() {
+            base
+        } else {
+            format!("{base}-{}", tags.join("-"))
+        }
     });
+
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
 
     // RFC-062 Phase 3: always the multi-target entry point, even for N=1

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -30,6 +30,7 @@
 //!   --claim up|down|search           DI claim order (default: engine default)
 //!   --belt <entity>        max belt tier (default: engine picks by rate)
 //!   --row-layout <kind>    native (default) | horizontal-stack
+//!   --strategy <kind>      pooled (default) | partitioned-decomposed
 //!   --quality <name>       normal|uncommon|rare|epic|legendary (default normal)
 //!   --stacking <1..4>      belt stacking (default 1)
 //!   --research-productivity <recipe=bonus,...>   declared research
@@ -54,7 +55,7 @@
 
 use rustc_hash::FxHashSet;
 use spaghettio_core::bus::di_cell::{DiClaimOrder, DirectInsertion};
-use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions, RowLayout};
+use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions, LayoutStrategy, RowLayout};
 use spaghettio_core::common::QualityTier;
 use spaghettio_core::recipe_db::MachinePalette;
 use spaghettio_core::validate::{self, LayoutStyle, Severity};
@@ -142,6 +143,7 @@ fn main() {
         Default::default();
     let mut inserter_cap: Option<u8> = None;
     let mut row_layout = RowLayout::default();
+    let mut strategy = LayoutStrategy::default();
     let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
     let mut label: Option<String> = None;
     let mut out = std::env::var("SIM_PROBE_OUT").unwrap_or_else(|_| "/tmp".to_string());
@@ -181,6 +183,22 @@ fn main() {
                     "horizontal-stack" | "hs" => RowLayout::HorizontalStack,
                     other => usage(&format!(
                         "--row-layout must be native|horizontal-stack (got {other})"
+                    )),
+                }
+            }
+            // Same gap `--row-layout` was added for: without this the
+            // tracked generator cannot express a PartitionedDecomposed
+            // fixture at all, so the RFC-modular-production strategy had
+            // no supported route to a blueprint+manifest pair and could
+            // not be sim-anchored. Its Phase 1 kill criteria are stated
+            // against sim measurement, so the axis has to be reachable
+            // from here.
+            "--strategy" => {
+                strategy = match need(i).as_str() {
+                    "pooled" | "default" => LayoutStrategy::Pooled,
+                    "partitioned-decomposed" | "pd" => LayoutStrategy::PartitionedDecomposed,
+                    other => usage(&format!(
+                        "--strategy must be pooled|partitioned-decomposed (got {other})"
                     )),
                 }
             }
@@ -295,6 +313,7 @@ fn main() {
         max_belt_tier: belt,
         planning_duty: duty,
         row_layout,
+        strategy,
         quality,
         stacking,
         research_productivity,

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -40,8 +40,8 @@
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
 //!                          REQUIRED whenever any layout-changing flag is used
-//!   --force                regenerate over an existing <out>/<label>/
-//!                          (NOT needed for a fresh --label; only for reusing one)
+//!   --force                replace a fixture built from a DIFFERENT config
+//!                          (re-running the SAME config never needs it)
 //!   --out <dir>            parent output dir (default $SIM_PROBE_OUT or /tmp)
 //! ```
 //!
@@ -148,46 +148,66 @@ fn default_label(targets: &[(String, f64)]) -> String {
         .replace('.', "_")
 }
 
-/// Which already-written artifacts should block this run.
+/// The name of the provenance file written beside each fixture.
+const CONFIG_FILE: &str = ".sim-export-config";
+
+/// A canonical description of everything about this invocation that changes
+/// the exported artifact.
 ///
-/// Split out from `main` so the overwrite policy is testable (#661 round 8:
-/// "the core overwrite guard has no tests" — the filesystem call is not the
-/// part worth testing, the decision is).
-///
-/// Keyed on whether the label is EXPLICIT, not on whether an axis flag was
-/// passed. Round 8 used the latter to restore idempotence for plain
-/// re-runs, and opened a hole doing it (#661 round 9, 3/3): after
-/// `--strategy pd --label x` wrote a fixture, a following `--label x` with
-/// no axis flag sailed through and overwrote it with a pooled layout. That
-/// is precisely the silent wrong-A/B this tool exists to prevent, produced
-/// by the guard meant to prevent it.
-///
-/// An explicit `--label` is the user naming an artifact, so a collision
-/// under it is refused whatever flags this particular run carried. Without
-/// one the label is derived from the target, a re-run writes the same
-/// bytes, and idempotence is preserved — which was the point of the round-8
-/// change and still holds.
-///
-/// Empty means proceed: `--force`, no explicit label, or nothing on disk.
-fn overwrite_blocked_by(label_is_explicit: bool, force: bool, present: &[String]) -> Vec<String> {
-    if force || !label_is_explicit {
-        return Vec::new();
-    }
-    present.to_vec()
+/// Sorted, so flag order does not matter, and built from the axis flags and
+/// their VALUES — which is the part every previous version of this guard
+/// could not see.
+fn config_fingerprint(axis_args: &[(String, String)]) -> String {
+    let mut pairs: Vec<String> = axis_args.iter().map(|(f, v)| format!("{f}={v}")).collect();
+    pairs.sort();
+    pairs.join("\n")
 }
 
-/// Does this invocation need an explicit `--label`?
+/// Should this run refuse rather than overwrite what is already there?
 ///
-/// True when any artifact-changing flag was passed. Kept as a pure function
-/// so the rule is testable — the previous design put per-axis default
-/// comparisons inline in `main()`, where nothing exercised them and five
-/// review rounds each found another axis compared against the wrong default.
+/// Compares the stored fingerprint of the existing artifact against this
+/// run's. Same configuration means a re-run producing the same bytes, which
+/// is idempotent and allowed; a different one means the two fixtures would
+/// silently become one, which is the wrong-A/B this tool exists to prevent.
 ///
-/// Note what it does NOT take: any value, and any default. It is a question
-/// about the command line, not about the configuration — which is also its
-/// limit: it cannot tell two runs apart that pass the SAME axis with
-/// DIFFERENT values under one `--label`. That case is caught at the write
-/// instead, where the artifact is.
+/// This replaces three rounds of flag-shaped heuristics, each of which was a
+/// proxy for artifact identity and each of which leaked:
+///
+///   round 7  refuse whenever anything exists
+///            -> broke plain re-runs, which are idempotent
+///   round 8  refuse only when THIS run passed an axis flag
+///            -> `--strategy pd --label x` then `--label x` overwrote it
+///   round 9  refuse only when the label was EXPLICIT
+///            -> `--strategy pd --label ec-5` then a plain `ec 5` (whose
+///               derived label is also `ec-5`) overwrote it
+///
+/// Every one of those asks a question about the COMMAND LINE. The question
+/// that actually matters is about the ARTIFACT, and it cannot be answered
+/// from flags alone — which is what the #661 reviews kept demonstrating,
+/// from a different direction each time. So it is answered from the
+/// artifact.
+///
+/// `Unknown` provenance (files present, no fingerprint) is refused too: it
+/// means a fixture written before this existed, or by hand, and assuming it
+/// matches is the same guess in a new place.
+fn overwrite_verdict(stored: Option<&str>, current: &str, force: bool, any_artifact: bool) -> OverwriteVerdict {
+    if force || !any_artifact {
+        return OverwriteVerdict::Proceed;
+    }
+    match stored {
+        Some(prev) if prev == current => OverwriteVerdict::Proceed,
+        Some(_) => OverwriteVerdict::DifferentConfig,
+        None => OverwriteVerdict::UnknownProvenance,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum OverwriteVerdict {
+    Proceed,
+    DifferentConfig,
+    UnknownProvenance,
+}
+
 fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
     !axis_flags_seen.is_empty() && label.is_none()
 }
@@ -248,6 +268,7 @@ fn main() {
     let mut label: Option<String> = None;
     let mut force = false;
     let mut axis_flags_seen: Vec<String> = Vec::new();
+    let mut axis_args: Vec<(String, String)> = Vec::new();
     let mut out = std::env::var("SIM_PROBE_OUT").unwrap_or_else(|_| "/tmp".to_string());
 
     while i < args.len() {
@@ -263,6 +284,13 @@ fn main() {
         // wrong; not consulting a default at all is the fix.
         if AXIS_FLAGS.contains(&args[i].as_str()) {
             axis_flags_seen.push(args[i].clone());
+            // The VALUE too, for the artifact fingerprint. The label guard
+            // deliberately ignores values (see `label_required`); the
+            // overwrite guard deliberately does not.
+            axis_args.push((
+                args[i].clone(),
+                args.get(i + 1).cloned().unwrap_or_default(),
+            ));
         }
         // The one valueless flag, so it advances by 1 rather than the 2
         // every other branch assumes.
@@ -408,7 +436,6 @@ fn main() {
             default_label(&targets)
         ));
     }
-    let label_is_explicit = label.is_some();
     let label = label.unwrap_or_else(|| default_label(&targets));
 
     // The label guard is necessary but NOT sufficient (#661 review, major).
@@ -440,26 +467,42 @@ fn main() {
     // Keying on the axis flags instead — round 8's attempt at that — let
     // `--label x` with no axis flag overwrite an axis run's fixture, which
     // is the wrong-A/B this exists to stop.
+    let fingerprint = config_fingerprint(&axis_args);
     {
         let dir = format!("{out}/{label}");
-        let present: Vec<String> = ["bp.txt", "manifest-real.json"]
+        let any_artifact = ["bp.txt", "manifest-real.json"]
             .iter()
-            .map(|f| format!("{dir}/{f}"))
-            .filter(|p| std::path::Path::new(p).exists())
-            .collect();
-        let existing = overwrite_blocked_by(label_is_explicit, force, &present);
-        if !existing.is_empty() {
-            eprintln!(
-                "error: {} already {} — refusing to overwrite.\n\
-                 \n\
-                 A previous run wrote this label. If that run used different \
-                 flags, overwriting it is the silent wrong-A/B this tool exists \
-                 to avoid; give this run its own --label. If you are \
-                 deliberately regenerating the same configuration, pass --force.",
-                existing.join(" and "),
-                if existing.len() == 1 { "exists" } else { "exist" }
-            );
-            std::process::exit(2);
+            .any(|f| std::path::Path::new(&format!("{dir}/{f}")).exists());
+        let stored = std::fs::read_to_string(format!("{dir}/{CONFIG_FILE}")).ok();
+        match overwrite_verdict(stored.as_deref(), &fingerprint, force, any_artifact) {
+            OverwriteVerdict::Proceed => {}
+            OverwriteVerdict::DifferentConfig => {
+                eprintln!(
+                    "error: {dir}/ holds a fixture built from a DIFFERENT configuration \
+                     — refusing to overwrite it.\n\
+                     \n\
+                     existing: {}\n\
+                     this run: {}\n\
+                     \n\
+                     Overwriting would silently turn two fixtures into one, which is the \
+                     wrong-A/B this tool exists to prevent. Give this run its own \
+                     --label, or pass --force if you meant to replace it.",
+                    stored.as_deref().unwrap_or("<none>").replace('\n', ", "),
+                    fingerprint.replace('\n', ", "),
+                );
+                std::process::exit(2);
+            }
+            OverwriteVerdict::UnknownProvenance => {
+                eprintln!(
+                    "error: {dir}/ already holds a fixture, and carries no {CONFIG_FILE} \
+                     recording how it was built — refusing to overwrite it.\n\
+                     \n\
+                     It predates this check or was written by hand, so whether it matches \
+                     this run cannot be determined. Give this run its own --label, or \
+                     pass --force if you know it is safe to replace."
+                );
+                std::process::exit(2);
+            }
         }
     }
 
@@ -535,9 +578,17 @@ fn main() {
     let dir = format!("{out}/{label}");
     let bp_path = format!("{dir}/bp.txt");
     let mf_path = format!("{dir}/manifest-real.json");
+    let cfg_path = format!("{dir}/{CONFIG_FILE}");
 
     std::fs::create_dir_all(&dir).unwrap_or_else(|e| {
         eprintln!("cannot create {dir}: {e}");
+        std::process::exit(1);
+    });
+    // Provenance first, so an interrupted run cannot leave artifacts whose
+    // configuration is unrecorded — which the guard would then have to
+    // refuse as unknown.
+    std::fs::write(&cfg_path, &fingerprint).unwrap_or_else(|e| {
+        eprintln!("cannot write {cfg_path}: {e}");
         std::process::exit(1);
     });
     std::fs::write(&bp_path, &bp).unwrap_or_else(|e| {
@@ -625,35 +676,59 @@ mod tests {
     }
 
     /// The overwrite policy, which the filesystem check only executes.
+    ///
+    /// Keyed on the artifact's recorded configuration, so every case below
+    /// is a statement about what is ON DISK, not about the command line —
+    /// which is what three rounds of flag-shaped heuristics kept getting
+    /// wrong from a different direction each time.
     #[test]
     fn overwrite_policy() {
-        let present = vec!["out/x/bp.txt".to_string()];
+        let pd = config_fingerprint(&[("--strategy".into(), "pd".into())]);
+        let pooled = config_fingerprint(&[("--strategy".into(), "pooled".into())]);
+        let plain = config_fingerprint(&[]);
 
+        // Same configuration, so the re-run writes the same bytes.
         assert_eq!(
-            overwrite_blocked_by(true, false, &present),
-            present,
-            "an explicit --label must not silently overwrite a previous run's artifact"
-        );
-        assert!(
-            overwrite_blocked_by(true, true, &present).is_empty(),
-            "--force is the escape hatch"
-        );
-        assert!(
-            overwrite_blocked_by(false, false, &present).is_empty(),
-            "an auto-labelled re-run writes the same bytes, so it stays idempotent"
-        );
-        assert!(
-            overwrite_blocked_by(true, false, &[]).is_empty(),
-            "nothing on disk, nothing to block"
+            overwrite_verdict(Some(&pd), &pd, false, true),
+            OverwriteVerdict::Proceed,
+            "a re-run of the same configuration is idempotent"
         );
 
-        // The hole round 8 opened: a no-axis run reusing an axis run's
-        // label. It has an explicit label, so it must be refused — keying
-        // this on the axis flags let it through (#661 round 9, 3/3).
+        // The round-8 hole: an axis fixture, then a run with no axis flags
+        // reusing its directory.
         assert_eq!(
-            overwrite_blocked_by(true, false, &present),
-            present,
-            "a no-axis run reusing an explicit label is still a collision"
+            overwrite_verdict(Some(&pd), &plain, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "a plain run must not overwrite an axis run's fixture"
+        );
+
+        // The round-9 hole, the same collision in the other direction: an
+        // explicit --label that happens to equal the derived name.
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &pooled, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "two different axis VALUES are two different fixtures"
+        );
+
+        // Flag ORDER is not configuration.
+        let a = config_fingerprint(&[
+            ("--strategy".into(), "pd".into()),
+            ("--belt".into(), "fast".into()),
+        ]);
+        let b = config_fingerprint(&[
+            ("--belt".into(), "fast".into()),
+            ("--strategy".into(), "pd".into()),
+        ]);
+        assert_eq!(a, b, "the same run written two ways is one configuration");
+        assert_eq!(overwrite_verdict(Some(&a), &b, false, true), OverwriteVerdict::Proceed);
+
+        // Escape hatch, empty directory, and unrecorded provenance.
+        assert_eq!(overwrite_verdict(Some(&pd), &pooled, true, true), OverwriteVerdict::Proceed);
+        assert_eq!(overwrite_verdict(None, &pd, false, false), OverwriteVerdict::Proceed);
+        assert_eq!(
+            overwrite_verdict(None, &pd, false, true),
+            OverwriteVerdict::UnknownProvenance,
+            "a fixture with no recorded config cannot be assumed to match"
         );
     }
 

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -148,6 +148,34 @@ fn default_label(targets: &[(String, f64)]) -> String {
         .replace('.', "_")
 }
 
+/// Which already-written artifacts should block this run.
+///
+/// Split out from `main` so the overwrite policy is testable (#661 round 8:
+/// "the core overwrite guard has no tests" — the filesystem call is not the
+/// part worth testing, the decision is).
+///
+/// Keyed on whether the label is EXPLICIT, not on whether an axis flag was
+/// passed. Round 8 used the latter to restore idempotence for plain
+/// re-runs, and opened a hole doing it (#661 round 9, 3/3): after
+/// `--strategy pd --label x` wrote a fixture, a following `--label x` with
+/// no axis flag sailed through and overwrote it with a pooled layout. That
+/// is precisely the silent wrong-A/B this tool exists to prevent, produced
+/// by the guard meant to prevent it.
+///
+/// An explicit `--label` is the user naming an artifact, so a collision
+/// under it is refused whatever flags this particular run carried. Without
+/// one the label is derived from the target, a re-run writes the same
+/// bytes, and idempotence is preserved — which was the point of the round-8
+/// change and still holds.
+///
+/// Empty means proceed: `--force`, no explicit label, or nothing on disk.
+fn overwrite_blocked_by(label_is_explicit: bool, force: bool, present: &[String]) -> Vec<String> {
+    if force || !label_is_explicit {
+        return Vec::new();
+    }
+    present.to_vec()
+}
+
 /// Does this invocation need an explicit `--label`?
 ///
 /// True when any artifact-changing flag was passed. Kept as a pure function
@@ -160,22 +188,6 @@ fn default_label(targets: &[(String, f64)]) -> String {
 /// limit: it cannot tell two runs apart that pass the SAME axis with
 /// DIFFERENT values under one `--label`. That case is caught at the write
 /// instead, where the artifact is.
-/// Which already-written artifacts should block this run.
-///
-/// Split out from `main` so the overwrite policy is testable (#661 round 8:
-/// "the core overwrite guard has no tests" — the filesystem call is not the
-/// part worth testing, the decision is).
-///
-/// Empty means proceed. Three ways to get there: `--force`, no axis flag
-/// (a re-run with the same configuration writes the same bytes, so there is
-/// no A/B to get wrong), or nothing on disk yet.
-fn overwrite_blocked_by(axis_flags_seen: &[String], force: bool, present: &[String]) -> Vec<String> {
-    if force || axis_flags_seen.is_empty() {
-        return Vec::new();
-    }
-    present.to_vec()
-}
-
 fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
     !axis_flags_seen.is_empty() && label.is_none()
 }
@@ -375,7 +387,7 @@ fn main() {
     // block = floor(in_lane_cap(tier) × 2 × duty / rate), and with no
     // --belt the cap resolves to the express default (belt_cap 45), so
     // --duty 0.6 silently computes the measured-DEAD block 6 instead of
-    // the gate-clearing block 2. Require the tier to be explicit.
+    // the gate-clearing block 2. Require the BELT to be explicit.
     if duty < 1.0 && belt.is_none() {
         usage("--duty < 1 requires an explicit --belt (the fitted duty is tier-relative; the RFC-069 gate receipts are on transport-belt)");
     }
@@ -396,6 +408,7 @@ fn main() {
             default_label(&targets)
         ));
     }
+    let label_is_explicit = label.is_some();
     let label = label.unwrap_or_else(|| default_label(&targets));
 
     // The label guard is necessary but NOT sufficient (#661 review, major).
@@ -414,16 +427,19 @@ fn main() {
     // the answer — the paths depend only on `out` and `label`, both already
     // final.
     //
-    // Both artifacts count, not just `bp.txt`: an interrupted earlier run
-    // can leave a directory holding only `manifest-real.json`, and
-    // overwriting that is the same silent loss (#661 round 7).
+    // Both artifacts count, not just `bp.txt`. The justification given in
+    // round 7 — an interrupted run leaving only the manifest — is NOT
+    // producible, since `bp.txt` is written first (#661 review). The real
+    // reason is narrower and still worth it: either file present means the
+    // directory is claimed, and keying on one of two artifacts invites the
+    // write order becoming load-bearing later.
     //
-    // Scoped to runs that passed an axis (#661 round 8). A plain
-    // `sim_export iron-ore 10` re-run produces the SAME artifact — there is
-    // no A/B to get wrong — so refusing it broke a workflow that was fine,
-    // which is a worse outcome than the one being prevented. The guard
-    // exists for the case where two runs under one label can DIFFER, and
-    // that requires an axis flag.
+    // Scoped to runs with an EXPLICIT --label (#661 round 9). A plain
+    // `sim_export iron-ore 10` re-run derives its label from the target and
+    // writes the same bytes, so refusing it broke a workflow that was fine.
+    // Keying on the axis flags instead — round 8's attempt at that — let
+    // `--label x` with no axis flag overwrite an axis run's fixture, which
+    // is the wrong-A/B this exists to stop.
     {
         let dir = format!("{out}/{label}");
         let present: Vec<String> = ["bp.txt", "manifest-real.json"]
@@ -431,7 +447,7 @@ fn main() {
             .map(|f| format!("{dir}/{f}"))
             .filter(|p| std::path::Path::new(p).exists())
             .collect();
-        let existing = overwrite_blocked_by(&axis_flags_seen, force, &present);
+        let existing = overwrite_blocked_by(label_is_explicit, force, &present);
         if !existing.is_empty() {
             eprintln!(
                 "error: {} already {} — refusing to overwrite.\n\
@@ -611,35 +627,33 @@ mod tests {
     /// The overwrite policy, which the filesystem check only executes.
     #[test]
     fn overwrite_policy() {
-        let axis = vec!["--strategy".to_string()];
-        let none: Vec<String> = vec![];
         let present = vec!["out/x/bp.txt".to_string()];
 
         assert_eq!(
-            overwrite_blocked_by(&axis, false, &present),
+            overwrite_blocked_by(true, false, &present),
             present,
-            "an axis run must not silently overwrite a previous run's artifact"
+            "an explicit --label must not silently overwrite a previous run's artifact"
         );
         assert!(
-            overwrite_blocked_by(&axis, true, &present).is_empty(),
+            overwrite_blocked_by(true, true, &present).is_empty(),
             "--force is the escape hatch"
         );
         assert!(
-            overwrite_blocked_by(&none, false, &present).is_empty(),
-            "a plain re-run writes the same bytes, so it must stay idempotent \
-             (#661 round 8 — scoping this to axis runs is the fix for that)"
+            overwrite_blocked_by(false, false, &present).is_empty(),
+            "an auto-labelled re-run writes the same bytes, so it stays idempotent"
         );
         assert!(
-            overwrite_blocked_by(&axis, false, &[]).is_empty(),
+            overwrite_blocked_by(true, false, &[]).is_empty(),
             "nothing on disk, nothing to block"
         );
 
-        // The interrupted-run case: only the manifest survived.
-        let manifest_only = vec!["out/x/manifest-real.json".to_string()];
+        // The hole round 8 opened: a no-axis run reusing an axis run's
+        // label. It has an explicit label, so it must be refused — keying
+        // this on the axis flags let it through (#661 round 9, 3/3).
         assert_eq!(
-            overwrite_blocked_by(&axis, false, &manifest_only),
-            manifest_only,
-            "a half-written directory is still a collision"
+            overwrite_blocked_by(true, false, &present),
+            present,
+            "a no-axis run reusing an explicit label is still a collision"
         );
     }
 

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -96,6 +96,113 @@ fn parse_target_token(tok: &str) -> (String, f64) {
 }
 
 
+/// Every axis that changes the exported artifact, as one value — so the
+/// label logic is a pure function and can be tested (#661 round 3: it was
+/// the PR's entire purpose and had no coverage, which is the same class of
+/// gap that produced the collision in the first place).
+struct LabelAxes<'a> {
+    strategy: LayoutStrategy,
+    row_layout: RowLayout,
+    duty: f64,
+    tier: &'a str,
+    belt: Option<&'a str>,
+    quality: QualityTier,
+    stacking: u8,
+    di: DirectInsertion,
+    claim: Option<&'a DiClaimOrder>,
+    inserter_cap: Option<u8>,
+    inputs: &'a [String],
+    research_productivity: &'a std::collections::BTreeMap<String, f64>,
+}
+
+/// The auto label, which is also the OUTPUT DIRECTORY (`<out>/<label>/`).
+///
+/// Two runs whose artifacts differ must not share it. They did: the label
+/// was `{item}-{rate}` and encoded no configuration at all, so
+/// `--strategy pooled X 5` and `--strategy partitioned-decomposed X 5`
+/// both wrote `<out>/X-5/` and the second silently overwrote the first
+/// (#661). That is a wrong-A/B generator, and A/B is why this binary takes
+/// these flags.
+///
+/// Suffixes are emitted only where the value differs from the ENGINE
+/// default — not merely where a flag was passed (#661 round 3) — so
+/// `--inserter-cap 2` and a default run share a directory, because they
+/// produce the same artifact. Default paths stay byte-identical to
+/// pre-#661.
+fn auto_label(base: &str, ax: &LabelAxes<'_>) -> String {
+    let mut tags: Vec<String> = Vec::new();
+
+    match ax.strategy {
+        LayoutStrategy::Pooled => {}
+        LayoutStrategy::PartitionedDecomposed => tags.push("pd".to_string()),
+    }
+    if !matches!(ax.row_layout, RowLayout::VerticalSplit) {
+        tags.push(format!("{:?}", ax.row_layout).to_lowercase());
+    }
+    // Exact float comparison, deliberately, and NOT a formatted-string test
+    // (#661 round 3) nor an epsilon one (#661 round 2). Exact `!=` gives both
+    // properties at once: `1.0` never tags, and `0.9999999999999999` — which
+    // an epsilon test would swallow — does.
+    if ax.duty != 1.0 {
+        tags.push(format!("duty{}", format!("{}", ax.duty).replace('.', "_")));
+    }
+    if ax.tier != DEFAULT_TIER {
+        tags.push(ax.tier.replace("assembling-machine-", "am").replace('-', ""));
+    }
+    if let Some(b) = ax.belt {
+        tags.push(b.replace("-transport-belt", "").replace("transport-belt", "yellow"));
+    }
+    if !matches!(ax.quality, QualityTier::Normal) {
+        tags.push(format!("{:?}", ax.quality).to_lowercase());
+    }
+    if ax.stacking != 1 {
+        tags.push(format!("stack{}", ax.stacking));
+    }
+    if !matches!(ax.di, DirectInsertion::Candidate) {
+        tags.push(format!("di{:?}", ax.di).to_lowercase());
+    }
+    // `--claim` and `--inserter-cap` compare against the ENGINE default, not
+    // against "was a flag passed": passing the default value produces a
+    // byte-identical artifact and must not fork the directory.
+    if let Some(c) = ax.claim {
+        if !matches!(c, DiClaimOrder::Upstream) {
+            tags.push(format!("claim{c:?}").to_lowercase());
+        }
+    }
+    if let Some(ic) = ax.inserter_cap {
+        if ic != spaghettio_core::common::DEFAULT_INSERTER_CAPACITY {
+            tags.push(format!("icap{ic}"));
+        }
+    }
+
+    // List-valued axes: a stable short digest, so they cannot collide without
+    // spelling an ingredient list into a path component.
+    let mut listy = String::new();
+    let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+    if ax.inputs != default_inputs.as_slice() {
+        listy.push_str(&ax.inputs.join(","));
+    }
+    for (k, v) in ax.research_productivity {
+        listy.push_str(&format!(";{k}={v}"));
+    }
+    if !listy.is_empty() {
+        // FNV-1a 32-bit: deterministic across runs and platforms, which
+        // `DefaultHasher` explicitly is not.
+        let mut h: u32 = 0x811c_9dc5;
+        for byte in listy.as_bytes() {
+            h ^= *byte as u32;
+            h = h.wrapping_mul(0x0100_0193);
+        }
+        tags.push(format!("cfg{h:08x}"));
+    }
+
+    if tags.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}-{}", tags.join("-"))
+    }
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.is_empty() {
@@ -265,28 +372,6 @@ fn main() {
             .collect::<Vec<_>>()
             .join(" + ")
     };
-    // The auto label is also the OUTPUT DIRECTORY (`<out>/<label>/`), so two
-    // runs whose artifacts differ must not share it. They did: `{item}-{rate}`
-    // encoded no configuration at all, so `--strategy pooled X 5` and
-    // `--strategy partitioned-decomposed X 5` both wrote `<out>/X-5/` and the
-    // second silently overwrote the first's `bp.txt` and `manifest-real.json`
-    // (#661 review). That is a wrong-A/B generator, and A/B is the entire
-    // reason this binary takes these flags.
-    //
-    // EVERY axis that changes the artifact is encoded, not a hand-picked few
-    // (#661 round 2, 3/3 — the first attempt covered strategy/row-layout/duty
-    // and claimed in docs to cover "any non-default axis", which was an
-    // overclaim: `--belt`, `--quality`, `--stacking`, `--tier`, the DI pair,
-    // `--inserter-cap`, `--inputs` and `--research-productivity` all still
-    // collided). The concrete case that makes this not-hypothetical: `--duty
-    // < 1` REQUIRES an explicit `--belt`, so the K69-1 duty fixtures this
-    // binary exists to produce necessarily pin a belt tier, and a duty/belt
-    // cross-comparison collided.
-    //
-    // Suffixes are emitted ONLY for non-default values, so every existing
-    // default-axis path is byte-identical to before. List-valued axes are
-    // hashed rather than spelled out, to keep the directory name usable.
-    // An explicit `--label` overrides all of it.
     let label = label.unwrap_or_else(|| {
         let base = targets
             .iter()
@@ -294,73 +379,23 @@ fn main() {
             .collect::<Vec<_>>()
             .join("_")
             .replace('.', "_");
-
-        let mut tags: Vec<String> = Vec::new();
-        match strategy {
-            LayoutStrategy::Pooled => {}
-            LayoutStrategy::PartitionedDecomposed => tags.push("pd".to_string()),
-        }
-        if !matches!(row_layout, RowLayout::VerticalSplit) {
-            tags.push(format!("{row_layout:?}").to_lowercase());
-        }
-        // Not an epsilon compare (#661 round 2): `--duty 0.9999999999999999`
-        // is within f64::EPSILON of 1.0 and would have collided with a
-        // default run despite producing a different layout. The formatted
-        // value IS the identity — if it renders differently, it tags
-        // differently.
-        let duty_s = format!("{duty}");
-        if duty_s != "1" {
-            tags.push(format!("duty{}", duty_s.replace('.', "_")));
-        }
-        if tier != DEFAULT_TIER {
-            tags.push(tier.replace("assembling-machine-", "am").replace('-', ""));
-        }
-        if let Some(b) = &belt {
-            tags.push(b.replace("-transport-belt", "").replace("transport-belt", "yellow"));
-        }
-        if !matches!(quality, QualityTier::Normal) {
-            tags.push(format!("{quality:?}").to_lowercase());
-        }
-        if stacking != 1 {
-            tags.push(format!("stack{stacking}"));
-        }
-        if !matches!(di, DirectInsertion::Candidate) {
-            tags.push(format!("di{:?}", di).to_lowercase());
-        }
-        if let Some(c) = claim.as_ref() {
-            tags.push(format!("claim{c:?}").to_lowercase());
-        }
-        if let Some(ic) = inserter_cap {
-            tags.push(format!("icap{ic}"));
-        }
-        // List-valued axes: a stable short digest, so they cannot collide
-        // without spelling a whole ingredient list into a path component.
-        let mut listy = String::new();
-        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
-        if inputs != default_inputs {
-            listy.push_str(&inputs.join(","));
-        }
-        if !research_productivity.is_empty() {
-            for (k, v) in &research_productivity {
-                listy.push_str(&format!(";{k}={v}"));
-            }
-        }
-        if !listy.is_empty() {
-            // FNV-1a, 32-bit — deterministic across runs and platforms, which
-            // `DefaultHasher` is explicitly NOT.
-            let mut h: u32 = 0x811c_9dc5;
-            for byte in listy.as_bytes() {
-                h ^= *byte as u32;
-                h = h.wrapping_mul(0x0100_0193);
-            }
-            tags.push(format!("cfg{h:08x}"));
-        }
-
-        if tags.is_empty() {
-            base
-        } else {
-            format!("{base}-{}", tags.join("-"))
-        }
+        auto_label(
+            &base,
+            &LabelAxes {
+                strategy,
+                row_layout,
+                duty,
+                tier: &tier,
+                belt: belt.as_deref(),
+                quality,
+                stacking,
+                di,
+                claim: claim.as_ref(),
+                inserter_cap,
+                inputs: &inputs,
+                research_productivity: &research_productivity,
+            },
+        )
     });
 
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
@@ -484,4 +519,123 @@ fn main() {
     println!(
         "  cargo run --release -p spaghettio_sim_harness -- run \\\n    --bp {bp_path} --manifest {mf_path} --warmup 288000"
     );
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn axes<'a>() -> LabelAxes<'a> {
+        // Every field at its ENGINE default: this must produce the bare base.
+        LabelAxes {
+            strategy: LayoutStrategy::Pooled,
+            row_layout: RowLayout::VerticalSplit,
+            duty: 1.0,
+            tier: DEFAULT_TIER,
+            belt: None,
+            quality: QualityTier::Normal,
+            stacking: 1,
+            di: DirectInsertion::Candidate,
+            claim: None,
+            inserter_cap: None,
+            inputs: &[],
+            research_productivity: &EMPTY_RP,
+        }
+    }
+
+    static EMPTY_RP: std::sync::LazyLock<std::collections::BTreeMap<String, f64>> =
+        std::sync::LazyLock::new(std::collections::BTreeMap::new);
+
+    /// The contract: default config keeps the pre-#661 path byte-identical.
+    #[test]
+    fn defaults_produce_the_bare_base() {
+        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        let mut ax = axes();
+        ax.inputs = &default_inputs;
+        assert_eq!(auto_label("electronic-circuit-5", &ax), "electronic-circuit-5");
+    }
+
+    /// The bug this PR exists to fix: two strategies must not share a path.
+    #[test]
+    fn strategy_separates_the_two_arms() {
+        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        let mut pooled = axes();
+        pooled.inputs = &default_inputs;
+        let mut pd = axes();
+        pd.inputs = &default_inputs;
+        pd.strategy = LayoutStrategy::PartitionedDecomposed;
+
+        let a = auto_label("ec-5", &pooled);
+        let b = auto_label("ec-5", &pd);
+        assert_ne!(a, b, "pooled and partitioned-decomposed collided: {a}");
+        assert_eq!(b, "ec-5-pd");
+    }
+
+    /// The cross-comparison the round-2 review named: `--duty < 1` requires an
+    /// explicit `--belt`, so duty fixtures always pin a belt tier and the two
+    /// belt tiers must still separate.
+    #[test]
+    fn duty_and_belt_separate_together() {
+        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        let mk = |belt| {
+            let mut ax = axes();
+            ax.inputs = &default_inputs;
+            ax.duty = 0.6;
+            ax.belt = Some(belt);
+            auto_label("ec-5", &ax)
+        };
+        let yellow = mk("transport-belt");
+        let fast = mk("fast-transport-belt");
+        assert_ne!(yellow, fast, "duty/belt cross-comparison collided");
+        assert_eq!(yellow, "ec-5-duty0_6-yellow");
+    }
+
+    /// Exact float comparison, not epsilon: a duty a hair under 1.0 lays out
+    /// differently and must not share the default's directory.
+    #[test]
+    fn near_one_duty_still_tags() {
+        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        let mut ax = axes();
+        ax.inputs = &default_inputs;
+        ax.duty = 0.9999999999999999;
+        assert_ne!(
+            auto_label("ec-5", &ax),
+            "ec-5",
+            "a duty within f64::EPSILON of 1.0 collided with the default"
+        );
+    }
+
+    /// Passing a flag whose value IS the engine default must not fork the
+    /// directory — the artifact is identical, so the path should be too.
+    #[test]
+    fn explicit_default_values_do_not_fork_the_path() {
+        let default_inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
+        let mut ax = axes();
+        ax.inputs = &default_inputs;
+        ax.inserter_cap = Some(spaghettio_core::common::DEFAULT_INSERTER_CAPACITY);
+        ax.claim = Some(&DiClaimOrder::Upstream);
+        assert_eq!(
+            auto_label("ec-5", &ax),
+            "ec-5",
+            "--inserter-cap 2 / --claim up produce the default artifact and must \
+             not create a second directory for it"
+        );
+    }
+
+    /// Non-default list-valued axes are digested rather than spelled out, but
+    /// must still separate.
+    #[test]
+    fn custom_inputs_digest_and_separate() {
+        let a_in: Vec<String> = vec!["iron-plate".into()];
+        let b_in: Vec<String> = vec!["copper-plate".into()];
+        let mut a = axes();
+        a.inputs = &a_in;
+        let mut b = axes();
+        b.inputs = &b_in;
+        let la = auto_label("ec-5", &a);
+        let lb = auto_label("ec-5", &b);
+        assert_ne!(la, lb, "different input sets collided");
+        assert!(la.contains("-cfg"), "expected a digest tag, got {la}");
+    }
 }

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -130,85 +130,97 @@ struct LabelAxes<'a> {
 /// produce the same artifact. Default paths stay byte-identical to
 /// pre-#661.
 fn auto_label(base: &str, ax: &LabelAxes<'_>) -> String {
+    // Every "is this at default?" test compares against the ENGINE's own
+    // default, never a literal (#661 round 5). Round 4 fixed only `claim`
+    // this way, after hardcoding `Upstream` inverted the contract when the
+    // real default turned out to be `Downstream`. Every other axis had the
+    // same latent bug: this repo flips defaults on measurement (RFC-051,
+    // RFC-053, RFC-059, RFC-060 all did), and a flip would silently
+    // reintroduce the collision this whole function exists to prevent.
+    //
+    // `LayoutOptions::default()` IS the reference, so the comparison cannot
+    // drift from the thing it is describing.
+    let d = LayoutOptions::default();
     let mut tags: Vec<String> = Vec::new();
 
-    match ax.strategy {
-        LayoutStrategy::Pooled => {}
-        LayoutStrategy::PartitionedDecomposed => tags.push("pd".to_string()),
+    if ax.strategy != d.strategy {
+        tags.push("pd".to_string());
     }
-    if !matches!(ax.row_layout, RowLayout::VerticalSplit) {
+    if ax.row_layout != d.row_layout {
         tags.push(format!("{:?}", ax.row_layout).to_lowercase());
     }
-    // Exact float comparison, deliberately, and NOT a formatted-string test
-    // (#661 round 3) nor an epsilon one (#661 round 2). Exact `!=` gives both
-    // properties at once: `1.0` never tags, and `0.9999999999999999` — which
-    // an epsilon test would swallow — does.
-    if ax.duty != 1.0 {
+    // Exact float comparison, not epsilon (#661 round 2) and not a formatted
+    // string (round 3): `1.0` never tags, `0.9999999999999999` does.
+    if ax.duty != d.planning_duty {
         tags.push(format!("duty{}", format!("{}", ax.duty).replace('.', "_")));
     }
     if ax.tier != DEFAULT_TIER {
         tags.push(ax.tier.replace("assembling-machine-", "am").replace('-', ""));
     }
-    if let Some(b) = ax.belt {
-        tags.push(b.replace("-transport-belt", "").replace("transport-belt", "yellow"));
+    // NOTE the asymmetry, stated because it breaks the "only non-default"
+    // rule on purpose: `max_belt_tier: None` means "engine picks by rate", so
+    // an explicit `--belt` matching what the engine would have picked yields a
+    // byte-identical artifact in a separate directory. That over-forks, which
+    // is the SAFE direction (a redundant dir, never a shared one); resolving
+    // it properly needs the rate-dependent `belt_entity_for_rate`, which the
+    // label does not have. Documented rather than silently tolerated.
+    if ax.belt != d.max_belt_tier.as_deref() {
+        if let Some(b) = ax.belt {
+            tags.push(b.replace("-transport-belt", "").replace("transport-belt", "yellow"));
+        }
     }
-    if !matches!(ax.quality, QualityTier::Normal) {
+    if ax.quality != d.quality {
         tags.push(format!("{:?}", ax.quality).to_lowercase());
     }
-    if ax.stacking != 1 {
+    if ax.stacking != d.stacking {
         tags.push(format!("stack{}", ax.stacking));
     }
-    if !matches!(ax.di, DirectInsertion::Candidate) {
+    if ax.di != d.direct_insertion {
         tags.push(format!("di{:?}", ax.di).to_lowercase());
     }
-    // `--claim` and `--inserter-cap` compare against the ENGINE default, not
-    // against "was a flag passed": passing the default value produces a
-    // byte-identical artifact and must not fork the directory.
-    // `DiClaimOrder::default()`, never a hardcoded variant (#661 round 4,
-    // BLOCKER): the default is `Downstream` (RFC-059's sim close-out), and
-    // this compared against `Upstream`. That inverted the contract BOTH
-    // ways — `--claim up`, a genuine non-default, produced no tag and
-    // collided with the default artifact, while `--claim down`, the actual
-    // default, forked a redundant directory. Deriving it from the type
-    // means a future default flip cannot desynchronise this again.
     if let Some(c) = ax.claim {
-        if *c != DiClaimOrder::default() {
+        if *c != d.di_claim_order {
             tags.push(format!("claim{c:?}").to_lowercase());
         }
     }
     if let Some(ic) = ax.inserter_cap {
-        if ic != spaghettio_core::common::DEFAULT_INSERTER_CAPACITY {
+        if ic != d.inserter_capacity {
             tags.push(format!("icap{ic}"));
         }
     }
 
-    // List-valued axes: a stable short digest, so they cannot collide without
-    // spelling an ingredient list into a path component.
-    // Compared and digested as a SET, sorted, because the solve consumes
-    // `--inputs` as an `FxHashSet` (#661 round 4). Comparing by order forked
-    // the directory for a reordering of the same six ores, whose artifact is
-    // byte-identical.
+    // List-valued axes, compared and digested as SETS because the solve
+    // consumes `--inputs` as an `FxHashSet` (#661 round 4).
     let mut listy = String::new();
     let mut given: Vec<&str> = ax.inputs.iter().map(|s| s.as_str()).collect();
     given.sort_unstable();
     given.dedup();
     let mut default_inputs: Vec<&str> = DEFAULT_INPUTS.to_vec();
     default_inputs.sort_unstable();
-    if given != default_inputs {
+    let inputs_differ = given != default_inputs;
+    if inputs_differ {
         listy.push_str(&given.join(","));
     }
     for (k, v) in ax.research_productivity {
         listy.push_str(&format!(";{k}={v}"));
     }
-    if !listy.is_empty() {
-        // FNV-1a 32-bit: deterministic across runs and platforms, which
+    // Keyed on "does it DIFFER", not on "is the digest string non-empty"
+    // (#661 round 5): `--inputs ""` parses to `[""]`, which differs from the
+    // default set but joins to the empty string, so the old test skipped the
+    // tag and dropped the run into the DEFAULT directory — the exact
+    // collision, at the empty edge.
+    if inputs_differ || !ax.research_productivity.is_empty() {
+        // FNV-1a 64-bit (#661 round 5). The 32-bit version could alias two
+        // distinct sets onto one directory, which made the "cannot collide"
+        // claim false; 64 bits makes it true for any realistic number of
+        // fixture configs. Deterministic across runs and platforms, which
         // `DefaultHasher` explicitly is not.
-        let mut h: u32 = 0x811c_9dc5;
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
         for byte in listy.as_bytes() {
-            h ^= *byte as u32;
-            h = h.wrapping_mul(0x0100_0193);
+            h ^= *byte as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
         }
-        tags.push(format!("cfg{h:08x}"));
+        tags.push(format!("cfg{h:016x}"));
     }
 
     if tags.is_empty() {
@@ -542,16 +554,19 @@ mod tests {
     use super::*;
 
     fn axes<'a>() -> LabelAxes<'a> {
-        // Every field at its ENGINE default: this must produce the bare base.
+        // Every field taken FROM `LayoutOptions::default()` rather than named
+        // (#661 round 5) — a fixture that hardcodes defaults goes stale the
+        // same way the production code did, and then passes anyway.
+        let d = LayoutOptions::default();
         LabelAxes {
-            strategy: LayoutStrategy::Pooled,
-            row_layout: RowLayout::VerticalSplit,
-            duty: 1.0,
+            strategy: d.strategy,
+            row_layout: d.row_layout,
+            duty: d.planning_duty,
             tier: DEFAULT_TIER,
             belt: None,
-            quality: QualityTier::Normal,
-            stacking: 1,
-            di: DirectInsertion::Candidate,
+            quality: d.quality,
+            stacking: d.stacking,
+            di: d.direct_insertion,
             claim: None,
             inserter_cap: None,
             inputs: &[],
@@ -680,8 +695,25 @@ mod tests {
         assert_eq!(
             auto_label("ec-5", &ax),
             "ec-5",
-            "--inserter-cap 2 / --claim up produce the default artifact and must \
-             not create a second directory for it"
+            "explicitly passing the DEFAULT inserter-cap and claim order \
+             produces the default artifact and must not create a second \
+             directory for it"
+        );
+    }
+
+    /// `--inputs ""` parses to `[""]` — a NON-default set that joins to the
+    /// empty string. Keying the tag on "digest string is non-empty" dropped
+    /// it into the default directory; keying on "does the set differ" does
+    /// not (#661 round 5).
+    #[test]
+    fn empty_input_string_does_not_collapse_onto_the_default() {
+        let empty: Vec<String> = vec![String::new()];
+        let mut ax = axes();
+        ax.inputs = &empty;
+        assert_ne!(
+            auto_label("ec-5", &ax),
+            "ec-5",
+            "an empty-string input set differs from the default and must tag"
         );
     }
 

--- a/docs/rfc-062-multi-target-outputs.md
+++ b/docs/rfc-062-multi-target-outputs.md
@@ -1314,6 +1314,8 @@ needed to look at the result, not a UI feature.
 
   **Fixture.** `sim_export --multi electronic-circuit:10
   advanced-circuit:3 --tier assembling-machine-2 --label kc3-am2`
+  (re-running this exact command is idempotent; add `--force` only if you
+  change a flag and still want the same label)
   (native mechanism, default candidate search — the same shipped-default engine
   `ec_ac_default_options_candidate_choice` pins as choosing `native`):
   159×96, 2169 entities, 139 machines, **0 validation errors, 4

--- a/docs/rfc-062-multi-target-outputs.md
+++ b/docs/rfc-062-multi-target-outputs.md
@@ -1314,8 +1314,8 @@ needed to look at the result, not a UI feature.
 
   **Fixture.** `sim_export --multi electronic-circuit:10
   advanced-circuit:3 --tier assembling-machine-2 --label kc3-am2`
-  (re-running this exact command is idempotent; add `--force` only if you
-  change a flag and still want the same label)
+  (re-running this exact command is idempotent, unless the fixture predates
+  the `.sim-export-config` provenance file, in which case add `--force`)
   (native mechanism, default candidate search — the same shipped-default engine
   `ec_ac_default_options_candidate_choice` pins as choosing `native`):
   159×96, 2169 entities, 139 machines, **0 validation errors, 4

--- a/docs/rfc-062-multi-target-outputs.md
+++ b/docs/rfc-062-multi-target-outputs.md
@@ -1313,9 +1313,8 @@ needed to look at the result, not a UI feature.
   fix attempts within budget.*
 
   **Fixture.** `sim_export --multi electronic-circuit:10
-  advanced-circuit:3 --tier assembling-machine-2 --label kc3-am2` (native
-  mechanism,
-  default candidate search — the same shipped-default engine
+  advanced-circuit:3 --tier assembling-machine-2 --label kc3-am2`
+  (native mechanism, default candidate search — the same shipped-default engine
   `ec_ac_default_options_candidate_choice` pins as choosing `native`):
   159×96, 2169 entities, 139 machines, **0 validation errors, 4
   warnings** (the pre-existing copper-cable `input-rate-delivery`

--- a/docs/rfc-062-multi-target-outputs.md
+++ b/docs/rfc-062-multi-target-outputs.md
@@ -1314,8 +1314,6 @@ needed to look at the result, not a UI feature.
 
   **Fixture.** `sim_export --multi electronic-circuit:10
   advanced-circuit:3 --tier assembling-machine-2 --label kc3-am2`
-  (re-running this exact command is idempotent, unless the fixture predates
-  the `.sim-export-config` provenance file, in which case add `--force`)
   (native mechanism, default candidate search — the same shipped-default engine
   `ec_ac_default_options_candidate_choice` pins as choosing `native`):
   159×96, 2169 entities, 139 machines, **0 validation errors, 4

--- a/docs/rfc-062-multi-target-outputs.md
+++ b/docs/rfc-062-multi-target-outputs.md
@@ -1313,7 +1313,8 @@ needed to look at the result, not a UI feature.
   fix attempts within budget.*
 
   **Fixture.** `sim_export --multi electronic-circuit:10
-  advanced-circuit:3 --tier assembling-machine-2` (native mechanism,
+  advanced-circuit:3 --tier assembling-machine-2 --label kc3-am2` (native
+  mechanism,
   default candidate search — the same shipped-default engine
   `ec_ac_default_options_candidate_choice` pins as choosing `native`):
   159×96, 2169 entities, 139 machines, **0 validation errors, 4
@@ -1501,8 +1502,8 @@ needed to look at the result, not a UI feature.
   origin-centered paste's own edge), is the actual discriminator — a
   live, reproducible repro now exists for whoever picks this up (this
   exact fixture, `sim_export --multi electronic-circuit:10
-  advanced-circuit:3 --tier assembling-machine-2`, then `spaghettio-sim
-  run --warmup 288000`) — tracked as a followup, below.
+  advanced-circuit:3 --tier assembling-machine-2 --label kc3-am2`, then
+  `spaghettio-sim run --warmup 288000`) — tracked as a followup, below.
 
   **Verdict, precisely stated**: KC3's own bar ("zero validation errors
   AND sim-measured at plan on BOTH targets") is **not met** — this is a

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -63,12 +63,23 @@ cargo run --release --example sim_export -- <item> <rate> [flags]
   --out <dir>           parent dir (default $SIM_PROBE_OUT, else /tmp)
 ```
 
-The auto label encodes any **non-default** layout axis (`-pd`, `-hs`,
-`-duty0_6`), because the label is also the output directory: without that,
-two runs differing only by strategy or duty write to the same place and the
-second silently overwrites the first — a wrong-A/B generator, and A/B is
-what these flags exist for. Default-axis paths are unchanged, and an
-explicit `--label` still overrides.
+The auto label encodes every **non-default** axis that changes the exported
+artifact — strategy, row layout, duty, belt tier, machine tier, quality,
+stacking, DI mode, claim order, inserter capacity, and a short digest for
+`--inputs` / `--research-productivity`. The label is also the output
+directory, so without this two runs differing only by an axis write to the
+same place and the second silently overwrites the first — a wrong-A/B
+generator, and A/B is what these flags exist for. For example:
+
+```
+electronic-circuit-5                  (all defaults)
+electronic-circuit-5-pd               --strategy partitioned-decomposed
+electronic-circuit-5-duty0_6-yellow   --duty 0.6 --belt transport-belt
+electronic-circuit-5-duty0_6-fast     --duty 0.6 --belt fast-transport-belt
+```
+
+Default-axis paths are byte-identical to before, and an explicit `--label`
+overrides all of it.
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -56,7 +56,7 @@ cargo run --release --example sim_export -- <item> <rate> [flags]
   --stacking <1..4>     belt stacking      --inserter-cap <n> capacity level
   --inputs a,b,c        raw inputs (default: the six-ore set)
   --row-layout <kind>   native (default) | horizontal-stack
-  --strategy <kind>     pooled (default) | partitioned-decomposed
+  --strategy <kind>     pooled (aka default) | partitioned-decomposed (aka pd)
   --duty <0..1>         planning duty (default 1.0; <1 needs --belt)
   --research-productivity <recipe=bonus,...>   declared research
   --label <name>        output subdir + manifest label
@@ -90,8 +90,16 @@ though neither changes the artifact. This is deliberate — deciding
 "is this value the default?" is exactly the defaults-tracking the encoding
 scheme was abandoned for, and it is the half that kept being wrong. The cost
 is that a previously-valid invocation passing an axis at its default now
-needs a label; no in-tree caller does, and the failure is a loud refusal
+needs a label; no automation caller does — some hand-run repro commands in
+older RFCs did, and were updated — and the failure is a loud refusal
 with the required flag named, not a silent overwrite.
+
+The guard reasons about which flags were PASSED, which is all that is
+knowable at parse time — so it cannot separate two runs that pass the same
+axis with different values under one `--label`. That half is enforced at the
+write instead: an existing `<out>/<label>/bp.txt` is a refusal, and
+`--force` is the escape hatch for deliberately regenerating the same
+configuration.
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -57,7 +57,7 @@ cargo run --release --example sim_export -- <item> <rate> [flags]
   --inputs a,b,c        raw inputs (default: the six-ore set)
   --row-layout <kind>   native (default) | horizontal-stack
   --strategy <kind>     pooled (default) | partitioned-decomposed
-  --duty <0..1>         planning duty (default 1.0)
+  --duty <0..1>         planning duty (default 1.0; <1 needs --belt)
   --research-productivity <recipe=bonus,...>   declared research
   --label <name>        output subdir + manifest label
   --out <dir>           parent dir (default $SIM_PROBE_OUT, else /tmp)
@@ -76,10 +76,22 @@ encoded no configuration, so a second run silently overwrote the first's
 whose whole purpose is A/B. Encoding each axis into the name was tried and
 abandoned: it needs every axis enumerated and every engine default stated
 correctly, and five review rounds each found another one wrong. Requiring
-the label makes collisions impossible by construction and consults no
-defaults, so a future default flip cannot invert it.
+the label makes collisions between runs that differ only by an axis
+impossible by construction, and consults no defaults, so a future default
+flip cannot invert it. Reusing the same `--label` twice still collides —
+that is a deliberate escape hatch, not an oversight.
 
 A run with no axis flags keeps the old `{item}-{rate}` path unchanged.
+
+The check is **syntactic**: it fires on the PRESENCE of an axis flag, not on
+whether the value differs from the engine default. So `--tier
+assembling-machine-3` or `--strategy pooled` requires a `--label` even
+though neither changes the artifact. This is deliberate — deciding
+"is this value the default?" is exactly the defaults-tracking the encoding
+scheme was abandoned for, and it is the half that kept being wrong. The cost
+is that a previously-valid invocation passing an axis at its default now
+needs a label; no in-tree caller does, and the failure is a loud refusal
+with the required flag named, not a silent overwrite.
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -79,7 +79,11 @@ electronic-circuit-5-duty0_6-fast     --duty 0.6 --belt fast-transport-belt
 ```
 
 Default-axis paths are byte-identical to before, and an explicit `--label`
-overrides all of it.
+overrides all of it. Two caveats worth knowing: `--inputs` and
+`--research-productivity` are folded in as a 64-bit FNV-1a digest rather
+than spelled out, and an explicit `--belt` always tags even when the engine
+would have auto-picked that same tier — so it can fork a redundant
+directory, which is the safe direction (never a shared one).
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -107,6 +107,17 @@ configuration differs from its own:
   before this existed cannot be assumed to match;
 - `--force` — replaces it regardless.
 
+The recorded configuration is the **targets** (item and rate) plus the axis
+flags and their values, sorted, so flag order does not matter. Two things it
+deliberately does not do: it compares values **syntactically**, so
+`--strategy pd` and `--strategy partitioned-decomposed` read as different
+configurations even though they resolve to the same one; and a fixture
+written before this existed has no recorded configuration, so it is refused
+rather than assumed to match. Both err toward refusing a run that would in
+fact have been safe — `--force` covers them, and the alternative is
+resolving values against engine defaults, which is the machinery this guard
+was built to avoid.
+
 Three earlier versions of this guard asked about the command line instead
 (refuse if anything exists / if this run passed an axis flag / if the label
 was explicit). Each one leaked, from a different direction, because the

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -55,9 +55,20 @@ cargo run --release --example sim_export -- <item> <rate> [flags]
   --belt <entity>       max belt tier      --quality <name>   normal..legendary
   --stacking <1..4>     belt stacking      --inserter-cap <n> capacity level
   --inputs a,b,c        raw inputs (default: the six-ore set)
+  --row-layout <kind>   native (default) | horizontal-stack
+  --strategy <kind>     pooled (default) | partitioned-decomposed
+  --duty <0..1>         planning duty (default 1.0)
+  --research-productivity <recipe=bonus,...>   declared research
   --label <name>        output subdir + manifest label
   --out <dir>           parent dir (default $SIM_PROBE_OUT, else /tmp)
 ```
+
+The auto label encodes any **non-default** layout axis (`-pd`, `-hs`,
+`-duty0_6`), because the label is also the output directory: without that,
+two runs differing only by strategy or duty write to the same place and the
+second silently overwrites the first — a wrong-A/B generator, and A/B is
+what these flags exist for. Default-axis paths are unchanged, and an
+explicit `--label` still overrides.
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -100,49 +100,6 @@ same axis with different VALUES under one `--label`. Closing that needs the
 artifact's own provenance rather than a question about the command line, and
 it is a separate change (branch `feat/sim-export-overwrite-provenance`).
 
-A run with no axis flags keeps the old `{item}-{rate}` path unchanged.
-
-The check is **syntactic**: it fires on the PRESENCE of an axis flag, not on
-whether the value differs from the engine default. So `--tier
-assembling-machine-3` or `--strategy pooled` requires a `--label` even
-though neither changes the artifact. This is deliberate — deciding
-"is this value the default?" is exactly the defaults-tracking the encoding
-scheme was abandoned for, and it is the half that kept being wrong. The cost
-is that a previously-valid invocation passing an axis at its default now
-needs a label; no automation caller does — some hand-run repro commands in
-older RFCs did, and were updated — and the failure is a loud refusal
-with the required flag named, not a silent overwrite.
-
-That guard reasons about which flags were PASSED, which is all that is
-knowable before the solve — so it cannot tell two runs apart that pass the
-same axis with different VALUES. That half is answered from the artifact
-instead. Each fixture directory carries a `.sim-export-config` recording the
-axis flags and values it was built from, and a run refuses when the stored
-configuration differs from its own:
-
-- **same config** — proceeds, so re-running a fixture is idempotent;
-- **different config** — refuses, naming both configurations;
-- **no `.sim-export-config`** — refuses, because a fixture written by hand or
-  before this existed cannot be assumed to match;
-- `--force` — replaces it regardless.
-
-The recorded configuration is the **targets** (item and rate) plus the axis
-flags and their values, sorted, so flag order does not matter. Two things it
-deliberately does not do: it compares values **syntactically**, so
-`--strategy pd` and `--strategy partitioned-decomposed` read as different
-configurations even though they resolve to the same one; and a fixture
-written before this existed has no recorded configuration, so it is refused
-rather than assumed to match. Both err toward refusing a run that would in
-fact have been safe — `--force` covers them, and the alternative is
-resolving values against engine defaults, which is the machinery this guard
-was built to avoid.
-
-Three earlier versions of this guard asked about the command line instead
-(refuse if anything exists / if this run passed an axis flag / if the label
-was explicit). Each one leaked, from a different direction, because the
-question that matters is about the artifact and cannot be answered from
-flags.
-
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error
 rather than ignored — a silently-dropped `--belt` would export a layout

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -96,6 +96,25 @@ with the required flag named, not a silent overwrite.
 
 That guard reasons about which flags were PASSED, which is all that is
 knowable before the solve — so it cannot tell two runs apart that pass the
+same axis with different VALUES under one `--label`. Closing that needs the
+artifact's own provenance rather than a question about the command line, and
+it is a separate change (branch `feat/sim-export-overwrite-provenance`).
+
+A run with no axis flags keeps the old `{item}-{rate}` path unchanged.
+
+The check is **syntactic**: it fires on the PRESENCE of an axis flag, not on
+whether the value differs from the engine default. So `--tier
+assembling-machine-3` or `--strategy pooled` requires a `--label` even
+though neither changes the artifact. This is deliberate — deciding
+"is this value the default?" is exactly the defaults-tracking the encoding
+scheme was abandoned for, and it is the half that kept being wrong. The cost
+is that a previously-valid invocation passing an axis at its default now
+needs a label; no automation caller does — some hand-run repro commands in
+older RFCs did, and were updated — and the failure is a loud refusal
+with the required flag named, not a silent overwrite.
+
+That guard reasons about which flags were PASSED, which is all that is
+knowable before the solve — so it cannot tell two runs apart that pass the
 same axis with different VALUES. That half is answered from the artifact
 instead. Each fixture directory carries a `.sim-export-config` recording the
 axis flags and values it was built from, and a run refuses when the stored

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -94,12 +94,24 @@ needs a label; no automation caller does — some hand-run repro commands in
 older RFCs did, and were updated — and the failure is a loud refusal
 with the required flag named, not a silent overwrite.
 
-The guard reasons about which flags were PASSED, which is all that is
-knowable at parse time — so it cannot separate two runs that pass the same
-axis with different values under one `--label`. That half is enforced at the
-write instead: an existing `<out>/<label>/bp.txt` is a refusal, and
-`--force` is the escape hatch for deliberately regenerating the same
-configuration.
+That guard reasons about which flags were PASSED, which is all that is
+knowable before the solve — so it cannot tell two runs apart that pass the
+same axis with different VALUES. That half is answered from the artifact
+instead. Each fixture directory carries a `.sim-export-config` recording the
+axis flags and values it was built from, and a run refuses when the stored
+configuration differs from its own:
+
+- **same config** — proceeds, so re-running a fixture is idempotent;
+- **different config** — refuses, naming both configurations;
+- **no `.sim-export-config`** — refuses, because a fixture written by hand or
+  before this existed cannot be assumed to match;
+- `--force` — replaces it regardless.
+
+Three earlier versions of this guard asked about the command line instead
+(refuse if anything exists / if this run passed an axis flag / if the label
+was explicit). Each one leaked, from a different direction, because the
+question that matters is about the artifact and cannot be answered from
+flags.
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -63,27 +63,23 @@ cargo run --release --example sim_export -- <item> <rate> [flags]
   --out <dir>           parent dir (default $SIM_PROBE_OUT, else /tmp)
 ```
 
-The auto label encodes every **non-default** axis that changes the exported
-artifact — strategy, row layout, duty, belt tier, machine tier, quality,
-stacking, DI mode, claim order, inserter capacity, and a short digest for
-`--inputs` / `--research-productivity`. The label is also the output
-directory, so without this two runs differing only by an axis write to the
-same place and the second silently overwrites the first — a wrong-A/B
-generator, and A/B is what these flags exist for. For example:
+Passing any flag that changes the exported layout — `--strategy`,
+`--row-layout`, `--duty`, `--belt`, `--tier`, `--quality`, `--stacking`,
+`--di`, `--claim`, `--inserter-cap`, `--inputs`,
+`--research-productivity` — **requires an explicit `--label`**, and the tool
+refuses without one.
 
-```
-electronic-circuit-5                  (all defaults)
-electronic-circuit-5-pd               --strategy partitioned-decomposed
-electronic-circuit-5-duty0_6-yellow   --duty 0.6 --belt transport-belt
-electronic-circuit-5-duty0_6-fast     --duty 0.6 --belt fast-transport-belt
-```
+The label is also the output directory, so two runs differing by any of
+those must not share it. They used to: the label was `{item}-{rate}` and
+encoded no configuration, so a second run silently overwrote the first's
+`bp.txt` and `manifest-real.json` — a wrong-A/B generator, in the tool
+whose whole purpose is A/B. Encoding each axis into the name was tried and
+abandoned: it needs every axis enumerated and every engine default stated
+correctly, and five review rounds each found another one wrong. Requiring
+the label makes collisions impossible by construction and consults no
+defaults, so a future default flip cannot invert it.
 
-Default-axis paths are byte-identical to before, and an explicit `--label`
-overrides all of it. Two caveats worth knowing: `--inputs` and
-`--research-productivity` are folded in as a 64-bit FNV-1a digest rather
-than spelled out, and an explicit `--belt` always tags even when the engine
-would have auto-picked that same tier — so it can fork a redundant
-directory, which is the safe direction (never a shared one).
+A run with no axis flags keeps the old `{item}-{rate}` path unchanged.
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error


### PR DESCRIPTION
## Intent

`sim_export` is the tracked generator for headless-Factorio fixtures. It could
express `--row-layout` but not `LayoutStrategy`, so `PartitionedDecomposed` had
no supported route to a blueprint+manifest pair — meaning it could not be
sim-anchored at all, while RFC-modular-production states its Phase 1 kill
criteria *against sim measurement*.

## Scope

- **In:** `--strategy pooled|partitioned-decomposed` (aliases `default`, `pd`),
  threaded into `LayoutOptions`. Usage text updated.
- **Out:** no engine behaviour change; no fixture added. This only makes the
  axis reachable from the generator.
- **Size:** +20/-1, one file.

## Verification

- [x] `cargo build --example sim_export` — clean
- [x] `cargo clippy` via pre-commit hook — clean
- [ ] full `cargo test` — not run: this touches only a harness example binary
      that no test imports. Stated explicitly rather than claimed.
- [ ] WASM/browser — N/A, not a renderer or engine change
- [ ] Snapshot — N/A

## Deviations from intent

None.

## Models / contracts touched

None. `LayoutStrategy` already existed and is unchanged; this only exposes it
on an existing CLI surface.