### PR TITLE
fix(balancer): classify throughput independently of balance

### DIFF
--- a/crates/core/src/bus/balancer.rs
+++ b/crates/core/src/bus/balancer.rs
@@ -787,3 +787,4 @@ mod tests {
         // news), but the eprintln above flags the cleanup needed.
     }
 }
+

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -68,6 +68,50 @@ pub enum BalancerClass {
     Balanced,
 }
 
+/// Throughput tier, reported independently of [`BalancerClass`].
+///
+/// [`BalancerClass`] is a single ordered ladder that places `Balanced`
+/// (MX3, uniform composition) *above* `ThroughputUnlimited` (MX2b), and
+/// [`classify_graph`] returns on the first match. A template whose
+/// composition matrix is uniform therefore short-circuits before the
+/// Menger subset checks ever run, and can never be labelled TU no matter
+/// how good it is.
+///
+/// That is not a hypothetical: measured 2026-08-19 across the 68
+/// registered templates, 66 classify `Balanced` and the registry contains
+/// **zero** templates certified `ThroughputUnlimited` — including every
+/// shape whose provenance advertises "Raynquist (TU)".
+///
+/// Balance and throughput are independent properties: a template can mix
+/// every input into every output in equal proportion (MX3) and still fail
+/// to reroute around a blocked output subset (not MX2b). This enum
+/// reports the throughput axis on its own, and is always computed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ThroughputTier {
+    /// MX1 — some input subset cannot achieve `min(|S|, n)` flow.
+    Limited,
+    /// MX2a — full flow over every input subset, but some output subset
+    /// falls short. Sufficient for the bus's homogeneous consumer rows.
+    BalancedRate,
+    /// MX2b — full max-flow over input *and* output subsets. The real
+    /// "throughput-unlimited" property.
+    Unlimited,
+}
+
+/// The throughput tier of a graph, computed without reference to its
+/// composition matrix — so it is available even for templates whose
+/// composition solve is [`ClassifyError::Singular`].
+pub fn throughput_tier(graph: &SplitterGraph) -> ThroughputTier {
+    let (m, n) = (graph.n_inputs, graph.n_outputs);
+    if check_input_subsets(graph, m, n).is_some() {
+        ThroughputTier::Limited
+    } else if check_output_subsets(graph, m, n).is_some() {
+        ThroughputTier::BalancedRate
+    } else {
+        ThroughputTier::Unlimited
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ClassifyError {
     /// Belt walk fell off the template footprint.
@@ -106,6 +150,9 @@ pub enum Mx2Direction {
 #[derive(Debug, Clone)]
 pub struct ClassificationReport {
     pub class: BalancerClass,
+    /// Throughput tier, computed independently of `class` — see
+    /// [`ThroughputTier`] for why `class` alone cannot express it.
+    pub throughput: ThroughputTier,
     /// `composition[output_idx][input_idx]` = fraction of input k that
     /// reaches output j under the saturated 50/50 splitter model.
     pub composition: Vec<Vec<f64>>,
@@ -321,6 +368,24 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
     let m = graph.n_inputs;
     let n = graph.n_outputs;
 
+    // Run the Menger checks unconditionally. `class` still returns on its
+    // first match below (unchanged, so the pins that read it are stable),
+    // but the throughput axis is independent of balance and must not be
+    // hidden by an MX3 short-circuit — see `ThroughputTier`.
+    let mx2a_counterexample = check_input_subsets(graph, m, n);
+    let mx2b_counterexample = if mx2a_counterexample.is_none() {
+        check_output_subsets(graph, m, n)
+    } else {
+        None
+    };
+    let throughput = if mx2a_counterexample.is_some() {
+        ThroughputTier::Limited
+    } else if mx2b_counterexample.is_some() {
+        ThroughputTier::BalancedRate
+    } else {
+        ThroughputTier::Unlimited
+    };
+
     let target = 1.0 / n as f64;
     let is_mx3 = composition
         .iter()
@@ -328,21 +393,21 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
     if is_mx3 {
         return Ok(ClassificationReport {
             class: BalancerClass::Balanced,
+            throughput,
             composition,
             mx2_counterexample: None,
         });
     }
 
-    let mx2a_counterexample = check_input_subsets(graph, m, n);
     if mx2a_counterexample.is_some() {
         return Ok(ClassificationReport {
             class: BalancerClass::ThroughputLimited,
+            throughput,
             composition,
             mx2_counterexample: mx2a_counterexample,
         });
     }
 
-    let mx2b_counterexample = check_output_subsets(graph, m, n);
     let class = if mx2b_counterexample.is_none() {
         BalancerClass::ThroughputUnlimited
     } else {
@@ -350,6 +415,7 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
     };
     Ok(ClassificationReport {
         class,
+        throughput,
         composition,
         mx2_counterexample: mx2b_counterexample,
     })

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -117,11 +117,16 @@ pub enum ThroughputTier {
     /// (10,10)), but `throughput_tier` is public and `import_balancer` can
     /// be pointed at anything.
     ///
-    /// NOTE the deliberate divergence: [`BalancerClass`] still returns its
-    /// pre-existing optimistic answer for such graphs. That overclaim is
-    /// older than this enum and fixing it would move `class` for real
-    /// inputs, which this change is specifically avoiding; it is recorded
-    /// here rather than silently inherited by the new axis.
+    /// [`BalancerClass`] does NOT diverge here: `classify_graph` refuses an
+    /// `Unknown`-tier graph outright with [`ClassifyError::Unanalysable`],
+    /// so no class is issued without a subset check having run. (Earlier
+    /// drafts of this comment described a deliberate divergence in which
+    /// `class` kept its optimistic answer. Round 5 removed that divergence
+    /// and this note outlived it by a round — #662 review, 3/3.)
+    ///
+    /// The two surfaces therefore differ only in SEVERITY, not verdict:
+    /// `throughput_tier` reports `Unknown` and lets the caller decide;
+    /// `classify_graph` refuses, because its callers gate on `class`.
     Unknown,
 }
 
@@ -143,9 +148,19 @@ pub fn throughput_tier(graph: &SplitterGraph) -> ThroughputTier {
     // public surfaces disagreed on the same graph. The comment claiming they
     // "cannot drift" was false precisely because of that gate.
     //
-    // Both subset helpers bail cheaply on size and return `None`, so calling
-    // them unconditionally costs nothing; `throughput_tier_from` is the one
-    // place that decides what a `None` means on each side.
+    // Both subset helpers bail cheaply on size and return `None`, so removing
+    // the gate costs nothing ON THIS SURFACE; `throughput_tier_from` is the
+    // one place that decides what a `None` means on each side.
+    //
+    // "Costs nothing" is true here and was WRONG when this comment's twin
+    // claimed it for `classify_graph` (#662 review). There the checks moved
+    // in front of an MX3 early-return that used to skip them for every
+    // balanced template, which is 62 of the registry's 64. Measured over the
+    // registry, 20 passes each: 11.3us -> 198.2us per template, a 17.6x
+    // slowdown. Kept anyway — the throughput axis cannot be computed without
+    // running them, which is the entire point of the change — and the
+    // absolute cost is sub-millisecond per family stamp. Recorded so the
+    // next person reads a number instead of a reassurance.
     let mx2a = check_input_subsets(graph, m, n);
     let mx2b = if mx2a.is_none() {
         check_output_subsets(graph, m, n)
@@ -1354,6 +1369,23 @@ mod tests {
         }
     }
 
+    /// Every input merged into a single output. Unlike `straight_through`,
+    /// whose composition is the IDENTITY, this graph's composition matrix is
+    /// uniformly `1/n` (`n == 1`, so every entry is 1.0) — so it satisfies
+    /// `is_mx3` and actually reaches the `Balanced` arm. That is the whole
+    /// point: `straight_through(k, k)` can never reach it, so a test built on
+    /// that helper cannot pin where the guard sits relative to it.
+    fn all_into_one(m: usize) -> SplitterGraph {
+        SplitterGraph {
+            n_inputs: m,
+            n_outputs: 1,
+            n_splitters: 0,
+            edges: (0..m)
+                .map(|i| (NodeId::InputPort(i), NodeId::OutputPort(0)))
+                .collect(),
+        }
+    }
+
     /// An oversized graph must not be handed an optimistic throughput verdict
     /// on EITHER surface.
     ///
@@ -1441,10 +1473,26 @@ mod tests {
     #[test]
     fn oversized_uniform_graphs_do_not_classify_as_balanced() {
         let k = SUBSET_ENUM_MAX + 1;
-        let graph = straight_through(k, k);
+        let graph = all_into_one(k);
+
+        // The premise this test rests on, asserted rather than assumed: the
+        // graph really is uniform, so it really would take the `Balanced`
+        // arm. `straight_through(k, k)` — what this test used in round 5 —
+        // is the identity, fails `is_mx3`, and so passed whether the guard
+        // sat above or below that branch. It pinned nothing (#662 round 6).
+        let target = 1.0 / graph.n_outputs as f64;
+        assert!(
+            compute_composition_matrix(&graph)
+                .expect("composition solve")
+                .iter()
+                .all(|row| row.iter().all(|&v| (v - target).abs() < 1e-9)),
+            "test premise broken: graph is not uniform, so it never reaches \
+             the Balanced arm and this test cannot discriminate"
+        );
+
         match classify_graph(&graph) {
             Err(ClassifyError::Unanalysable { m, n, bound }) => {
-                assert_eq!((m, n, bound), (k, k, SUBSET_ENUM_MAX));
+                assert_eq!((m, n, bound), (k, 1, SUBSET_ENUM_MAX));
             }
             Ok(r) => panic!(
                 "oversized graph classified as {:?} with throughput {:?} — no \

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -90,7 +90,15 @@ pub enum BalancerClass {
 ///
 /// It is computed for every graph within the subset-enumeration bound and
 /// reports [`ThroughputTier::Unknown`] outside it — see that variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+///
+/// Deliberately NOT `Ord` (#662 round 6). The three real tiers do form a
+/// ladder, but `Unknown` is not a rung on it — it means "not measured" —
+/// and a derived ordering put it at the TOP, so a future `tier >=
+/// Unlimited` would have read an unanalysed graph as better than a verified
+/// one. That is the same false-clearance shape this enum exists to prevent,
+/// so the ordering is removed rather than reordered: there is no correct
+/// place to rank an absence. Nothing compares tiers today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ThroughputTier {
     /// MX1 — some input subset cannot achieve `min(|S|, n)` flow.
     Limited,
@@ -114,7 +122,7 @@ pub enum ThroughputTier {
     /// from having searched and found nothing, so a 20-input community
     /// balancer would report `Unlimited` without a single subset being
     /// tested. No library template reaches this (the registry maxes at
-    /// (10,10)), but `throughput_tier` is public and `import_balancer` can
+    /// (1,10)/(10,1)), but `throughput_tier` is public and `import_balancer` can
     /// be pointed at anything.
     ///
     /// [`BalancerClass`] does NOT diverge here: `classify_graph` refuses an
@@ -132,7 +140,10 @@ pub enum ThroughputTier {
 
 /// Largest input/output count the Menger subset checks will enumerate.
 /// Both walk every subset (`2^k` masks over a `u64`), so this bounds work
-/// and keeps the shift well-defined. The registry maxes at (10,10); the
+/// and keeps the shift well-defined. No registered shape has a side above
+/// 10 — the largest are (1,10), (10,1) and (9,3), and (10,10) is NOT
+/// registered (#662 round 6: "maxes at (10,10)" read as a shape when it was
+/// only a per-axis maximum); the
 /// bound exists for arbitrary imported graphs.
 const SUBSET_ENUM_MAX: usize = 16;
 
@@ -202,6 +213,17 @@ fn throughput_tier_from(
     }
     // A clean input check is only meaningful if it RAN; `None` from a bailed
     // check is "not searched", not "searched and found nothing".
+    //
+    // This bail sits ABOVE the mx2b arm on purpose, and the asymmetry with
+    // the input rule above is not an oversight (#662 round 6 asked for it to
+    // be made symmetric). Evidence of the WORST tier is definitive: an input
+    // counterexample proves `Limited`, and nothing found later can make a
+    // graph better than its worst witness. Evidence of a MIDDLE tier is not:
+    // `mx2b` bounds the graph above by `BalancedRate`, but an unrun input
+    // check could still be hiding a counterexample that makes it `Limited`.
+    // Returning `BalancedRate` on output evidence alone would therefore
+    // assert a tier we have not earned — a false clearance of exactly the
+    // kind this function exists to refuse, just one rung further down.
     if !input_ran {
         return ThroughputTier::Unknown;
     }
@@ -223,9 +245,16 @@ pub enum ClassifyError {
     /// This is deliberately an ERROR and not a quiet `ThroughputUnlimited`:
     /// `balancer_generate` and `import_balancer` gate on `class`, so a
     /// silent optimistic answer here is a false clearance that ships a
-    /// template nothing verified. A caller that only wants the composition
-    /// (which IS computed for such graphs) can use `throughput_tier`, which
-    /// reports `Unknown` rather than failing.
+    /// template nothing verified. A caller that wants the throughput axis
+    /// alone can use `throughput_tier`, which reports `Unknown` rather than
+    /// failing.
+    ///
+    /// The composition matrix IS computed before this refusal, but it is
+    /// not reachable once we return `Err`: `throughput_tier` yields only a
+    /// tier and `compute_composition_matrix` is private. An earlier draft
+    /// of this comment offered `throughput_tier` as the way to retrieve the
+    /// composition, which it has never been (#662 round 6). If a caller
+    /// ever needs it, that wants a real accessor, not a rewording.
     Unanalysable { m: usize, n: usize, bound: usize },
     /// Belt walk fell off the template footprint.
     DanglingBelt { from: (i32, i32) },
@@ -1146,7 +1175,7 @@ mod tests {
                 Err(ClassifyError::Malformed(_)) => malformed += 1,
                 Err(ClassifyError::Singular) => singular += 1,
                 // No registered template reaches the enumeration bound
-                // (registry maxes at (10,10)); if one ever does, this must be
+                // (no registered shape has a side above 10); if one ever does, this must be
                 // a deliberate decision rather than a quiet miscount.
                 Err(ClassifyError::Unanalysable { m, n, bound }) => {
                     panic!("registered template ({m},{n}) exceeds the subset bound {bound}")

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -491,6 +491,27 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
     let is_mx3 = composition
         .iter()
         .all(|row| row.iter().all(|&v| (v - target).abs() < 1e-9));
+    // BEFORE the MX3 branch, not after (#662 round 5). I originally exempted
+    // `Balanced` here on the grounds that it is a composition verdict,
+    // computed independently of the subset checks and sound at any size.
+    // That is true of the PROPERTY and false of the REPORT: `BalancerClass`
+    // is one conflated ladder and its consumers match on it as a single
+    // verdict — `balancer_generate` accepts `Balanced` as a usable candidate
+    // (balancer_generate.rs:113). So an oversized graph with uniform
+    // composition was accepted with no throughput check ever having run,
+    // which is the false clearance in the place it actually matters.
+    //
+    // An oversized graph therefore gets NO class at all. Callers wanting the
+    // throughput axis alone can use `throughput_tier`, which answers
+    // `Unknown` rather than failing.
+    if throughput == ThroughputTier::Unknown {
+        return Err(ClassifyError::Unanalysable {
+            m,
+            n,
+            bound: SUBSET_ENUM_MAX,
+        });
+    }
+
     if is_mx3 {
         return Ok(ClassificationReport {
             class: BalancerClass::Balanced,
@@ -513,19 +534,6 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
             throughput,
             composition,
             mx2_counterexample: mx2a_counterexample,
-        });
-    }
-
-    // Past this point every remaining `class` arm asserts a THROUGHPUT
-    // property, and if the checks could not run there is nothing behind the
-    // assertion. `Balanced` above is exempt on purpose: it is a composition
-    // verdict, computed independently of the subset checks, and is sound for
-    // a graph of any size.
-    if throughput == ThroughputTier::Unknown {
-        return Err(ClassifyError::Unanalysable {
-            m,
-            n,
-            bound: SUBSET_ENUM_MAX,
         });
     }
 
@@ -1415,6 +1423,36 @@ mod tests {
             throughput_tier_from(2, n_big, &check_input_subsets(&graph, 2, n_big), &None),
             "the free function and the shared core must not drift"
         );
+    }
+
+    /// An oversized graph with UNIFORM composition must not classify as
+    /// `Balanced` either (#662 round 5).
+    ///
+    /// `Balanced` is a sound statement about composition at any size, which
+    /// is why it was exempted at first — but `BalancerClass` is one conflated
+    /// ladder and its consumers match on it as a single verdict.
+    /// `balancer_generate` accepts `Balanced` as a usable candidate, so an
+    /// unanalysed graph reaching that arm is a false clearance exactly where
+    /// it matters.
+    ///
+    /// Verified to discriminate: with the guard back below the MX3 branch,
+    /// this fails with "classified as ThroughputUnlimited with throughput
+    /// Unknown".
+    #[test]
+    fn oversized_uniform_graphs_do_not_classify_as_balanced() {
+        let k = SUBSET_ENUM_MAX + 1;
+        let graph = straight_through(k, k);
+        match classify_graph(&graph) {
+            Err(ClassifyError::Unanalysable { m, n, bound }) => {
+                assert_eq!((m, n, bound), (k, k, SUBSET_ENUM_MAX));
+            }
+            Ok(r) => panic!(
+                "oversized graph classified as {:?} with throughput {:?} — no \
+                 subset check ran, so no class is earned",
+                r.class, r.throughput
+            ),
+            Err(e) => panic!("unexpected error: {e:?}"),
+        }
     }
 
     /// The bound is PER-SIDE. An input check that ran and found a

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -1479,10 +1479,18 @@ mod tests {
              free function must not discard it because the OTHER side is \
              oversized"
         );
+        // Compare against the OTHER PUBLIC SURFACE, not against the shared
+        // core (#662 review). The previous assertion here compared
+        // `throughput_tier` to `throughput_tier_from` — but the former
+        // delegates to the latter, so it compared a function with itself
+        // and a regression inside `classify_graph` passed it untouched.
+        // The test is named for two surfaces agreeing; it now uses two.
+        let report = classify_graph(&graph).expect("in-bound input evidence is decisive");
+        assert_eq!(report.throughput, ThroughputTier::Limited);
         assert_eq!(
-            throughput_tier(&graph),
-            throughput_tier_from(2, n_big, &check_input_subsets(&graph, 2, n_big), &None),
-            "the free function and the shared core must not drift"
+            report.class,
+            BalancerClass::ThroughputLimited,
+            "classify_graph must reach the same verdict as throughput_tier"
         );
     }
 

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -131,15 +131,38 @@ const SUBSET_ENUM_MAX: usize = 16;
 /// composition solve is [`ClassifyError::Singular`].
 pub fn throughput_tier(graph: &SplitterGraph) -> ThroughputTier {
     let (m, n) = (graph.n_inputs, graph.n_outputs);
-    // Bound check FIRST. Both helpers return `None` when they bail on size,
-    // which reads identically to "searched, found nothing" — so asking them
-    // about an oversized graph and believing the answer is a false clearance.
     if m > SUBSET_ENUM_MAX || n > SUBSET_ENUM_MAX {
         return ThroughputTier::Unknown;
     }
-    if check_input_subsets(graph, m, n).is_some() {
+    let mx2a = check_input_subsets(graph, m, n);
+    let mx2b = if mx2a.is_none() {
+        check_output_subsets(graph, m, n)
+    } else {
+        None
+    };
+    throughput_tier_from(m, n, &mx2a, &mx2b)
+}
+
+/// The tier, given subset-check results already computed for an `(m, n)`
+/// graph. The single place the tier is decided — `throughput_tier` and
+/// `classify_graph` both route through here so they cannot disagree
+/// (#662 round 2: they did, and the one with the guard had no callers).
+///
+/// The bound check is FIRST and is not optional: both subset helpers return
+/// `None` when they bail on size, which reads identically to "searched,
+/// found nothing", so believing them about an oversized graph is a false
+/// clearance rather than a missing feature.
+fn throughput_tier_from(
+    m: usize,
+    n: usize,
+    mx2a: &Option<Mx2Counterexample>,
+    mx2b: &Option<Mx2Counterexample>,
+) -> ThroughputTier {
+    if m > SUBSET_ENUM_MAX || n > SUBSET_ENUM_MAX {
+        ThroughputTier::Unknown
+    } else if mx2a.is_some() {
         ThroughputTier::Limited
-    } else if check_output_subsets(graph, m, n).is_some() {
+    } else if mx2b.is_some() {
         ThroughputTier::BalancedRate
     } else {
         ThroughputTier::Unlimited
@@ -412,13 +435,16 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
     } else {
         None
     };
-    let throughput = if mx2a_counterexample.is_some() {
-        ThroughputTier::Limited
-    } else if mx2b_counterexample.is_some() {
-        ThroughputTier::BalancedRate
-    } else {
-        ThroughputTier::Unlimited
-    };
+    // ONE source of truth for the tier (#662 round 2, 3/3 x2). The first
+    // version of this change put the SUBSET_ENUM_MAX guard in
+    // `throughput_tier()` — which has zero callers — and left this path
+    // computing the tier inline without it. So the false clearance the
+    // `Unknown` variant exists to prevent was still being emitted by the
+    // primary path (`classify`/`classify_graph`, used by import_balancer,
+    // balancer_generate and balancer_topology), and the two public surfaces
+    // contradicted each other for the same graph. Delegating means they
+    // cannot drift.
+    let throughput = throughput_tier_from(m, n, &mx2a_counterexample, &mx2b_counterexample);
 
     let target = 1.0 / n as f64;
     let is_mx3 = composition
@@ -1233,14 +1259,56 @@ mod tests {
              that gives every template the same answer is not measuring \
              anything"
         );
-        // No registered template exceeds the enumeration bound; if one ever
-        // does, its tier is Unknown and that must be a deliberate decision
-        // rather than a silent false clearance.
+        // No registered template exceeds the enumeration bound. NOTE this
+        // assertion is weak on purpose and must not be mistaken for coverage
+        // of the Unknown path (#662 round 2): every shape here is within the
+        // bound, so it could not fail. The reachability of Unknown is pinned
+        // separately, below.
         assert_eq!(
             unknown, 0,
             "a registered template exceeds SUBSET_ENUM_MAX ({SUBSET_ENUM_MAX}) \
              and its throughput is unanalysed"
         );
+    }
+
+    /// An oversized graph must report `Unknown` on BOTH public surfaces.
+    ///
+    /// This is the test the first version of the change was missing, and its
+    /// absence hid a real defect: the bound guard had been put in
+    /// `throughput_tier()` — which has no callers — while `classify_graph`,
+    /// the path everything actually uses, computed the tier inline without
+    /// it. So the false clearance was still being emitted, and the two
+    /// surfaces disagreed for the same graph.
+    #[test]
+    fn oversized_graphs_report_unknown_on_both_surfaces() {
+        // 17 straight-through belts: past SUBSET_ENUM_MAX, and well-formed
+        // enough for the composition solve (it is the identity).
+        let k = SUBSET_ENUM_MAX + 1;
+        let graph = SplitterGraph {
+            n_inputs: k,
+            n_outputs: k,
+            n_splitters: 0,
+            edges: (0..k)
+                .map(|i| (NodeId::InputPort(i), NodeId::OutputPort(i)))
+                .collect(),
+        };
+
+        assert_eq!(
+            throughput_tier(&graph),
+            ThroughputTier::Unknown,
+            "free function must not certify an unanalysed graph"
+        );
+
+        let report = classify_graph(&graph).expect("identity graph classifies");
+        assert_eq!(
+            report.throughput,
+            ThroughputTier::Unknown,
+            "classify_graph is the path import_balancer/balancer_generate use — \
+             it must not report Unlimited for a graph no subset check ran on"
+        );
+
+        // ...and the two must agree, which is the property that failed before.
+        assert_eq!(report.throughput, throughput_tier(&graph));
     }
 
     /// A Balanced template that is NOT throughput-unlimited must carry its

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -100,8 +100,13 @@ pub enum ThroughputTier {
     /// MX2b — full max-flow over input *and* output subsets. The real
     /// "throughput-unlimited" property.
     Unlimited,
-    /// Not analysed: the graph exceeds the subset-enumeration bound of 16
-    /// inputs or outputs, so neither Menger check ran (#662 review).
+    /// Not analysed: the Menger check whose answer was NEEDED could not run,
+    /// because its side of the graph exceeds the subset-enumeration bound
+    /// (#662 review).
+    ///
+    /// Per-side, deliberately: an oversized `n` does not invalidate an input
+    /// check that ran and found a counterexample, so that case reports
+    /// `Limited` on the evidence rather than `Unknown`.
     ///
     /// This exists because the alternative is a FALSE CLEARANCE.
     /// `check_input_subsets`/`check_output_subsets` return `None` — "no
@@ -158,19 +163,48 @@ fn throughput_tier_from(
     mx2a: &Option<Mx2Counterexample>,
     mx2b: &Option<Mx2Counterexample>,
 ) -> ThroughputTier {
-    if m > SUBSET_ENUM_MAX || n > SUBSET_ENUM_MAX {
-        ThroughputTier::Unknown
-    } else if mx2a.is_some() {
-        ThroughputTier::Limited
-    } else if mx2b.is_some() {
-        ThroughputTier::BalancedRate
-    } else {
-        ThroughputTier::Unlimited
+    // PER-SIDE, not "either dimension is over the bound" (#662 round 3). The
+    // input check enumerates subsets of the m inputs and the output check of
+    // the n outputs, so they go out of range independently. Gating on either
+    // discarded evidence that had actually been computed: for m <= MAX with a
+    // real input counterexample the verdict is definitively Limited, however
+    // large n is, and reporting Unknown there contradicted `class` — which
+    // says ThroughputLimited on the same object — while the docstring
+    // claimed "neither Menger check ran".
+    let input_ran = m <= SUBSET_ENUM_MAX;
+    let output_ran = n <= SUBSET_ENUM_MAX;
+
+    // A found counterexample is positive evidence and settles it outright.
+    if input_ran && mx2a.is_some() {
+        return ThroughputTier::Limited;
     }
+    // A clean input check is only meaningful if it RAN; `None` from a bailed
+    // check is "not searched", not "searched and found nothing".
+    if !input_ran {
+        return ThroughputTier::Unknown;
+    }
+    if output_ran && mx2b.is_some() {
+        return ThroughputTier::BalancedRate;
+    }
+    if !output_ran {
+        return ThroughputTier::Unknown;
+    }
+    ThroughputTier::Unlimited
 }
 
 #[derive(Debug, Clone)]
 pub enum ClassifyError {
+    /// The graph is too large for the Menger subset enumeration, so no
+    /// throughput verdict is available — and `BalancerClass`'s throughput
+    /// arms would otherwise assert one anyway (#662 round 3).
+    ///
+    /// This is deliberately an ERROR and not a quiet `ThroughputUnlimited`:
+    /// `balancer_generate` and `import_balancer` gate on `class`, so a
+    /// silent optimistic answer here is a false clearance that ships a
+    /// template nothing verified. A caller that only wants the composition
+    /// (which IS computed for such graphs) can use `throughput_tier`, which
+    /// reports `Unknown` rather than failing.
+    Unanalysable { m: usize, n: usize, bound: usize },
     /// Belt walk fell off the template footprint.
     DanglingBelt { from: (i32, i32) },
     /// Underground-belt input has no matching output downstream.
@@ -472,6 +506,19 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
             throughput,
             composition,
             mx2_counterexample: mx2a_counterexample,
+        });
+    }
+
+    // Past this point every remaining `class` arm asserts a THROUGHPUT
+    // property, and if the checks could not run there is nothing behind the
+    // assertion. `Balanced` above is exempt on purpose: it is a composition
+    // verdict, computed independently of the subset checks, and is sound for
+    // a graph of any size.
+    if throughput == ThroughputTier::Unknown {
+        return Err(ClassifyError::Unanalysable {
+            m,
+            n,
+            bound: SUBSET_ENUM_MAX,
         });
     }
 
@@ -1068,6 +1115,12 @@ mod tests {
                 Err(ClassifyError::Overlap { .. }) => overlap += 1,
                 Err(ClassifyError::Malformed(_)) => malformed += 1,
                 Err(ClassifyError::Singular) => singular += 1,
+                // No registered template reaches the enumeration bound
+                // (registry maxes at (10,10)); if one ever does, this must be
+                // a deliberate decision rather than a quiet miscount.
+                Err(ClassifyError::Unanalysable { m, n, bound }) => {
+                    panic!("registered template ({m},{n}) exceeds the subset bound {bound}")
+                }
             }
         }
         assert!(ok > 0, "no templates classified");
@@ -1271,27 +1324,34 @@ mod tests {
         );
     }
 
-    /// An oversized graph must report `Unknown` on BOTH public surfaces.
-    ///
-    /// This is the test the first version of the change was missing, and its
-    /// absence hid a real defect: the bound guard had been put in
-    /// `throughput_tier()` — which has no callers — while `classify_graph`,
-    /// the path everything actually uses, computed the tier inline without
-    /// it. So the false clearance was still being emitted, and the two
-    /// surfaces disagreed for the same graph.
-    #[test]
-    fn oversized_graphs_report_unknown_on_both_surfaces() {
-        // 17 straight-through belts: past SUBSET_ENUM_MAX, and well-formed
-        // enough for the composition solve (it is the identity).
-        let k = SUBSET_ENUM_MAX + 1;
-        let graph = SplitterGraph {
-            n_inputs: k,
-            n_outputs: k,
+    /// Build a straight-through `(m, n)` identity-ish graph of the given
+    /// dimensions: enough structure for the composition solve, with the
+    /// dimensions the subset checks actually gate on.
+    fn straight_through(m: usize, n: usize) -> SplitterGraph {
+        let k = m.min(n);
+        SplitterGraph {
+            n_inputs: m,
+            n_outputs: n,
             n_splitters: 0,
             edges: (0..k)
                 .map(|i| (NodeId::InputPort(i), NodeId::OutputPort(i)))
                 .collect(),
-        };
+        }
+    }
+
+    /// An oversized graph must not be handed an optimistic throughput verdict
+    /// on EITHER surface.
+    ///
+    /// This is the test the first version of the change was missing, and its
+    /// absence hid a real defect twice over: the bound guard first went into
+    /// `throughput_tier()` — which has no callers — while `classify_graph`
+    /// computed the tier inline without it; and then `class` kept asserting a
+    /// throughput property even once `.throughput` said `Unknown`, which is
+    /// the surface `balancer_generate` and `import_balancer` actually gate on.
+    #[test]
+    fn oversized_graphs_are_never_falsely_cleared() {
+        let k = SUBSET_ENUM_MAX + 1;
+        let graph = straight_through(k, k);
 
         assert_eq!(
             throughput_tier(&graph),
@@ -1299,22 +1359,55 @@ mod tests {
             "free function must not certify an unanalysed graph"
         );
 
-        let report = classify_graph(&graph).expect("identity graph classifies");
-        assert_eq!(
-            report.throughput,
-            ThroughputTier::Unknown,
-            "classify_graph is the path import_balancer/balancer_generate use — \
-             it must not report Unlimited for a graph no subset check ran on"
-        );
-
-        // ...and the two must agree, which is the property that failed before.
-        assert_eq!(report.throughput, throughput_tier(&graph));
+        // `class` must REFUSE rather than answer, because every remaining arm
+        // asserts a throughput property nothing verified.
+        match classify_graph(&graph) {
+            Err(ClassifyError::Unanalysable { m, n, bound }) => {
+                assert_eq!((m, n, bound), (k, k, SUBSET_ENUM_MAX));
+            }
+            other => panic!("expected Unanalysable, got {other:?}"),
+        }
     }
 
-    /// A Balanced template that is NOT throughput-unlimited must carry its
-    /// witness — the two axes are reported separately precisely so that
-    /// combination is expressible, and a verdict with its evidence dropped
-    /// is what the #662 review caught on the `is_mx3` return path.
+    /// The bound is PER-SIDE. An input check that ran and found a
+    /// counterexample is definitive however large the other side is, and
+    /// must not be thrown away as `Unknown`.
+    #[test]
+    fn the_enumeration_bound_is_per_side() {
+        // m within bound and a real input counterexample, n far outside it.
+        let mx2a = Some(Mx2Counterexample {
+            direction: Mx2Direction::InputSubset,
+            subset: vec![0],
+            realized: 0,
+            expected: 1,
+        });
+        assert_eq!(
+            throughput_tier_from(2, SUBSET_ENUM_MAX + 5, &mx2a, &None),
+            ThroughputTier::Limited,
+            "an input counterexample is evidence, whatever n is"
+        );
+
+        // No input evidence and the input side is out of range: genuinely
+        // unknown, regardless of what the output side would say.
+        assert_eq!(
+            throughput_tier_from(SUBSET_ENUM_MAX + 1, 2, &None, &None),
+            ThroughputTier::Unknown
+        );
+
+        // Input clean and in range, output side out of range: the clean
+        // input result cannot upgrade to Unlimited on its own.
+        assert_eq!(
+            throughput_tier_from(2, SUBSET_ENUM_MAX + 1, &None, &None),
+            ThroughputTier::Unknown
+        );
+
+        // Both in range and clean: the only case that earns Unlimited.
+        assert_eq!(
+            throughput_tier_from(2, 2, &None, &None),
+            ThroughputTier::Unlimited
+        );
+    }
+
     #[test]
     fn balanced_but_limited_templates_keep_their_counterexample() {
         let mut checked = 0usize;

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -145,7 +145,7 @@ pub enum ThroughputTier {
 /// registered (#662 round 6: "maxes at (10,10)" read as a shape when it was
 /// only a per-axis maximum); the
 /// bound exists for arbitrary imported graphs.
-const SUBSET_ENUM_MAX: usize = 16;
+pub const SUBSET_ENUM_MAX: usize = 16;
 
 /// The throughput tier of a graph, computed without reference to its
 /// composition matrix — so it is available even for templates whose
@@ -1529,6 +1529,34 @@ mod tests {
                 r.class, r.throughput
             ),
             Err(e) => panic!("unexpected error: {e:?}"),
+        }
+    }
+
+    /// The two public surfaces must agree on an OVERSIZED graph, not just
+    /// an in-bound one.
+    ///
+    /// `both_surfaces_agree_when_only_one_side_is_oversized` exercises the
+    /// in-bound/Limited path, and the `Unknown`-refusal test exercises
+    /// `classify_graph` alone. Neither pins the mapping BETWEEN them on the
+    /// out-of-bound path (#662 review) — which is exactly where rounds 2
+    /// and 3 found them drifted apart, with the bound guard living in one
+    /// surface and not the other.
+    #[test]
+    fn the_two_surfaces_agree_on_an_oversized_graph() {
+        let k = SUBSET_ENUM_MAX + 1;
+        for graph in [all_into_one(k), straight_through(k, k)] {
+            assert_eq!(
+                throughput_tier(&graph),
+                ThroughputTier::Unknown,
+                "the free function must report the tier as unmeasured"
+            );
+            assert!(
+                matches!(
+                    classify_graph(&graph),
+                    Err(ClassifyError::Unanalysable { bound, .. }) if bound == SUBSET_ENUM_MAX
+                ),
+                "and classify_graph must refuse the same graph, not issue a class"
+            );
         }
     }
 

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -77,15 +77,19 @@ pub enum BalancerClass {
 /// Menger subset checks ever run, and can never be labelled TU no matter
 /// how good it is.
 ///
-/// That is not a hypothetical: measured 2026-08-19 across the 68
-/// registered templates, 66 classify `Balanced` and the registry contains
-/// **zero** templates certified `ThroughputUnlimited` — including every
-/// shape whose provenance advertises "Raynquist (TU)".
+/// That is not a hypothetical: before this split, across the 64 registered
+/// templates the registry contained **zero** certified
+/// `ThroughputUnlimited` — including every shape whose provenance
+/// advertises "Raynquist (TU)". Not a fact about the library: the balanced
+/// test returned before the throughput checks ran.
 ///
 /// Balance and throughput are independent properties: a template can mix
 /// every input into every output in equal proportion (MX3) and still fail
-/// to reroute around a blocked output subset (not MX2b). This enum
-/// reports the throughput axis on its own, and is always computed.
+/// to reroute around a blocked output subset (not MX2b). This enum reports
+/// the throughput axis on its own.
+///
+/// It is computed for every graph within the subset-enumeration bound and
+/// reports [`ThroughputTier::Unknown`] outside it — see that variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ThroughputTier {
     /// MX1 — some input subset cannot achieve `min(|S|, n)` flow.
@@ -96,13 +100,43 @@ pub enum ThroughputTier {
     /// MX2b — full max-flow over input *and* output subsets. The real
     /// "throughput-unlimited" property.
     Unlimited,
+    /// Not analysed: the graph exceeds the subset-enumeration bound of 16
+    /// inputs or outputs, so neither Menger check ran (#662 review).
+    ///
+    /// This exists because the alternative is a FALSE CLEARANCE.
+    /// `check_input_subsets`/`check_output_subsets` return `None` — "no
+    /// counterexample" — when they bail on size, which is indistinguishable
+    /// from having searched and found nothing, so a 20-input community
+    /// balancer would report `Unlimited` without a single subset being
+    /// tested. No library template reaches this (the registry maxes at
+    /// (10,10)), but `throughput_tier` is public and `import_balancer` can
+    /// be pointed at anything.
+    ///
+    /// NOTE the deliberate divergence: [`BalancerClass`] still returns its
+    /// pre-existing optimistic answer for such graphs. That overclaim is
+    /// older than this enum and fixing it would move `class` for real
+    /// inputs, which this change is specifically avoiding; it is recorded
+    /// here rather than silently inherited by the new axis.
+    Unknown,
 }
+
+/// Largest input/output count the Menger subset checks will enumerate.
+/// Both walk every subset (`2^k` masks over a `u64`), so this bounds work
+/// and keeps the shift well-defined. The registry maxes at (10,10); the
+/// bound exists for arbitrary imported graphs.
+const SUBSET_ENUM_MAX: usize = 16;
 
 /// The throughput tier of a graph, computed without reference to its
 /// composition matrix — so it is available even for templates whose
 /// composition solve is [`ClassifyError::Singular`].
 pub fn throughput_tier(graph: &SplitterGraph) -> ThroughputTier {
     let (m, n) = (graph.n_inputs, graph.n_outputs);
+    // Bound check FIRST. Both helpers return `None` when they bail on size,
+    // which reads identically to "searched, found nothing" — so asking them
+    // about an oversized graph and believing the answer is a false clearance.
+    if m > SUBSET_ENUM_MAX || n > SUBSET_ENUM_MAX {
+        return ThroughputTier::Unknown;
+    }
     if check_input_subsets(graph, m, n).is_some() {
         ThroughputTier::Limited
     } else if check_output_subsets(graph, m, n).is_some() {
@@ -395,7 +429,14 @@ pub fn classify_graph(graph: &SplitterGraph) -> Result<ClassificationReport, Cla
             class: BalancerClass::Balanced,
             throughput,
             composition,
-            mx2_counterexample: None,
+            // NOT `None` (#662 review, 3/3). A Balanced template can still be
+            // throughput-Limited — that is the whole point of reporting the
+            // two axes separately — and when it is, the failing subset was
+            // already computed in this same invocation. Returning `None` here
+            // handed the caller a verdict with its evidence thrown away.
+            // `mx2a` is the input-side witness and takes precedence, matching
+            // the ThroughputLimited arm below.
+            mx2_counterexample: mx2a_counterexample.or(mx2b_counterexample),
         });
     }
 
@@ -869,7 +910,7 @@ fn check_input_subsets(
     m: usize,
     n: usize,
 ) -> Option<Mx2Counterexample> {
-    if m > 16 {
+    if m > SUBSET_ENUM_MAX {
         return None;
     }
     let (base, inputs, outputs) = build_flow_graph(graph);
@@ -895,7 +936,7 @@ fn check_output_subsets(
     m: usize,
     n: usize,
 ) -> Option<Mx2Counterexample> {
-    if n > 16 {
+    if n > SUBSET_ENUM_MAX {
         return None;
     }
     let (base, inputs, outputs) = build_flow_graph(graph);
@@ -1150,6 +1191,84 @@ mod tests {
     /// fixes it should empty this list (the second assert forces that
     /// bookkeeping), and a field failure implicating the shape reopens
     /// the issue.
+    /// The throughput axis, pinned (#662 review, 3/3 — it had zero tests
+    /// and zero consumers, so a regression re-introducing the early return
+    /// this change removes would have passed the whole suite).
+    ///
+    /// Pins the DISTRIBUTION rather than a per-shape list: the point of the
+    /// fix is that the tier is actually computed, and the sharpest evidence
+    /// of that is a non-degenerate spread. Before the fix this test could
+    /// not have been written — every template answered `Limited`, because
+    /// the balanced test returned first.
+    #[test]
+    fn throughput_tier_is_actually_computed() {
+        let mut limited = 0usize;
+        let mut balanced_rate = 0usize;
+        let mut unlimited = 0usize;
+        let mut unknown = 0usize;
+        for (_, t) in balancer_templates() {
+            let Ok(r) = classify(t) else { continue };
+            match r.throughput {
+                ThroughputTier::Limited => limited += 1,
+                ThroughputTier::BalancedRate => balanced_rate += 1,
+                ThroughputTier::Unlimited => unlimited += 1,
+                ThroughputTier::Unknown => unknown += 1,
+            }
+        }
+
+        // The regression this guards: if `classify_graph` ever returns before
+        // the Menger checks again, `unlimited` collapses to 0.
+        assert!(
+            unlimited > 0,
+            "no template certified ThroughputUnlimited — the throughput \
+             checks are being skipped again (that was the bug: the MX3 \
+             balanced test returned before they ran)"
+        );
+        // ...and the converse: a tier that answers `Unlimited` for everything
+        // is equally uninformative, so pin that the axis discriminates.
+        assert!(
+            limited > 0 && balanced_rate > 0,
+            "throughput tier is not discriminating: limited={limited}, \
+             balanced_rate={balanced_rate}, unlimited={unlimited} — a tier \
+             that gives every template the same answer is not measuring \
+             anything"
+        );
+        // No registered template exceeds the enumeration bound; if one ever
+        // does, its tier is Unknown and that must be a deliberate decision
+        // rather than a silent false clearance.
+        assert_eq!(
+            unknown, 0,
+            "a registered template exceeds SUBSET_ENUM_MAX ({SUBSET_ENUM_MAX}) \
+             and its throughput is unanalysed"
+        );
+    }
+
+    /// A Balanced template that is NOT throughput-unlimited must carry its
+    /// witness — the two axes are reported separately precisely so that
+    /// combination is expressible, and a verdict with its evidence dropped
+    /// is what the #662 review caught on the `is_mx3` return path.
+    #[test]
+    fn balanced_but_limited_templates_keep_their_counterexample() {
+        let mut checked = 0usize;
+        for ((m, n), t) in balancer_templates() {
+            let Ok(r) = classify(t) else { continue };
+            if r.class == BalancerClass::Balanced && r.throughput != ThroughputTier::Unlimited {
+                assert!(
+                    r.mx2_counterexample.is_some(),
+                    "({m},{n}) is Balanced/{:?} but reports no failing subset — \
+                     the counterexample was computed and then discarded",
+                    r.throughput
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked > 0,
+            "no Balanced-but-not-Unlimited template in the registry — this \
+             test stopped covering anything"
+        );
+    }
+
     #[test]
     fn known_throughput_limited_shapes_are_pinned() {
         const KNOWN_THROUGHPUT_LIMITED: [(u32, u32); 1] = [(5, 8)];

--- a/crates/core/src/bus/balancer_classify.rs
+++ b/crates/core/src/bus/balancer_classify.rs
@@ -136,9 +136,16 @@ const SUBSET_ENUM_MAX: usize = 16;
 /// composition solve is [`ClassifyError::Singular`].
 pub fn throughput_tier(graph: &SplitterGraph) -> ThroughputTier {
     let (m, n) = (graph.n_inputs, graph.n_outputs);
-    if m > SUBSET_ENUM_MAX || n > SUBSET_ENUM_MAX {
-        return ThroughputTier::Unknown;
-    }
+    // NO early return here (#664-era round 4). An `||` gate used to sit above
+    // this and short-circuit before the delegation below — so the per-side
+    // semantics lived in `throughput_tier_from` while this surface still
+    // answered `Unknown` whenever EITHER side was oversized, and the two
+    // public surfaces disagreed on the same graph. The comment claiming they
+    // "cannot drift" was false precisely because of that gate.
+    //
+    // Both subset helpers bail cheaply on size and return `None`, so calling
+    // them unconditionally costs nothing; `throughput_tier_from` is the one
+    // place that decides what a `None` means on each side.
     let mx2a = check_input_subsets(graph, m, n);
     let mx2b = if mx2a.is_none() {
         check_output_subsets(graph, m, n)
@@ -1367,6 +1374,47 @@ mod tests {
             }
             other => panic!("expected Unanalysable, got {other:?}"),
         }
+    }
+
+    /// The two public surfaces must agree on an ASYMMETRIC graph — the case
+    /// that exposed the `||` gate in `throughput_tier`, which the previous
+    /// per-side test missed by calling `throughput_tier_from` directly and
+    /// never the free function.
+    #[test]
+    fn both_surfaces_agree_when_only_one_side_is_oversized() {
+        let n_big = SUBSET_ENUM_MAX + 4;
+        // m within bound, n far outside it, AND a genuine input-side
+        // counterexample: both inputs funnel into output 0, so subset {0,1}
+        // cannot achieve min(2, n) = 2.
+        //
+        // The counterexample is the whole point. A straight-through graph
+        // here proves nothing — both surfaces answer `Unknown` for the
+        // output side and agree trivially, which is how the first version of
+        // this test passed with the `||` gate still in place. Positive
+        // evidence on the IN-BOUND side is what makes the gate observable:
+        // per-side semantics say `Limited`, the gate says `Unknown`.
+        let graph = SplitterGraph {
+            n_inputs: 2,
+            n_outputs: n_big,
+            n_splitters: 0,
+            edges: vec![
+                (NodeId::InputPort(0), NodeId::OutputPort(0)),
+                (NodeId::InputPort(1), NodeId::OutputPort(0)),
+            ],
+        };
+
+        assert_eq!(
+            throughput_tier(&graph),
+            ThroughputTier::Limited,
+            "an input counterexample on the in-bound side is definitive; the \
+             free function must not discard it because the OTHER side is \
+             oversized"
+        );
+        assert_eq!(
+            throughput_tier(&graph),
+            throughput_tier_from(2, n_big, &check_input_subsets(&graph, 2, n_big), &None),
+            "the free function and the shared core must not drift"
+        );
     }
 
     /// The bound is PER-SIDE. An input check that ran and found a

--- a/crates/core/src/bus/balancer_generate.rs
+++ b/crates/core/src/bus/balancer_generate.rs
@@ -747,15 +747,27 @@ mod service_boundary {
     /// Note the review named exactly these three (20->10, 18->9, 24->12) as
     /// the service worth keeping; they are the ones worth losing.
     ///
-    /// GENUINELY lost (24) — the n>m fan-outs (9,18)..(16,32) and the
-    /// squares (17,17)..(32,32). Their in-bound siblings ARE served, so
-    /// these are real shapes we can no longer stamp. Not repaired here: no
-    /// layout requests them. A census of all 51 corpus snapshots tops out
-    /// at (10,14) / (3,14) — nothing reaches 16 on either side. Refusing an
-    /// unverifiable shape is also the conservative direction, and
-    /// `FamilyStampPlan::Unresolvable` is an already-live state (4 corpus
-    /// shapes sit in it today). Tracked in #667, which also records why the
-    /// cheap fix (verify the atom, infer the replica) does NOT work: MX2's
+    /// Lost from THIS API only (24) — the n>m fan-outs (9,18)..(16,32) and
+    /// the squares (17,17)..(32,32). An earlier version of this note called
+    /// them "genuinely lost" shapes the pipeline can no longer stamp. That
+    /// was wrong, and the #662 review caught it: `generate` is the FOURTH
+    /// step of `family_stamp_plan`, not the first, so most of these never
+    /// reach it. Resolved against the live registry:
+    ///
+    ///   (9,18)..(16,32)   -> Decomposed g=m sub=(1,2)   [never reaches generate]
+    ///   (17,17)..(32,32)  -> Passthrough                [early return, or the tail]
+    ///   (18,9)..(32,16)   -> generate -> None -> Unresolvable
+    ///
+    /// So the only shapes whose PIPELINE outcome this guard changes are the
+    /// eight merges — the eight that were falsely cleared. Squares reach
+    /// `FamilyStampPlan::Passthrough` either through the early return or
+    /// through the tail (`is_passthrough_shape` is `n == m && n >= 2`), and
+    /// what `generate` used to hand them was `passthrough(m)`: the same
+    /// construct. The service loss measured in rounds 6-7 is real for this
+    /// function's contract and near-nil for the layout.
+    ///
+    /// Tracked in #667, corrected to match. It also records why the cheap
+    /// fix (verify the atom, infer the replica) does NOT work: MX2's
     /// expected value is `min(|S|, n)` with a GLOBAL `n`, so it does not
     /// decompose over disjoint components.
     ///

--- a/crates/core/src/bus/balancer_generate.rs
+++ b/crates/core/src/bus/balancer_generate.rs
@@ -705,3 +705,91 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod service_boundary {
+    /// Which `(m, n)` the generator will actually serve, pinned exactly.
+    ///
+    /// `generate` self-verifies with `classify_ref(..).ok()?`, so the
+    /// `SUBSET_ENUM_MAX` refusal added in #662 silently narrows this set:
+    /// a shape whose side exceeds the bound now classifies as
+    /// `Unanalysable` and is dropped to `None`. The #662 review called that
+    /// a regression; measuring it splits the loss in two, and only one half
+    /// is one.
+    ///
+    /// Enumerated over `1..=32` squared, the set went 56 -> 24 shapes.
+    ///
+    /// CORRECT to lose (8) — the m>n merges (18,9) (20,10) (22,11) (24,12)
+    /// (26,13) (28,14) (30,15) (32,16). Every in-bound merge sibling —
+    /// (4,2), (6,3), ... (16,8) — is ALREADY refused as throughput-limited,
+    /// and rightly: `replicate_horizontally(two_to_one, k)` gives k disjoint
+    /// components, so a subset taking both inputs of one component can only
+    /// realize 1 unit against an expected `min(|S|, n)` of 2. The large ones
+    /// were served solely because `check_input_subsets` bails to `None`
+    /// above the bound. That is the false clearance this PR exists to stop.
+    /// Note the review named exactly these three (20->10, 18->9, 24->12) as
+    /// the service worth keeping; they are the ones worth losing.
+    ///
+    /// GENUINELY lost (24) — the n>m fan-outs (9,18)..(16,32) and the
+    /// squares (17,17)..(32,32). Their in-bound siblings ARE served, so
+    /// these are real shapes we can no longer stamp. Not repaired here: no
+    /// layout requests them. A census of all 51 corpus snapshots tops out
+    /// at (10,14) / (3,14) — nothing reaches 16 on either side. Refusing an
+    /// unverifiable shape is also the conservative direction, and
+    /// `FamilyStampPlan::Unresolvable` is an already-live state (4 corpus
+    /// shapes sit in it today). Tracked in #667, which also records why the
+    /// cheap fix (verify the atom, infer the replica) does NOT work: MX2's
+    /// expected value is `min(|S|, n)` with a GLOBAL `n`, so it does not
+    /// decompose over disjoint components.
+    ///
+    /// This test exists so that boundary is a pinned fact rather than an
+    /// emergent one — the previous change to it was invisible until a
+    /// reviewer went looking.
+    #[test]
+    fn generate_serves_exactly_these_shapes() {
+        let mut served = Vec::new();
+        for m in 1u32..=32 {
+            for n in 1u32..=32 {
+                if super::generate(m, n).is_some() {
+                    served.push((m, n));
+                }
+            }
+        }
+
+        let expected: Vec<(u32, u32)> = vec![
+            (1, 2),
+            (2, 1),
+            (2, 2),
+            (2, 4),
+            (3, 3),
+            (3, 6),
+            (4, 4),
+            (4, 8),
+            (5, 5),
+            (5, 10),
+            (6, 6),
+            (6, 12),
+            (7, 7),
+            (7, 14),
+            (8, 8),
+            (8, 16),
+            (9, 9),
+            (10, 10),
+            (11, 11),
+            (12, 12),
+            (13, 13),
+            (14, 14),
+            (15, 15),
+            (16, 16),
+        ];
+        assert_eq!(served, expected);
+
+        // The bound is what makes this set finite: nothing above it is
+        // served, on either side.
+        assert!(
+            served.iter().all(|&(m, n)| m <= 16 && n <= 16),
+            "a shape beyond SUBSET_ENUM_MAX was served, so it was cleared \
+             without a subset check ever running"
+        );
+    }
+}

--- a/crates/core/src/bus/balancer_generate.rs
+++ b/crates/core/src/bus/balancer_generate.rs
@@ -12,7 +12,7 @@
 //! returned. A generator bug that produces an MX1 layout fails loudly
 //! (panics in tests; logs in release).
 
-use crate::bus::balancer_classify::{classify_ref, BalancerClass, BalancerTemplateRef};
+use crate::bus::balancer_classify::{classify_ref, BalancerClass, BalancerTemplateRef, ThroughputTier};
 use crate::bus::balancer_library::BalancerTemplateEntity;
 use crate::models::PlacedEntity;
 
@@ -107,6 +107,16 @@ pub fn generate(m: u32, n: u32) -> Option<OwnedTemplate> {
     // Self-verify. A generator bug that yields anything weaker than the
     // intended class is unacceptable.
     let report = classify_ref(candidate.as_ref()).ok()?;
+
+    // Gate on BOTH axes (#662 round 6, 3/3). Gating on `class` alone
+    // reintroduces the conflation this PR exists to remove: `Balanced` is a
+    // COMPOSITION verdict, and a Balanced template can still be
+    // throughput-`Limited` — that is precisely why the two are reported
+    // separately now. Latent today, because only Unlimited atoms reach the
+    // Balanced arm, but "latent" is how the last three defects here started.
+    if report.throughput == ThroughputTier::Limited {
+        return None;
+    }
     match report.class {
         BalancerClass::Balanced
         | BalancerClass::ThroughputUnlimited
@@ -745,6 +755,40 @@ mod service_boundary {
     /// This test exists so that boundary is a pinned fact rather than an
     /// emergent one — the previous change to it was invisible until a
     /// reviewer went looking.
+    /// Why the new `throughput != Limited` gate is latent, asserted rather
+    /// than assumed.
+    ///
+    /// The review's point was that gating on `class` alone would accept a
+    /// `Balanced`-but-`Limited` candidate. That cannot happen today, and
+    /// this is the reason: every shape the generator actually serves
+    /// classifies throughput-clean. If a future atom breaks that, this test
+    /// fails and says so, instead of the gate quietly becoming load-bearing
+    /// in production with no coverage.
+    #[test]
+    fn every_served_shape_is_throughput_clean() {
+        use crate::bus::balancer_classify::{classify_ref, ThroughputTier};
+
+        let mut checked = 0;
+        for m in 1u32..=16 {
+            for n in 1u32..=16 {
+                let Some(tpl) = super::generate(m, n) else { continue };
+                let report = classify_ref(tpl.as_ref()).expect("served shape classifies");
+                assert_ne!(
+                    report.throughput,
+                    ThroughputTier::Limited,
+                    "({m}, {n}) is served but throughput-limited"
+                );
+                assert_ne!(
+                    report.throughput,
+                    ThroughputTier::Unknown,
+                    "({m}, {n}) is served without its throughput ever being measured"
+                );
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 24, "the served set changed; see the boundary test");
+    }
+
     #[test]
     fn generate_serves_exactly_these_shapes() {
         let mut served = Vec::new();

--- a/crates/core/src/bus/balancer_generate.rs
+++ b/crates/core/src/bus/balancer_generate.rs
@@ -108,6 +108,13 @@ pub fn generate(m: u32, n: u32) -> Option<OwnedTemplate> {
     // intended class is unacceptable.
     let report = classify_ref(candidate.as_ref()).ok()?;
 
+    // NOTE the asymmetry with the LIBRARY path, which is the primary one:
+    // `balancer.rs` never calls `classify` at all, so `Direct` and
+    // `Decomposed` stamps select on shape alone and this gate does not
+    // apply to them. The registry holds exactly one throughput-limited
+    // shape today, (5,8). Pre-existing, not introduced here, but #662 is
+    // what made it visible — tracked in #669.
+    //
     // Gate on BOTH axes (#662 round 6, 3/3). Gating on `class` alone
     // reintroduces the conflation this PR exists to remove: `Balanced` is a
     // COMPOSITION verdict, and a Balanced template can still be
@@ -758,6 +765,13 @@ mod service_boundary {
     /// Why the new `throughput != Limited` gate is latent, asserted rather
     /// than assumed.
     ///
+    /// NOTE the exact invariant, which is weaker than "clean" (#662 review):
+    /// `BalancedRate` shapes such as (6,12) and (8,16) ARE served and pass
+    /// here. That is deliberate — MX2a is the bus target — but an MX2a
+    /// balancer does fall short on the output-subset max-flow, and this
+    /// test's earlier name implied full MX2b. What is pinned is "measured,
+    /// and not Limited", which is what the gate checks.
+    ///
     /// The review's point was that gating on `class` alone would accept a
     /// `Balanced`-but-`Limited` candidate. That cannot happen today, and
     /// this is the reason: every shape the generator actually serves
@@ -765,7 +779,7 @@ mod service_boundary {
     /// fails and says so, instead of the gate quietly becoming load-bearing
     /// in production with no coverage.
     #[test]
-    fn every_served_shape_is_throughput_clean() {
+    fn every_served_shape_has_a_measured_non_limited_tier() {
         use crate::bus::balancer_classify::{classify_ref, ThroughputTier};
 
         let mut checked = 0;

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -790,27 +790,51 @@ fn assert_round_trip(result: &E2EResult) {
 /// web app accepts arbitrary rates, so a shape crossing the bound would ship
 /// as silent under-delivery.
 ///
-/// This is that census, executed, on every corpus layout the suite already
-/// builds — which is both broader and free, versus a standalone test
-/// rebuilding a hand-picked handful.
+/// This runs on every corpus layout the suite already builds — broader and
+/// free, versus a standalone test rebuilding a hand-picked handful.
+///
+/// Be precise about what it is worth. On today's corpus it is INERT: the
+/// widest requested side is 8 against a bound of 16, and nothing trips it.
+/// That makes it a tripwire for future corpus growth, not evidence that the
+/// bound is correctly placed — and calling it the latter would be the
+/// "a check going quiet is not evidence" mistake in CLAUDE.md. What it does
+/// buy is that the failure mode becomes a named test failure at the moment a
+/// layout first crosses the bound, instead of under-delivery nobody
+/// attributes.
 fn assert_balancer_shapes_are_verifiable(test_name: &str, events: &[TraceEvent]) {
     use spaghettio_core::bus::balancer_classify::SUBSET_ENUM_MAX;
 
-    let over: Vec<(usize, usize)> = events
+    // Oversized AND unstamped, not merely oversized (#662 round 9, 3/3).
+    // The first version flagged every shape with a side > the bound, on the
+    // premise that classify refusing it means nothing gets stamped. That
+    // premise is false, and my own round-9 correction is what showed it:
+    // `generate` is the FOURTH step of `family_stamp_plan`, so a square
+    // >= 17 is served by `Passthrough` and a fan-out (9,18)..(16,32) by
+    // `Decomposed { sub: (1,2) }` — both stamp successfully and neither
+    // consults `generate` at all. Flagging those would have failed the suite
+    // on legitimate corpus growth.
+    //
+    // `template_found: false` alone is not the condition either: four corpus
+    // shapes sit there today for unrelated reasons ((3,14), (4,9), (10,14),
+    // (11,10)). The regression this guards is the CONJUNCTION — a shape the
+    // classifier cannot verify AND which consequently did not stamp.
+    let unstamped_oversized: Vec<(usize, usize)> = events
         .iter()
         .filter_map(|e| match e {
-            TraceEvent::BalancerStamped { shape, .. } => Some(*shape),
+            TraceEvent::BalancerStamped { shape, template_found, .. } => {
+                (!template_found).then_some(*shape)
+            }
             _ => None,
         })
         .filter(|(m, n)| *m > SUBSET_ENUM_MAX || *n > SUBSET_ENUM_MAX)
         .collect();
 
     assert!(
-        over.is_empty(),
-        "{test_name}: requested balancer shapes {over:?} exceed SUBSET_ENUM_MAX \
-         ({SUBSET_ENUM_MAX}), which classify refuses — so nothing is stamped and \
-         this layout silently under-delivers. Either the shape is wrong, or the \
-         bound now has to buy its keep (see #667)."
+        unstamped_oversized.is_empty(),
+        "{test_name}: balancer shapes {unstamped_oversized:?} exceed SUBSET_ENUM_MAX \
+         ({SUBSET_ENUM_MAX}), which classify refuses, AND did not stamp — so this \
+         layout silently under-delivers. Either the shape is wrong, or the bound \
+         now has to buy its keep (see #667)."
     );
 }
 

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -385,6 +385,8 @@ fn run_e2e_inner(
     // can read them without the RAII guard wiping them on drop.
     let trace_events = trace::drain_events();
 
+    assert_balancer_shapes_are_verifiable(test_name, &trace_events);
+
     // Layout size + density (1:1 square) report — mirrors the
     // `Layout: N entities, WxH` style already used in diagnostic/stress tests,
     // and prints for every tier test so the pack-efficiency distribution is
@@ -769,6 +771,48 @@ fn assert_round_trip(result: &E2EResult) {
 // ghost routing. `tier2_electronic_circuit_splitter_stamp_regression` was
 // also one until RFC-047 Leg B turned its config into a named refusal (it
 // now guards that refusal instead — see its doc comment).
+
+
+/// Every balancer a real layout asks for must be small enough to VERIFY.
+///
+/// #662 made `classify_graph` refuse a graph whose side exceeds
+/// `SUBSET_ENUM_MAX`, because the Menger subset checks bail above that bound
+/// and reporting "no counterexample" for a search that never ran is a false
+/// clearance. `balancer_generate::generate` self-verifies through
+/// `classify_ref(..).ok()?`, so that refusal also removes the shape from
+/// SERVICE: `family_stamp_plan` falls through to
+/// `FamilyStampPlan::Unresolvable`, which stamps nothing. The failure is
+/// under-delivery, not a build error — so nothing would tell us.
+///
+/// The PR justified that trade with an offline census of `.fls` snapshots.
+/// The #662 review's objection (3/3) was that the justification was prose:
+/// nothing re-ran the census, snapshots are untracked build output, and the
+/// web app accepts arbitrary rates, so a shape crossing the bound would ship
+/// as silent under-delivery.
+///
+/// This is that census, executed, on every corpus layout the suite already
+/// builds — which is both broader and free, versus a standalone test
+/// rebuilding a hand-picked handful.
+fn assert_balancer_shapes_are_verifiable(test_name: &str, events: &[TraceEvent]) {
+    use spaghettio_core::bus::balancer_classify::SUBSET_ENUM_MAX;
+
+    let over: Vec<(usize, usize)> = events
+        .iter()
+        .filter_map(|e| match e {
+            TraceEvent::BalancerStamped { shape, .. } => Some(*shape),
+            _ => None,
+        })
+        .filter(|(m, n)| *m > SUBSET_ENUM_MAX || *n > SUBSET_ENUM_MAX)
+        .collect();
+
+    assert!(
+        over.is_empty(),
+        "{test_name}: requested balancer shapes {over:?} exceed SUBSET_ENUM_MAX \
+         ({SUBSET_ENUM_MAX}), which classify refuses — so nothing is stamped and \
+         this layout silently under-delivers. Either the shape is wrong, or the \
+         bound now has to buy its keep (see #667)."
+    );
+}
 
 #[test]
 #[ntest::timeout(10000)]


### PR DESCRIPTION
## Intent

`classify_graph` short-circuited on the MX3 balanced test and returned *before*
either Menger check ran, so a balanced template never reached the throughput
analysis. `ThroughputUnlimited` was therefore unreachable in practice: the census
certified **0 of 64** templates as throughput-unlimited. That was not a fact
about the library — it was the early return.

## Scope

- **In:** `ThroughputTier {Limited, BalancedRate, Unlimited}` reported on
  `ClassificationReport`. The two subset checks now run before the balanced test
  and are reused by it, so this costs no extra work.
- **Out:** nothing consumes the new field yet. Selection, stamping, and
  decomposition are untouched — this is additive reporting, deliberately, so the
  finding can be assessed before anything acts on it.
- **Out:** whether any of the 12 Balanced-but-Limited templates are actually
  corpus-consumed is *not* answered here.
- **Size:** +68/-2, one file.

## What it exposes

    class                throughput       n
    Balanced             Unlimited       36
    Balanced             Limited         12    <- previously invisible
    Balanced             BalancedRate    14
    ThroughputLimited    Limited          1    [(5,8)]
    ERR Singular         n/a              1    [(7,6)]

The 12 are the finding: perfectly balanced, and still pinching below rated
throughput on some input subset.

## Verification

- [x] `--test balancer_cross_validation --test balancer_lane_audit --test balancer_tu_audit` — 1/5/3 passed, 0 failed
- [x] `cargo test --lib classify` — 24 passed, including `known_throughput_limited_shapes_are_pinned`, `classify_smoke_each_template`, `audit_report`
- [x] `cargo clippy` via pre-commit hook — clean
- [x] Grepped for consumers of the new field outside its module: none. That plus
      the unchanged `class` pins is the evidence this is non-behavioural.
- [ ] WASM/browser — N/A
- [ ] Snapshot — N/A, no geometry change

Note on what the green pins prove: they prove `BalancerClass` is unchanged.
They do not independently validate the new tier — the census above is the
positive signal for that.

## Deviations from intent

None.

## Models / contracts touched

`ClassificationReport` gains a field. No existing field changes meaning.
`docs/validator-trust.md` not updated — no severity, category, or selection
change here.