### PR TITLE
test(ac7): the pin says what it pins — no severed connections, not "clean"

### DIFF
--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2239,9 +2239,10 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
 
 /// #652: ac7-HS at duty 0.6 (the RFC-069 flip shape) ships zero
 /// validation ERRORS. That is all it says. The fixture is NOT healthy:
-/// it sims at 64.4% of plan and pins 14 input-rate-delivery warnings —
-/// see the guard at the end of this test, which exists to stop the zero
-/// below being cited as health.
+/// it sims at 64.4% of plan and pins 14 input-rate-delivery warnings (10 of
+/// them belts reading 0.0/s, measured 2026-08-20). The NAME is what stops
+/// the zero below being cited as health; see the note at the end of this
+/// test for why an assertion is not.
 ///
 /// This pin has inverted twice and the history is the point of the
 /// comment — it is the record of what each fix actually bought:
@@ -2406,37 +2407,29 @@ fn tier4_ac7_duty06_has_no_severed_connections() {
     // so that a future reader cannot mistake the zero above for health and
     // so that anyone who genuinely fixes delivery has to come here and say
     // so deliberately rather than silently inheriting a green test.
-    let ird: Vec<&ValidationIssue> = issues
-        .iter()
-        .filter(|i| i.category == "input-rate-delivery")
-        .collect();
-    let ird_zero = ird
-        .iter()
-        .filter(|i| i.message.contains("delivers 0.0/s"))
-        .count();
-    // Pinned EXACTLY, not as `> 0` (#663 review, 3/3). A floor lets a partial
-    // regression through silently — 14 -> 2 would still "pass" while every
-    // specific claim in the comment above went stale, which is the precise
-    // failure mode docs/validator-reporting.md catalogues. Both directions
-    // trip: a fix and a worsening are equally things the comment must be
-    // re-measured for.
+    // NO ASSERT HERE, DELIBERATELY — a guard was tried twice and removed.
     //
-    // Yes, this reds CI when the deficit is FIXED. That is deliberate and is
-    // not the `committed >= 25` hazard this file rejected earlier: that was an
-    // incidental byproduct count that drifts under unrelated work. These two
-    // numbers move only when someone changes provisioning for this fixture on
-    // purpose (RFC-069 / #519), and when they do, the fixture needs
-    // re-measuring and this comment needs rewriting — which is exactly what a
-    // failure here forces.
-    assert_eq!(
-        (ird.len(), ird_zero),
-        (14, 10),
-        "ac7-HS duty-0.6 input-rate-delivery census moved — (total, at-0.0/s) \
-         is printed above; the expected pair was measured 2026-08-20 against a \
-         64.4%-of-plan sim. If this is an IMPROVEMENT that is GOOD NEWS — \
-         re-measure the fixture, rewrite the comment at the top of this test, \
-         and re-point these numbers. Do not just delete the guard."
-    );
+    // v1 pinned `ird > 0`; v2 pinned the exact census `(14, 10)`. Both red CI
+    // when the deficit IMPROVES, and the #663 review's decisive point is that
+    // they also red it when nothing about this fixture changes at all: the
+    // census is an ENGINE OUTPUT, not a property of the provisioning, so it
+    // drifts with belt stitching, inserter margins, lane-rate arbitration and
+    // the walker model. This repo has the receipt — #644's phantom-UG-source
+    // walker fix moved input-rate-delivery counts 32 -> 13 on pu2-am3 and
+    // 11 -> 7 on ac-from-ore AM2 (docs/status.md), touching no provisioning.
+    // My argument that these numbers "move only on purpose" was simply wrong.
+    //
+    // It is the same hazard this file already conceded for the `committed`
+    // floor a few hundred lines up, and conceding it there and not here would
+    // be inconsistent.
+    //
+    // The residual risk is real and accepted: a comment cannot fail, so the
+    // "NOT healthy" note above can rot. The mitigation is the test NAME —
+    // `has_no_severed_connections` cannot be cited as evidence the fixture
+    // works, which is what the old `lays_out_clean` invited and is the whole
+    // reason this test was renamed. If you want enforcement, pin the SIM
+    // number (RFC-069's A/B), not the validator's model of it: that is the
+    // claim being made, and it is the one a warning census does not measure.
 }
 
 /// Regression test for the `place_poles` rightward-only probe bug.

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2384,11 +2384,18 @@ fn tier4_ac7_duty06_has_no_severed_connections() {
     // WHAT ZERO ERRORS DOES NOT MEAN (read this before citing the test):
     // this fixture is NOT healthy. It sims at 64.4% of plan (4.51/7.00,
     // converged, kit-clean, 2026-08-17) and carries input-rate-delivery
-    // warnings, TEN of which are belts whose modelled delivery is 0.0/s.
-    // (An earlier version of this comment said six. It was never
-    // measured; the count below is, and the assert now pins it so the
-    // next wrong number fails instead of ageing quietly.) Those belts
-    // are physically connected — each was walked 159-195 tiles upstream
+    // 14 input-rate-delivery warnings, TEN of which are belts whose
+    // modelled delivery is 0.0/s (measured 2026-08-20).
+    //
+    // Both numbers are UNENFORCED, and that is a deliberate choice rather
+    // than an oversight — see the note at the end of this test. An earlier
+    // draft of this comment said "six" from memory and was wrong, which is
+    // the honest argument for enforcement; the argument against is that the
+    // only quantity available to assert on here is the validator's model,
+    // which drifts under unrelated engine work. Re-measure before citing
+    // these figures anywhere that matters.
+    //
+    // Those belts are physically connected — each was walked 159-195 tiles upstream
     // to a real source — so they are a provisioning deficit (RFC-069 /
     // #519 territory), not a routing one, and nothing in this test
     // touches them. The name says what it pins: no SEVERED connections.

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2275,7 +2275,7 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
 /// which is the name #652's comments refer to.)
 #[test]
 #[ntest::timeout(300000)]
-fn tier4_ac7_duty06_lays_out_clean() {
+fn tier4_ac7_duty06_has_no_severed_connections() {
     use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions, RowLayout};
 
     let inputs: FxHashSet<String> = ["iron-plate", "copper-plate", "coal", "water", "crude-oil"]
@@ -2369,10 +2369,20 @@ fn tier4_ac7_duty06_lays_out_clean() {
     };
     let errors: Vec<&ValidationIssue> =
         issues.iter().filter(|i| i.severity == Severity::Error).collect();
-    // The whole-fixture pin. Deliberately NOT scoped to a category:
+    // The whole-fixture ERROR pin. Deliberately NOT scoped to a category:
     // every previous version of this test tolerated some class it had
     // decided was out of scope, and the balancer spill hid inside that
     // tolerance for a full campaign round. Zero means zero.
+    //
+    // WHAT ZERO ERRORS DOES NOT MEAN (read this before citing the test):
+    // this fixture is NOT healthy. It sims at 64.4% of plan (4.51/7.00,
+    // converged, kit-clean, 2026-08-17) and carries input-rate-delivery
+    // warnings including SIX belts whose modelled delivery is 0.0/s. Those
+    // belts are physically connected — each was walked 159-195 tiles
+    // upstream to a real source — so they are a provisioning deficit
+    // (RFC-069 / #519 territory), not a routing one, and nothing in this
+    // test touches them. The name says what it pins: no SEVERED
+    // connections. It does not say the layout works.
     assert!(
         errors.is_empty(),
         "ac7-HS duty-0.6 shipped {} errors (expected 0). If a balancer \
@@ -2381,6 +2391,22 @@ fn tier4_ac7_duty06_lays_out_clean() {
          reservation first: {:#?}",
         errors.len(),
         errors.iter().take(12).collect::<Vec<_>>()
+    );
+
+    // Anti-gospel guard. The fixture's KNOWN deficiency must stay visible,
+    // so that a future reader cannot mistake the zero above for health and
+    // so that anyone who genuinely fixes delivery has to come here and say
+    // so deliberately rather than silently inheriting a green test.
+    let ird = issues
+        .iter()
+        .filter(|i| i.category == "input-rate-delivery")
+        .count();
+    assert!(
+        ird > 0,
+        "ac7-HS duty-0.6 reports no input-rate-delivery warnings — it had 14, \
+         including six belts at 0.0/s, against a 64.4%-of-plan sim. If that is \
+         genuinely fixed this is GOOD NEWS: re-measure the fixture, update the \
+         comment above, and re-point this guard. Do not just delete it."
     );
 }
 

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -2237,7 +2237,11 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
     }
 }
 
-/// #652: ac7-HS at duty 0.6 (the RFC-069 flip shape) lays out CLEAN.
+/// #652: ac7-HS at duty 0.6 (the RFC-069 flip shape) ships zero
+/// validation ERRORS. That is all it says. The fixture is NOT healthy:
+/// it sims at 64.4% of plan and pins 14 input-rate-delivery warnings —
+/// see the guard at the end of this test, which exists to stop the zero
+/// below being cited as health.
 ///
 /// This pin has inverted twice and the history is the point of the
 /// comment — it is the record of what each fix actually bought:
@@ -2271,8 +2275,10 @@ fn tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass() {
 /// no longer severs anything, and a 7-fixture sweep on this same code
 /// path found no remaining exhibitor anywhere. Do NOT read its absence
 /// as the machinery being fine — a synthetic pin for it is tracked on
-/// #652. (Renamed from `tier4_ac7_duty06_unresolved_crossings_fail_safe`,
-/// which is the name #652's comments refer to.)
+/// #652. (Renamed twice: `tier4_ac7_duty06_unresolved_crossings_fail_safe`
+/// -> `tier4_ac7_duty06_lays_out_clean` -> this name. #652's comments
+/// refer to the first; the second overclaimed and is why the guard below
+/// exists.)
 #[test]
 #[ntest::timeout(300000)]
 fn tier4_ac7_duty06_has_no_severed_connections() {
@@ -2377,12 +2383,15 @@ fn tier4_ac7_duty06_has_no_severed_connections() {
     // WHAT ZERO ERRORS DOES NOT MEAN (read this before citing the test):
     // this fixture is NOT healthy. It sims at 64.4% of plan (4.51/7.00,
     // converged, kit-clean, 2026-08-17) and carries input-rate-delivery
-    // warnings including SIX belts whose modelled delivery is 0.0/s. Those
-    // belts are physically connected — each was walked 159-195 tiles
-    // upstream to a real source — so they are a provisioning deficit
-    // (RFC-069 / #519 territory), not a routing one, and nothing in this
-    // test touches them. The name says what it pins: no SEVERED
-    // connections. It does not say the layout works.
+    // warnings, TEN of which are belts whose modelled delivery is 0.0/s.
+    // (An earlier version of this comment said six. It was never
+    // measured; the count below is, and the assert now pins it so the
+    // next wrong number fails instead of ageing quietly.) Those belts
+    // are physically connected — each was walked 159-195 tiles upstream
+    // to a real source — so they are a provisioning deficit (RFC-069 /
+    // #519 territory), not a routing one, and nothing in this test
+    // touches them. The name says what it pins: no SEVERED connections.
+    // It does not say the layout works.
     assert!(
         errors.is_empty(),
         "ac7-HS duty-0.6 shipped {} errors (expected 0). If a balancer \
@@ -2397,16 +2406,36 @@ fn tier4_ac7_duty06_has_no_severed_connections() {
     // so that a future reader cannot mistake the zero above for health and
     // so that anyone who genuinely fixes delivery has to come here and say
     // so deliberately rather than silently inheriting a green test.
-    let ird = issues
+    let ird: Vec<&ValidationIssue> = issues
         .iter()
         .filter(|i| i.category == "input-rate-delivery")
+        .collect();
+    let ird_zero = ird
+        .iter()
+        .filter(|i| i.message.contains("delivers 0.0/s"))
         .count();
-    assert!(
-        ird > 0,
-        "ac7-HS duty-0.6 reports no input-rate-delivery warnings — it had 14, \
-         including six belts at 0.0/s, against a 64.4%-of-plan sim. If that is \
-         genuinely fixed this is GOOD NEWS: re-measure the fixture, update the \
-         comment above, and re-point this guard. Do not just delete it."
+    // Pinned EXACTLY, not as `> 0` (#663 review, 3/3). A floor lets a partial
+    // regression through silently — 14 -> 2 would still "pass" while every
+    // specific claim in the comment above went stale, which is the precise
+    // failure mode docs/validator-reporting.md catalogues. Both directions
+    // trip: a fix and a worsening are equally things the comment must be
+    // re-measured for.
+    //
+    // Yes, this reds CI when the deficit is FIXED. That is deliberate and is
+    // not the `committed >= 25` hazard this file rejected earlier: that was an
+    // incidental byproduct count that drifts under unrelated work. These two
+    // numbers move only when someone changes provisioning for this fixture on
+    // purpose (RFC-069 / #519), and when they do, the fixture needs
+    // re-measuring and this comment needs rewriting — which is exactly what a
+    // failure here forces.
+    assert_eq!(
+        (ird.len(), ird_zero),
+        (14, 10),
+        "ac7-HS duty-0.6 input-rate-delivery census moved — (total, at-0.0/s) \
+         is printed above; the expected pair was measured 2026-08-20 against a \
+         64.4%-of-plan sim. If this is an IMPROVEMENT that is GOOD NEWS — \
+         re-measure the fixture, rewrite the comment at the top of this test, \
+         and re-point these numbers. Do not just delete the guard."
     );
 }
 


### PR DESCRIPTION
## Intent

`tier4_ac7_duty06_lays_out_clean` asserted zero validation errors and was *named*
as though that meant the fixture worked. It does not — ac7-HS duty-0.6 sims at
**64.4% of plan** (4.51/7.00, converged, kit-clean, 2026-08-17) and carries 14
`input-rate-delivery` warnings, six of them belts whose modelled delivery is
0.0/s.

Those six are physically connected (each walked 159–195 tiles upstream to a real
source), so they are a *provisioning* deficit — RFC-069 / #519 territory — not a
routing one, and nothing in this test touches them. A green test called "lays out
clean" invites exactly the mistake of citing it as evidence of health.

## Scope

- **In:** rename to `tier4_ac7_duty06_has_no_severed_connections`; a comment
  stating what zero errors does *not* mean; an anti-gospel guard asserting the
  known deficit stays visible.
- **Out:** no attempt to *fix* the deficit. That is provisioning work and belongs
  with RFC-069, not in a test rename.
- **Size:** +28/-2, one file, test-only.

## Why the guard rather than just a comment

Comments do not fail. If someone genuinely fixes delivery, the guard fires and
forces them to come here, re-measure, and re-point it deliberately — instead of
silently inheriting a green test whose name now overclaims in the other
direction. The assert message says exactly that, including "this is GOOD NEWS".

It is also fail-safe: if the category string drifts, the count goes to zero and
the assert fires loudly rather than passing quietly — the failure mode
`docs/validator-reporting.md` catalogues ten times over.

## Verification

- [x] `cargo test --release --test e2e tier4_ac7_duty06_has_no_severed_connections -- --exact` — 1 passed
- [x] Grepped for dangling references to the old test name — none
- [x] `cargo clippy` via pre-commit hook — clean
- [ ] full suite — not run: test-only change to one `#[test]` fn, no engine code
      touched. Stated explicitly.
- [ ] WASM/browser, snapshot — N/A

## Deviations from intent

None.

## Models / contracts touched

None. The sim figure cited is the one already recorded in RFC-069's decision log.