### PR TITLE
probe(rfc068): P0 self-stamp fidelity — PASSED, P1 unblocked

### DIFF
--- a/crates/core/tests/rfc068_p0_selfstamp.rs
+++ b/crates/core/tests/rfc068_p0_selfstamp.rs
@@ -14,12 +14,15 @@
 //!      which would silently void the isolation premise (RFC-068 decision
 //!      log, review round 1, item 3).
 //!   3. Run the adapter: derive the band's `RowSpan`-shaped contract from
-//!      the entry's DECLARED PORTS alone — input belt ys ordered by the
-//!      spec's input schedule, output edge/flow vs the slot's band role,
-//!      `output_feed_x_min` from drop coverage — and check every field
-//!      against the native band's actual geometry (via a fresh
-//!      `extract_unit` of the same layout, which the celldb drift test
-//!      independently pins to the store).
+//!      the STORE ENTRY ALONE (ports + entities + motif — never the native
+//!      band's row bookkeeping) — input belt ys per the spec's input
+//!      schedule, output edge/flow vs the slot's band role,
+//!      `output_feed_x_min` from drop coverage — and check every field two
+//!      ways: against a fresh `extract_unit` of the same layout (drift
+//!      isolation), and against an INDEPENDENT re-derivation of the band's
+//!      run heads/exits that shares no code with `extract_unit` (#672
+//!      review: without the second anchor, adapter-vs-fresh is circular
+//!      through the extraction logic that also produced the store).
 //!   4. Substitute the fragment at the band's native slot with an
 //!      index-preserving swap (`LayoutResult` power-wire records reference
 //!      entity indices; reordering would fabricate a record-integrity
@@ -29,18 +32,26 @@
 //!      path re-stamps them via normal lane planning.
 //!   5. Validator verdict diff: K68-1's bar is Error-parity; identity
 //!      makes full issue-list parity the expectation, so both are
-//!      asserted. Stated limit (RFC): this gate cannot catch the
-//!      `output_feed_x_min` throughput class — that is P2/P3's meter/sim
-//!      obligation.
+//!      asserted. Honest weighting (#672 review, major 1): GIVEN the
+//!      bijection in step 4, verdict parity follows necessarily — these
+//!      asserts are harness sanity (the splice does not perturb records),
+//!      and the ADJUDICATING evidence is steps 3-4: the adapter-field
+//!      anchors and the entity bijection. Stated limits (RFC): this gate
+//!      cannot catch the `output_feed_x_min` throughput class (the
+//!      `Some(...)` arm is DEAD CODE on P0's seeds — P2's donors exercise
+//!      it under meter/sim instruments), and schedule-INDEX equivalence
+//!      against the native `RowSpan` vector is P1's byte-identical
+//!      control, not provable here (the per-item ys are anchored; their
+//!      index positions are not observable from a `LayoutResult`).
 //!
 //! Escape hatches used (K68-2 unit half): ZERO — every unmappable port,
 //! schedule item without a port, or unfilled field is a hard failure here,
 //! never a workaround.
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use spaghettio_core::bus::layout::{self, LayoutOptions};
 use spaghettio_core::celldb::{self, CellEntry, Motif, PortKind};
-use spaghettio_core::common::is_machine_entity;
+use spaghettio_core::common::{dir_to_vec, is_machine_entity, oriented_entity_dims};
 use spaghettio_core::models::{EntityDirection, LayoutResult, PlacedEntity, SolverResult};
 use spaghettio_core::solver;
 use spaghettio_core::validate::{self, LayoutStyle, Severity, ValidationIssue};
@@ -56,11 +67,17 @@ fn error_count(issues: &[ValidationIssue]) -> usize {
     issues.iter().filter(|i| i.severity == Severity::Error).count()
 }
 
-/// Compact issue fingerprint for parity diffs.
+/// Compact issue fingerprint for parity diffs — includes `detail` so the
+/// full-parity claim is literal (#672 review, minor 7).
 fn fingerprint(issues: &[ValidationIssue]) -> Vec<String> {
     let mut v: Vec<String> = issues
         .iter()
-        .map(|i| format!("{:?}|{}|{:?},{:?}|{}", i.severity, i.category, i.x, i.y, i.message))
+        .map(|i| {
+            format!(
+                "{:?}|{}|{:?},{:?}|{}|{:?}",
+                i.severity, i.category, i.x, i.y, i.message, i.detail
+            )
+        })
         .collect();
     v.sort();
     v
@@ -207,9 +224,12 @@ fn adapt(
         .entities
         .iter()
         .filter(|e| {
-            e.segment_id
-                .as_deref()
-                .is_some_and(|s| s.split(':').nth(2) == Some("inserter-out"))
+            e.segment_id.as_deref().is_some_and(|s| {
+                // inserter-out2 is the lane-split second drop row
+                // (templates.rs) — no current seed carries it; included so
+                // a future one is counted, not miscounted (#672 review).
+                matches!(s.split(':').nth(2), Some("inserter-out") | Some("inserter-out2"))
+            })
         })
         .collect();
     if drops.is_empty() {
@@ -281,11 +301,34 @@ fn probe_fixture(
             .filter(|f| !f.is_fluid)
             .map(|f| f.item.clone())
             .collect();
-        let role_final = sr.external_outputs.iter().any(|o| &o.item == recipe);
+        // Mirror `place_rows`' actual is_final predicate (placer.rs:3227):
+        // external solid output AND not internally consumed by a non-voider
+        // machine. A naive "is an external output" test is wrong for the
+        // RFC-062 dual-purpose class (target with an internal consumer →
+        // west-flowing band) — #672 review, major 2. No current seed is
+        // dual-purpose; mirrored so a future one adjudicates instead of
+        // false-failing.
+        let internally_consumed: FxHashSet<&str> = sr
+            .machines
+            .iter()
+            .filter(|m| !m.voider)
+            .flat_map(|m| m.inputs.iter())
+            .filter(|f| !f.is_fluid)
+            .map(|f| f.item.as_str())
+            .collect();
+        let role_final = spec.outputs.iter().any(|o| {
+            !o.is_fluid
+                && sr.external_outputs.iter().any(|x| x.item == o.item)
+                && !internally_consumed.contains(o.item.as_str())
+        });
 
         // --- adapter under test ---
-        let out = adapt(entry, slot, &schedule, role_final)
-            .unwrap_or_else(|e| panic!("{recipe}: adapter refusal (K68-2 escape hatch): {e}"));
+        let out = adapt(entry, slot, &schedule, role_final).unwrap_or_else(|e| {
+            panic!(
+                "{recipe}: adapter refusal — a real contract gap OR a legitimate \
+                 engine shape change; re-adjudicate, don't override (K68-2): {e}"
+            )
+        });
 
         // Field checks against native geometry, via the fresh extraction's
         // port coordinates (slot-relative → slot-absolute).
@@ -312,6 +355,84 @@ fn probe_fixture(
         got_out.sort();
         assert_eq!(got_out, expect_out, "{recipe}: output belt ys diverge from native");
         assert_eq!(out.output_east, role_final, "{recipe}: output flow vs band role");
+
+        // --- INDEPENDENT native-geometry anchor (#672 review, majors 1/
+        // minors 4-5: the fresh-extraction comparisons above tie the
+        // adapter to native geometry only THROUGH `extract_unit`, which
+        // also produced the store — circular against a shared extraction
+        // bug). This block re-derives the band's belt-in run heads and
+        // belt-out exits directly from the native entities, sharing no
+        // code with `extract_unit`, and is what makes the parity verdict
+        // below evidence rather than tautology: a shared-extraction defect
+        // now fails HERE even though both port lists agree.
+        let band: Vec<&PlacedEntity> = idx.iter().map(|&i| &native.entities[i]).collect();
+        let seg_kind_item = |e: &PlacedEntity| -> Option<(String, String)> {
+            let s = e.segment_id.as_deref()?;
+            let p: Vec<&str> = s.split(':').collect();
+            Some((
+                (*p.get(2)?).to_string(),
+                p.get(3).map(|i| (*i).to_string()).unwrap_or_else(|| (*recipe).to_string()),
+            ))
+        };
+        for (item, adapter_ys) in &out.input_ys {
+            let run: Vec<&&PlacedEntity> = band
+                .iter()
+                .filter(|e| seg_kind_item(e) == Some(("belt-in".to_string(), item.clone())))
+                .collect();
+            let mut heads: Vec<i32> = run
+                .iter()
+                .filter(|t| {
+                    !run.iter().any(|f| {
+                        let (dx, dy) = dir_to_vec(f.direction);
+                        (f.x + dx, f.y + dy) == (t.x, t.y)
+                    })
+                })
+                .map(|t| t.y)
+                .collect();
+            heads.sort();
+            let mut got = adapter_ys.clone();
+            got.sort();
+            assert_eq!(
+                got, heads,
+                "{recipe}: adapter input ys for '{item}' diverge from independently-derived run heads"
+            );
+        }
+        let mut band_occ: FxHashSet<(i32, i32)> = FxHashSet::default();
+        for e in &band {
+            let (w, h) = oriented_entity_dims(&e.name, e.direction);
+            for dx in 0..w {
+                for dy in 0..h {
+                    band_occ.insert((e.x + dx, e.y + dy));
+                }
+            }
+        }
+        let out_run: Vec<&&PlacedEntity> = band
+            .iter()
+            .filter(|e| seg_kind_item(e).is_some_and(|(k, _)| k == "belt-out"))
+            .collect();
+        let exits: Vec<&&PlacedEntity> = out_run
+            .iter()
+            .filter(|t| {
+                let (dx, dy) = dir_to_vec(t.direction);
+                !band_occ.contains(&(t.x + dx, t.y + dy))
+            })
+            .copied()
+            .collect();
+        let mut exit_ys: Vec<i32> = exits.iter().map(|t| t.y).collect();
+        exit_ys.sort();
+        assert_eq!(
+            got_out, exit_ys,
+            "{recipe}: adapter output ys diverge from independently-derived run exits"
+        );
+        let expect_exit_dir =
+            if role_final { EntityDirection::East } else { EntityDirection::West };
+        for t in &exits {
+            assert_eq!(
+                t.direction, expect_exit_dir,
+                "{recipe}: native exit tile at ({}, {}) contradicts the band role",
+                t.x, t.y
+            );
+        }
         assert_eq!(
             out.output_feed_x_min, None,
             "{recipe}: engine seed derived a discrete-drop coverage; expected continuous"

--- a/crates/core/tests/rfc068_p0_selfstamp.rs
+++ b/crates/core/tests/rfc068_p0_selfstamp.rs
@@ -1,0 +1,408 @@
+//! RFC-068 Phase 0 — the self-stamp fidelity probe (K68-1, plus the unit
+//! half of K68-2). See `docs/rfc-068-multi-group-stamping.md`.
+//!
+//! NO PRODUCT CODE: the ports→`RowSpan`-semantics adapter under test lives
+//! HERE, in the probe, per the RFC's P0 phasing. P1 builds the real stamp
+//! path in `place_rows` only if this gate passes.
+//!
+//! Per seed fixture (`celldb::seed_sources()`):
+//!   1. Build the NATIVE layout (`build_bus_layout`, default options) and
+//!      validate it — the control.
+//!   2. Select each engine seed **by provenance (`engine@…`), never by
+//!      `query_unit`** — the copper-plate@48 key collision resolves the
+//!      normal query to the community donor (753 < 817 interior tiles),
+//!      which would silently void the isolation premise (RFC-068 decision
+//!      log, review round 1, item 3).
+//!   3. Run the adapter: derive the band's `RowSpan`-shaped contract from
+//!      the entry's DECLARED PORTS alone — input belt ys ordered by the
+//!      spec's input schedule, output edge/flow vs the slot's band role,
+//!      `output_feed_x_min` from drop coverage — and check every field
+//!      against the native band's actual geometry (via a fresh
+//!      `extract_unit` of the same layout, which the celldb drift test
+//!      independently pins to the store).
+//!   4. Substitute the fragment at the band's native slot with an
+//!      index-preserving swap (`LayoutResult` power-wire records reference
+//!      entity indices; reordering would fabricate a record-integrity
+//!      seam) and assert entity identity modulo id/order/rate. Rate stamps
+//!      are restored from the native entity: rates are derived by the
+//!      pipeline, never stored (the celldb schema rule), and P1's stamp
+//!      path re-stamps them via normal lane planning.
+//!   5. Validator verdict diff: K68-1's bar is Error-parity; identity
+//!      makes full issue-list parity the expectation, so both are
+//!      asserted. Stated limit (RFC): this gate cannot catch the
+//!      `output_feed_x_min` throughput class — that is P2/P3's meter/sim
+//!      obligation.
+//!
+//! Escape hatches used (K68-2 unit half): ZERO — every unmappable port,
+//! schedule item without a port, or unfilled field is a hard failure here,
+//! never a workaround.
+
+use rustc_hash::FxHashMap;
+use spaghettio_core::bus::layout::{self, LayoutOptions};
+use spaghettio_core::celldb::{self, CellEntry, Motif, PortKind};
+use spaghettio_core::common::is_machine_entity;
+use spaghettio_core::models::{EntityDirection, LayoutResult, PlacedEntity, SolverResult};
+use spaghettio_core::solver;
+use spaghettio_core::validate::{self, LayoutStyle, Severity, ValidationIssue};
+
+fn issues_of(l: &LayoutResult, s: &SolverResult) -> Vec<ValidationIssue> {
+    match validate::validate(l, Some(s), LayoutStyle::Bus) {
+        Ok(issues) => issues,
+        Err(e) => e.issues,
+    }
+}
+
+fn error_count(issues: &[ValidationIssue]) -> usize {
+    issues.iter().filter(|i| i.severity == Severity::Error).count()
+}
+
+/// Compact issue fingerprint for parity diffs.
+fn fingerprint(issues: &[ValidationIssue]) -> Vec<String> {
+    let mut v: Vec<String> = issues
+        .iter()
+        .map(|i| format!("{:?}|{}|{:?},{:?}|{}", i.severity, i.category, i.x, i.y, i.message))
+        .collect();
+    v.sort();
+    v
+}
+
+/// The band: every entity `extract_unit` claims for this recipe — its
+/// machines plus every `row:{recipe}:*` segment entity. Indices, so the
+/// substitution can be index-preserving.
+fn band_indices(entities: &[PlacedEntity], recipe: &str) -> Vec<usize> {
+    let prefix = format!("row:{recipe}:");
+    entities
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| {
+            (e.recipe.as_deref() == Some(recipe) && is_machine_entity(&e.name))
+                || e.segment_id.as_deref().is_some_and(|s| s.starts_with(&prefix))
+        })
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// Identity key: the full serialized entity with rate stripped and
+/// coordinates normalized to the band origin. "Identical modulo entity
+/// id/order" (RFC P0 verification bullet) — rate is additionally excluded
+/// because the store strips it at extraction (rates are derived, never
+/// stored) and the substitution restores the native stamp.
+fn identity_key(e: &PlacedEntity, origin: (i32, i32)) -> String {
+    let mut n = e.clone();
+    n.rate = None;
+    n.x -= origin.0;
+    n.y -= origin.1;
+    serde_json::to_string(&n).expect("PlacedEntity serializes")
+}
+
+/// What the probe's adapter produced for one band, in slot-absolute
+/// coordinates.
+struct AdapterOut {
+    /// Per solid input item, IN THE SPEC'S SCHEDULE ORDER: the input belt
+    /// port ys (multi-port per item allowed — split rows).
+    input_ys: Vec<(String, Vec<i32>)>,
+    output_ys: Vec<i32>,
+    output_east: bool,
+    output_feed_x_min: Option<i32>,
+}
+
+/// The ports→RowSpan-semantics adapter under test. Consumes ONLY the store
+/// entry (ports + entities + motif) plus the slot origin, the group's
+/// input schedule, and the slot's band role — never the native band.
+fn adapt(
+    entry: &CellEntry,
+    slot: (i32, i32),
+    schedule: &[String],
+    role_final: bool,
+) -> Result<AdapterOut, String> {
+    // --- input belt ys, schedule-ordered (RFC round-1 obligation 2:
+    // the lane planner indexes input belts by schedule order; an item the
+    // adapter cannot place at its schedule index is a refusal).
+    let mut input_ys = Vec::new();
+    for item in schedule {
+        let ys: Vec<i32> = entry
+            .ports
+            .iter()
+            .filter(|p| p.kind == PortKind::BeltIn && &p.item == item)
+            .map(|p| slot.1 + p.dy)
+            .collect();
+        if ys.is_empty() {
+            return Err(format!("schedule item '{item}' has no belt-in port"));
+        }
+        input_ys.push((item.clone(), ys));
+    }
+    for p in &entry.ports {
+        if p.kind == PortKind::BeltIn && !schedule.iter().any(|s| s == &p.item) {
+            return Err(format!("belt-in port for '{}' not in the input schedule", p.item));
+        }
+    }
+
+    // --- output edge/flow vs slot role (orientation is resolved at
+    // storage time; a mismatched edge is inadmissible, never transformed).
+    let out_ports: Vec<_> =
+        entry.ports.iter().filter(|p| p.kind == PortKind::BeltOut).collect();
+    if out_ports.is_empty() {
+        return Err("no belt-out port".into());
+    }
+    // Edge admissibility per the RFC: the belt-out PORT edge must match
+    // the slot's role — east edge for a final band, west edge for an
+    // intermediate band. Judged on the port tile (the run's exit), not on
+    // every run tile: runs legitimately contain corner/UG tiles whose own
+    // direction is not the run's flow.
+    let mut east_votes = 0usize;
+    let mut west_votes = 0usize;
+    for p in &out_ports {
+        let on_east = p.dx == entry.metrics.bbox_w - 1;
+        let on_west = p.dx == 0;
+        if on_east == on_west {
+            return Err(format!(
+                "belt-out port at ({}, {}) is not on an x-edge of the {}x{} fragment",
+                p.dx, p.dy, entry.metrics.bbox_w, entry.metrics.bbox_h
+            ));
+        }
+        // Corroborate with the exit tile's own direction — it flows OFF
+        // the fragment, so it must point outward along x.
+        let tile = entry
+            .entities
+            .iter()
+            .find(|e| e.x == p.dx && e.y == p.dy)
+            .ok_or_else(|| format!("belt-out port ({}, {}) has no entity", p.dx, p.dy))?;
+        let expect_dir = if on_east { EntityDirection::East } else { EntityDirection::West };
+        if tile.direction != expect_dir {
+            return Err(format!(
+                "belt-out exit tile at ({}, {}) flows {:?}, expected {:?} for its edge",
+                p.dx, p.dy, tile.direction, expect_dir
+            ));
+        }
+        if on_east {
+            east_votes += 1;
+        } else {
+            west_votes += 1;
+        }
+    }
+    if east_votes > 0 && west_votes > 0 {
+        return Err("belt-out ports disagree on exit edge".into());
+    }
+    let east = east_votes > 0;
+    if role_final != east {
+        return Err(format!(
+            "slot role (final={role_final}) does not match stored output edge (east={east})"
+        ));
+    }
+    let output_ys: Vec<i32> = out_ports.iter().map(|p| slot.1 + p.dy).collect();
+
+    // --- output_feed_x_min: drop-coverage branch (RFC round-2). Engine
+    // unit seeds are ordinary rows — one output drop per machine, coverage
+    // continuous from the run start → None (exactly what `place_rows`
+    // sets, so self-stamps stay native-identical). The discrete-drop
+    // (DI-shape) arm returns Some(rightmost drop column); P2's donor
+    // adapter owes the full geometric derivation — this probe's derivation
+    // is the count form, sufficient for engine seeds where templates place
+    // exactly one output inserter per machine.
+    let machine_count = match &entry.motif {
+        Motif::Unit { count, .. } => *count as usize,
+        Motif::Fused { .. } => return Err("fused motifs are out of P0 scope".into()),
+    };
+    let drops: Vec<&PlacedEntity> = entry
+        .entities
+        .iter()
+        .filter(|e| {
+            e.segment_id
+                .as_deref()
+                .is_some_and(|s| s.split(':').nth(2) == Some("inserter-out"))
+        })
+        .collect();
+    if drops.is_empty() {
+        return Err("no inserter-out drops; cannot derive output coverage".into());
+    }
+    let output_feed_x_min = if drops.len() >= machine_count {
+        None // continuous — the ordinary-row shape
+    } else {
+        Some(slot.0 + drops.iter().map(|e| e.x).max().unwrap())
+    };
+
+    Ok(AdapterOut { input_ys, output_ys, output_east: east, output_feed_x_min })
+}
+
+/// Run the whole probe for one fixture; returns (targets probed).
+fn probe_fixture(
+    item: &str,
+    rate: f64,
+    machine: &str,
+    inputs: &[&str],
+    targets: &[(&str, &str)],
+    print_seam: bool,
+) -> usize {
+    let input_set = inputs.iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve(item, rate, &input_set, machine).expect("seed source solves");
+    let native =
+        layout::build_bus_layout(&sr, LayoutOptions::default()).expect("seed source lays out");
+    let native_issues = issues_of(&native, &sr);
+
+    let mut probed = 0usize;
+    for (recipe, target_machine) in targets {
+        // Provenance-scoped entry selection (never query_unit — see module
+        // doc). Mirrors the celldb drift test's lookup exactly.
+        let entry = celldb::celldb()
+            .entries
+            .iter()
+            .find(|e| {
+                e.provenance.starts_with("engine@")
+                    && matches!(&e.motif, Motif::Unit { recipe: r, machine: m, .. }
+                        if r == recipe && m == target_machine)
+            })
+            .unwrap_or_else(|| panic!("{recipe} engine seed is in the store"));
+
+        // Native band + slot origin.
+        let idx = band_indices(&native.entities, recipe);
+        assert!(!idx.is_empty(), "{recipe}: native band not found");
+        let slot = (
+            idx.iter().map(|&i| native.entities[i].x).min().unwrap(),
+            idx.iter().map(|&i| native.entities[i].y).min().unwrap(),
+        );
+
+        // Freshly extract the band; the drift test pins stored==fresh, but
+        // re-assert here so a probe failure isolates locally.
+        let (fresh, warnings) =
+            celldb::extract_unit(&native.entities, recipe, target_machine, "probe");
+        assert!(warnings.is_empty(), "{recipe}: extraction escape hatches: {warnings:?}");
+        let fresh = fresh.expect("fresh extraction succeeds");
+        assert_eq!(entry.ports, fresh.ports, "{recipe}: stored ports drifted from geometry");
+
+        // The group's input schedule: solid inputs, spec order.
+        let spec = sr
+            .machines
+            .iter()
+            .find(|m| m.recipe == *recipe)
+            .unwrap_or_else(|| panic!("{recipe}: no machine group in solve"));
+        let schedule: Vec<String> = spec
+            .inputs
+            .iter()
+            .filter(|f| !f.is_fluid)
+            .map(|f| f.item.clone())
+            .collect();
+        let role_final = sr.external_outputs.iter().any(|o| &o.item == recipe);
+
+        // --- adapter under test ---
+        let out = adapt(entry, slot, &schedule, role_final)
+            .unwrap_or_else(|e| panic!("{recipe}: adapter refusal (K68-2 escape hatch): {e}"));
+
+        // Field checks against native geometry, via the fresh extraction's
+        // port coordinates (slot-relative → slot-absolute).
+        for (item, ys) in &out.input_ys {
+            let mut expect: Vec<i32> = fresh
+                .ports
+                .iter()
+                .filter(|p| p.kind == PortKind::BeltIn && &p.item == item)
+                .map(|p| slot.1 + p.dy)
+                .collect();
+            let mut got = ys.clone();
+            expect.sort();
+            got.sort();
+            assert_eq!(got, expect, "{recipe}: input belt ys for '{item}' diverge from native");
+        }
+        let mut expect_out: Vec<i32> = fresh
+            .ports
+            .iter()
+            .filter(|p| p.kind == PortKind::BeltOut)
+            .map(|p| slot.1 + p.dy)
+            .collect();
+        let mut got_out = out.output_ys.clone();
+        expect_out.sort();
+        got_out.sort();
+        assert_eq!(got_out, expect_out, "{recipe}: output belt ys diverge from native");
+        assert_eq!(out.output_east, role_final, "{recipe}: output flow vs band role");
+        assert_eq!(
+            out.output_feed_x_min, None,
+            "{recipe}: engine seed derived a discrete-drop coverage; expected continuous"
+        );
+
+        // --- index-preserving substitution ---
+        let mut frag_by_key: FxHashMap<String, &PlacedEntity> = FxHashMap::default();
+        for e in &entry.entities {
+            let prev = frag_by_key.insert(identity_key(e, (0, 0)), e);
+            assert!(prev.is_none(), "{recipe}: duplicate identity key in fragment");
+        }
+        assert_eq!(
+            idx.len(),
+            entry.entities.len(),
+            "{recipe}: native band and stored fragment entity counts differ"
+        );
+        let mut stamped = native.clone();
+        for &i in &idx {
+            let nat = &native.entities[i];
+            let key = identity_key(nat, slot);
+            let frag = frag_by_key.remove(&key).unwrap_or_else(|| {
+                panic!("{recipe}: native band entity has no fragment counterpart: {key}")
+            });
+            let mut e = frag.clone();
+            e.x += slot.0;
+            e.y += slot.1;
+            e.rate = nat.rate; // derived, never stored — restored from native
+            stamped.entities[i] = e;
+        }
+        assert!(
+            frag_by_key.is_empty(),
+            "{recipe}: {} fragment entities had no native slot",
+            frag_by_key.len()
+        );
+
+        // --- verdict diff: K68-1 ---
+        let stamped_issues = issues_of(&stamped, &sr);
+        assert_eq!(
+            error_count(&stamped_issues),
+            error_count(&native_issues),
+            "{recipe}: ERROR-PARITY FAILED (K68-1)\nnative: {:?}\nstamped: {:?}",
+            fingerprint(&native_issues),
+            fingerprint(&stamped_issues),
+        );
+        assert_eq!(
+            fingerprint(&stamped_issues),
+            fingerprint(&native_issues),
+            "{recipe}: full issue parity failed (identity substitution should be verdict-identical)"
+        );
+
+        if print_seam && probed == 0 {
+            let y0 = idx.iter().map(|&i| native.entities[i].y).min().unwrap();
+            let y1 = idx.iter().map(|&i| native.entities[i].y).max().unwrap();
+            println!("── seam tiles for {recipe} band (y {y0}..{y1}) ──");
+            for e in &stamped.entities {
+                if e.y == y0 - 1 || e.y == y1 + 1 {
+                    println!("  {} @ ({},{}) dir={:?} seg={:?}", e.name, e.x, e.y, e.direction, e.segment_id);
+                }
+            }
+        }
+        probed += 1;
+    }
+    probed
+}
+
+/// ec@20-from-ore: four engine seeds — copper-plate / iron-plate
+/// (intermediate west-flowing furnace bands), copper-cable (intermediate),
+/// electronic-circuit (final east-flowing) — both K68-1 band roles.
+#[test]
+fn p0_selfstamp_ec20_from_ore() {
+    let sources = celldb::seed_sources();
+    let (item, rate, machine, inputs, targets) = sources
+        .iter()
+        .find(|s| s.0 == "electronic-circuit")
+        .expect("ec seed source");
+    let inputs: Vec<&str> = inputs.to_vec();
+    let n = probe_fixture(item, *rate, machine, &inputs, targets, true);
+    assert_eq!(n, 4, "all four ec-fixture engine seeds probed");
+}
+
+/// ac@4-from-plates: the advanced-circuit final band (3-group layout — ec
+/// and copper-cable co-solve, so the band has real seam neighbors; RFC-068
+/// review round 3).
+#[test]
+fn p0_selfstamp_ac4_from_plates() {
+    let sources = celldb::seed_sources();
+    let (item, rate, machine, inputs, targets) = sources
+        .iter()
+        .find(|s| s.0 == "advanced-circuit")
+        .expect("ac seed source");
+    let inputs: Vec<&str> = inputs.to_vec();
+    let n = probe_fixture(item, *rate, machine, &inputs, targets, false);
+    assert_eq!(n, 1, "the ac engine seed probed");
+}

--- a/crates/core/tests/rfc068_p0_selfstamp.rs
+++ b/crates/core/tests/rfc068_p0_selfstamp.rs
@@ -17,12 +17,26 @@
 //!      the STORE ENTRY ALONE (ports + entities + motif — never the native
 //!      band's row bookkeeping) — input belt ys per the spec's input
 //!      schedule, output edge/flow vs the slot's band role,
-//!      `output_feed_x_min` from drop coverage — and check every field two
-//!      ways: against a fresh `extract_unit` of the same layout (drift
-//!      isolation), and against an INDEPENDENT re-derivation of the band's
-//!      run heads/exits that shares no code with `extract_unit` (#672
-//!      review: without the second anchor, adapter-vs-fresh is circular
-//!      through the extraction logic that also produced the store).
+//!      `output_feed_x_min` from drop coverage — and check every field
+//!      three ways: against a fresh `extract_unit` of the same layout
+//!      (drift isolation); against a re-derivation of run heads/exits
+//!      that shares no CODE with `extract_unit` (anchor A); and, for
+//!      input heads, against the OUTSIDE-FEEDER anchor (anchor B) — a
+//!      different METHOD entirely (who feeds the tile, from outside the
+//!      band), since anchor A shares the extractor's run-boundary
+//!      heuristic and would reproduce a systematic bug in it (#672
+//!      rounds 1-2). Honest residual: the belt-out EXIT derivation has
+//!      no second method here — it shares the boundary-scan approach —
+//!      and is corroborated instead by the fragment-side port-edge +
+//!      exit-direction contract; the router-facing instrument for exits
+//!      is P1's byte-identical control.
+//!
+//!      The probe's NOVEL margin, stated precisely (#672 round 2): the
+//!      RowSpan-semantics interpretation of the ports plus these
+//!      geometry anchors. The bijection and verdict-parity steps below
+//!      are guarded consequences of the celldb drift test and serve as
+//!      harness-sanity checks (they catch probe-side translation/index
+//!      bugs), not as adjudicating evidence.
 //!   4. Substitute the fragment at the band's native slot with an
 //!      index-preserving swap (`LayoutResult` power-wire records reference
 //!      entity indices; reordering would fabricate a record-integrity
@@ -51,7 +65,10 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use spaghettio_core::bus::layout::{self, LayoutOptions};
 use spaghettio_core::celldb::{self, CellEntry, Motif, PortKind};
-use spaghettio_core::common::{dir_to_vec, is_machine_entity, oriented_entity_dims};
+use spaghettio_core::common::{
+    dir_to_vec, is_machine_entity, is_splitter, is_surface_belt, is_ug_belt,
+    oriented_entity_dims,
+};
 use spaghettio_core::models::{EntityDirection, LayoutResult, PlacedEntity, SolverResult};
 use spaghettio_core::solver;
 use spaghettio_core::validate::{self, LayoutStyle, Severity, ValidationIssue};
@@ -100,10 +117,12 @@ fn band_indices(entities: &[PlacedEntity], recipe: &str) -> Vec<usize> {
 }
 
 /// Identity key: the full serialized entity with rate stripped and
-/// coordinates normalized to the band origin. "Identical modulo entity
-/// id/order" (RFC P0 verification bullet) — rate is additionally excluded
-/// because the store strips it at extraction (rates are derived, never
-/// stored) and the substitution restores the native stamp.
+/// coordinates normalized to the band origin. The RFC's "identical modulo
+/// entity id/order" phrase covers exporters that assign ids —
+/// `PlacedEntity` itself carries none, so concretely this is "modulo
+/// order and rate": rate because the store strips it at extraction
+/// (rates are derived, never stored) and the substitution restores the
+/// native stamp.
 fn identity_key(e: &PlacedEntity, origin: (i32, i32)) -> String {
     let mut n = e.clone();
     n.rate = None;
@@ -235,8 +254,39 @@ fn adapt(
     if drops.is_empty() {
         return Err("no inserter-out drops; cannot derive output coverage".into());
     }
+    // Continuity needs geometry, not just a count (#672 round 2): a
+    // count-sufficient but left-sparse drop set would misclassify. Require
+    // the leftmost drop within one machine-width of the run start; a
+    // count-sufficient set that fails that is AMBIGUOUS → refuse (K67-1:
+    // loud refusal, never a guessed field).
+    let machine_w = entry
+        .entities
+        .iter()
+        .find(|e| is_machine_entity(&e.name))
+        .map(|e| oriented_entity_dims(&e.name, e.direction).0)
+        .unwrap_or(3);
+    let run_min_x = entry
+        .entities
+        .iter()
+        .filter(|e| {
+            e.segment_id
+                .as_deref()
+                .is_some_and(|s| s.split(':').nth(2) == Some("belt-out"))
+        })
+        .map(|e| e.x)
+        .min()
+        .ok_or("no belt-out run tiles")?;
+    let min_drop_x = drops.iter().map(|e| e.x).min().unwrap();
     let output_feed_x_min = if drops.len() >= machine_count {
-        None // continuous — the ordinary-row shape
+        if min_drop_x <= run_min_x + machine_w {
+            None // continuous from the run start — the ordinary-row shape
+        } else {
+            return Err(format!(
+                "drop coverage ambiguous: {} drops but leftmost at x={min_drop_x} \
+                 vs run start x={run_min_x} — refusing to guess output_feed_x_min",
+                drops.len()
+            ));
+        }
     } else {
         Some(slot.0 + drops.iter().map(|e| e.x).max().unwrap())
     };
@@ -354,7 +404,9 @@ fn probe_fixture(
         expect_out.sort();
         got_out.sort();
         assert_eq!(got_out, expect_out, "{recipe}: output belt ys diverge from native");
-        assert_eq!(out.output_east, role_final, "{recipe}: output flow vs band role");
+        // (output_east == role_final is enforced inside adapt(); the
+        // redundant re-assert here was removed on #672 round 2.)
+        let _ = out.output_east;
 
         // --- INDEPENDENT native-geometry anchor (#672 review, majors 1/
         // minors 4-5: the fresh-extraction comparisons above tie the
@@ -374,11 +426,15 @@ fn probe_fixture(
                 p.get(3).map(|i| (*i).to_string()).unwrap_or_else(|| (*recipe).to_string()),
             ))
         };
+        let band_idx_set: FxHashSet<usize> = idx.iter().copied().collect();
         for (item, adapter_ys) in &out.input_ys {
             let run: Vec<&&PlacedEntity> = band
                 .iter()
                 .filter(|e| seg_kind_item(e) == Some(("belt-in".to_string(), item.clone())))
                 .collect();
+            // Anchor A — run-head derivation (independent implementation,
+            // SAME method as extract_unit's; see the honest-scope note in
+            // the module doc).
             let mut heads: Vec<i32> = run
                 .iter()
                 .filter(|t| {
@@ -390,11 +446,44 @@ fn probe_fixture(
                 .map(|t| t.y)
                 .collect();
             heads.sort();
+            // Anchor B — OUTSIDE-FEEDER derivation (independent METHOD,
+            // #672 round-2 review): a head is the run tile some NON-band
+            // entity feeds head-on. Rests on the owner-confirmed invariant
+            // that the engine never sideloads into a row input belt —
+            // external feeders (trunk taps, bridges, UG exits) hit heads
+            // head-on only, so "externally fed run tile" ≡ "head" by a
+            // route the extractor's topology heuristic never takes.
+            let mut fed_heads: Vec<i32> = run
+                .iter()
+                .filter(|t| {
+                    native.entities.iter().enumerate().any(|(fi, f)| {
+                        if band_idx_set.contains(&fi) {
+                            return false;
+                        }
+                        // A FEEDER is belt-family — belts flow items onto
+                        // the head. Inserters along the run also point at
+                        // it (pickup side) and must not count; first run
+                        // of this anchor caught exactly that class.
+                        if !(is_surface_belt(&f.name) || is_ug_belt(&f.name) || is_splitter(&f.name))
+                        {
+                            return false;
+                        }
+                        let (dx, dy) = dir_to_vec(f.direction);
+                        (f.x + dx, f.y + dy) == (t.x, t.y)
+                    })
+                })
+                .map(|t| t.y)
+                .collect();
+            fed_heads.sort();
             let mut got = adapter_ys.clone();
             got.sort();
             assert_eq!(
                 got, heads,
-                "{recipe}: adapter input ys for '{item}' diverge from independently-derived run heads"
+                "{recipe}: adapter input ys for '{item}' diverge from run-head derivation"
+            );
+            assert_eq!(
+                got, fed_heads,
+                "{recipe}: adapter input ys for '{item}' diverge from the outside-feeder anchor"
             );
         }
         let mut band_occ: FxHashSet<(i32, i32)> = FxHashSet::default();

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -154,9 +154,13 @@ verification protocol (suite green + clippy + WASM build), not just compile.
 `bus/template_candidate.rs` (200 + 149 tests) are all kept alive, by name, in
 RFC-064's 2026-08-14 decision log *solely* as the RFC-068 celldb campaign's
 entry path (`run_candidate_field` → `objective::measure` → Transit scoring).
-RFC-068 status as of 2026-08-20: PR #628 (docs-only) merged 2026-08-13, P0
-never started, no branch, tracking #629 silent — stalled 7 days, not
-confirmed dead. `celldb.rs` (617) + `data/celldb.json` (20,775 lines)
+**RESOLVED 2026-08-20: RFC-068 is ALIVE — Tier 3 is KEEP-CAMPAIGN.** The
+owner's status check ran P0 the same day; it PASSED (K68-1, full verdict
+parity, zero escape hatches — RFC-068 decision log). The five modules
+stay, now with a live consumer again; this tier re-opens only if a later
+kill criterion (K68-2 donor half, K68-3) fires. Original stall evidence,
+kept for the record: PR #628 (docs-only) merged 2026-08-13, P0 not
+started, tracking #629 silent for 7 days. `celldb.rs` (617) + `data/celldb.json` (20,775 lines)
 additionally carry RFC-067's independent "measured baseline" retention and
 survive even if RFC-068 dies; `preview.rs` likewise (K67-2 killed its
 consumer but the RFC forbids rebuilding without a decision-log amendment and

--- a/docs/rfc-068-multi-group-stamping.md
+++ b/docs/rfc-068-multi-group-stamping.md
@@ -341,21 +341,34 @@ registry row if it stays within the size norm.
   standing ~4s regression, not a one-shot) adjudicates: on both seed
   fixtures and all five engine seeds (both band roles —
   copper-plate/iron-plate/copper-cable intermediates, ec and ac finals),
-  a ports→RowSpan adapter written in the probe FROM DECLARED PORTS ALONE
-  reproduces the native band's input-belt ys in schedule order, output
-  ys, edge/role admissibility, and the continuous-coverage →
-  `output_feed_x_min = None` branch; index-preserving substitution
-  (power-wire records reference entity indices) reaches FULL validator
-  verdict parity — issue-list equality, stronger than the Error-parity
-  bar. Escape hatches: ZERO. Scope, honestly: with identity proven,
-  verdict parity cannot probe the router *reacting* to a differing
-  stamp — that instrument arrives with P1's byte-identical controls and
-  P2's donors, as this RFC designed. One probe-harness bug (not a
-  contract escape hatch) found en route: judging run flow by per-tile
-  direction refuses real runs containing corner/UG tiles; the RFC's
-  port-EDGE criterion is the correct test and is what the probe
-  implements. Context: executed on the owner's resume-vs-kill check
-  (2026-08-20) after the campaign sat 7 days idle; the off-path audit
+  a RowSpan-semantics adapter written in the probe from the STORE ENTRY
+  ALONE (ports + entities + motif — never the native band's row
+  bookkeeping) reproduces the native band's per-item input-belt ys,
+  output ys, port-edge/role admissibility, and the continuous-coverage →
+  `output_feed_x_min = None` branch — anchored BOTH against a fresh
+  `extract_unit` re-extraction AND against an independent run-head/exit
+  derivation sharing no code with the extractor (added on the #672
+  review, which correctly showed the first anchor alone is circular
+  through shared extraction logic). Index-preserving substitution
+  (power-wire records reference entity indices) then bijects the band
+  exactly, and the validator verdict is fully parity-checked
+  (issue-list + detail equality). Honest weighting, from the same
+  review: GIVEN the bijection, verdict parity follows necessarily — the
+  parity asserts are harness sanity, and the ADJUDICATING evidence is
+  the adapter-field anchors plus the bijection. Escape hatches: ZERO.
+  Known limits, recorded: the `output_feed_x_min = Some(...)` arm is
+  dead code on engine seeds (P2's donors exercise it under meter/sim);
+  schedule-INDEX equivalence vs the native RowSpan vector is P1's
+  byte-identical control (per-item ys are anchored; index positions are
+  not observable from a `LayoutResult`); the role predicate mirrors
+  `place_rows`' `is_final` exactly (external AND not internally
+  consumed, voiders excluded) though no current seed exercises the
+  dual-purpose class. One probe-harness bug (not a contract escape
+  hatch) found en route: judging run flow by per-tile direction refuses
+  real runs containing corner/UG tiles; the RFC's port-EDGE criterion
+  is the correct test and is what the probe implements. Context:
+  executed on the owner's resume-vs-kill check (2026-08-20) after the
+  campaign sat 7 days idle; the off-path audit
   (docs/offpath-code-followups.md) had queued ~3.7k lines of this
   campaign's entry-path plumbing behind exactly this gate. **P1 is
   unblocked.***

--- a/docs/rfc-068-multi-group-stamping.md
+++ b/docs/rfc-068-multi-group-stamping.md
@@ -336,6 +336,29 @@ registry row if it stays within the size norm.
   checklist items; K68-3 calibration note added (an epsilon-scraping
   pass is weak evidence, the reopening cleared the bar 18–22×).
   Tracking: work proceeds under #629.*
+- *2026-08-20 — **P0 EXECUTED AND PASSED** (K68-1; K68-2's unit half).
+  The self-stamp probe (`crates/core/tests/rfc068_p0_selfstamp.rs` — a
+  standing ~4s regression, not a one-shot) adjudicates: on both seed
+  fixtures and all five engine seeds (both band roles —
+  copper-plate/iron-plate/copper-cable intermediates, ec and ac finals),
+  a ports→RowSpan adapter written in the probe FROM DECLARED PORTS ALONE
+  reproduces the native band's input-belt ys in schedule order, output
+  ys, edge/role admissibility, and the continuous-coverage →
+  `output_feed_x_min = None` branch; index-preserving substitution
+  (power-wire records reference entity indices) reaches FULL validator
+  verdict parity — issue-list equality, stronger than the Error-parity
+  bar. Escape hatches: ZERO. Scope, honestly: with identity proven,
+  verdict parity cannot probe the router *reacting* to a differing
+  stamp — that instrument arrives with P1's byte-identical controls and
+  P2's donors, as this RFC designed. One probe-harness bug (not a
+  contract escape hatch) found en route: judging run flow by per-tile
+  direction refuses real runs containing corner/UG tiles; the RFC's
+  port-EDGE criterion is the correct test and is what the probe
+  implements. Context: executed on the owner's resume-vs-kill check
+  (2026-08-20) after the campaign sat 7 days idle; the off-path audit
+  (docs/offpath-code-followups.md) had queued ~3.7k lines of this
+  campaign's entry-path plumbing behind exactly this gate. **P1 is
+  unblocked.***
 - *2026-08-13 — third review round, verdict "no blocker/major": three
   minors absorbed — the relocation distinction now claimed against the
   three relocation deaths specifically (wide-row splitting and folding

--- a/docs/rfc-068-multi-group-stamping.md
+++ b/docs/rfc-068-multi-group-stamping.md
@@ -345,11 +345,22 @@ registry row if it stays within the size norm.
   ALONE (ports + entities + motif — never the native band's row
   bookkeeping) reproduces the native band's per-item input-belt ys,
   output ys, port-edge/role admissibility, and the continuous-coverage →
-  `output_feed_x_min = None` branch — anchored BOTH against a fresh
-  `extract_unit` re-extraction AND against an independent run-head/exit
-  derivation sharing no code with the extractor (added on the #672
-  review, which correctly showed the first anchor alone is circular
-  through shared extraction logic). Index-preserving substitution
+  `output_feed_x_min = None` branch (guarded: a count-sufficient but
+  left-sparse drop set now REFUSES rather than guesses) — anchored three
+  ways: a fresh `extract_unit` re-extraction (drift isolation); a
+  run-head/exit re-derivation sharing no code with the extractor; and,
+  for input heads, an OUTSIDE-FEEDER anchor — a different METHOD (which
+  belt-family entity feeds the tile from outside the band, valid on the
+  owner-confirmed no-sideload-into-row-inputs invariant), added when
+  #672's round-2 review correctly showed the code-independent anchor
+  still shares the extractor's run-boundary heuristic. Honest residual:
+  belt-out exits have no second method (boundary-scan both times),
+  corroborated by the fragment-side port-edge/direction contract; P1's
+  byte-identical control is the router-facing exit instrument. The
+  feeder anchor's first run also caught a real subtlety worth recording:
+  machine-feeding inserters' direction vectors land on the run and must
+  not count as feeders — feeder ≡ belt-family. Index-preserving
+  substitution
   (power-wire records reference entity indices) then bijects the band
   exactly, and the validator verdict is fully parity-checked
   (issue-list + detail equality). Honest weighting, from the same


### PR DESCRIPTION
## Intent

Execute RFC-068's Phase 0 (owner call, 2026-08-20, after the resume-vs-kill status check): the self-stamp fidelity probe that adjudicates K68-1 and the unit half of K68-2 before any donor work is funded. It PASSED.

## Scope

One new test file (`rfc068_p0_selfstamp.rs`, ~430 lines — a single atomic instrument, not splittable) + the RFC decision-log entry + the off-path followups Tier-3 resolution (KEEP-CAMPAIGN). No product code, per the RFC's P0 phasing. Slightly over the 400-add norm because the probe is one instrument whose halves are meaningless separately.

## Verification actually run

- Probe run with pinned SAT zone cache: **2/2 tests green in ~4s** — all five engine seeds (copper-plate / iron-plate / copper-cable intermediates, ec + ac finals), both K68-1 band roles.
- Asserted per seed: adapter-from-declared-ports reproduces native input-belt ys in schedule order, output ys, port-edge/role admissibility, continuous-coverage → `output_feed_x_min = None`; stored-vs-fresh port drift (isolation re-assert); entity identity under index-preserving substitution; **full validator issue-list parity** (stronger than K68-1's Error-parity bar).
- Escape hatches used: **zero** (K68-2 unit half). One probe-harness bug fixed en route (per-tile direction vs the RFC's port-edge criterion) — recorded in the decision log, not an escape hatch.
- Seed selection is provenance-scoped (`engine@…`), never `query_unit` — the copper-plate@48 collision would otherwise silently stamp the community donor and void isolation.

## Deviations

None from the RFC's P0 spec. Stated scope limit (also in the decision log): with identity proven, verdict parity cannot probe the router reacting to a *differing* stamp — that instrument is P1's byte-identical controls and P2's donors, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)