### PR TITLE
del(tier1): scattered verified-dead — belt_flow twins, junction cluster, orphaned helpers

### DIFF
--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -645,12 +645,9 @@ pub struct NamedAnalysis {
     pub analysis: BlueprintAnalysis,
 }
 
-/// Parse a blueprint string and analyze it in one step.
-pub fn analyze_blueprint_string(bp: &str) -> Result<(LayoutResult, BlueprintAnalysis), String> {
-    let layout = blueprint_parser::parse_blueprint_string(bp)?;
-    let analysis = analyze(&layout);
-    Ok((layout, analysis))
-}
+// (The singular analyze_blueprint_string wrapper was deleted 2026-08-20,
+// offpath Tier 1 — mining-cli, the only production consumer, calls the
+// `_any` form exclusively for book support.)
 
 /// Parse a blueprint string (single or book) and analyze all blueprints.
 pub fn analyze_blueprint_string_any(bp: &str) -> Result<Vec<NamedAnalysis>, String> {
@@ -748,7 +745,7 @@ mod tests {
     fn round_trip_analysis() {
         let layout = make_test_layout();
         let bp = blueprint::export(&layout, "test");
-        let (_, analysis) = analyze_blueprint_string(&bp).unwrap();
+        let analysis = analyze_blueprint_string_any(&bp).unwrap().remove(0).analysis;
         assert_eq!(analysis.machine_count, 2);
         assert!(analysis.final_products.contains(&"iron-gear-wheel".to_string()));
     }

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -252,11 +252,8 @@ impl SatConstraints {
     }
 }
 
-impl Default for SatConstraints {
-    fn default() -> Self {
-        Self::unrestricted()
-    }
-}
+// (impl Default for SatConstraints deleted 2026-08-20, offpath Tier 1 —
+// every site uses the named constructors.)
 
 pub struct SatStrategy {
     name: &'static str,

--- a/crates/core/src/bus/junction_sat_strategy.rs
+++ b/crates/core/src/bus/junction_sat_strategy.rs
@@ -1,5 +1,6 @@
-//! SAT-based junction strategy — wraps `crate::sat::solve_crossing_zone`
-//! over a grown region.
+//! SAT-based junction strategy — wraps
+//! `crate::sat::solve_crossing_zone_per_channel` (and its cost-cap
+//! variant) over a grown region.
 //!
 //! Only fires on regions that have grown past the initial single-tile
 //! crossing: a 1×1 zone has entry==exit for every spec, which is not a

--- a/crates/core/src/bus/junction_solver.rs
+++ b/crates/core/src/bus/junction_solver.rs
@@ -13,9 +13,10 @@
 //!   representing the range of path tiles currently in the region,
 //! - and a cached tile set so "is this tile in the region?" is O(1).
 //!
-//! Each iteration of `grow()` advances both ends of each frontier by
-//! one step. The bbox is the tight enclosing rectangle of the accumulated
-//! tile set. Tiles inside the bbox that belong to non-participating
+//! Each growth iteration (`expand_bbox`; the per-frontier `grow()`
+//! primitive it superseded was deleted 2026-08-20, offpath Tier 1)
+//! widens the region. The bbox is the tight enclosing rectangle of the
+//! accumulated tile set. Tiles inside the bbox that belong to non-participating
 //! specs' paths are marked forbidden — strategies must avoid them. If
 //! a future strategy wants to also rewrite one of those specs, it can
 //! be promoted to participating in a later pass (not yet implemented —
@@ -243,9 +244,10 @@ impl GrowingRegion {
     /// the SAT encoder with specs that aren't part of the actual
     /// crossing being resolved.
     ///
-    /// This is the growth primitive used by the CEGAR loop: unlike
-    /// `grow()` (which walks each spec's frontier by one step along
-    /// its own axis), `expand_bbox` grows perpendicular to spec axes
+    /// This is the growth primitive used by the CEGAR loop: unlike the
+    /// deleted per-frontier `grow()` (which walked each spec's frontier
+    /// one step along its own axis), `expand_bbox` grows perpendicular
+    /// to spec axes
     /// and can absorb perpendicular trunks the seed crossing had never
     /// heard of — the copper-cable column-4 trunk in the
     /// tier2_electronic_circuit case being the canonical example.
@@ -398,88 +400,10 @@ impl GrowingRegion {
         true
     }
 
-    /// Advance each participating spec's frontier by one step in each
-    /// direction along its path. Updates the bbox, the tile set, and
-    /// the forbidden cache. Returns `true` if any new tile entered the
-    /// region.
-    #[allow(dead_code)]
-    pub fn grow(
-        &mut self,
-        routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
-        hard_obstacles: &FxHashSet<(i32, i32)>,
-        strict_obstacles: &FxHashSet<(i32, i32)>,
-        placed_entities: &[PlacedEntity],
-    ) -> bool {
-        let mut added_any = false;
-        let keys: Vec<String> = self.participating.clone();
-        for key in &keys {
-            let Some(path) = routed_paths.get(key) else {
-                continue;
-            };
-            let Some(&(start, end)) = self.frontiers.get(key) else {
-                continue;
-            };
-            let mut new_start = start;
-            let mut new_end = end;
-            if start > 0 {
-                new_start = start - 1;
-                let t = path[new_start];
-                if self.tiles.insert(t) {
-                    added_any = true;
-                }
-            }
-            if end + 1 < path.len() {
-                new_end = end + 1;
-                let t = path[new_end];
-                if self.tiles.insert(t) {
-                    added_any = true;
-                }
-            }
-            self.frontiers.insert(key.clone(), (new_start, new_end));
-        }
-        if added_any {
-            self.recompute_bbox();
-            self.refresh_forbidden(
-                routed_paths,
-                hard_obstacles,
-                strict_obstacles,
-                placed_entities,
-            );
-        }
-        added_any
-    }
-
     /// Number of tiles currently in the region. Checked against
     /// `MAX_REGION_TILES` by the outer loop.
     pub fn tile_count(&self) -> usize {
         self.tiles.len()
-    }
-
-    fn recompute_bbox(&mut self) {
-        let mut min_x = i32::MAX;
-        let mut max_x = i32::MIN;
-        let mut min_y = i32::MAX;
-        let mut max_y = i32::MIN;
-        for &(x, y) in &self.tiles {
-            if x < min_x {
-                min_x = x;
-            }
-            if x > max_x {
-                max_x = x;
-            }
-            if y < min_y {
-                min_y = y;
-            }
-            if y > max_y {
-                max_y = y;
-            }
-        }
-        self.bbox = Rect {
-            x: min_x,
-            y: min_y,
-            w: (max_x - min_x + 1) as u32,
-            h: (max_y - min_y + 1) as u32,
-        };
     }
 
     fn refresh_forbidden(
@@ -602,54 +526,6 @@ impl GrowingRegion {
                 self.forbidden_tiles.insert(t);
             }
         }
-    }
-
-    /// Promote any encountered spec whose *entire* routed path is already
-    /// inside the current tile set. These specs are "fully engulfed" —
-    /// every tile they occupy is within the zone bbox — and must be routed
-    /// by the SAT solver or they become orphaned crossing specs.
-    ///
-    /// Typical case: a 1-tile trunk column that sits directly on the path
-    /// of a longer tap. The tap's crossing zone grows to include that tile,
-    /// which causes the trunk to appear in `encountered`. Without promotion
-    /// the SAT doesn't know about the trunk and places an entity that
-    /// conflicts with it.
-    #[allow(dead_code)]
-    pub fn promote_fully_enclosed(
-        &mut self,
-        routed_paths: &FxHashMap<String, Vec<(i32, i32)>>,
-        hard_obstacles: &FxHashSet<(i32, i32)>,
-        strict_obstacles: &FxHashSet<(i32, i32)>,
-        placed_entities: &[PlacedEntity],
-    ) {
-        let to_promote: Vec<String> = self
-            .encountered
-            .iter()
-            .filter(|key| {
-                routed_paths
-                    .get(key.as_str())
-                    .is_some_and(|path| path.iter().all(|t| self.tiles.contains(t)))
-            })
-            .cloned()
-            .collect();
-        if to_promote.is_empty() {
-            return;
-        }
-        for key in &to_promote {
-            if let Some(path) = routed_paths.get(key.as_str()) {
-                let start = 0;
-                let end = path.len().saturating_sub(1);
-                self.frontiers.insert(key.clone(), (start, end));
-            }
-            self.participating.push(key.clone());
-        }
-        self.encountered.retain(|k| !to_promote.contains(k));
-        self.refresh_forbidden(
-            routed_paths,
-            hard_obstacles,
-            strict_obstacles,
-            placed_entities,
-        );
     }
 
     /// Materialize a `Junction` snapshot suitable for strategy input.
@@ -2004,22 +1880,6 @@ fn try_solve_on_region(
 
     TryOutcome::Continue { veto_tiles, deferred }
 }
-
-/// Every tile inside `bbox` (inclusive on the min side, exclusive on the
-/// max side, per `Rect`'s convention). Kept as a helper in case future
-/// strategies want to release the whole footprint — the current walker
-/// wiring releases only SAT-proposed tiles instead.
-#[allow(dead_code)]
-fn bbox_tiles_set(bbox: Rect) -> FxHashSet<(i32, i32)> {
-    let mut out = FxHashSet::default();
-    for dy in 0..bbox.h as i32 {
-        for dx in 0..bbox.w as i32 {
-            out.insert((bbox.x + dx, bbox.y + dy));
-        }
-    }
-    out
-}
-
 /// True iff `(x, y)` falls inside `bbox` expanded by one tile on each
 /// side. The walker uses this to decide which routed paths to check —
 /// anything one tile beyond the bbox can still interact with the

--- a/crates/core/src/bus/partitioner.rs
+++ b/crates/core/src/bus/partitioner.rs
@@ -27,7 +27,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::models::{ItemFlow, MachineSpec, SolverResult};
+use crate::models::{MachineSpec, SolverResult};
 use crate::trace::{self, TraceEvent};
 
 /// Per-belt-tier per-lane (belt-side) capacity in items/s. Mirrors
@@ -66,52 +66,9 @@ pub fn lane_capacity(max_belt_tier: Option<&str>) -> f64 {
     }
 }
 
-/// `lane_rate / (capacity * 0.75)` — the saturation fraction relative
-/// to the utilization ceiling. Returns `> 1.0` when the lane busts the
-/// 75% gate. Phase 1 partitioner emits
-/// `TraceEvent::PartitionRejectedByUtilization` and produces an invalid
-/// layout when this happens, instead of silently falling back to
-/// `Pooled`.
-pub fn lane_utilization(lane_rate: f64, max_belt_tier: Option<&str>) -> f64 {
-    let cap = lane_capacity(max_belt_tier);
-    if cap <= 0.0 {
-        return f64::INFINITY;
-    }
-    lane_rate / (cap * UTILIZATION_CEILING)
-}
-
-/// Per-item count of consuming recipe-rows. The partitioner uses this
-/// to decide which items need K>1 modules under
-/// `PartitionedDecomposed`. Iteration over `solver_result.machines` is
-/// the right unit because the placer turns each `MachineSpec` into one
-/// or more `RowSpan` instances; the count of unique consuming
-/// recipes is a conservative under-estimate of consuming rows
-/// (post-`placer.rs` row-splitting can multiply this further). For PR1's
-/// K=1-vs-K>1 fan-out check, the conservative count is sufficient
-/// because it can only over-detect K=1 cases (false negatives for
-/// partitioning), never the other way around.
-pub fn consumers_per_item(solver_result: &SolverResult) -> FxHashMap<String, u32> {
-    let mut counts: FxHashMap<String, u32> = FxHashMap::default();
-    for m in &solver_result.machines {
-        for inp in &m.inputs {
-            *counts.entry(inp.item.clone()).or_insert(0) += 1;
-        }
-    }
-    counts
-}
-
-/// Items that the partitioner would produce K>1 modules for. Under
-/// `PartitionedDecomposed`, these are the items whose handling diverges
-/// from `Pooled`.
-pub fn multi_consumer_items(solver_result: &SolverResult) -> Vec<String> {
-    let mut items: Vec<String> = consumers_per_item(solver_result)
-        .into_iter()
-        .filter(|(_, k)| *k > 1)
-        .map(|(item, _)| item)
-        .collect();
-    items.sort();
-    items
-}
+// (lane_utilization, consumers_per_item, and multi_consumer_items were
+// deleted 2026-08-20, offpath-code-followups Tier 1 — zero callers;
+// plan_partitioning derives utilization inline.)
 
 /// Per-recipe partition assignment. Under `PartitionedDecomposed`,
 /// item X with K consuming recipes gets K modules, indexed by the
@@ -162,19 +119,8 @@ impl PartitionPlan {
         self.modules.is_empty()
     }
 
-    /// Look up a module by `(item, consumer_recipe)`. Returns `None`
-    /// if the item is not partitioned (i.e. K=1 or fluid).
-    pub fn module_for_consumer(&self, item: &str, consumer_recipe: &str) -> Option<&ModuleAssignment> {
-        self.modules
-            .iter()
-            .find(|m| m.item == item && m.consumer_recipe == consumer_recipe)
-    }
-
-    /// Number of modules allocated for `item`. `0` when not
-    /// partitioned (treat as Pooled / module_id 0).
-    pub fn modules_for_item(&self, item: &str) -> u32 {
-        self.modules.iter().filter(|m| m.item == item).count() as u32
-    }
+    // (module_for_consumer and modules_for_item deleted 2026-08-20,
+    // offpath Tier 1 — zero callers.)
 
     /// The plan's `lane_count` for `(item, module_id)`, or `None` if no
     /// module is recorded. The lane planner consults this as a lower
@@ -979,17 +925,14 @@ pub(crate) fn apply_cap_driven_split(
     new_modules
 }
 
-/// Convenience helper: an `ItemFlow` constructor that fills in `module_id: 0`.
-/// Used by call sites that don't care about partitioning.
-pub fn pooled_flow(item: impl Into<String>, rate: f64, is_fluid: bool) -> ItemFlow {
-    ItemFlow { item: item.into(), rate, is_fluid, module_id: 0 }
-}
+// (pooled_flow deleted 2026-08-20, offpath Tier 1 — its doc-claimed call
+// sites did not exist.)
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::bus::layout::LayoutStrategy;
-    use crate::models::MachineSpec;
+    use crate::models::{ItemFlow, MachineSpec};
 
     #[test]
     fn lane_capacity_falls_back_to_fastest_tier() {
@@ -1000,16 +943,6 @@ mod tests {
         assert_eq!(lane_capacity(Some("express-transport-belt")), 22.5);
         // Unknown tier → fastest.
         assert_eq!(lane_capacity(Some("not-a-belt")), 22.5);
-    }
-
-    #[test]
-    fn utilization_ceiling_at_75_percent() {
-        // Yellow belt: 7.5/s per side × 0.75 = 5.625 ceiling.
-        assert!((lane_utilization(5.625, Some("transport-belt")) - 1.0).abs() < 1e-9);
-        // Just over → > 1.0.
-        assert!(lane_utilization(5.7, Some("transport-belt")) > 1.0);
-        // Just under → < 1.0.
-        assert!(lane_utilization(5.5, Some("transport-belt")) < 1.0);
     }
 
     fn flow(item: &str, rate: f64) -> ItemFlow {

--- a/crates/core/src/classify.rs
+++ b/crates/core/src/classify.rs
@@ -894,7 +894,8 @@ mod tests {
             ..Default::default()
         };
         let bp = blueprint::export(&layout, "di-test");
-        let (imported, analysis) = crate::analysis::analyze_blueprint_string(&bp).unwrap();
+        let parsed = crate::analysis::analyze_blueprint_string_any(&bp).unwrap().remove(0);
+        let (imported, analysis) = (parsed.layout, parsed.analysis);
         let f = classify(&imported, &analysis);
         assert_eq!(f.direct_insertion, 1, "round-trip should preserve DI");
     }

--- a/crates/core/src/sat.rs
+++ b/crates/core/src/sat.rs
@@ -1740,43 +1740,6 @@ pub fn ug_name_for_tier(belt_tier: &str) -> &str {
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Solve a crossing zone, returning placed entities or None if unsatisfiable.
-/// Unrestricted: both surface and underground-belt entities are allowed,
-/// no UG budget. Callers that want to cost-shape the solver should use
-/// `solve_crossing_zone_with_stats` directly with a `max_ug_ins` cap.
-pub fn solve_crossing_zone(
-    zone: &CrossingZone,
-    max_ug_reach: u32,
-    belt_tier: &str,
-) -> Option<CrossingZoneSolution> {
-    let (entities, stats) =
-        solve_crossing_zone_with_stats(zone, max_ug_reach, belt_tier, None);
-    entities.map(|ents| CrossingZoneSolution { entities: ents, stats })
-}
-
-/// Same as `solve_crossing_zone` but always returns the encoder/solver
-/// stats, even on UNSAT. Callers doing instrumentation (trace events,
-/// diagnostics) use this so variables/clauses/solve_time are still
-/// surfaced when the solver couldn't find a satisfying assignment.
-///
-/// `max_ug_ins`: optional cap on the number of UG corridors.
-/// - `None`: unlimited (original behaviour).
-/// - `Some(0)`: hard-forbid UG entities (surface-only routing).
-/// - `Some(k)` for `k ≥ 1`: at most `k` UG-in tiles, used to find the
-///   simplest layout that still routes (e.g. spend exactly one UG on a
-///   real crossing and keep every other item on the surface).
-pub fn solve_crossing_zone_with_stats(
-    zone: &CrossingZone,
-    max_ug_reach: u32,
-    belt_tier: &str,
-    max_ug_ins: Option<u32>,
-) -> (Option<Vec<PlacedEntity>>, CrossingZoneStats) {
-    let channel_info = channel_info_from_boundaries(&zone.boundaries);
-    let n_channels = channel_info.len() as u32;
-    let channel_reaches: Vec<u32> = vec![max_ug_reach; n_channels.max(1) as usize];
-    solve_crossing_zone_per_channel(zone, &channel_reaches, belt_tier, max_ug_ins)
-}
-
 /// If any channel's boundaries are all sources or all sinks, the zone cannot
 /// conserve flow and is therefore UNSAT — return a short human-readable
 /// reason (`"chN Xin/Yout"`). `None` means every channel has at least one
@@ -2054,6 +2017,24 @@ pub fn solve_crossing_zone_with_pins(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Test-local stand-in for the deleted legacy `solve_crossing_zone`
+    /// wrapper (offpath-code-followups Tier 1, 2026-08-20; its
+    /// `_with_stats` sibling went with it) — production calls
+    /// `solve_crossing_zone_per_channel` directly, and these tests keep
+    /// the old single-reach convenience shape.
+    fn solve_crossing_zone(
+        zone: &CrossingZone,
+        max_ug_reach: u32,
+        belt_tier: &str,
+    ) -> Option<CrossingZoneSolution> {
+        let channel_info = channel_info_from_boundaries(&zone.boundaries);
+        let n_channels = channel_info.len() as u32;
+        let channel_reaches: Vec<u32> = vec![max_ug_reach; n_channels.max(1) as usize];
+        let (entities, stats) =
+            solve_crossing_zone_per_channel(zone, &channel_reaches, belt_tier, None);
+        entities.map(|ents| CrossingZoneSolution { entities: ents, stats })
+    }
 
     fn simple_crossing_zone(width: u32, height: u32) -> CrossingZone {
         let mid_x = width / 2;

--- a/crates/core/src/snapshot.rs
+++ b/crates/core/src/snapshot.rs
@@ -167,12 +167,9 @@ impl LayoutSnapshot {
         std::fs::write(path, encoded)
     }
 
-    /// Read and decode a snapshot from a file.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn read_from_file(path: &Path) -> Result<Self, SnapshotError> {
-        let contents = std::fs::read_to_string(path).map_err(SnapshotError::Io)?;
-        Self::decode(&contents)
-    }
+    // (read_from_file deleted 2026-08-20, offpath Tier 1 — zero callers;
+    // the documented .fls read-back is the shell pipeline in
+    // docs/layout-snapshot-debugger.md.)
 }
 
 /// Errors that can occur during snapshot encode/decode.

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1155,8 +1155,11 @@ pub enum TraceEvent {
         elapsed_us: u64,
     },
 
-    /// Emitted by the SAT strategy every time `solve_crossing_zone` is
-    /// called, with the full invocation signature. This is enough to
+    /// Emitted by the SAT strategy every time the SAT solver is invoked
+    /// (`solve_crossing_zone_per_channel` / `_with_cost_cap` — the legacy
+    /// `solve_crossing_zone` wrapper this comment once named was deleted
+    /// 2026-08-20, offpath Tier 1), with the full invocation signature.
+    /// This is enough to
     /// replay a single SAT solve in isolation (outside the larger
     /// junction solver). Complements JunctionStrategyAttempt with
     /// SAT-specific numbers.

--- a/crates/core/src/validate/belt_flow.rs
+++ b/crates/core/src/validate/belt_flow.rs
@@ -1367,150 +1367,6 @@ pub fn check_belt_flow_reachability(
 
     issues
 }
-
-// ---------------------------------------------------------------------------
-// 7. check_belt_throughput
-// ---------------------------------------------------------------------------
-
-pub fn check_belt_throughput(layout: &LayoutResult) -> Vec<ValidationIssue> {
-    let mut issues = Vec::new();
-
-    let mut tile_counts: FxHashMap<(i32, i32), usize> = FxHashMap::default();
-    let mut tile_names: FxHashMap<(i32, i32), &str> = FxHashMap::default();
-
-    for e in &layout.entities {
-        if is_belt_entity(&e.name) {
-            let pos = (e.x, e.y);
-            *tile_counts.entry(pos).or_insert(0) += 1;
-            tile_names.insert(pos, &e.name);
-        }
-    }
-
-    for (&pos, &count) in &tile_counts {
-        if count > 1 {
-            let belt_name = tile_names.get(&pos).copied().unwrap_or("transport-belt");
-            let max_throughput = match belt_name {
-                "transport-belt" | "underground-belt" => 15.0_f64,
-                "fast-transport-belt" | "fast-underground-belt" => 30.0,
-                "express-transport-belt" | "express-underground-belt" => 45.0,
-                _ => 15.0,
-            };
-            issues.push(ValidationIssue::with_pos(
-                Severity::Warning,
-                "belt-throughput",
-                format!(
-                    "Belt at ({},{}): {} overlapping routes on {} (max {}/s)",
-                    pos.0, pos.1, count, belt_name, max_throughput
-                ),
-                pos.0,
-                pos.1,
-            ));
-        }
-    }
-
-    issues
-}
-
-// ---------------------------------------------------------------------------
-// 8. check_output_belt_coverage
-// ---------------------------------------------------------------------------
-
-pub fn check_output_belt_coverage(
-    layout: &LayoutResult,
-    solver: Option<&SolverResult>,
-) -> Vec<ValidationIssue> {
-    let mut issues = Vec::new();
-
-    let mut fluid_output_recipes: FxHashSet<String> = FxHashSet::default();
-    if let Some(sr) = solver {
-        for spec in &sr.machines {
-            if !spec.outputs.iter().any(|f| !f.is_fluid) {
-                fluid_output_recipes.insert(spec.recipe.clone());
-            }
-        }
-    }
-
-    let machine_tiles_set = build_machine_tile_set(layout);
-    let belt_tiles = build_belt_tile_set(&layout.entities);
-
-    let mut checked: FxHashSet<(i32, i32)> = FxHashSet::default();
-    for e in &layout.entities {
-        if !is_machine_entity(&e.name) {
-            continue;
-        }
-        if !checked.insert((e.x, e.y)) {
-            continue;
-        }
-        if e.recipe
-            .as_deref()
-            .is_some_and(|r| fluid_output_recipes.contains(r))
-        {
-            continue;
-        }
-
-        let (mw, mh) = machine_dims(&e.name);
-        let (mw, mh) = (mw as i32, mh as i32);
-        let my_tiles: FxHashSet<(i32, i32)> = (0..mw)
-            .flat_map(|dx| (0..mh).map(move |dy| (e.x + dx, e.y + dy)))
-            .collect();
-
-        let mut has_output_belt = false;
-        'outer: for ins in &layout.entities {
-            if !is_inserter(&ins.name) {
-                continue;
-            }
-            let (dx, dy) = dir_to_vec(ins.direction);
-            let reach = inserter_reach(&ins.name);
-            let (odx, ody) = (-dx, -dy);
-            let pickup_pos = (ins.x + odx * reach, ins.y + ody * reach);
-            let drop_pos = (ins.x + dx * reach, ins.y + dy * reach);
-
-            if my_tiles.contains(&pickup_pos)
-                && !machine_tiles_set.contains(&drop_pos)
-                && belt_tiles.contains(&drop_pos)
-            {
-                has_output_belt = true;
-                break 'outer;
-            }
-        }
-
-        // RFC-053: a DI-cell producer's output leaves by inserter into the
-        // consumer machine, never onto a belt. See `is_di_cell_entity`.
-        // Both ends are tested. Picking from this machine is not enough:
-        // the cell tags EVERY entity it stamps, including the consumer's
-        // own output inserter, which also picks from inside its machine —
-        // but drops onto a real belt and must stay under this check.
-        // Requiring the drop tile to be a machine too is what distinguishes
-        // a coupler from an ordinary output inserter living in a cell.
-        let served_by_di_cell = layout.entities.iter().any(|ins| {
-            is_inserter(&ins.name)
-                && super::is_di_cell_entity(ins.segment_id.as_deref())
-                && {
-                    let (dx, dy) = dir_to_vec(ins.direction);
-                    let reach = inserter_reach(&ins.name);
-                    let pick = (ins.x - dx * reach, ins.y - dy * reach);
-                    let drop = (ins.x + dx * reach, ins.y + dy * reach);
-                    my_tiles.contains(&pick) && machine_tiles_set.contains(&drop)
-                }
-        });
-
-        if !has_output_belt && !served_by_di_cell {
-            issues.push(ValidationIssue::with_pos(
-                Severity::Error,
-                "output-belt",
-                format!(
-                    "{} at ({},{}): no output inserter has a belt at its drop position",
-                    e.name, e.x, e.y
-                ),
-                e.x,
-                e.y,
-            ));
-        }
-    }
-
-    issues
-}
-
 // ---------------------------------------------------------------------------
 // 9. check_underground_belt_pairs
 // ---------------------------------------------------------------------------
@@ -1751,53 +1607,6 @@ pub fn check_underground_belt_entry_sideload(layout: &LayoutResult) -> Vec<Valid
                     ));
                 }
             }
-        }
-    }
-
-    issues
-}
-
-// ---------------------------------------------------------------------------
-// 15. check_belt_inserter_conflict
-// ---------------------------------------------------------------------------
-
-pub fn check_belt_inserter_conflict(layout: &LayoutResult) -> Vec<ValidationIssue> {
-    let mut issues = Vec::new();
-
-    let belt_tiles = build_belt_tile_set(&layout.entities);
-    let mut drop_map: FxHashMap<(i32, i32), Vec<String>> = FxHashMap::default();
-
-    for e in &layout.entities {
-        if !is_inserter(&e.name) {
-            continue;
-        }
-        let carries = match &e.carries {
-            Some(c) => c.clone(),
-            None => continue,
-        };
-        let (dx, dy) = dir_to_vec(e.direction);
-        let reach = inserter_reach(&e.name);
-        let drop = (e.x + dx * reach, e.y + dy * reach);
-        if belt_tiles.contains(&drop) {
-            drop_map.entry(drop).or_default().push(carries);
-        }
-    }
-
-    for (&(bx, by), items) in &drop_map {
-        let unique: FxHashSet<&str> = items.iter().map(|s| s.as_str()).collect();
-        if unique.len() >= 2 {
-            let mut sorted: Vec<&str> = unique.into_iter().collect();
-            sorted.sort();
-            issues.push(ValidationIssue::with_pos(
-                Severity::Error,
-                "belt-item-isolation",
-                format!(
-                    "Belt at ({},{}): inserters drop conflicting items {:?} and {:?}",
-                    bx, by, sorted[0], sorted[1]
-                ),
-                bx,
-                by,
-            ));
         }
     }
 
@@ -4484,40 +4293,6 @@ mod tests {
         assert_eq!(errors.len(), 1);
     }
 
-    // --- check_belt_throughput ---
-
-    #[test]
-    fn belt_throughput_no_overlap_ok() {
-        let lr = LayoutResult {
-            entities: vec![
-                belt(0, 0, EntityDirection::East),
-                belt(1, 0, EntityDirection::East),
-            ],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        assert!(check_belt_throughput(&lr).is_empty());
-    }
-
-    #[test]
-    fn belt_throughput_overlapping_warning() {
-        let lr = LayoutResult {
-            entities: vec![
-                belt(0, 0, EntityDirection::East),
-                belt(0, 0, EntityDirection::South),
-            ],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        let issues = check_belt_throughput(&lr);
-        let warnings: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Warning).collect();
-        assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].category, "belt-throughput");
-        assert!(warnings[0].message.contains("2 overlapping"));
-    }
-
     // --- check_belt_junctions ---
 
     #[test]
@@ -4968,73 +4743,14 @@ mod tests {
     // checks (never dispatched from validate/mod.rs) — deleted per issue
     // #488's cleanup; belt_structural::tests carries the equivalent coverage
     // (belt_loop_* / item_isolation_* tests).
-
-    // --- check_belt_inserter_conflict ---
-
-    #[test]
-    fn inserter_conflict_same_item_ok() {
-        let belt_e = PlacedEntity {
-            name: "transport-belt".to_string(),
-            x: 0,
-            y: 1,
-            direction: EntityDirection::East,
-            carries: Some("iron-plate".to_string()),
-            ..Default::default()
-        };
-        let ins = PlacedEntity {
-            name: "inserter".to_string(),
-            x: 0,
-            y: 0,
-            direction: EntityDirection::South,
-            carries: Some("iron-plate".to_string()),
-            ..Default::default()
-        };
-        let lr = LayoutResult {
-            entities: vec![belt_e, ins],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        assert!(check_belt_inserter_conflict(&lr).is_empty());
-    }
-
-    #[test]
-    fn inserter_conflict_different_items_error() {
-        // Two inserters dropping onto the same belt tile with different items
-        let belt_e = PlacedEntity {
-            name: "transport-belt".to_string(),
-            x: 0,
-            y: 1,
-            direction: EntityDirection::East,
-            carries: Some("iron-plate".to_string()),
-            ..Default::default()
-        };
-        let ins1 = PlacedEntity {
-            name: "inserter".to_string(),
-            x: 0,
-            y: 0,
-            direction: EntityDirection::South,
-            carries: Some("iron-plate".to_string()),
-            ..Default::default()
-        };
-        let ins2 = PlacedEntity {
-            name: "inserter".to_string(),
-            x: 1,
-            y: 1,
-            direction: EntityDirection::West,
-            carries: Some("copper-plate".to_string()),
-            ..Default::default()
-        };
-        let lr = LayoutResult {
-            entities: vec![belt_e, ins1, ins2],
-            width: 10,
-            height: 10,
-            ..Default::default()
-        };
-        let issues = check_belt_inserter_conflict(&lr);
-        let errors: Vec<_> = issues.iter().filter(|i| i.severity == Severity::Error).collect();
-        assert!(!errors.is_empty());
-    }
+    //
+    // 2026-08-20 (offpath-code-followups Tier 1): the same disease's third
+    // harvest — check_belt_throughput, check_output_belt_coverage, and
+    // check_belt_inserter_conflict were the remaining shadowed twins of
+    // belt_structural's dispatched copies (the #632 B5 arbitration cleaned
+    // the lane-throughput twin in the other direction) and were deleted
+    // with their tests here; belt_structural::tests carries the live
+    // coverage.
 
     // --- check_lane_throughput ---
 

--- a/crates/core/src/zone_cache.rs
+++ b/crates/core/src/zone_cache.rs
@@ -110,18 +110,12 @@ static LOOKUP_HIT_UNSAT: AtomicUsize = AtomicUsize::new(0);
 /// Subset of hits that were `Timeout` cache entries — caller saved a SAT call.
 static LOOKUP_HIT_TIMEOUT: AtomicUsize = AtomicUsize::new(0);
 
-/// Return `(total, hits, misses)` across all `lookup_zone` calls so far.
-/// Counters use `Relaxed` ordering — eventual consistency only, no guarantees
-/// about cross-thread visibility at any exact instant. Good enough for stats.
-pub fn cache_stats() -> (usize, usize, usize) {
-    (
-        LOOKUP_TOTAL.load(Ordering::Relaxed),
-        LOOKUP_HIT.load(Ordering::Relaxed),
-        LOOKUP_MISS.load(Ordering::Relaxed),
-    )
-}
+// (cache_stats deleted 2026-08-20, offpath Tier 1 — superseded by
+// cache_stats_extended, the copy everything calls.)
 
 /// Extended stats: `(total, hits_solved, hits_unsat, hits_timeout, misses)`.
+/// Counters use `Relaxed` ordering — eventual consistency only, no guarantees
+/// about cross-thread visibility at any exact instant. Good enough for stats.
 pub fn cache_stats_extended() -> (usize, usize, usize, usize, usize) {
     let total  = LOOKUP_TOTAL.load(Ordering::Relaxed);
     let hits   = LOOKUP_HIT.load(Ordering::Relaxed);

--- a/crates/core/tests/region_fixtures/README.md
+++ b/crates/core/tests/region_fixtures/README.md
@@ -143,7 +143,7 @@ The capture filters `routed_paths`, obstacles, and `placed_entities` to a 20-til
 
 | | `sat_fixtures/` | `region_fixtures/` (this dir) |
 |---|---|---|
-| Target | `solve_crossing_zone_with_stats` (SAT encoder) | `solve_crossing` (full region solver) |
+| Target | `solve_crossing_zone_with_pins` (empty pin set) (SAT encoder) | `solve_crossing` (full region solver) |
 | Tests | boundary handling, UG budget, encoding correctness | growth loop, walker veto, DeferredExit, strategy fallback |
 | Inputs | `CrossingZone` (just boundaries + bbox) | `RegionFixture` (every solve_crossing argument) |
 | Size on disk | small (1–3 KB typical) | larger (10–50 KB typical — routed_paths and placed_entities dominate) |

--- a/crates/core/tests/sat_fixtures.rs
+++ b/crates/core/tests/sat_fixtures.rs
@@ -13,7 +13,7 @@
 
 use spaghettio_core::bus::junction_cost::solution_cost;
 use spaghettio_core::fixture::{build_zone, Fixture};
-use spaghettio_core::sat::solve_crossing_zone_with_stats;
+use spaghettio_core::sat::solve_crossing_zone_with_pins;
 use std::path::Path;
 
 #[test]
@@ -68,8 +68,12 @@ fn sat_fixtures() {
         let zone = build_zone(&fixture);
         let belt_name: &str = &fixture.belt_tier;
 
+        // Empty pin set ≡ the deleted legacy `solve_crossing_zone_with_stats`
+        // wrapper (offpath Tier 1, 2026-08-20) — the identity the sat_pins
+        // suite itself asserts; the pins entry is also the production
+        // (WASM re-solve) path, so fixtures now exercise the live API.
         let (result, _stats) =
-            solve_crossing_zone_with_stats(&zone, fixture.max_reach, belt_name, None);
+            solve_crossing_zone_with_pins(&zone, &[], fixture.max_reach, belt_name, None);
 
         match fixture.expected.mode.as_str() {
             "solve" => match result {

--- a/crates/core/tests/sat_fixtures/README.md
+++ b/crates/core/tests/sat_fixtures/README.md
@@ -12,7 +12,7 @@ the solver behaves as expected.
 
 `crates/core/tests/sat_fixtures.rs` reads every `*.json` in this directory,
 deserialises each into a `Fixture` struct, constructs a `CrossingZone`, calls
-`solve_crossing_zone_with_stats`, and compares the result against
+`solve_crossing_zone_with_pins` (empty pin set), and compares the result against
 `expected.mode`. Failures are accumulated and reported together at the end.
 
 Run the suite:

--- a/crates/core/tests/sat_pins.rs
+++ b/crates/core/tests/sat_pins.rs
@@ -114,8 +114,10 @@ fn pin_on_forbidden_tile_rejects() {
     assert!(result.is_none(), "pin on forbidden tile must reject");
 }
 
-/// Empty pin set must behave identically to `solve_crossing_zone_with_stats`
-/// — i.e. the sample fixture solves to the known 2-belt layout.
+/// Empty pin set must behave identically to the unpinned solve (formerly
+/// the `solve_crossing_zone_with_stats` wrapper, deleted 2026-08-20,
+/// offpath Tier 1) — i.e. the sample fixture solves to the known 2-belt
+/// layout.
 #[test]
 fn empty_pins_solves_like_baseline() {
     let fixture = load_sample_fixture();

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -1,7 +1,11 @@
 # Off-path code followups — the golden-path deletion backlog
 
-**Status (2026-08-20)**: audit COMPLETE; execution started — Tier 1 item 1
-(row_rotation) in flight as PR #670. Tier 1 below is
+**Status (2026-08-20, end of day)**: audit COMPLETE; execution underway —
+tracking issue **#675** is the live queue. Tier 1 item 1 (row_rotation)
+MERGED (#670); items 2–4 in flight (#674, this doc's own PR). Owner
+decisions taken 2026-08-20: Tier 2 items 5–8 all APPROVED for deletion;
+item 9 (inserter-check pair) still open; Tier 3 resolved KEEP-CAMPAIGN
+(RFC-068 P0 ran and PASSED, #672). Tier 1 below is
 actionable by any session without further evidence. Tiers 2–3 each name the
 single owner decision that unlocks them. Bugs and stale-docs findings at the
 bottom are independent of any deletion.
@@ -95,9 +99,12 @@ or retarget those in the same change, they are counted in the 2.9k figure.
    `snapshot.rs:172` `read_from_file` (zero callers; the documented read-back
    is the shell pipeline); `analysis.rs:649` `analyze_blueprint_string`
    (mining-cli calls `_any` exclusively); `junction_sat_strategy.rs:256`
-   `impl Default for SatConstraints`; the self-documented unreachable
-   fallback arm at `ghost_router.rs:262`. Lower-confidence, verify first:
-   `recipe_db.rs:402` `machine_for_recipe`.
+   `impl Default for SatConstraints`. Two items adjudicated no-change at
+   execution (#674): `ghost_router.rs:262`'s dead arm stays (exhaustiveness-
+   load-bearing; `unreachable!()` would trade a silent no-op for a WASM
+   panic on a wrong analysis) and `recipe_db::machine_for_recipe` stays
+   (4-line doc-anchor wrapper, 10+ test callers — deletion is
+   churn-positive).
 
 Tier 1 items are still **layout-engine-adjacent deletions**: run the full
 verification protocol (suite green + clippy + WASM build), not just compile.


### PR DESCRIPTION
## Intent

Tier 1 items 2–4 of the merged off-path audit backlog (docs/offpath-code-followups.md): the scattered verified-dead code, −588/+70 across 13 files.

## Scope

- **belt_flow.rs (−292)**: the three orphaned validator twins (`check_belt_throughput`, `check_output_belt_coverage`, `check_belt_inserter_conflict`) + their test blocks — the #488/#632-B5 shadowed-twin disease's third harvest; dispatch runs only the `belt_structural` copies; tombstone extended in the test module.
- **junction_solver.rs (−142)**: `GrowingRegion::{grow, recompute_bbox, promote_fully_enclosed}`, `bbox_tiles_set` — six `#[allow(dead_code)]` markers, superseded by `expand_bbox`; two stale doc comments updated.
- **partitioner.rs**: six zero-caller helpers + their test.
- **sat.rs**: legacy `solve_crossing_zone{,_with_stats}` wrappers. In-file tests keep a test-local stand-in composing `_per_channel` identically; `sat_fixtures` retargeted to `solve_crossing_zone_with_pins(&zone, &[], …)` — the identity the sat_pins suite itself asserts, and an upgrade: the fixture harness now exercises the production (WASM re-solve) entry.
- **Small orphans**: `zone_cache::cache_stats`, `snapshot::read_from_file`, singular `analyze_blueprint_string` (2 test callers retargeted to `_any`, incl. one in classify.rs the audit missed), `junction_sat_strategy`'s unused `Default` impl.

## Intentionally skipped (recorded in commit + followups)

`ghost_router.rs:262`'s dead match arm (exhaustiveness-load-bearing; `unreachable!()` would trade a silent no-op for a WASM panic if the analysis is ever wrong) and `recipe_db::machine_for_recipe` (4-line doc-anchor wrapper, 10+ test callers — deletion is churn-positive).

## Verification actually run

Full protocol on this exact commit: suite green 26/26 result lines (pinned SAT zone cache, **pin file verified restored and NOT in the diff** — the #670 lesson), clippy clean, wasm-pack build green. Residual-reference grep returns tombstones only.

## Deviations

One deletion-scope addition found by compiler, not the audit: `sat_fixtures.rs` imported `solve_crossing_zone_with_stats` (the audit's caller sweep covered call expressions, not `use` statements in tests/) — retargeted as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)