### PR TITLE
fix(analysis): module quality scales effects in the reverse path (B1)

### DIFF
--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -320,8 +320,11 @@ pub fn analyze(layout: &LayoutResult) -> BlueprintAnalysis {
             let mut prod = 0.0;
             for mi in &e.items {
                 let eff = common::module_effect(&mi.item);
-                speed += eff.speed * mi.count as f64;
-                prod += eff.productivity * mi.count as f64;
+                // Same quality rule as the machine-internal loop (B1).
+                speed += crate::module_policy::effect_component_scaled(eff.speed, mi.quality)
+                    * mi.count as f64;
+                prod += crate::module_policy::effect_component_scaled(eff.productivity, mi.quality)
+                    * mi.count as f64;
             }
             beacons.push(BeaconInfo {
                 cx,
@@ -362,13 +365,21 @@ pub fn analyze(layout: &LayoutResult) -> BlueprintAnalysis {
             None => continue,
         };
 
-        // Internal module bonuses
+        // Internal module bonuses. Per-module quality scales beneficial
+        // effects (harmful ones are quality-flat) — the same RFC-044 rule
+        // the forward planner applies; this path was quality-blind until
+        // 2026-08-20 (offpath B1) and underestimated quality-module
+        // blueprints.
         let mut speed_bonus = 0.0f64;
         let mut prod_bonus = 0.0f64;
         for mi in &e.items {
             let eff = common::module_effect(&mi.item);
-            speed_bonus += eff.speed * mi.count as f64;
-            prod_bonus += eff.productivity * mi.count as f64;
+            speed_bonus +=
+                crate::module_policy::effect_component_scaled(eff.speed, mi.quality)
+                    * mi.count as f64;
+            prod_bonus +=
+                crate::module_policy::effect_component_scaled(eff.productivity, mi.quality)
+                    * mi.count as f64;
         }
 
         // Beacon bonuses: check which beacons are in range
@@ -818,6 +829,86 @@ mod tests {
             (*gear_rate - 3.15).abs() < 0.1,
             "expected ~3.15/s, got {}",
             gear_rate
+        );
+    }
+
+    /// B1 (offpath campaign, 2026-08-20): module QUALITY must scale
+    /// beneficial effects in the reverse-analysis path exactly as the
+    /// forward planner scales them — this path was quality-blind.
+    /// Discriminating by construction: every expectation below differs
+    /// from the quality-blind value (prod 1.00 vs 0.40; speed 3.50 vs
+    /// 2.00), so the pre-fix code cannot pass this test.
+    #[test]
+    fn module_quality_scales_analysis_effects() {
+        use crate::common::QualityTier;
+        use crate::models::ModuleItem;
+        let machine = |name: &str, x: i32, recipe: &str, items: Vec<ModuleItem>| PlacedEntity {
+            name: name.into(),
+            x,
+            y: 0,
+            direction: EntityDirection::North,
+            recipe: Some(recipe.into()),
+            items,
+            ..Default::default()
+        };
+        let layout = LayoutResult {
+            entities: vec![
+                // 4x legendary productivity-module-3: +0.10 each scales
+                // ×2.5 (level 5) → +0.25 each → prod bonus 1.00. The
+                // −0.15 speed PENALTY is quality-flat → mult
+                // max(0.2, 1 − 0.60) = 0.40.
+                machine(
+                    "assembling-machine-3",
+                    0,
+                    "iron-gear-wheel",
+                    vec![ModuleItem {
+                        item: "productivity-module-3".into(),
+                        count: 4,
+                        quality: Some(QualityTier::Legendary),
+                    }],
+                ),
+                // 2x legendary speed-module-3: +0.50 each scales ×2.5 →
+                // +1.25 each → mult 1 + 2.50 = 3.50.
+                machine(
+                    "assembling-machine-3",
+                    10,
+                    "copper-cable",
+                    vec![ModuleItem {
+                        item: "speed-module-3".into(),
+                        count: 2,
+                        quality: Some(QualityTier::Legendary),
+                    }],
+                ),
+            ],
+            width: 20,
+            height: 10,
+            ..Default::default()
+        };
+        let analysis = analyze(&layout);
+        let gear = analysis
+            .recipe_groups
+            .iter()
+            .find(|g| g.recipe == "iron-gear-wheel")
+            .unwrap();
+        assert!(
+            (gear.productivity_bonus - 1.00).abs() < 0.01,
+            "legendary prod modules must scale: got {}",
+            gear.productivity_bonus
+        );
+        assert!(
+            (gear.effective_speed_multiplier - 0.40).abs() < 0.01,
+            "speed PENALTY must stay quality-flat: got {}",
+            gear.effective_speed_multiplier
+        );
+        let cable = analysis
+            .recipe_groups
+            .iter()
+            .find(|g| g.recipe == "copper-cable")
+            .unwrap();
+        assert!(
+            (cable.effective_speed_multiplier - 3.50).abs() < 0.01,
+            "legendary speed modules must scale: got {}",
+            cable.effective_speed_multiplier
         );
     }
 }

--- a/crates/core/src/analysis.rs
+++ b/crates/core/src/analysis.rs
@@ -367,9 +367,12 @@ pub fn analyze(layout: &LayoutResult) -> BlueprintAnalysis {
 
         // Internal module bonuses. Per-module quality scales beneficial
         // effects (harmful ones are quality-flat) — the same RFC-044 rule
-        // the forward planner applies; this path was quality-blind until
-        // 2026-08-20 (offpath B1) and underestimated quality-module
-        // blueprints.
+        // the forward planner applies to MODULE effects; this path was
+        // quality-blind until 2026-08-20 (offpath B1). Scope (#681
+        // review): parity is module-effect-only — the analyzer still
+        // credits neither the machine's built-in base_effect_productivity
+        // nor entity-quality crafting speed (both pre-existing analyzer
+        // gaps, recorded on #675).
         let mut speed_bonus = 0.0f64;
         let mut prod_bonus = 0.0f64;
         for mi in &e.items {
@@ -909,6 +912,56 @@ mod tests {
             (cable.effective_speed_multiplier - 3.50).abs() < 0.01,
             "legendary speed modules must scale: got {}",
             cable.effective_speed_multiplier
+        );
+    }
+
+    /// #681 review: the BEACON aggregation path must also quality-scale
+    /// (it shares the fix but was untested). One machine + one adjacent
+    /// beacon carrying 2x legendary speed-module-3: beacon contribution =
+    /// 2 × 1.25 × 0.5 (transmission) = +1.25 → multiplier 2.25.
+    /// Quality-blind value would be 2 × 0.50 × 0.5 = +0.50 → 1.50, so the
+    /// expectation discriminates.
+    #[test]
+    fn beacon_module_quality_scales() {
+        use crate::common::QualityTier;
+        use crate::models::ModuleItem;
+        let layout = LayoutResult {
+            entities: vec![
+                PlacedEntity {
+                    name: "assembling-machine-3".into(),
+                    x: 0,
+                    y: 0,
+                    direction: EntityDirection::North,
+                    recipe: Some("iron-gear-wheel".into()),
+                    ..Default::default()
+                },
+                PlacedEntity {
+                    name: "beacon".into(),
+                    x: 3,
+                    y: 0,
+                    direction: EntityDirection::North,
+                    items: vec![ModuleItem {
+                        item: "speed-module-3".into(),
+                        count: 2,
+                        quality: Some(QualityTier::Legendary),
+                    }],
+                    ..Default::default()
+                },
+            ],
+            width: 10,
+            height: 5,
+            ..Default::default()
+        };
+        let analysis = analyze(&layout);
+        let gear = analysis
+            .recipe_groups
+            .iter()
+            .find(|g| g.recipe == "iron-gear-wheel")
+            .unwrap();
+        assert!(
+            (gear.effective_speed_multiplier - 2.25).abs() < 0.01,
+            "legendary beacon modules must scale: got {}",
+            gear.effective_speed_multiplier
         );
     }
 }

--- a/crates/core/src/module_policy.rs
+++ b/crates/core/src/module_policy.rs
@@ -74,8 +74,20 @@ impl MachineModuleEffects {
 /// epsilon absorbs f64 representation error on products that land
 /// exactly on a step (steps are a full 1.0 apart in percent space, so it
 /// can never jump one).
-fn quality_scaled(base: f64, quality: QualityTier) -> f64 {
+pub(crate) fn quality_scaled(base: f64, quality: QualityTier) -> f64 {
     (base * (1.0 + 0.3 * quality.level() as f64) * 100.0 + 1e-9).floor() / 100.0
+}
+
+/// RFC-044 game-rule model applied to one module's effect component:
+/// beneficial (positive) effects scale with the module's quality; harmful
+/// ones are quality-flat. Shared with `analysis`'s reverse
+/// blueprint-analysis path so the forward planner and the analyzer agree
+/// (B1 on the offpath campaign, 2026-08-20 — analysis was quality-blind).
+pub(crate) fn effect_component_scaled(base: f64, quality: Option<QualityTier>) -> f64 {
+    match quality {
+        Some(q) if base > 0.0 => quality_scaled(base, q),
+        _ => base,
+    }
 }
 
 /// Prototype name for a family + tier (tier 1 has no suffix).


### PR DESCRIPTION
## Intent

B1 from the deletion-campaign tracker (#675): the domain-physics audit's verified live bug — `analysis.rs`'s module aggregation was quality-blind, so `blueprint-analyze` silently underestimated quality-module blueprints.

## Scope

Both aggregation loops (machine-internal + beacon) now share `module_policy`'s RFC-044 rule via a new `effect_component_scaled` helper: beneficial effects scale ×(1 + 0.3·level) with the game's 1%-step floor, penalties stay quality-flat. `None`/Normal quality is bit-identical to the old behavior, so existing quality-less analyses are unchanged.

## Verification actually run

- New discriminating test (`module_quality_scales_analysis_effects`) whose every expectation differs from the quality-blind value — **and the discrimination was executed**: with the bug temporarily restored, the test fails at exactly 0.40 (the blind value) where 1.00 is required.
- `analysis` (6/6) + `module_policy` (17/17) lib tests green; clippy clean. Analysis-tool-only change — no layout-generation path touches this code (the forward planner already scaled).

## Deviations

None. One process note: the discrimination check's restore step initially clobbered the uncommitted fix via `git checkout --` (recovered from context) — commit before bug-restoring, next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)