### PR TITLE
feat(sim): refuse to overwrite a fixture built from a different config

### DIFF
--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -29,8 +29,8 @@
 //!   --di off|candidate|forced        direct insertion (default candidate)
 //!   --claim up|down|search           DI claim order (default: engine default)
 //!   --belt <entity>        max belt tier (default: engine picks by rate)
-//!   --row-layout <kind>    native (default) | horizontal-stack
-//!   --strategy <kind>      pooled (aka default) | partitioned-decomposed (aka pd)
+//!   --row-layout <kind>    native aka vertical-split | horizontal-stack
+//!   --strategy <kind>      pooled | partitioned-decomposed (aka pd)
 //!   --duty <0..1>          planning duty (default 1.0; <1 needs --belt)
 //!   --quality <name>       normal|uncommon|rare|epic|legendary (default normal)
 //!   --stacking <1..4>      belt stacking (default 1)
@@ -40,6 +40,8 @@
 //!   --inputs a,b,c         raw inputs (default: the six-ore set)
 //!   --label <name>         output subdirectory + manifest label
 //!                          REQUIRED whenever any layout-changing flag is used
+//!   --force                replace a fixture built from a DIFFERENT config
+//!                          (re-running the SAME config never needs it)
 //!   --out <dir>            parent output dir (default $SIM_PROBE_OUT or /tmp)
 //! ```
 //!
@@ -146,6 +148,76 @@ fn default_label(targets: &[(String, f64)]) -> String {
         .replace('.', "_")
 }
 
+/// The name of the provenance file written beside each fixture.
+const CONFIG_FILE: &str = ".sim-export-config";
+
+/// A canonical description of everything about this invocation that changes
+/// the exported artifact.
+///
+/// Sorted, so flag order does not matter, and built from the axis flags and
+/// their VALUES — which is the part every previous version of this guard
+/// could not see.
+fn config_fingerprint(targets: &[(String, f64)], axis_args: &[(String, String)]) -> String {
+    // The TARGETS are configuration too (#661 round 11, 3/3). Leaving them
+    // out meant `ec 5 --strategy pd --label x` and `copper-cable 20
+    // --strategy pd --label x` fingerprinted identically, so the second
+    // silently overwrote the first — the same wrong-A/B, in the fourth
+    // direction this guard has been caught from. The artifact depends on
+    // what is being built, not only on how.
+    let mut pairs: Vec<String> = targets
+        .iter()
+        .map(|(item, rate)| format!("target:{item}={rate}"))
+        .collect();
+    pairs.extend(axis_args.iter().map(|(f, v)| format!("{f}={v}")));
+    pairs.sort();
+    pairs.join("\n")
+}
+
+/// Should this run refuse rather than overwrite what is already there?
+///
+/// Compares the stored fingerprint of the existing artifact against this
+/// run's. Same configuration means a re-run producing the same bytes, which
+/// is idempotent and allowed; a different one means the two fixtures would
+/// silently become one, which is the wrong-A/B this tool exists to prevent.
+///
+/// This replaces three rounds of flag-shaped heuristics, each of which was a
+/// proxy for artifact identity and each of which leaked:
+///
+///   round 7  refuse whenever anything exists
+///            -> broke plain re-runs, which are idempotent
+///   round 8  refuse only when THIS run passed an axis flag
+///            -> `--strategy pd --label x` then `--label x` overwrote it
+///   round 9  refuse only when the label was EXPLICIT
+///            -> `--strategy pd --label ec-5` then a plain `ec 5` (whose
+///               derived label is also `ec-5`) overwrote it
+///
+/// Every one of those asks a question about the COMMAND LINE. The question
+/// that actually matters is about the ARTIFACT, and it cannot be answered
+/// from flags alone — which is what the #661 reviews kept demonstrating,
+/// from a different direction each time. So it is answered from the
+/// artifact.
+///
+/// `Unknown` provenance (files present, no fingerprint) is refused too: it
+/// means a fixture written before this existed, or by hand, and assuming it
+/// matches is the same guess in a new place.
+fn overwrite_verdict(stored: Option<&str>, current: &str, force: bool, any_artifact: bool) -> OverwriteVerdict {
+    if force || !any_artifact {
+        return OverwriteVerdict::Proceed;
+    }
+    match stored {
+        Some(prev) if prev == current => OverwriteVerdict::Proceed,
+        Some(_) => OverwriteVerdict::DifferentConfig,
+        None => OverwriteVerdict::UnknownProvenance,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum OverwriteVerdict {
+    Proceed,
+    DifferentConfig,
+    UnknownProvenance,
+}
+
 /// Does this invocation need an explicit `--label`?
 ///
 /// True when any artifact-changing flag was passed. Kept as a pure function
@@ -156,8 +228,8 @@ fn default_label(targets: &[(String, f64)]) -> String {
 /// Note what it does NOT take: any value, and any default. It is a question
 /// about the command line, not about the configuration — which is also its
 /// limit: it cannot separate two runs that pass the SAME axis with DIFFERENT
-/// values under one `--label`. Closing that needs artifact provenance, which
-/// is a separate change (branch `feat/sim-export-overwrite-provenance`).
+/// values under one `--label`. That is what `overwrite_verdict` is for, and
+/// why this predicate is necessary but not sufficient on its own.
 fn label_required(axis_flags_seen: &[String], label: &Option<String>) -> bool {
     !axis_flags_seen.is_empty() && label.is_none()
 }
@@ -216,7 +288,9 @@ fn main() {
     let mut strategy = LayoutStrategy::default();
     let mut inputs: Vec<String> = DEFAULT_INPUTS.iter().map(|s| s.to_string()).collect();
     let mut label: Option<String> = None;
+    let mut force = false;
     let mut axis_flags_seen: Vec<String> = Vec::new();
+    let mut axis_args: Vec<(String, String)> = Vec::new();
     let mut out = std::env::var("SIM_PROBE_OUT").unwrap_or_else(|_| "/tmp".to_string());
 
     while i < args.len() {
@@ -232,6 +306,20 @@ fn main() {
         // wrong; not consulting a default at all is the fix.
         if AXIS_FLAGS.contains(&args[i].as_str()) {
             axis_flags_seen.push(args[i].clone());
+            // The VALUE too, for the artifact fingerprint. The label guard
+            // deliberately ignores values (see `label_required`); the
+            // overwrite guard deliberately does not.
+            axis_args.push((
+                args[i].clone(),
+                args.get(i + 1).cloned().unwrap_or_default(),
+            ));
+        }
+        // The one valueless flag, so it advances by 1 rather than the 2
+        // every other branch assumes.
+        if args[i] == "--force" {
+            force = true;
+            i += 1;
+            continue;
         }
         match args[i].as_str() {
             "--tier" => tier = need(i),
@@ -258,10 +346,19 @@ fn main() {
             // blueprint+manifest pair and could not be sim-anchored.
             "--row-layout" => {
                 row_layout = match need(i).as_str() {
-                    "native" | "default" => RowLayout::default(),
+                    // Pinned to the CONCRETE variant, not `RowLayout::default()`.
+                    // `native` was an alias for the default, so it carried the
+                    // same defect as `default`: identical provenance either
+                    // side of a `#[default]` change, different bytes.
+                    "native" | "vertical-split" => RowLayout::VerticalSplit,
+                    "default" => usage(
+                        "--row-layout default is not accepted: it would record the same \
+                         provenance for two different layouts if the engine default \
+                         changes. Name the layout — native | horizontal-stack.",
+                    ),
                     "horizontal-stack" | "hs" => RowLayout::HorizontalStack,
                     other => usage(&format!(
-                        "--row-layout must be native|horizontal-stack (got {other})"
+                        "--row-layout must be native|vertical-split|horizontal-stack (got {other})"
                     )),
                 }
             }
@@ -275,11 +372,18 @@ fn main() {
             "--strategy" => {
                 strategy = match need(i).as_str() {
                     "pooled" => LayoutStrategy::Pooled,
-                    // Delegate, matching `--row-layout`'s "native"|"default"
-                    // (#661 review). Hardcoding Pooled here meant a change to
-                    // the #[default] would silently stop being what
-                    // `--strategy default` selects.
-                    "default" => LayoutStrategy::default(),
+                    // `default` is REFUSED, not resolved. The fingerprint
+                    // records the spelling you typed, so "default" would
+                    // fingerprint identically before and after a change to
+                    // the engine's `#[default]` while producing different
+                    // bytes — an under-refusal, and the only direction this
+                    // guard must never fail in. Naming the strategy costs
+                    // nothing and makes the fixture self-describing.
+                    "default" => usage(
+                        "--strategy default is not accepted: it would record the same \
+                         provenance for two different layouts if the engine default \
+                         changes. Name the strategy — pooled | partitioned-decomposed.",
+                    ),
                     "partitioned-decomposed" | "pd" => LayoutStrategy::PartitionedDecomposed,
                     other => usage(&format!(
                         "--strategy must be pooled|default|partitioned-decomposed|pd (got {other})"
@@ -371,6 +475,73 @@ fn main() {
         ));
     }
     let label = label.unwrap_or_else(|| default_label(&targets));
+
+    // The label guard is necessary but NOT sufficient (#661 review, major).
+    // It reasons about flag PRESENCE, so it cannot separate two runs that
+    // pass the same axis with different VALUES under one `--label` —
+    // `--strategy pd --label x` then `--strategy pooled --label x` both
+    // satisfy it, and the second silently overwrote the first. That is the
+    // original wrong-A/B bug, reachable through the guard added to prevent
+    // it. Presence is knowable at parse time; artifact identity is not, so
+    // the second half of the invariant is enforced against the filesystem.
+    //
+    // Checked HERE, before the solve, and not at the write (#661 round 7,
+    // 3/3): everything between is minutes of layout and validation, and a
+    // refusal the user could have been given immediately is a bad trade for
+    // a `Path::exists` call. Nothing between here and the write can change
+    // the answer — the paths depend only on `out` and `label`, both already
+    // final.
+    //
+    // Either artifact present means the directory is claimed. Which one
+    // arrives first is deliberately not load-bearing: this diff put the
+    // config file ahead of both, so an interrupted run leaves its
+    // provenance readable rather than a fixture nobody can attribute.
+    //
+    // Applies to EVERY run, explicit label or not. Earlier rounds scoped
+    // this by axis flags and then by label-explicitness; both were proxies
+    // for artifact identity and both leaked. The verdict now comes from
+    // comparing recorded configurations, so no scoping is needed — an
+    // identical re-run is allowed because it IS identical, not because of
+    // how it was invoked.
+    let fingerprint = config_fingerprint(&targets, &axis_args);
+    {
+        let dir = format!("{out}/{label}");
+        let any_artifact = ["bp.txt", "manifest-real.json"]
+            .iter()
+            .any(|f| std::path::Path::new(&format!("{dir}/{f}")).exists());
+        let stored = std::fs::read_to_string(format!("{dir}/{CONFIG_FILE}")).ok();
+        match overwrite_verdict(stored.as_deref(), &fingerprint, force, any_artifact) {
+            OverwriteVerdict::Proceed => {}
+            OverwriteVerdict::DifferentConfig => {
+                eprintln!(
+                    "error: {dir}/ holds a fixture built from a DIFFERENT configuration \
+                     — refusing to overwrite it.\n\
+                     \n\
+                     existing: {}\n\
+                     this run: {}\n\
+                     \n\
+                     Overwriting would silently turn two fixtures into one, which is the \
+                     wrong-A/B this tool exists to prevent. Give this run its own \
+                     --label, or pass --force if you meant to replace it.",
+                    stored.as_deref().unwrap_or("<none>").replace('\n', ", "),
+                    fingerprint.replace('\n', ", "),
+                );
+                std::process::exit(2);
+            }
+            OverwriteVerdict::UnknownProvenance => {
+                eprintln!(
+                    "error: {dir}/ already holds a fixture, and carries no {CONFIG_FILE} \
+                     recording how it was built — refusing to overwrite it.\n\
+                     \n\
+                     It predates this check or was written by hand, so whether it matches \
+                     this run cannot be determined. Give this run its own --label, or \
+                     pass --force if you know it is safe to replace."
+                );
+                std::process::exit(2);
+            }
+        }
+    }
+
     let input_set: FxHashSet<String> = inputs.iter().cloned().collect();
 
     // RFC-062 Phase 3: always the multi-target entry point, even for N=1
@@ -443,9 +614,17 @@ fn main() {
     let dir = format!("{out}/{label}");
     let bp_path = format!("{dir}/bp.txt");
     let mf_path = format!("{dir}/manifest-real.json");
+    let cfg_path = format!("{dir}/{CONFIG_FILE}");
 
     std::fs::create_dir_all(&dir).unwrap_or_else(|e| {
         eprintln!("cannot create {dir}: {e}");
+        std::process::exit(1);
+    });
+    // Provenance first, so an interrupted run cannot leave artifacts whose
+    // configuration is unrecorded — which the guard would then have to
+    // refuse as unknown.
+    std::fs::write(&cfg_path, &fingerprint).unwrap_or_else(|e| {
+        eprintln!("cannot write {cfg_path}: {e}");
         std::process::exit(1);
     });
     std::fs::write(&bp_path, &bp).unwrap_or_else(|e| {
@@ -532,6 +711,83 @@ mod tests {
             .collect()
     }
 
+    /// The overwrite policy, which the filesystem check only executes.
+    ///
+    /// Keyed on the artifact's recorded configuration, so every case below
+    /// is a statement about what is ON DISK, not about the command line —
+    /// which is what three rounds of flag-shaped heuristics kept getting
+    /// wrong from a different direction each time.
+    #[test]
+    fn overwrite_policy() {
+        let ec = vec![("electronic-circuit".to_string(), 5.0)];
+        let pd = config_fingerprint(&ec, &[("--strategy".into(), "pd".into())]);
+        let pooled = config_fingerprint(&ec, &[("--strategy".into(), "pooled".into())]);
+        let plain = config_fingerprint(&ec, &[]);
+
+        // Same configuration, so the re-run writes the same bytes.
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &pd, false, true),
+            OverwriteVerdict::Proceed,
+            "a re-run of the same configuration is idempotent"
+        );
+
+        // The round-8 hole: an axis fixture, then a run with no axis flags
+        // reusing its directory.
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &plain, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "a plain run must not overwrite an axis run's fixture"
+        );
+
+        // The round-9 hole, the same collision in the other direction: an
+        // explicit --label that happens to equal the derived name.
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &pooled, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "two different axis VALUES are two different fixtures"
+        );
+
+        // Flag ORDER is not configuration.
+        let a = config_fingerprint(&ec, &[
+            ("--strategy".into(), "pd".into()),
+            ("--belt".into(), "fast".into()),
+        ]);
+        let b = config_fingerprint(&ec, &[
+            ("--belt".into(), "fast".into()),
+            ("--strategy".into(), "pd".into()),
+        ]);
+        assert_eq!(a, b, "the same run written two ways is one configuration");
+        assert_eq!(overwrite_verdict(Some(&a), &b, false, true), OverwriteVerdict::Proceed);
+
+        // Escape hatch, empty directory, and unrecorded provenance.
+        assert_eq!(overwrite_verdict(Some(&pd), &pooled, true, true), OverwriteVerdict::Proceed);
+        assert_eq!(overwrite_verdict(None, &pd, false, false), OverwriteVerdict::Proceed);
+        assert_eq!(
+            overwrite_verdict(None, &pd, false, true),
+            OverwriteVerdict::UnknownProvenance,
+            "a fixture with no recorded config cannot be assumed to match"
+        );
+
+        // The TARGETS are configuration too (#661 round 11, 3/3). Same
+        // flags, same label, different thing being built.
+        let cable = vec![("copper-cable".to_string(), 20.0)];
+        let cable_pd = config_fingerprint(&cable, &[("--strategy".into(), "pd".into())]);
+        assert_ne!(cable_pd, pd, "different targets are different configurations");
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &cable_pd, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "a different target must not overwrite an earlier fixture's directory"
+        );
+
+        // ...including a differing RATE for the same item.
+        let ec_faster = vec![("electronic-circuit".to_string(), 30.0)];
+        let faster_pd = config_fingerprint(&ec_faster, &[("--strategy".into(), "pd".into())]);
+        assert_eq!(
+            overwrite_verdict(Some(&pd), &faster_pd, false, true),
+            OverwriteVerdict::DifferentConfig,
+            "the rate changes the artifact, so it changes the fingerprint"
+        );
+    }
 
     /// Every flag the PARSER accepts must be documented.
     ///
@@ -585,8 +841,10 @@ mod tests {
     #[test]
     fn axis_flag_list_and_docs_agree_both_ways() {
         // Not axes: these change WHERE a run writes, or WHETHER it may,
-        // never WHAT it exports.
-        const NOT_AXES: &[&str] = &["--label", "--out", "--multi"];
+        // never WHAT it exports. `--force` joined them when the overwrite
+        // guard landed — and this test caught the omission on its first
+        // run, which is the whole reason it is bidirectional.
+        const NOT_AXES: &[&str] = &["--label", "--out", "--multi", "--force"];
         let doc = include_str!("sim_export.rs");
         let documented: Vec<String> = doc
             .lines()

--- a/crates/core/examples/sim_export.rs
+++ b/crates/core/examples/sim_export.rs
@@ -80,9 +80,11 @@ const DEFAULT_TIER: &str = "assembling-machine-3";
 /// enumerated and every engine default stated correctly, and which took five
 /// review rounds without converging — passing any of these simply REQUIRES an
 /// explicit `--label`. Collisions between runs that differ only by an axis
-/// become impossible by construction — reusing the same `--label` twice
-/// still collides, and deliberately so — and the
-/// check consults no defaults, so a future default flip cannot invert it.
+/// become impossible by construction, and the check consults no defaults, so
+/// a future default flip cannot invert it. Reusing the same `--label` for a
+/// DIFFERENT configuration is caught separately, by `overwrite_verdict`
+/// against the fixture's recorded provenance; reusing it for the same one is
+/// idempotent.
 ///
 /// Slightly over-strict on purpose: `--strategy pooled` is the default value
 /// and still demands a label. Erring toward "be explicit" costs a flag; erring
@@ -358,7 +360,7 @@ fn main() {
                     ),
                     "horizontal-stack" | "hs" => RowLayout::HorizontalStack,
                     other => usage(&format!(
-                        "--row-layout must be native|vertical-split|horizontal-stack (got {other})"
+                        "--row-layout must be native|vertical-split|horizontal-stack|hs (got {other})"
                     )),
                 }
             }
@@ -386,7 +388,7 @@ fn main() {
                     ),
                     "partitioned-decomposed" | "pd" => LayoutStrategy::PartitionedDecomposed,
                     other => usage(&format!(
-                        "--strategy must be pooled|default|partitioned-decomposed|pd (got {other})"
+                        "--strategy must be pooled|partitioned-decomposed|pd (got {other})"
                     )),
                 }
             }

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -78,8 +78,8 @@ abandoned: it needs every axis enumerated and every engine default stated
 correctly, and five review rounds each found another one wrong. Requiring
 the label makes collisions between runs that differ only by an axis
 impossible by construction, and consults no defaults, so a future default
-flip cannot invert it. Reusing the same `--label` twice still collides —
-that is a deliberate escape hatch, not an oversight.
+flip cannot invert it. Reusing the same `--label` for a DIFFERENT configuration is refused by the
+provenance check below; reusing it for the same one is idempotent.
 
 A run with no axis flags keeps the old `{item}-{rate}` path unchanged.
 
@@ -96,9 +96,40 @@ with the required flag named, not a silent overwrite.
 
 That guard reasons about which flags were PASSED, which is all that is
 knowable before the solve — so it cannot tell two runs apart that pass the
-same axis with different VALUES under one `--label`. Closing that needs the
-artifact's own provenance rather than a question about the command line, and
-it is a separate change (branch `feat/sim-export-overwrite-provenance`).
+same axis with different VALUES under one `--label`. That half is answered
+from the artifact instead. Each fixture directory carries a
+`.sim-export-config` recording what it was built from, and a run compares
+its own configuration against the stored one:
+
+- **same config** — proceeds, so re-running a fixture is idempotent;
+- **different config** — refuses, printing both configurations;
+- **no `.sim-export-config`** — refuses; a fixture written by hand, or before
+  this existed, cannot be assumed to match;
+- `--force` — replaces it regardless.
+
+The recorded configuration is the **targets** (item and rate) plus the axis
+flags and their values, sorted, so flag order does not matter.
+
+Three things it deliberately does not do. It compares values
+**syntactically**, so `--strategy pd` and `--strategy partitioned-decomposed`
+read as different configurations; a fixture predating the provenance file is
+refused rather than assumed to match; and the **engine revision is not part
+of the configuration**, so a fixture regenerated after a layout-engine change
+is treated as a match even though the bytes differ. The first two err toward
+refusing a safe run, which `--force` covers. The third is the one that errs
+the other way: after an engine change, regenerate deliberately rather than
+trusting idempotence.
+
+For the same reason `--strategy default` and `--row-layout default` are
+refused outright. They record the spelling, not the resolved value, so they
+would fingerprint identically either side of a change to the engine's
+`#[default]` while producing different bytes — the one direction this guard
+must never fail in. Name the strategy or layout instead.
+
+Earlier versions of the guard asked about the command line instead (refuse if
+anything exists / if this run passed an axis flag / if the label was
+explicit). Each leaked, from a different direction, because the question that
+matters is about the artifact and cannot be answered from flags.
 
 It writes `<out>/<label>/bp.txt` and `<out>/<label>/manifest-real.json`,
 and prints the ready-to-paste `run` command. Unknown flags are an error

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -55,8 +55,8 @@ cargo run --release --example sim_export -- <item> <rate> [flags]
   --belt <entity>       max belt tier      --quality <name>   normal..legendary
   --stacking <1..4>     belt stacking      --inserter-cap <n> capacity level
   --inputs a,b,c        raw inputs (default: the six-ore set)
-  --row-layout <kind>   native (default) | horizontal-stack
-  --strategy <kind>     pooled (aka default) | partitioned-decomposed (aka pd)
+  --row-layout <kind>   native|vertical-split | horizontal-stack|hs
+  --strategy <kind>     pooled | partitioned-decomposed (aka pd)
   --duty <0..1>         planning duty (default 1.0; <1 needs --belt)
   --research-productivity <recipe=bonus,...>   declared research
   --label <name>        output subdir + manifest label


### PR DESCRIPTION
## Intent

Close the half of the `sim_export` collision guard that #661 deliberately
left open.

#661 merged the `--label` requirement: passing any layout-changing flag
demands an explicit label. That is necessary but **not sufficient** — it
reasons about which flags were *passed*, so it cannot separate two runs that
pass the same axis with different *values* under one label:

```
sim_export ec 5 --strategy pd     --label x   # writes a PD fixture
sim_export ec 5 --strategy pooled --label x   # silently overwrote it
```

That is the wrong-A/B this tool exists to prevent, in the tool whose whole
purpose is A/B.

## Approach

Ask the **artifact**, not the command line.

Each fixture directory carries a `.sim-export-config` recording the targets
and the axis flags and values it was built from, written *before* the
artifacts so an interrupted run leaves readable provenance rather than files
nobody can attribute. A run compares its configuration against the stored
one:

| stored vs current | outcome |
|---|---|
| same | proceeds — re-running a fixture is idempotent |
| different | refuses, printing both configurations |
| absent | refuses — a hand-written or pre-existing fixture cannot be assumed to match |
| any, with `--force` | proceeds |

**Why not a flag-based rule.** Four were tried in #661 review and every one
leaked from a direction the previous fix had not considered: *refuse if
anything exists* (broke idempotent re-runs) → *refuse if this run passed an
axis flag* (`--strategy pd --label x` then `--label x` overwrote it) →
*refuse if the label was explicit* (`--strategy pd --label ec-5` then a plain
`ec 5`, whose derived label is also `ec-5`) → *compare the flags* (missed the
targets: `ec 5` and `copper-cable 20` under one label fingerprinted the
same). No predicate over flags decides whether two invocations produce the
same artifact.

**`--strategy default` and `--row-layout default` are now refused**, and
`--row-layout native` is pinned to `VerticalSplit` rather than
`RowLayout::default()`. The fingerprint records the spelling, so a
default-resolving alias fingerprints identically either side of a change to
the engine's `#[default]` while producing different bytes. That is an
**under-refusal** — the one direction this guard must never fail in. The
alias over-strictness in the other direction (`pd` and
`partitioned-decomposed` reading as different configs) merely refuses a run
that would have been safe, and `--force` covers it.

## Known limitation, stated not buried

The **engine revision is not part of the configuration**. A fixture
regenerated after a layout-engine change is treated as a match though the
bytes differ — the same under-refusal direction as the `default` aliases.
Closing it wants an engine-version term in the fingerprint; that is a
separate change, and the doc says so.

## Verification

`cargo nextest run -p spaghettio_core --profile ci` — 1193 passed.
`cargo clippy --workspace -- -D warnings` — clean.

`overwrite_verdict` and `config_fingerprint` are pure and unit-tested: same
config, different axis value, different target, different rate,
order-independence, `--force`, empty directory, unknown provenance.

Behaviour checked by running the binary on every path — identical re-run
proceeds; different target / different rate / different axis value /
no-axis-run-reusing-an-axis-label all refuse; `--force` overrides; both
`default` spellings refuse and name the concrete alternatives.

## Not done

No `main()`-level integration test. Raised repeatedly in #661 review and
still fair: the parse loop and the filesystem check are covered by running
the binary by hand, not by a test. An example target has no
`CARGO_BIN_EXE_*`, so an in-tree test would shell out to a reconstructed
path. Worth doing; not bundled here.
