### PR TITLE
process(w1d): codify the deletion-cadence rule for RFC close-outs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,9 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
     `RFC-NNN` chronologically; existing files keep their names (numbers live
     in the registry), new RFCs are named `rfc-NNN-short-name.md` and get a
     registry row in the same commit. Rejected/obsolete RFCs move to
-    `docs/archive/`.
+    `docs/archive/`. **Close-out deletes the code** unless the decision log
+    names a retention contract with a flip condition — see the template's
+    "Deletion cadence" note.
   - **Followups** (`*-followups.md`) — deferred-work backlogs with pick-up
     notes. Named for what they track, not the session that produced them;
     status line at the top so a cold pick-up knows what's open.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,9 @@ For full build commands (WASM rebuild, release builds), see [`docs/build-systems
     `RFC-NNN` chronologically; existing files keep their names (numbers live
     in the registry), new RFCs are named `rfc-NNN-short-name.md` and get a
     registry row in the same commit. Rejected/obsolete RFCs move to
-    `docs/archive/`. **Close-out deletes the code** unless the decision log
-    names a retention contract with a flip condition — see the template's
-    "Deletion cadence" note.
+    `docs/archive/`. **A killed or concluded-failed RFC's close-out deletes
+    its code** unless the decision log names a retention contract with a
+    flip condition — see the template's "Deletion cadence" note.
   - **Followups** (`*-followups.md`) — deferred-work backlogs with pick-up
     notes. Named for what they track, not the session that produced them;
     status line at the top so a cold pick-up knows what's open.

--- a/docs/rfc-template.md
+++ b/docs/rfc-template.md
@@ -95,3 +95,15 @@ Append entries here as the RFC progresses. Date them.
 
 The decision log is the part that prevents "why did we drop this?"
 amnesia six months later. Don't skip it.
+
+### Deletion cadence
+
+**A killed or concluded-failed RFC's code is deleted in its close-out
+PR**, unless the decision log names a retention contract with an
+explicit flip condition (who re-enables it, and on what trigger). A
+close-out that leaves code behind without such a contract is
+incomplete — falsifying an approach is cheap and prompt; leaving its
+code in place for someone else to notice, audit, and remove later is
+not. (The off-path audit that motivated this rule found ~11k lines of
+retained-but-dead code across five RFCs, all falsified weeks-to-months
+before deletion.)

--- a/docs/rfc-template.md
+++ b/docs/rfc-template.md
@@ -91,7 +91,10 @@ Append entries here as the RFC progresses. Date them.
 - *2026-MM-DD — phase 1 landed in <commit>; phase 2 deferred pending …*
 - *2026-MM-DD — abandoned; kill criterion <X> tripped on <test>. See
   follow-up notes in `docs/<...>.md`. Move this file to `docs/archive/`
-  with a status of "Rejected" in the archive README.*
+  with a status of "Rejected" in the archive README, **and delete the
+  RFC's code in this same close-out PR** (or append a retention
+  contract with a flip condition — see "Deletion cadence" below) — an
+  archived RFC whose code is still sitting live is not actually closed.*
 
 The decision log is the part that prevents "why did we drop this?"
 amnesia six months later. Don't skip it.
@@ -102,8 +105,16 @@ amnesia six months later. Don't skip it.
 PR**, unless the decision log names a retention contract with an
 explicit flip condition (who re-enables it, and on what trigger). A
 close-out that leaves code behind without such a contract is
-incomplete — falsifying an approach is cheap and prompt; leaving its
-code in place for someone else to notice, audit, and remove later is
-not. (The off-path audit that motivated this rule found ~11k lines of
-retained-but-dead code across five RFCs, all falsified weeks-to-months
-before deletion.)
+incomplete — concluding an approach didn't pan out is cheap and prompt;
+leaving its code in place for someone else to notice, audit, and remove
+later is not. (Motivated by
+[`docs/offpath-code-followups.md`](offpath-code-followups.md)'s Tier 1 +
+Tier 2 findings: ~11k lines of retained code — not all of it RFC-owned,
+and not every instance a clean falsification; some (the CP-SAT pipeline,
+RFC-063 Phase C) were simply never wired in or never funded a
+follow-on — sitting live for weeks to months after their RFC stopped
+being worked on.) For the retention-contract shape, see RFC-067's
+decision log: its preview consumer was killed (K67-2) while the module
+itself was explicitly retained as a baseline, "reopening only by a
+decision-log amendment" — that's the level of specificity a flip
+condition needs.


### PR DESCRIPTION
## Intent

Part of RFC-070 track W1d (tracking #689). The off-path audit's clearest
process finding: falsification of an approach is prompt, but deletion of
its code lags weeks-to-months — the legacy solver walk, STRESSGOLD-era
scaffolding, `bus::compaction`, then bands / CP-SAT / cells-placement all
followed the same curve, ~11k lines that needed a dedicated audit to find
and remove. Codify the fix so the next close-out doesn't repeat it.

## Scope

- **In:** a "Deletion cadence" rule added to `docs/rfc-template.md` next
  to the Decision log section (a killed/concluded-failed RFC's code is
  deleted in its close-out PR unless the decision log names a retention
  contract with an explicit flip condition); a one-line pointer to it from
  `CLAUDE.md`'s RFC bullet (no duplicated text, per CLAUDE.md's own "stays
  lean" instruction).
- **Out:** `docs/rfcs.md` (the registry). Checked `git log --oneline -20
  origin/main -- docs/rfcs.md` and the current file first — PR #680
  ("docs(offpath): close the three documentation gaps + D1 sweep")
  already added a Status column and filled in deletion/retention
  annotations for every RFC the audit flagged (RFC-021/022/023/024,
  RFC-057, RFC-058, RFC-064, etc). Nothing left to do there; duplicating
  guidance would just be two places to keep in sync.
- **Size:** 15 lines added. Docs-only.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml --no-fail-fast` (unpiped) — exit 0, full suite green (docs-only change, no Rust touched)
- [x] `cargo clippy --workspace -- -D warnings` (the exact invocation `ci.yml` runs) — exit 0, clean
- [ ] WASM rebuild — not applicable, no `crates/core` changes
- [ ] Snapshot inspection — not applicable, no layout-engine change

## Deviations from intent

None.

## Models / contracts touched

None — process documentation only. `docs/rfc-template.md` and `CLAUDE.md`
are the "Reference" doc class per CLAUDE.md's own taxonomy; both updated
directly, no separate contract doc to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>