### PR TITLE
diag(w1d): production census of junction seeds — G1 follow-up

### DIFF
--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -2898,9 +2898,13 @@ pub fn route_bus_ghost(
     // always installs a trace collector *and* sink, so gating on
     // `trace::is_active()` alone would not skip this in production; an
     // explicit opt-in env var is what actually makes it zero-cost by
-    // default (round 1 review finding).
-    let junction_seed_census_enabled =
-        std::env::var_os("SPAGHETTIO_JUNCTION_SEED_CENSUS").is_some();
+    // default (round 1 review finding). Value-based, not merely
+    // presence-based (round 3 review finding): a shop-wide diagnostics
+    // block that sets every `SPAGHETTIO_*` var to `"0"` to disable them
+    // must not accidentally enable this one.
+    let junction_seed_census_enabled = std::env::var("SPAGHETTIO_JUNCTION_SEED_CENSUS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
 
     for cluster in &clusters {
         // `corridor_handled` grows during this loop — a prior cluster's
@@ -3000,10 +3004,30 @@ pub fn route_bus_ghost(
             // the item as the first colon-delimited segment after its
             // prefix — recover it from the key itself (same technique the
             // fluid catch-up above already uses) before falling back to
-            // the key as an absolute last resort.
+            // the key as an absolute last resort. `"tap:mergetap:"` MUST
+            // be checked before the plain `"tap:"` prefix (round 3 review
+            // finding): a merge-tap feed key is
+            // `format!("tap{MERGE_TAP_SEGMENT_TAG}{item}:{x}:{y}")` =
+            // `"tap:mergetap:{item}:{x}:{y}"`, so stripping only `"tap:"`
+            // would recover the literal string "mergetap" as the item
+            // instead of the real one. Currently these keys are always
+            // registered as regular `BeltSpec`s (so `spec_items.get(key)`
+            // above already resolves them and this fallback path is never
+            // reached for them today) — ordering the prefixes this way
+            // keeps it correct if that ever changes.
             fn resolve_item<'a>(key: &'a str, spec_items: &'a FxHashMap<String, String>) -> &'a str {
                 if let Some(item) = spec_items.get(key) {
                     return item.as_str();
+                }
+                // Checked ahead of the generic "tap:" prefix below, tied
+                // to the real constant (not a duplicated literal) so it
+                // can't drift from the merge-tap key format itself.
+                if let Some(rest) =
+                    key.strip_prefix("tap").and_then(|r| r.strip_prefix(MERGE_TAP_SEGMENT_TAG))
+                {
+                    if let Some((item, _)) = rest.split_once(':') {
+                        return item;
+                    }
                 }
                 for prefix in ["trunk:", "tap:", "flow:"] {
                     if let Some(rest) = key.strip_prefix(prefix) {

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -2964,6 +2964,37 @@ pub fn route_bus_ghost(
             .map(|(key, _)| key.as_str())
             .collect();
 
+        // Census-only instrumentation (offpath-code-followups.md G1
+        // follow-up, #689 W1d): record this seed's shape before it reaches
+        // `solve_crossing`. Purely observational — `trace::emit` is a
+        // no-op unless a collector/sink is active, so this cannot change
+        // routing. `has_pipe` is measured over the RAW spec set touching
+        // the cluster's tiles, i.e. BEFORE the `SpecKind::Pipe` filter
+        // above runs, so it can actually detect pipe presence instead of
+        // trivially reading false through the filter that excludes them.
+        {
+            let n_specs = keys_at_tile.len();
+            let n_distinct_items: usize = keys_at_tile
+                .iter()
+                .filter_map(|&key| spec_items.get(key).map(|s| s.as_str()))
+                .collect::<FxHashSet<&str>>()
+                .len();
+            let has_pipe = routed_paths.iter().any(|(key, path)| {
+                path.iter().any(|t| cluster_tiles.contains(t))
+                    && matches!(
+                        spec_kinds.get(key.as_str()),
+                        Some(crate::bus::junction::SpecKind::Pipe)
+                    )
+            });
+            trace::emit(trace::TraceEvent::JunctionSeedCensus {
+                seed_x: cluster[0].0,
+                seed_y: cluster[0].1,
+                n_specs,
+                n_distinct_items,
+                has_pipe,
+            });
+        }
+
         // Pending crossings for the DeferredExit check: the subset of
         // `crossing_set` whose cluster hasn't committed yet. Excluding
         // `corridor_handled` avoids false deferrals when a zone's exit

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -3000,11 +3000,12 @@ pub fn route_bus_ghost(
             // synth key when its path is ENTIRELY on pipe tiles; a fluid
             // synth key touching any non-pipe tile stays untagged). Every
             // synthetic key format in this file (`trunk:{item}:{x}`,
-            // `tap:{item}:{x}:{tap_y}`, `flow:{item}:{x}[:ret:{y}]`) puts
-            // the item as the first colon-delimited segment after its
-            // prefix — recover it from the key itself (same technique the
-            // fluid catch-up above already uses) before falling back to
-            // the key as an absolute last resort. `"tap:mergetap:"` MUST
+            // `tap:{item}:{x}:{tap_y}`, `flow:{item}:{x}[:ret:{y}]`,
+            // `feeder:{item}:{x}:{y}`, ghost_router.rs:1935) puts the item
+            // as the first colon-delimited segment after its prefix —
+            // recover it from the key itself (same technique the fluid
+            // catch-up above already uses) before falling back to the
+            // key as an absolute last resort. `"tap:mergetap:"` MUST
             // be checked before the plain `"tap:"` prefix (round 3 review
             // finding): a merge-tap feed key is
             // `format!("tap{MERGE_TAP_SEGMENT_TAG}{item}:{x}:{y}")` =
@@ -3029,13 +3030,28 @@ pub fn route_bus_ghost(
                         return item;
                     }
                 }
-                for prefix in ["trunk:", "tap:", "flow:"] {
+                for prefix in ["trunk:", "tap:", "flow:", "feeder:"] {
                     if let Some(rest) = key.strip_prefix(prefix) {
                         if let Some((item, _)) = rest.split_once(':') {
                             return item;
                         }
                     }
                 }
+                // Absolute last resort, reached only if BOTH the
+                // `spec_items` lookup and every known prefix above miss —
+                // not observed in any corpus run to date (round 4 review
+                // fence, since this path is genuinely untested): treating
+                // the raw key as a unique pseudo-item is the conservative
+                // choice for THIS census's specific failure mode (round 1
+                // review: never silently manufacture a same-item pair
+                // that isn't real), but it has its own opposite residual
+                // risk — two specs that truly share an item under some
+                // future, unrecognized key format would each get their
+                // own unique key here and read as "distinct", hiding a
+                // real same-item pair instead of fabricating one. If this
+                // path is ever observed firing (add an eprintln! probe if
+                // investigating), extend the prefix list above rather
+                // than trusting the count it produces.
                 key
             }
             let n_distinct_items: usize = keys_at_tile
@@ -3043,6 +3059,12 @@ pub fn route_bus_ghost(
                 .map(|&key| resolve_item(key, &spec_items))
                 .collect::<FxHashSet<&str>>()
                 .len();
+            // Round 4 review: this is O(sum of every routed path's
+            // length) per cluster when the census is on, not O(1) — it
+            // re-scans every path in `routed_paths` (the same cost class
+            // `keys_at_tile`'s own filter above already pays). Acceptable
+            // for an opt-in diagnostic gated off by default, but not
+            // free; don't reach for this pattern in an always-on path.
             let has_pipe = routed_paths.iter().any(|(key, path)| {
                 path.iter().any(|t| cluster_tiles.contains(t))
                     && matches!(

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -2988,18 +2988,35 @@ pub fn route_bus_ghost(
         // trivially reading false through the filter that excludes them.
         if junction_seed_census_enabled {
             let n_specs = keys_at_tile.len();
+            // Round 2 review: the round-1 fallback (unwrap_or the raw key,
+            // guaranteed unique) errs the OTHER way from round 1's
+            // filter_map bug — it can HIDE a genuine same-item pair
+            // whenever `spec_items` lacks an entry, which is not
+            // hypothetical (`ghost_router.rs`'s fluid catch-up only tags a
+            // synth key when its path is ENTIRELY on pipe tiles; a fluid
+            // synth key touching any non-pipe tile stays untagged). Every
+            // synthetic key format in this file (`trunk:{item}:{x}`,
+            // `tap:{item}:{x}:{tap_y}`, `flow:{item}:{x}[:ret:{y}]`) puts
+            // the item as the first colon-delimited segment after its
+            // prefix — recover it from the key itself (same technique the
+            // fluid catch-up above already uses) before falling back to
+            // the key as an absolute last resort.
+            fn resolve_item<'a>(key: &'a str, spec_items: &'a FxHashMap<String, String>) -> &'a str {
+                if let Some(item) = spec_items.get(key) {
+                    return item.as_str();
+                }
+                for prefix in ["trunk:", "tap:", "flow:"] {
+                    if let Some(rest) = key.strip_prefix(prefix) {
+                        if let Some((item, _)) = rest.split_once(':') {
+                            return item;
+                        }
+                    }
+                }
+                key
+            }
             let n_distinct_items: usize = keys_at_tile
                 .iter()
-                // Fall back to the spec's own key (unique by construction)
-                // rather than dropping a key missing from `spec_items` —
-                // dropping would silently undercount `n_distinct_items`
-                // and manufacture a false same-item pair (round 1 review
-                // finding). A missing entry is not expected (synthetic
-                // trunk keys populate `spec_items` at insertion, same as
-                // `routed_paths`), but this keeps a violated invariant
-                // from quietly biasing the census instead of crashing the
-                // routing hot path this instrumentation must never affect.
-                .map(|&key| spec_items.get(key).map(|s| s.as_str()).unwrap_or(key))
+                .map(|&key| resolve_item(key, &spec_items))
                 .collect::<FxHashSet<&str>>()
                 .len();
             let has_pipe = routed_paths.iter().any(|(key, path)| {

--- a/crates/core/src/bus/ghost_router.rs
+++ b/crates/core/src/bus/ghost_router.rs
@@ -2890,6 +2890,18 @@ pub fn route_bus_ghost(
     // used to scrape from the trace collector — without needing a trace guard.
     let mut cap_coords: Vec<(i32, i32)> = Vec::new();
 
+    // Census-only instrumentation (offpath-code-followups.md G1 follow-up,
+    // #689 W1d): checked ONCE per `route_bus_ghost` call, outside the
+    // cluster loop, rather than per cluster (the `dump_region_fixture`
+    // precedent's per-call env lookup, hoisted one level further). Off by
+    // default — the shipped web path (`build_bus_layout_streaming`)
+    // always installs a trace collector *and* sink, so gating on
+    // `trace::is_active()` alone would not skip this in production; an
+    // explicit opt-in env var is what actually makes it zero-cost by
+    // default (round 1 review finding).
+    let junction_seed_census_enabled =
+        std::env::var_os("SPAGHETTIO_JUNCTION_SEED_CENSUS").is_some();
+
     for cluster in &clusters {
         // `corridor_handled` grows during this loop — a prior cluster's
         // SAT footprint may have absorbed tiles that belong to this
@@ -2966,17 +2978,28 @@ pub fn route_bus_ghost(
 
         // Census-only instrumentation (offpath-code-followups.md G1
         // follow-up, #689 W1d): record this seed's shape before it reaches
-        // `solve_crossing`. Purely observational — `trace::emit` is a
-        // no-op unless a collector/sink is active, so this cannot change
-        // routing. `has_pipe` is measured over the RAW spec set touching
-        // the cluster's tiles, i.e. BEFORE the `SpecKind::Pipe` filter
-        // above runs, so it can actually detect pipe presence instead of
+        // `solve_crossing`. Purely observational and gated behind
+        // `junction_seed_census_enabled` (checked once above, not per
+        // cluster) — off by default, so production pays nothing beyond
+        // the one hoisted env lookup per `route_bus_ghost` call.
+        // `has_pipe` is measured over the RAW spec set touching the
+        // cluster's tiles, i.e. BEFORE the `SpecKind::Pipe` filter above
+        // runs, so it can actually detect pipe presence instead of
         // trivially reading false through the filter that excludes them.
-        {
+        if junction_seed_census_enabled {
             let n_specs = keys_at_tile.len();
             let n_distinct_items: usize = keys_at_tile
                 .iter()
-                .filter_map(|&key| spec_items.get(key).map(|s| s.as_str()))
+                // Fall back to the spec's own key (unique by construction)
+                // rather than dropping a key missing from `spec_items` —
+                // dropping would silently undercount `n_distinct_items`
+                // and manufacture a false same-item pair (round 1 review
+                // finding). A missing entry is not expected (synthetic
+                // trunk keys populate `spec_items` at insertion, same as
+                // `routed_paths`), but this keeps a violated invariant
+                // from quietly biasing the census instead of crashing the
+                // routing hot path this instrumentation must never affect.
+                .map(|&key| spec_items.get(key).map(|s| s.as_str()).unwrap_or(key))
                 .collect::<FxHashSet<&str>>()
                 .len();
             let has_pipe = routed_paths.iter().any(|(key, path)| {
@@ -2989,6 +3012,7 @@ pub fn route_bus_ghost(
             trace::emit(trace::TraceEvent::JunctionSeedCensus {
                 seed_x: cluster[0].0,
                 seed_y: cluster[0].1,
+                cluster_tile_count: cluster.len(),
                 n_specs,
                 n_distinct_items,
                 has_pipe,

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1437,20 +1437,41 @@ pub enum TraceEvent {
     },
 
     /// Census-only instrumentation (offpath-code-followups.md G1 follow-up,
-    /// #689 W1d): emitted once per junction seed in `ghost_router`'s
-    /// cluster loop — every `keys_at_tile` computation that survives the
-    /// `corridor_handled` / `any_undecidable` skips and reaches
-    /// `junction_solver::solve_crossing` — purely observational, no effect
-    /// on routing. Answers "do same-item belt crossings ever seed
-    /// junctions?": `n_specs > n_distinct_items` at a seed means yes.
-    /// `has_pipe` is measured over the RAW spec set touching the cluster's
-    /// tiles *before* `keys_at_tile`'s `SpecKind::Pipe` filter runs (that
-    /// filter is why pipes can never appear in `n_specs`/`n_distinct_items`
-    /// — see #687) — kept as a corroborating receipt of that finding, not
-    /// a new hypothesis.
+    /// #689 W1d): emitted once per junction seed (once per outer
+    /// cluster-loop iteration in `ghost_router` that reaches
+    /// `junction_solver::solve_crossing` — NOT re-emitted by the muted
+    /// context-conflict retry, which reuses this same `keys_at_tile`
+    /// without recomputing it) — purely observational, no effect on
+    /// routing (gated behind `SPAGHETTIO_JUNCTION_SEED_CENSUS`, so
+    /// production pays nothing by default — see the emit site).
+    ///
+    /// `n_specs`/`n_distinct_items` are CLUSTER-WIDE: the union of every
+    /// spec whose path touches ANY tile in the cluster, which can span
+    /// multiple tiles already at seed time (before `solve_crossing`'s own
+    /// growth). `n_specs > n_distinct_items` therefore means "this
+    /// cluster's participants include an item-sharing pair SOMEWHERE in
+    /// the cluster" — not "one tile has two same-item specs", which is
+    /// the rung's actual `tile_count == 1` predicate. `cluster_tile_count`
+    /// (the cluster's tile count at seed time) lets a consumer recover the
+    /// precise question: when `cluster_tile_count == 1`, the cluster IS a
+    /// single tile, so `keys_at_tile` is exactly the spec set at that one
+    /// tile and `n_specs > n_distinct_items` becomes a true single-tile
+    /// same-item crossing (#689 W1d review round 1 caught the conflation
+    /// in an earlier version of this doc comment).
+    ///
+    /// `has_pipe` is measured over the RAW spec set touching the
+    /// cluster's tiles *before* `keys_at_tile`'s `SpecKind::Pipe` filter
+    /// runs (that filter is why pipes can never appear in
+    /// `n_specs`/`n_distinct_items` — see #687) — kept as a corroborating
+    /// receipt of that finding, not a new hypothesis.
     JunctionSeedCensus {
         seed_x: i32,
         seed_y: i32,
+        /// Number of tiles in this seed's cluster at seed time (before any
+        /// growth). `1` means `n_specs`/`n_distinct_items` describe a
+        /// single physical tile; `>1` means they're a cluster-wide union
+        /// that may conflate specs from different tiles.
+        cluster_tile_count: usize,
         n_specs: usize,
         n_distinct_items: usize,
         has_pipe: bool,

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1435,6 +1435,26 @@ pub enum TraceEvent {
         new_rate: f64,
         full_belt_cap: f64,
     },
+
+    /// Census-only instrumentation (offpath-code-followups.md G1 follow-up,
+    /// #689 W1d): emitted once per junction seed in `ghost_router`'s
+    /// cluster loop — every `keys_at_tile` computation that survives the
+    /// `corridor_handled` / `any_undecidable` skips and reaches
+    /// `junction_solver::solve_crossing` — purely observational, no effect
+    /// on routing. Answers "do same-item belt crossings ever seed
+    /// junctions?": `n_specs > n_distinct_items` at a seed means yes.
+    /// `has_pipe` is measured over the RAW spec set touching the cluster's
+    /// tiles *before* `keys_at_tile`'s `SpecKind::Pipe` filter runs (that
+    /// filter is why pipes can never appear in `n_specs`/`n_distinct_items`
+    /// — see #687) — kept as a corroborating receipt of that finding, not
+    /// a new hypothesis.
+    JunctionSeedCensus {
+        seed_x: i32,
+        seed_y: i32,
+        n_specs: usize,
+        n_distinct_items: usize,
+        has_pipe: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/tests/junction_seed_census.rs
+++ b/crates/core/tests/junction_seed_census.rs
@@ -27,7 +27,7 @@
 //! this zero-cost there).
 //!
 //! **The rung's EXACT firing predicate** (`PerpendicularTemplateStrategy::
-//! try_solve`, ghost_router.rs ~6166-6171): `region.tile_count() == 1`
+//! try_solve`, ghost_router.rs 6177/6183/6186): `region.tile_count() == 1`
 //! AND `junction.specs.len() == 2`. This census's "true rung shape"
 //! bucket below requires both — `cluster_tile_count == 1`,
 //! `n_specs == 2`, `n_distinct_items == 1` (round 2 review finding: an
@@ -106,17 +106,54 @@ use spaghettio_core::bus::layout::{self, LayoutOptions};
 use spaghettio_core::solver;
 use spaghettio_core::trace::{self, TraceEvent};
 
+/// RAII guard: sets an env var for the guard's lifetime and restores
+/// whatever value (or absence) it had before, on drop — including on
+/// panic unwind, so an assertion failure mid-test doesn't leak the
+/// mutation into any test that runs afterward in this process (round 3
+/// review finding: this test's own env mutation was never restored).
+struct EnvVarGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: `std::env::set_var` requires `unsafe` on this toolchain
+        // at edition 2021 (verified: rustc 1.95.0 flags an unnecessary
+        // `unsafe` block under `#[deny(unused_unsafe)]` for an ordinary
+        // safe call — e.g. `unsafe { println!(...) }` — but does NOT flag
+        // this one, confirming the wrapper is required, not vestigial;
+        // round 3 review's claim that it's "unnecessary under edition
+        // 2021" does not hold on this toolchain). This test binary is
+        // single-threaded for env mutations — no other thread reads/
+        // writes process env concurrently here.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        EnvVarGuard { key, prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: same as `set` above.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 #[test]
 #[ignore = "G1 diagnostic census — run with --ignored --nocapture; see module doc for the zone-cache pin"]
 fn junction_seed_census() {
     // The emit site is gated behind this env var (off by default in
     // production — round 1 review finding). Set it for the duration of
-    // this test only.
-    // SAFETY: single-threaded test binary process for this env mutation;
-    // no other thread reads/writes process env concurrently here.
-    unsafe {
-        std::env::set_var("SPAGHETTIO_JUNCTION_SEED_CENSUS", "1");
-    }
+    // this test only; restored on drop regardless of how the test exits.
+    let _census_env_guard = EnvVarGuard::set("SPAGHETTIO_JUNCTION_SEED_CENSUS", "1");
 
     // (label, item, rate, machine, belt_tier, inputs)
     #[allow(clippy::type_complexity)]
@@ -206,14 +243,15 @@ fn junction_seed_census() {
     let mut pipe_tagged_but_not_single_spec = 0usize;
     let mut single_spec_but_not_pipe_tagged = 0usize;
 
-    // Every seed falls into exactly one of these five buckets — printed
-    // total must equal `total_seeds` (checked below, not just asserted in
-    // prose).
+    // Every seed falls into exactly one of these six buckets — printed
+    // total must equal `total_seeds` (checked below via assert_eq!, not
+    // just asserted in prose).
+    let mut zero_specs_after_filter = 0usize; // n_specs=0 (round 3 review finding: reachable — e.g. a pipe-only seed where keys_at_tile filters out the sole participant — and precisely the kind of case this census exists to surface, never to crash on)
     let mut single_tile_bypass = 0usize; // tiles=1, n_specs=1 (the belt-over-forbidden-tile bypass)
     let mut single_tile_diff_item = 0usize; // tiles=1, n_specs=2, distinct=2
     let mut single_tile_same_item = 0usize; // tiles=1, n_specs=2, distinct=1 — the rung's EXACT predicate shape
     let mut single_tile_gt2_specs = 0usize; // tiles=1, n_specs>2 (outside the rung's specs.len()==2 gate regardless of item-sharing)
-    let mut multi_tile_all_distinct = 0usize; // tiles>1, n_specs==n_distinct_items
+    let mut multi_tile_all_distinct = 0usize; // tiles>1, n_specs==n_distinct_items, n_specs>0
     let mut multi_tile_same_item = 0usize; // tiles>1, n_specs>n_distinct_items — weak signal, see module doc
 
     let mut same_item_single_tile: Vec<(String, i32, i32)> = Vec::new();
@@ -275,7 +313,21 @@ fn junction_seed_census() {
                     single_spec_but_not_pipe_tagged += 1;
                 }
 
+                // Round 3 review finding: n_specs == 0 IS reachable (a
+                // single-tile — or, in principle, multi-tile — cluster
+                // whose only participant(s) were pipes, all filtered out
+                // of keys_at_tile) and is exactly the kind of edge case
+                // this census exists to surface, so it gets its own
+                // bucket ahead of everything else — never a crash. Every
+                // other arm below is now genuinely exhaustive without a
+                // data-dependent catch-all: once n_specs == 0 is handled
+                // first, n_distinct_items is provably in 1..=n_specs for
+                // every remaining case (a non-empty HashSet's size can't
+                // exceed its input count or be zero), so the trailing
+                // `_ => unreachable!()` only catches a violated counting
+                // invariant, not a real corpus shape.
                 match (*cluster_tile_count == 1, *n_specs, *n_distinct_items) {
+                    (_, 0, _) => zero_specs_after_filter += 1,
                     (true, 1, _) => single_tile_bypass += 1,
                     (true, 2, 2) => single_tile_diff_item += 1,
                     (true, 2, 1) => {
@@ -284,7 +336,7 @@ fn junction_seed_census() {
                     }
                     (true, n, _) if n > 2 => single_tile_gt2_specs += 1,
                     (false, n, d) if n == d => multi_tile_all_distinct += 1,
-                    (false, _, _) => {
+                    (false, n, d) if n > d => {
                         multi_tile_same_item += 1;
                         same_item_multi_tile_union.push((
                             label.to_string(),
@@ -295,7 +347,10 @@ fn junction_seed_census() {
                             *n_distinct_items,
                         ));
                     }
-                    _ => unreachable!("n_specs < n_distinct_items should never occur"),
+                    _ => unreachable!(
+                        "counting invariant violated: n_distinct_items ({n_distinct_items}) \
+                         must be in 1..=n_specs ({n_specs}) once n_specs > 0"
+                    ),
                 }
             }
         }
@@ -315,7 +370,8 @@ fn junction_seed_census() {
     // is an arithmetic invariant true by construction (the match above is
     // exhaustive over the same fields the table sums), not a data-
     // dependent claim, so it can't spuriously fail from corpus drift.
-    let bucket_sum = single_tile_bypass
+    let bucket_sum = zero_specs_after_filter
+        + single_tile_bypass
         + single_tile_diff_item
         + single_tile_same_item
         + single_tile_gt2_specs
@@ -325,6 +381,7 @@ fn junction_seed_census() {
 
     println!(
         "\n--- bucket breakdown (sums to {total_seeds}) ---\n\
+         n_specs == 0 after the pipe filter (never a crash — see module doc): {zero_specs_after_filter}\n\
          single-tile, 1 spec (belt-over-forbidden-tile bypass): {single_tile_bypass}\n\
          single-tile, 2 specs, different items:                 {single_tile_diff_item}\n\
          single-tile, 2 specs, SAME item (rung's exact shape):  {single_tile_same_item}\n\
@@ -340,8 +397,20 @@ fn junction_seed_census() {
          count here would mean pipes DO reach a cluster tile candidate, \
          just always get filtered before solve_crossing): {pipe_tagged_seeds}"
     );
+    // Round 3 review finding: enforce the "pipe-tagged == single-spec"
+    // identity with assert_eq!, not just prose — if the corpus ever
+    // drifts so a pipe-tagged seed isn't single-spec (or vice versa),
+    // this test fails loudly instead of the doc silently going stale.
+    assert_eq!(
+        pipe_tagged_but_not_single_spec, 0,
+        "expected every pipe-tagged seed to be single-spec (the belt-crosses-a-placed-pipe bypass) — found one that wasn't"
+    );
+    assert_eq!(
+        single_spec_but_not_pipe_tagged, 0,
+        "expected every single-spec seed to be pipe-tagged — found one that wasn't"
+    );
     println!(
-        "cross-check (round 2 review — measured, not asserted): \
+        "cross-check (assert_eq!-enforced above, not just prose): \
          pipe-tagged & single-spec = {pipe_tagged_and_single_spec}, \
          pipe-tagged but NOT single-spec = {pipe_tagged_but_not_single_spec}, \
          single-spec but NOT pipe-tagged = {single_spec_but_not_pipe_tagged}"

--- a/crates/core/tests/junction_seed_census.rs
+++ b/crates/core/tests/junction_seed_census.rs
@@ -1,0 +1,213 @@
+//! G1 (offpath campaign, #689 W1d) — the production census of junction
+//! seeds that `docs/offpath-code-followups.md`'s G1 entry named as the
+//! one remaining follow-up. #687 established the ~795-line perpendicular-
+//! template rung (`crates/core/src/bus/ghost_router.rs`,
+//! `solve_perpendicular_template` area) appears production-unreachable on
+//! BOTH its shapes: belt×belt two-item crossings die on
+//! `junction_solver`'s item-conflict gate before the rung's single-tile
+//! window, and pipe×belt crossings never seed junctions because
+//! `keys_at_tile` filters `SpecKind::Pipe` out of seeding entirely. The
+//! ONE remaining reachability hypothesis: same-item belt crossings — do
+//! they ever seed junctions? This census answers exactly that question,
+//! nothing else — CENSUS-ONLY, no gate/behavior change regardless of the
+//! result (see the G1 entry for what a zero count would and would not
+//! authorize).
+//!
+//! Instrumentation: `TraceEvent::JunctionSeedCensus`
+//! (`crates/core/src/trace.rs`), emitted once per junction seed in
+//! `ghost_router`'s cluster loop — every `keys_at_tile` computation that
+//! survives the `corridor_handled`/`any_undecidable` skips and reaches
+//! `junction_solver::solve_crossing` (`crates/core/src/bus/ghost_router.rs`,
+//! right after `keys_at_tile` is built). Purely observational —
+//! `trace::emit` is a no-op unless a collector/sink is active on the
+//! thread, so adding it cannot change routing.
+//!
+//! Corpus (stated exactly, per the W1d brief): the same six tier-ladder
+//! fixtures `check_firing_census.rs` uses (G2's hardcoded slice — kept
+//! identical so the two censuses describe the same baseline corpus), plus
+//! the six explicit "from-ore" fixtures defined in `tests/e2e.rs`
+//! (`tier1_iron_gear_wheel_from_ore`, `tier2_electronic_circuit_from_ore`,
+//! `tier2_electronic_circuit_20s_from_ore`, `tier3_plastic_bar_from_crude`,
+//! `tier4_advanced_circuit_from_ore_am2`, `tier5_processing_unit_from_ore_am3`)
+//! that differ from the tier-ladder slice in belt-tier constraint and/or
+//! rate/machine (both listed so a reader can see what widened the corpus
+//! over G2's). Each fixture builds ONCE under `LayoutOptions::default()`
+//! (plus the fixture's own belt-tier constraint) — this census is about
+//! whether the rung is reachable from the shape the engine actually
+//! ships, not about candidate-search variants (G2's concern).
+//!
+//! Determinism: like every SAT-backed layout run, seed shapes depend on
+//! which zone solutions the cache replays. Run pinned, per
+//! `docs/offpath-code-followups.md`'s method section and CLAUDE.md's
+//! verification protocol:
+//!
+//! ```text
+//! SPAGHETTIO_ZONE_CACHE_PATH=$(pwd)/crates/core/data/sat-zones-ci.bin \
+//!   cargo test --manifest-path crates/core/Cargo.toml \
+//!   --test junction_seed_census -- --ignored --nocapture
+//! git checkout -- crates/core/data/sat-zones-ci.bin   # ALWAYS, every run —
+//! # the cache file is written to by the run above; it must never appear
+//! # in a commit.
+//! ```
+
+use rustc_hash::FxHashSet;
+use spaghettio_core::bus::layout::{self, LayoutOptions};
+use spaghettio_core::solver;
+use spaghettio_core::trace::{self, TraceEvent};
+
+#[test]
+#[ignore = "G1 diagnostic census — run with --ignored --nocapture; see module doc for the zone-cache pin"]
+fn junction_seed_census() {
+    // (label, item, rate, machine, belt_tier, inputs)
+    #[allow(clippy::type_complexity)]
+    let fixtures: &[(&str, &str, f64, &str, Option<&str>, &[&str])] = &[
+        // --- tier-ladder slice (identical to check_firing_census.rs's six,
+        // so both censuses describe the same baseline corpus) ---
+        ("tier1_gear_am1", "iron-gear-wheel", 10.0, "assembling-machine-1", None, &["iron-plate"]),
+        ("tier2_ec_am1_10_ore", "electronic-circuit", 10.0, "assembling-machine-1", None, &["iron-ore", "copper-ore"]),
+        ("tier2_ec_am2_30_ore", "electronic-circuit", 30.0, "assembling-machine-2", None, &["iron-ore", "copper-ore"]),
+        ("tier3_plastic_cp_5", "plastic-bar", 5.0, "chemical-plant", None, &["coal", "water", "crude-oil"]),
+        (
+            "tier4_ac_am2_5_unconstrained",
+            "advanced-circuit",
+            5.0,
+            "assembling-machine-2",
+            None,
+            &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+        ),
+        (
+            "tier5_pu_am3_2_unconstrained",
+            "processing-unit",
+            2.0,
+            "assembling-machine-3",
+            None,
+            &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+        ),
+        // --- e2e "from-ore" fixtures, each distinct from the slice above in
+        // belt-tier constraint and/or rate/machine (widening the corpus) ---
+        (
+            "e2e_tier1_iron_gear_wheel_from_ore",
+            "iron-gear-wheel",
+            10.0,
+            "assembling-machine-2",
+            None,
+            &["iron-ore"],
+        ),
+        (
+            "e2e_tier2_electronic_circuit_from_ore",
+            "electronic-circuit",
+            10.0,
+            "assembling-machine-1",
+            Some("transport-belt"),
+            &["iron-ore", "copper-ore"],
+        ),
+        (
+            "e2e_tier2_electronic_circuit_20s_from_ore",
+            "electronic-circuit",
+            20.0,
+            "assembling-machine-2",
+            None,
+            &["iron-ore", "copper-ore"],
+        ),
+        (
+            "e2e_tier3_plastic_bar_from_crude",
+            "plastic-bar",
+            10.0,
+            "chemical-plant",
+            None,
+            &["crude-oil", "coal"],
+        ),
+        (
+            "e2e_tier4_advanced_circuit_from_ore_am2",
+            "advanced-circuit",
+            5.0,
+            "assembling-machine-2",
+            Some("transport-belt"),
+            &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+        ),
+        (
+            "e2e_tier5_processing_unit_from_ore_am3",
+            "processing-unit",
+            2.0,
+            "assembling-machine-3",
+            Some("fast-transport-belt"),
+            &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+        ),
+    ];
+
+    // (n_specs, n_distinct_items) -> occurrence count across the corpus.
+    let mut table: std::collections::BTreeMap<(usize, usize), usize> = Default::default();
+    let mut total_seeds = 0usize;
+    let mut pipe_tagged_seeds = 0usize;
+    let mut same_item_seeds: Vec<(String, i32, i32, usize, usize)> = Vec::new();
+    let mut builds_ok = 0usize;
+    let mut builds_refused = 0usize;
+    let mut solver_skipped = 0usize;
+
+    for &(label, item, rate, machine, belt_tier, inputs) in fixtures {
+        let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let sr = match solver::solve(item, rate, &input_set, machine) {
+            Ok(sr) => sr,
+            Err(e) => {
+                eprintln!("SKIP (no solve): {label}: {e}");
+                solver_skipped += 1;
+                continue;
+            }
+        };
+        let opts = LayoutOptions {
+            max_belt_tier: belt_tier.map(|s| s.to_string()),
+            ..LayoutOptions::default()
+        };
+        let _guard = trace::start_trace();
+        let build_result = layout::build_bus_layout(&sr, opts);
+        let events = trace::drain_events();
+        match build_result {
+            Ok(_) => builds_ok += 1,
+            Err(e) => {
+                // Still tabulate whatever seeds fired before the refusal —
+                // route_bus_ghost's cluster loop emits the census event
+                // per seed as it goes, independent of whether the overall
+                // layout pass later refuses for an unrelated reason.
+                eprintln!("REFUSED: {label}: {e}");
+                builds_refused += 1;
+            }
+        }
+        for ev in &events {
+            if let TraceEvent::JunctionSeedCensus { seed_x, seed_y, n_specs, n_distinct_items, has_pipe } = ev
+            {
+                total_seeds += 1;
+                *table.entry((*n_specs, *n_distinct_items)).or_insert(0) += 1;
+                if *has_pipe {
+                    pipe_tagged_seeds += 1;
+                }
+                if *n_specs > *n_distinct_items {
+                    same_item_seeds.push((label.to_string(), *seed_x, *seed_y, *n_specs, *n_distinct_items));
+                }
+            }
+        }
+    }
+
+    println!(
+        "\n=== junction seed census: {total_seeds} seeds across {} fixtures ({builds_ok} built, {builds_refused} refused, {solver_skipped} solver-skipped) ===",
+        fixtures.len()
+    );
+    println!("{:>8} {:>9} {:>7}", "n_specs", "distinct", "count");
+    for ((n_specs, n_distinct), count) in &table {
+        println!("{n_specs:>8} {n_distinct:>9} {count:>7}");
+    }
+    println!(
+        "\npipe-tagged seeds (measured on the RAW spec set at each cluster's \
+         tiles, BEFORE keys_at_tile's SpecKind::Pipe filter runs — expected \
+         0 by construction if #687's pipe×belt finding holds; a nonzero \
+         count here would mean pipes DO reach a cluster tile candidate, \
+         just always get filtered before solve_crossing): {pipe_tagged_seeds}"
+    );
+    println!(
+        "\nsame-item seeds (n_specs > n_distinct_items — the G1 open \
+         question, same-item belt crossings seeding junctions): {}",
+        same_item_seeds.len()
+    );
+    for (label, x, y, n_specs, n_distinct) in &same_item_seeds {
+        println!("  {label} @ ({x},{y}): {n_specs} specs, {n_distinct} distinct items");
+    }
+}

--- a/crates/core/tests/junction_seed_census.rs
+++ b/crates/core/tests/junction_seed_census.rs
@@ -26,20 +26,52 @@
 //! active, so gating on "is tracing active" alone would not have made
 //! this zero-cost there).
 //!
-//! **Methodology note (round 1 review finding, corrected here):**
-//! `n_specs`/`n_distinct_items` are CLUSTER-WIDE — the union of every
-//! spec whose path touches ANY tile in the seed's cluster, which can
-//! already span multiple tiles before `solve_crossing`'s own growth. So
-//! `n_specs > n_distinct_items` on a multi-tile cluster means "this
-//! cluster's participants include an item-sharing pair somewhere in it",
-//! NOT "one tile has two same-item specs" — the rung's actual
-//! `tile_count == 1` predicate. `cluster_tile_count` (also recorded)
-//! disambiguates: when it's `1`, the cluster IS a single tile, so
-//! `keys_at_tile` is exactly that tile's spec set and `n_specs >
-//! n_distinct_items` becomes a true single-tile same-item crossing. This
-//! census reports BOTH numbers — single-tile (the precise answer to the
-//! rung's own question) and multi-tile cluster-wide (a weaker, separate
-//! signal) — rather than conflating them into one count.
+//! **The rung's EXACT firing predicate** (`PerpendicularTemplateStrategy::
+//! try_solve`, ghost_router.rs ~6166-6171): `region.tile_count() == 1`
+//! AND `junction.specs.len() == 2`. This census's "true rung shape"
+//! bucket below requires both — `cluster_tile_count == 1`,
+//! `n_specs == 2`, `n_distinct_items == 1` (round 2 review finding: an
+//! earlier version of this test flagged ANY single-tile seed with
+//! `n_specs > n_distinct_items`, which is a superset of the rung's
+//! predicate — a single-tile 3+-spec cluster with an item-sharing pair
+//! would have counted as a "hit" even though the rung can never fire on
+//! it, since it hard-refuses whenever `specs.len() != 2`). This corpus
+//! happens to have zero single-tile clusters with more than 2 specs, so
+//! the superset bug didn't change the reported number, but the metric
+//! itself needed tightening.
+//!
+//! **Methodology note (round 1 review finding):** `n_specs`/
+//! `n_distinct_items` are CLUSTER-WIDE — the union of every spec whose
+//! path touches ANY tile in the seed's cluster, which can already span
+//! multiple tiles before `solve_crossing`'s own growth. `cluster_tile_count`
+//! disambiguates: when it's `1` the union IS that one tile's spec set;
+//! when it's `>1`, "some tile in this cluster" is not "this tile" — the
+//! rung structurally cannot ever run on a `tile_count > 1` region (see
+//! above), so a per-tile breakdown of multi-tile clusters is not needed
+//! to answer the reachability question — those clusters are provably
+//! outside the rung's domain regardless of what any one tile inside them
+//! looks like. This census still reports the multi-tile same-item count
+//! as a separate, explicitly weaker signal (round 2 review: likely
+//! dominated by the mundane case of a trunk column and its own non-last
+//! tap-off sharing an item, per `docs/rfc-unified-belt-specs.md` Phase 2
+//! — that's a parent/child relationship within ONE logical flow, not two
+//! independent specs crossing, so treat the multi-tile count as an upper
+//! bound on anything resembling a same-item crossing, not evidence of
+//! one).
+//!
+//! **Scope note (round 2 review):** `build_bus_layout` runs the full
+//! candidate search + junction-cap retry machinery
+//! (`decomposition_search::select_best_decomposition` →
+//! `run_layout_with_retry_inner`), each of which can invoke
+//! `route_bus_ghost` more than once per fixture (once per evaluated
+//! candidate variant, plus a pass-2 retry when pass 1 caps). This
+//! census's totals are seed-OBSERVATIONS across every such invocation
+//! during a fixture's full build, not deduplicated by physical
+//! coordinate — a seed whose geometry is untouched by a retry can appear
+//! more than once. This is intentional (every invocation is a real
+//! `route_bus_ghost` call the shipped pipeline actually makes), but it
+//! means "111 seeds" is not "111 distinct physical crossings in the
+//! final shipped layout".
 //!
 //! Corpus (stated exactly, per the W1d brief): the same six tier-ladder
 //! fixtures `check_firing_census.rs` uses (G2's hardcoded slice — kept
@@ -167,13 +199,24 @@ fn junction_seed_census() {
     let mut table: std::collections::BTreeMap<(usize, usize, usize), usize> = Default::default();
     let mut total_seeds = 0usize;
     let mut pipe_tagged_seeds = 0usize;
-    // Precise answer: single-tile clusters (cluster_tile_count == 1) where
-    // the tile's own spec set has a same-item pair. This is exactly the
-    // rung's own predicate shape.
-    let mut same_item_single_tile: Vec<(String, i32, i32, usize, usize)> = Vec::new();
-    // Weaker signal: multi-tile clusters whose UNION of participants
-    // includes an item-sharing pair somewhere in the cluster — NOT
-    // evidence any one tile has two same-item specs.
+    // Cross-check (round 2 review): does "pipe-tagged" actually coincide
+    // with "single-spec seed", as the prose has claimed? Measure it
+    // instead of asserting it.
+    let mut pipe_tagged_and_single_spec = 0usize;
+    let mut pipe_tagged_but_not_single_spec = 0usize;
+    let mut single_spec_but_not_pipe_tagged = 0usize;
+
+    // Every seed falls into exactly one of these five buckets — printed
+    // total must equal `total_seeds` (checked below, not just asserted in
+    // prose).
+    let mut single_tile_bypass = 0usize; // tiles=1, n_specs=1 (the belt-over-forbidden-tile bypass)
+    let mut single_tile_diff_item = 0usize; // tiles=1, n_specs=2, distinct=2
+    let mut single_tile_same_item = 0usize; // tiles=1, n_specs=2, distinct=1 — the rung's EXACT predicate shape
+    let mut single_tile_gt2_specs = 0usize; // tiles=1, n_specs>2 (outside the rung's specs.len()==2 gate regardless of item-sharing)
+    let mut multi_tile_all_distinct = 0usize; // tiles>1, n_specs==n_distinct_items
+    let mut multi_tile_same_item = 0usize; // tiles>1, n_specs>n_distinct_items — weak signal, see module doc
+
+    let mut same_item_single_tile: Vec<(String, i32, i32)> = Vec::new();
     let mut same_item_multi_tile_union: Vec<(String, i32, i32, usize, usize, usize)> = Vec::new();
     let mut builds_ok = 0usize;
     let mut builds_refused = 0usize;
@@ -219,14 +262,30 @@ fn junction_seed_census() {
             {
                 total_seeds += 1;
                 *table.entry((*cluster_tile_count, *n_specs, *n_distinct_items)).or_insert(0) += 1;
+
+                let is_single_spec = *n_specs == 1;
                 if *has_pipe {
                     pipe_tagged_seeds += 1;
-                }
-                if *n_specs > *n_distinct_items {
-                    if *cluster_tile_count == 1 {
-                        same_item_single_tile
-                            .push((label.to_string(), *seed_x, *seed_y, *n_specs, *n_distinct_items));
+                    if is_single_spec {
+                        pipe_tagged_and_single_spec += 1;
                     } else {
+                        pipe_tagged_but_not_single_spec += 1;
+                    }
+                } else if is_single_spec {
+                    single_spec_but_not_pipe_tagged += 1;
+                }
+
+                match (*cluster_tile_count == 1, *n_specs, *n_distinct_items) {
+                    (true, 1, _) => single_tile_bypass += 1,
+                    (true, 2, 2) => single_tile_diff_item += 1,
+                    (true, 2, 1) => {
+                        single_tile_same_item += 1;
+                        same_item_single_tile.push((label.to_string(), *seed_x, *seed_y));
+                    }
+                    (true, n, _) if n > 2 => single_tile_gt2_specs += 1,
+                    (false, n, d) if n == d => multi_tile_all_distinct += 1,
+                    (false, _, _) => {
+                        multi_tile_same_item += 1;
                         same_item_multi_tile_union.push((
                             label.to_string(),
                             *seed_x,
@@ -236,6 +295,7 @@ fn junction_seed_census() {
                             *n_distinct_items,
                         ));
                     }
+                    _ => unreachable!("n_specs < n_distinct_items should never occur"),
                 }
             }
         }
@@ -249,6 +309,30 @@ fn junction_seed_census() {
     for ((tiles, n_specs, n_distinct), count) in &table {
         println!("{tiles:>7} {n_specs:>8} {n_distinct:>9} {count:>7}");
     }
+
+    // Reconciliation: every seed must land in exactly one bucket. Assert
+    // it rather than trust hand-transcribed prose (round 2 review) — this
+    // is an arithmetic invariant true by construction (the match above is
+    // exhaustive over the same fields the table sums), not a data-
+    // dependent claim, so it can't spuriously fail from corpus drift.
+    let bucket_sum = single_tile_bypass
+        + single_tile_diff_item
+        + single_tile_same_item
+        + single_tile_gt2_specs
+        + multi_tile_all_distinct
+        + multi_tile_same_item;
+    assert_eq!(bucket_sum, total_seeds, "seed buckets must partition total_seeds exactly");
+
+    println!(
+        "\n--- bucket breakdown (sums to {total_seeds}) ---\n\
+         single-tile, 1 spec (belt-over-forbidden-tile bypass): {single_tile_bypass}\n\
+         single-tile, 2 specs, different items:                 {single_tile_diff_item}\n\
+         single-tile, 2 specs, SAME item (rung's exact shape):  {single_tile_same_item}\n\
+         single-tile, >2 specs (outside rung's specs.len()==2): {single_tile_gt2_specs}\n\
+         multi-tile,  all participants distinct items:          {multi_tile_all_distinct}\n\
+         multi-tile,  item-sharing pair somewhere in union:     {multi_tile_same_item}"
+    );
+
     println!(
         "\npipe-tagged seeds (measured on the RAW spec set at each cluster's \
          tiles, BEFORE keys_at_tile's SpecKind::Pipe filter runs — expected \
@@ -257,19 +341,27 @@ fn junction_seed_census() {
          just always get filtered before solve_crossing): {pipe_tagged_seeds}"
     );
     println!(
-        "\nsame-item SINGLE-TILE seeds (cluster_tile_count == 1 AND n_specs \
-         > n_distinct_items — the precise answer to the G1 question, the \
-         rung's own tile_count==1 predicate shape): {}",
+        "cross-check (round 2 review — measured, not asserted): \
+         pipe-tagged & single-spec = {pipe_tagged_and_single_spec}, \
+         pipe-tagged but NOT single-spec = {pipe_tagged_but_not_single_spec}, \
+         single-spec but NOT pipe-tagged = {single_spec_but_not_pipe_tagged}"
+    );
+
+    println!(
+        "\nsame-item seeds matching the rung's EXACT predicate \
+         (cluster_tile_count == 1 AND n_specs == 2 AND n_distinct_items == 1): {}",
         same_item_single_tile.len()
     );
-    for (label, x, y, n_specs, n_distinct) in &same_item_single_tile {
-        println!("  {label} @ ({x},{y}): {n_specs} specs, {n_distinct} distinct items");
+    for (label, x, y) in &same_item_single_tile {
+        println!("  {label} @ ({x},{y})");
     }
     println!(
         "\nsame-item MULTI-TILE cluster-wide seeds (cluster_tile_count > 1 \
          AND the cluster's participant UNION has an item-sharing pair \
-         somewhere in it — NOT evidence any single tile has two same-item \
-         specs; see the module doc's methodology note): {}",
+         somewhere in it — a weak, likely trunk/tap-contaminated signal; \
+         see the module doc's methodology note. NOT evidence of a same-item \
+         crossing, and not further examined per-tile because the rung \
+         structurally cannot act on tile_count > 1 regardless): {}",
         same_item_multi_tile_union.len()
     );
     for (label, x, y, tiles, n_specs, n_distinct) in &same_item_multi_tile_union {

--- a/crates/core/tests/junction_seed_census.rs
+++ b/crates/core/tests/junction_seed_census.rs
@@ -67,19 +67,38 @@
 //! bound on anything resembling a same-item crossing, not evidence of
 //! one).
 //!
-//! **Scope note (round 2 review):** `build_bus_layout` runs the full
-//! candidate search + junction-cap retry machinery
+//! **Scope note (round 2 review, CORRECTED round 5):** `build_bus_layout`
+//! runs the full candidate search + junction-cap retry machinery
 //! (`decomposition_search::select_best_decomposition` →
 //! `run_layout_with_retry_inner`), each of which can invoke
 //! `route_bus_ghost` more than once per fixture (once per evaluated
-//! candidate variant, plus a pass-2 retry when pass 1 caps). This
-//! census's totals are seed-OBSERVATIONS across every such invocation
-//! during a fixture's full build, not deduplicated by physical
-//! coordinate — a seed whose geometry is untouched by a retry can appear
-//! more than once. This is intentional (every invocation is a real
-//! `route_bus_ghost` call the shipped pipeline actually makes), but it
-//! means "111 seeds" is not "111 distinct physical crossings in the
-//! final shipped layout".
+//! candidate variant, plus a pass-2 retry when pass 1 caps). An earlier
+//! version of this note claimed the totals count "every ... invocation
+//! ... not deduplicated" — that overstates it: when a candidate's pass 1
+//! caps, `run_layout_with_retry_inner` calls
+//! `trace::truncate_events(trace_start)` to discard that candidate's
+//! pass-1 events (including any `JunctionSeedCensus` it emitted) before
+//! pass 2 runs, specifically so a streaming consumer never sees an
+//! abandoned pass. So this census counts the SHIPPED (surviving) pass
+//! per candidate evaluation — a retried candidate's pass-1 seeds are
+//! silently dropped from what this test observes, not double-counted.
+//! Seeds are still not deduplicated ACROSS independent candidate
+//! evaluations (each candidate's own final pass counts separately), and
+//! a seed whose geometry is untouched across passes within one candidate
+//! can still appear at most once per candidate (pass 1 is gone if pass 2
+//! ran). This test also tallies `TraceEvent::LayoutRetried` occurrences
+//! (emitted right after the truncate, so it survives into what this test
+//! observes) as a directly-measured count of how many truncation
+//! episodes happened — printed next to the summary line. **This cannot
+//! flip the zero conclusion to a false positive**: truncation only
+//! REMOVES seed observations this census would otherwise have counted;
+//! it can never fabricate a same-item hit that didn't occur. It CAN hide
+//! a true positive that occurred only in a truncated pass-1 — the zero
+//! reported below is therefore a lower bound on this corpus's true
+//! same-item-crossing count, not a certainty that no such pass-1 ever
+//! existed. `SPAGHETTIO_JUNCTION_SEED_CENSUS`, once wired to fire from
+//! inside `layout_pass` before the truncate point (out of scope for this
+//! CENSUS-ONLY PR), would close this gap.
 //!
 //! Corpus (stated exactly, per the W1d brief): the same six tier-ladder
 //! fixtures `check_firing_census.rs` uses (G2's hardcoded slice — kept
@@ -275,6 +294,13 @@ fn junction_seed_census() {
     let mut builds_ok = 0usize;
     let mut builds_refused = 0usize;
     let mut solver_skipped = 0usize;
+    // Round 5 review: directly measure truncation episodes rather than
+    // just caveating them in prose. `LayoutRetried` is emitted AFTER
+    // `run_layout_with_retry_inner`'s `trace::truncate_events` call (see
+    // the module doc's scope note), so it survives into what this test
+    // observes and counts exactly how many times a candidate's pass-1
+    // census events were discarded before this test ever saw them.
+    let mut retried_episodes = 0usize;
 
     for &(label, item, rate, machine, belt_tier, inputs) in fixtures {
         let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
@@ -305,6 +331,9 @@ fn junction_seed_census() {
             }
         }
         for ev in &events {
+            if matches!(ev, TraceEvent::LayoutRetried { .. }) {
+                retried_episodes += 1;
+            }
             if let TraceEvent::JunctionSeedCensus {
                 seed_x,
                 seed_y,
@@ -376,6 +405,24 @@ fn junction_seed_census() {
         "\n=== junction seed census: {total_seeds} seeds across {} fixtures ({builds_ok} built, {builds_refused} refused, {solver_skipped} solver-skipped) ===",
         fixtures.len()
     );
+    // Round 5 review: the seed counts above are partial in two distinct
+    // ways, both DECREASING what this census can observe (never
+    // inflating it — see the module doc's scope note for why that means
+    // the zero conclusion below is a lower bound, not a certainty):
+    // (1) a REFUSED build's counted seeds are only whatever fired before
+    // the failure — the layout never finished, so there may have been
+    // more; (2) a build that internally retried had its pass-1 seeds
+    // discarded by the engine itself (`trace::truncate_events`) before
+    // this test could ever see them — `retried_episodes` below is a
+    // direct, measured count of how many such discards happened, not a
+    // guess.
+    println!(
+        "(seed counts are PARTIAL, never inflated: {builds_refused} build(s) refused \
+         partway through, and {retried_episodes} candidate-evaluation(s) internally \
+         retried — each retry's pass-1 census events were discarded by \
+         `trace::truncate_events` before this test observed them; see the \
+         module doc's scope note)"
+    );
     println!("{:>7} {:>8} {:>9} {:>7}", "tiles", "n_specs", "distinct", "count");
     for ((tiles, n_specs, n_distinct), count) in &table {
         println!("{tiles:>7} {n_specs:>8} {n_distinct:>9} {count:>7}");
@@ -400,10 +447,36 @@ fn junction_seed_census() {
          n_specs == 0 after the pipe filter (never a crash — see module doc): {zero_specs_after_filter}\n\
          single-tile, 1 spec (belt-over-forbidden-tile bypass): {single_tile_bypass}\n\
          single-tile, 2 specs, different items:                 {single_tile_diff_item}\n\
-         single-tile, 2 specs, SAME item (rung's exact shape):  {single_tile_same_item}\n\
+         single-tile, 2 specs, SAME item (necessary-superset):  {single_tile_same_item}\n\
          single-tile, >2 specs (outside rung's specs.len()==2): {single_tile_gt2_specs}\n\
          multi-tile,  all participants distinct items:          {multi_tile_all_distinct}\n\
          multi-tile,  item-sharing pair somewhere in union:     {multi_tile_same_item}"
+    );
+
+    // Round 5 review: this is THE conclusion the census exists to check
+    // — not an exploratory tally where an unexpected value is itself
+    // informative (that's what the demoted checks below are for; round
+    // 4's "never abort on discovery" call was about those, not this).
+    // Deliberately a hard `assert_eq!`: this diagnostic is `#[ignore]`d,
+    // so it only runs when someone deliberately re-executes the
+    // evidence behind a deletion or reachability decision — exactly the
+    // moment a changed conclusion should be loud, not a silently-updated
+    // number in a printed line nobody re-reads. If this ever fires, DO
+    // NOT proceed with any deletion of the perpendicular-template rung
+    // (ghost_router.rs, `solve_perpendicular_template`/`try_bridge`/
+    // `bridge_belt_over_pipe`) on the strength of this census — the
+    // reachability conclusion has changed, and `docs/offpath-code-
+    // followups.md`'s G1 entry must be updated with the new finding
+    // before anyone trusts a deletion call built on the old "zero"
+    // result.
+    assert_eq!(
+        single_tile_same_item, 0,
+        "same-item seed(s) found in the rung's necessary-superset bucket \
+         (cluster_tile_count == 1, n_specs == 2, n_distinct_items == 1) — \
+         the G1 census's zero-reachability conclusion no longer holds on \
+         this corpus. Update docs/offpath-code-followups.md's G1 entry \
+         with this finding BEFORE trusting any deletion decision that \
+         cited the old zero."
     );
 
     println!(
@@ -416,6 +489,32 @@ fn junction_seed_census() {
          multi-spec seed also touched by a pipe, which #687's pipe×belt \
          finding does not rule out and this census has not previously \
          checked for."
+    );
+    // Round 5 review: this corroboration, and the same_item_single_tile
+    // zero conclusion above, both inherit an acknowledged residual risk
+    // from n_distinct_items's item-resolution path in ghost_router.rs —
+    // TWO independent biases, and both bias toward HIDING a same-item
+    // pair rather than fabricating one: (1) the fluid catch-up sweep
+    // only tags a synth key as Pipe when its path sits ENTIRELY on pipe
+    // tiles, so a fluid synth key touching any non-pipe tile falls
+    // through to `resolve_item`'s prefix-recovery path instead of being
+    // excluded as a pipe outright; (2) `resolve_item`'s absolute-last-
+    // resort (no `spec_items` entry, no recognized key prefix) treats
+    // the raw key as a unique pseudo-item, which can make two specs that
+    // truly share an item read as "distinct" if their key format is one
+    // this census doesn't yet recognize. Neither has been observed
+    // firing in any run to date (this census would need dedicated
+    // instrumentation on `resolve_item` itself to prove that beyond
+    // "not observed so far"), so the zero conclusion above is honest but
+    // not airtight: a same-item pair COULD be hiding behind either bias.
+    // Any deletion follow-up that cites this census's zero should say so.
+    println!(
+        "(both the corroboration above and the zero same-item conclusion \
+         below share an acknowledged residual risk: ghost_router.rs's \
+         item-resolution fallback path can HIDE a true same-item pair — \
+         never fabricate one — under an unrecognized key format; not \
+         observed in any run to date, but not proven absent either. Cite \
+         this caveat alongside the zero in any deletion follow-up.)"
     );
     // Round 4 review finding: these two correlation checks were hard
     // `assert_eq!`s in an earlier pass, but a legitimate new seed shape

--- a/crates/core/tests/junction_seed_census.rs
+++ b/crates/core/tests/junction_seed_census.rs
@@ -18,9 +18,28 @@
 //! `ghost_router`'s cluster loop — every `keys_at_tile` computation that
 //! survives the `corridor_handled`/`any_undecidable` skips and reaches
 //! `junction_solver::solve_crossing` (`crates/core/src/bus/ghost_router.rs`,
-//! right after `keys_at_tile` is built). Purely observational —
-//! `trace::emit` is a no-op unless a collector/sink is active on the
-//! thread, so adding it cannot change routing.
+//! right after `keys_at_tile` is built). Purely observational — the emit
+//! site is gated behind `SPAGHETTIO_JUNCTION_SEED_CENSUS` (checked once
+//! per `route_bus_ghost` call, off by default), so this test must set
+//! that env var, and production pays nothing without it (round 1 review
+//! finding: the shipped web path always has a trace collector *and* sink
+//! active, so gating on "is tracing active" alone would not have made
+//! this zero-cost there).
+//!
+//! **Methodology note (round 1 review finding, corrected here):**
+//! `n_specs`/`n_distinct_items` are CLUSTER-WIDE — the union of every
+//! spec whose path touches ANY tile in the seed's cluster, which can
+//! already span multiple tiles before `solve_crossing`'s own growth. So
+//! `n_specs > n_distinct_items` on a multi-tile cluster means "this
+//! cluster's participants include an item-sharing pair somewhere in it",
+//! NOT "one tile has two same-item specs" — the rung's actual
+//! `tile_count == 1` predicate. `cluster_tile_count` (also recorded)
+//! disambiguates: when it's `1`, the cluster IS a single tile, so
+//! `keys_at_tile` is exactly that tile's spec set and `n_specs >
+//! n_distinct_items` becomes a true single-tile same-item crossing. This
+//! census reports BOTH numbers — single-tile (the precise answer to the
+//! rung's own question) and multi-tile cluster-wide (a weaker, separate
+//! signal) — rather than conflating them into one count.
 //!
 //! Corpus (stated exactly, per the W1d brief): the same six tier-ladder
 //! fixtures `check_firing_census.rs` uses (G2's hardcoded slice — kept
@@ -58,6 +77,15 @@ use spaghettio_core::trace::{self, TraceEvent};
 #[test]
 #[ignore = "G1 diagnostic census — run with --ignored --nocapture; see module doc for the zone-cache pin"]
 fn junction_seed_census() {
+    // The emit site is gated behind this env var (off by default in
+    // production — round 1 review finding). Set it for the duration of
+    // this test only.
+    // SAFETY: single-threaded test binary process for this env mutation;
+    // no other thread reads/writes process env concurrently here.
+    unsafe {
+        std::env::set_var("SPAGHETTIO_JUNCTION_SEED_CENSUS", "1");
+    }
+
     // (label, item, rate, machine, belt_tier, inputs)
     #[allow(clippy::type_complexity)]
     let fixtures: &[(&str, &str, f64, &str, Option<&str>, &[&str])] = &[
@@ -135,11 +163,18 @@ fn junction_seed_census() {
         ),
     ];
 
-    // (n_specs, n_distinct_items) -> occurrence count across the corpus.
-    let mut table: std::collections::BTreeMap<(usize, usize), usize> = Default::default();
+    // (cluster_tile_count, n_specs, n_distinct_items) -> occurrence count.
+    let mut table: std::collections::BTreeMap<(usize, usize, usize), usize> = Default::default();
     let mut total_seeds = 0usize;
     let mut pipe_tagged_seeds = 0usize;
-    let mut same_item_seeds: Vec<(String, i32, i32, usize, usize)> = Vec::new();
+    // Precise answer: single-tile clusters (cluster_tile_count == 1) where
+    // the tile's own spec set has a same-item pair. This is exactly the
+    // rung's own predicate shape.
+    let mut same_item_single_tile: Vec<(String, i32, i32, usize, usize)> = Vec::new();
+    // Weaker signal: multi-tile clusters whose UNION of participants
+    // includes an item-sharing pair somewhere in the cluster — NOT
+    // evidence any one tile has two same-item specs.
+    let mut same_item_multi_tile_union: Vec<(String, i32, i32, usize, usize, usize)> = Vec::new();
     let mut builds_ok = 0usize;
     let mut builds_refused = 0usize;
     let mut solver_skipped = 0usize;
@@ -173,15 +208,34 @@ fn junction_seed_census() {
             }
         }
         for ev in &events {
-            if let TraceEvent::JunctionSeedCensus { seed_x, seed_y, n_specs, n_distinct_items, has_pipe } = ev
+            if let TraceEvent::JunctionSeedCensus {
+                seed_x,
+                seed_y,
+                cluster_tile_count,
+                n_specs,
+                n_distinct_items,
+                has_pipe,
+            } = ev
             {
                 total_seeds += 1;
-                *table.entry((*n_specs, *n_distinct_items)).or_insert(0) += 1;
+                *table.entry((*cluster_tile_count, *n_specs, *n_distinct_items)).or_insert(0) += 1;
                 if *has_pipe {
                     pipe_tagged_seeds += 1;
                 }
                 if *n_specs > *n_distinct_items {
-                    same_item_seeds.push((label.to_string(), *seed_x, *seed_y, *n_specs, *n_distinct_items));
+                    if *cluster_tile_count == 1 {
+                        same_item_single_tile
+                            .push((label.to_string(), *seed_x, *seed_y, *n_specs, *n_distinct_items));
+                    } else {
+                        same_item_multi_tile_union.push((
+                            label.to_string(),
+                            *seed_x,
+                            *seed_y,
+                            *cluster_tile_count,
+                            *n_specs,
+                            *n_distinct_items,
+                        ));
+                    }
                 }
             }
         }
@@ -191,9 +245,9 @@ fn junction_seed_census() {
         "\n=== junction seed census: {total_seeds} seeds across {} fixtures ({builds_ok} built, {builds_refused} refused, {solver_skipped} solver-skipped) ===",
         fixtures.len()
     );
-    println!("{:>8} {:>9} {:>7}", "n_specs", "distinct", "count");
-    for ((n_specs, n_distinct), count) in &table {
-        println!("{n_specs:>8} {n_distinct:>9} {count:>7}");
+    println!("{:>7} {:>8} {:>9} {:>7}", "tiles", "n_specs", "distinct", "count");
+    for ((tiles, n_specs, n_distinct), count) in &table {
+        println!("{tiles:>7} {n_specs:>8} {n_distinct:>9} {count:>7}");
     }
     println!(
         "\npipe-tagged seeds (measured on the RAW spec set at each cluster's \
@@ -203,11 +257,22 @@ fn junction_seed_census() {
          just always get filtered before solve_crossing): {pipe_tagged_seeds}"
     );
     println!(
-        "\nsame-item seeds (n_specs > n_distinct_items — the G1 open \
-         question, same-item belt crossings seeding junctions): {}",
-        same_item_seeds.len()
+        "\nsame-item SINGLE-TILE seeds (cluster_tile_count == 1 AND n_specs \
+         > n_distinct_items — the precise answer to the G1 question, the \
+         rung's own tile_count==1 predicate shape): {}",
+        same_item_single_tile.len()
     );
-    for (label, x, y, n_specs, n_distinct) in &same_item_seeds {
+    for (label, x, y, n_specs, n_distinct) in &same_item_single_tile {
         println!("  {label} @ ({x},{y}): {n_specs} specs, {n_distinct} distinct items");
+    }
+    println!(
+        "\nsame-item MULTI-TILE cluster-wide seeds (cluster_tile_count > 1 \
+         AND the cluster's participant UNION has an item-sharing pair \
+         somewhere in it — NOT evidence any single tile has two same-item \
+         specs; see the module doc's methodology note): {}",
+        same_item_multi_tile_union.len()
+    );
+    for (label, x, y, tiles, n_specs, n_distinct) in &same_item_multi_tile_union {
+        println!("  {label} @ ({x},{y}): {tiles} tiles, {n_specs} specs, {n_distinct} distinct items");
     }
 }

--- a/crates/core/tests/junction_seed_census.rs
+++ b/crates/core/tests/junction_seed_census.rs
@@ -26,19 +26,27 @@
 //! active, so gating on "is tracing active" alone would not have made
 //! this zero-cost there).
 //!
-//! **The rung's EXACT firing predicate** (`PerpendicularTemplateStrategy::
-//! try_solve`, ghost_router.rs 6177/6183/6186): `region.tile_count() == 1`
-//! AND `junction.specs.len() == 2`. This census's "true rung shape"
-//! bucket below requires both — `cluster_tile_count == 1`,
-//! `n_specs == 2`, `n_distinct_items == 1` (round 2 review finding: an
-//! earlier version of this test flagged ANY single-tile seed with
-//! `n_specs > n_distinct_items`, which is a superset of the rung's
-//! predicate — a single-tile 3+-spec cluster with an item-sharing pair
-//! would have counted as a "hit" even though the rung can never fire on
-//! it, since it hard-refuses whenever `specs.len() != 2`). This corpus
-//! happens to have zero single-tile clusters with more than 2 specs, so
-//! the superset bug didn't change the reported number, but the metric
-//! itself needed tightening.
+//! **A NECESSARY (not exact) predicate for the rung's firing** (round 4
+//! review finding: the previous wording overclaimed precision).
+//! `PerpendicularTemplateStrategy::try_solve` (ghost_router.rs
+//! 6177/6183/6186) actually gates on THREE things: `region.tile_count()
+//! == 1`, `junction.specs.len() == 2`, AND `is_perpendicular(da, db)` on
+//! the two specs' directions — this census records neither direction,
+//! so it cannot evaluate the third condition, and `specs.len()` at the
+//! moment `try_solve` runs may include specs the growth loop
+//! *encountered* after this seed's `keys_at_tile` was captured, not only
+//! the original seed set. So `cluster_tile_count == 1 && n_specs == 2 &&
+//! n_distinct_items == 1` is a bucket the rung's firing conditions are
+//! a SUBSET of — not the predicate itself. That's still enough to
+//! support the zero conclusion: any actual firing must land in this
+//! bucket, so an empty bucket means zero firings, full stop; it just
+//! isn't the tightest possible bucket. (Round 2 review separately fixed
+//! a real superset bug in an earlier pass — flagging ANY single-tile
+//! seed with `n_specs > n_distinct_items`, which would have counted a
+//! single-tile 3+-spec cluster as a "hit" even though the rung hard-
+//! refuses whenever `specs.len() != 2`; this corpus has zero such
+//! clusters, so the number didn't change, but the metric needed
+//! tightening regardless.)
 //!
 //! **Methodology note (round 1 review finding):** `n_specs`/
 //! `n_distinct_items` are CLUSTER-WIDE — the union of every spec whose
@@ -119,30 +127,38 @@ struct EnvVarGuard {
 impl EnvVarGuard {
     fn set(key: &'static str, value: &str) -> Self {
         let prev = std::env::var(key).ok();
-        // SAFETY: `std::env::set_var` requires `unsafe` on this toolchain
-        // at edition 2021 (verified: rustc 1.95.0 flags an unnecessary
-        // `unsafe` block under `#[deny(unused_unsafe)]` for an ordinary
-        // safe call — e.g. `unsafe { println!(...) }` — but does NOT flag
-        // this one, confirming the wrapper is required, not vestigial;
-        // round 3 review's claim that it's "unnecessary under edition
-        // 2021" does not hold on this toolchain). This test binary is
-        // single-threaded for env mutations — no other thread reads/
-        // writes process env concurrently here.
-        unsafe {
-            std::env::set_var(key, value);
-        }
+        // No `unsafe` here: `crates/core/Cargo.toml` pins `edition =
+        // "2021"` (verified directly, not guessed — round 4 review),
+        // and `std::env::set_var`/`remove_var` are plain safe functions
+        // at edition 2021 on this toolchain (rustc 1.95.0) — confirmed
+        // by compiling a bare, unwrapped call with `--edition 2021`:
+        // zero errors, zero warnings. (Round 3's claim that the wrapper
+        // WAS required was based on a flawed test: wrapping the call in
+        // `unsafe {}` also produces no `unused_unsafe` warning at this
+        // edition, which looks like "required" but isn't — these two
+        // functions carry a `#[rustc_deprecated_safe_2024]`-style
+        // edition-conditional attribute that specifically suppresses
+        // `unused_unsafe` for them, precisely so pre-emptive wrapping
+        // doesn't warn during the safe→unsafe migration window. The
+        // decisive test is whether the BARE call compiles, not whether
+        // the wrapped call warns: at edition 2024 the bare call fails
+        // with E0133 "call to unsafe function"; at edition 2021 it
+        // compiles clean. This crate is 2021, so the wrapper is
+        // genuinely unneeded today — re-add it if this crate ever bumps
+        // to edition 2024.) This test binary is single-threaded for env
+        // mutations — no other thread reads/writes process env
+        // concurrently here.
+        std::env::set_var(key, value);
         EnvVarGuard { key, prev }
     }
 }
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        // SAFETY: same as `set` above.
-        unsafe {
-            match &self.prev {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
-            }
+        // See `set` above — no `unsafe` needed at this crate's edition.
+        match &self.prev {
+            Some(v) => std::env::set_var(self.key, v),
+            None => std::env::remove_var(self.key),
         }
     }
 }
@@ -392,33 +408,53 @@ fn junction_seed_census() {
 
     println!(
         "\npipe-tagged seeds (measured on the RAW spec set at each cluster's \
-         tiles, BEFORE keys_at_tile's SpecKind::Pipe filter runs — expected \
-         0 by construction if #687's pipe×belt finding holds; a nonzero \
-         count here would mean pipes DO reach a cluster tile candidate, \
-         just always get filtered before solve_crossing): {pipe_tagged_seeds}"
+         tiles, BEFORE keys_at_tile's SpecKind::Pipe filter runs): \
+         {pipe_tagged_seeds} — expected to equal the single-spec bypass \
+         count ({single_tile_bypass} + {zero_specs_after_filter} zero-spec, \
+         since a zero-spec seed's sole participant was necessarily a \
+         filtered-out pipe); any EXCESS beyond that is the signal — a \
+         multi-spec seed also touched by a pipe, which #687's pipe×belt \
+         finding does not rule out and this census has not previously \
+         checked for."
     );
-    // Round 3 review finding: enforce the "pipe-tagged == single-spec"
-    // identity with assert_eq!, not just prose — if the corpus ever
-    // drifts so a pipe-tagged seed isn't single-spec (or vice versa),
-    // this test fails loudly instead of the doc silently going stale.
-    assert_eq!(
-        pipe_tagged_but_not_single_spec, 0,
-        "expected every pipe-tagged seed to be single-spec (the belt-crosses-a-placed-pipe bypass) — found one that wasn't"
-    );
-    assert_eq!(
-        single_spec_but_not_pipe_tagged, 0,
-        "expected every single-spec seed to be pipe-tagged — found one that wasn't"
-    );
+    // Round 4 review finding: these two correlation checks were hard
+    // `assert_eq!`s in an earlier pass, but a legitimate new seed shape
+    // (round 3's zero_specs_after_filter bucket: has_pipe=true,
+    // n_specs=0, so NOT single-spec) trips `pipe_tagged_but_not_single_
+    // spec` by construction — the census would abort exactly when it
+    // finds something worth reporting. A census must never crash on
+    // discovery; demoted to printed diagnostics with a loud marker.
+    // `bucket_sum == total_seeds` below remains the one hard assertion —
+    // that one is a true tautology (the match is exhaustive), not a
+    // data-dependent correlation that a real corpus shape can trip.
+    if pipe_tagged_but_not_single_spec > 0 {
+        println!(
+            "  ⚠ UNEXPECTED: {pipe_tagged_but_not_single_spec} pipe-tagged \
+             seed(s) are NOT single-spec (n_specs > 1 with a pipe also \
+             touching the cluster) — investigate before trusting the \
+             pipe-bypass narrative for these"
+        );
+    }
+    if single_spec_but_not_pipe_tagged > 0 {
+        println!(
+            "  ⚠ UNEXPECTED: {single_spec_but_not_pipe_tagged} single-spec \
+             seed(s) are NOT pipe-tagged — a bypass reason other than the \
+             belt-crosses-a-placed-pipe case may exist"
+        );
+    }
     println!(
-        "cross-check (assert_eq!-enforced above, not just prose): \
-         pipe-tagged & single-spec = {pipe_tagged_and_single_spec}, \
+        "cross-check (printed, not asserted — see round 4 review note \
+         above): pipe-tagged & single-spec = {pipe_tagged_and_single_spec}, \
          pipe-tagged but NOT single-spec = {pipe_tagged_but_not_single_spec}, \
          single-spec but NOT pipe-tagged = {single_spec_but_not_pipe_tagged}"
     );
 
     println!(
-        "\nsame-item seeds matching the rung's EXACT predicate \
-         (cluster_tile_count == 1 AND n_specs == 2 AND n_distinct_items == 1): {}",
+        "\nsame-item seeds matching the census's necessary-superset bucket \
+         for the rung's predicate (cluster_tile_count == 1 AND n_specs == 2 \
+         AND n_distinct_items == 1 — see the module doc's precision note; \
+         zero here proves zero actual firings, but the bucket may be \
+         broader than the rung's true firing set): {}",
         same_item_single_tile.len()
     );
     for (label, x, y) in &same_item_single_tile {

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -251,10 +251,10 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
        reworked to let the cheap template actually fire. Don't delete on
        this note alone; run the census.
     3. **Census run 2026-08-21 (#689 W1d, `crates/core/tests/
-       junction_seed_census.rs`, two rounds of adversarial review
-       absorbed) — zero seeds matching the rung's exact firing predicate
-       observed; a separate, weaker multi-tile signal is common but
-       doesn't bear on reachability.** New behavior-neutral
+       junction_seed_census.rs`, four rounds of adversarial review
+       absorbed) — zero seeds observed in the necessary-superset bucket
+       for the rung's firing conditions; a separate, weaker multi-tile
+       signal is common but doesn't bear on reachability.** New behavior-neutral
        `TraceEvent::JunctionSeedCensus` (`trace.rs`, gated behind
        `SPAGHETTIO_JUNCTION_SEED_CENSUS`, off by default — the shipped web
        path always has a trace collector *and* sink active, so an
@@ -266,11 +266,23 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
        e2e "from-ore" fixtures listed in the test's module doc (12
        fixtures total, default `LayoutOptions` + each fixture's own
        belt-tier constraint; SAT zone cache pinned to `sat-zones-ci.bin`).
-       **The rung's exact firing predicate**
-       (`PerpendicularTemplateStrategy::try_solve`, ghost_router.rs
-       6177/6183/6186): `region.tile_count() == 1` AND `specs.len() == 2`.
-       Three review rounds found real methodology gaps in earlier passes of
-       this census, both now fixed:
+       **The rung's actual firing gate is threefold** (`Perpendicular
+       TemplateStrategy::try_solve`, ghost_router.rs 6177/6183/6186):
+       `region.tile_count() == 1` AND `specs.len() == 2` AND
+       `is_perpendicular(da, db)` on the two specs' directions (round 4
+       review finding — an earlier version of this entry said "exact
+       firing predicate" for just the first two conditions, overclaiming
+       precision). This census records neither direction, so it cannot
+       evaluate the third condition, and `specs.len()` at the exact
+       moment `try_solve` runs may include specs the growth loop
+       encountered after this seed's `keys_at_tile` was captured. So
+       `cluster_tile_count == 1 && n_specs == 2 && n_distinct_items == 1`
+       is a NECESSARY condition for firing (a superset), not the firing
+       predicate itself — which is still sufficient for the zero
+       conclusion below: any actual firing must land in this bucket, so
+       an empty bucket means zero firings observed, full stop; it just
+       isn't the tightest possible bucket. Four review rounds found real
+       methodology gaps in earlier passes of this census, all now fixed:
        - **Round 1**: `n_specs`/`n_distinct_items` are the union of every
          spec touching ANY tile in a cluster, and a cluster can already
          span multiple tiles at seed time — so `n_specs > n_distinct_items`
@@ -325,29 +337,75 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
          before the fallback is ever consulted), but fixed by checking the
          merge-tap-specific prefix first so it can't matter later either.
          (d) the "pipe-tagged == single-spec" identity was prose-only —
-         now `assert_eq!`-enforced, so corpus drift fails the test instead
-         of quietly rotting this doc. (e) one claim in round 2's
-         absorption was refuted rather than applied: the bot's assertion
-         that the `unsafe { std::env::set_var(...) }` wrapper is
-         "unnecessary under edition 2021" does not hold on this repo's
-         pinned toolchain (rustc 1.95.0) — verified directly:
-         `unsafe { std::env::set_var(...) }` under
-         `#[deny(unused_unsafe)]` compiles with zero warnings, while the
-         same experiment on an ordinary safe call (`unsafe {
-         println!(...) }`) correctly fires `unused_unsafe` — so the
-         wrapper is required, not vestigial, on this toolchain regardless
-         of edition. The env var IS now restored after the test via an
-         RAII guard (the valid half of that finding — the mutation was
-         never being undone, which could pollute a future test added to
-         this same file).
+         initially made `assert_eq!`-enforced (superseded in round 4,
+         below). (e) one claim was INITIALLY refuted, then that
+         refutation was itself corrected in round 4 (see below) — the
+         `unsafe { std::env::set_var(...) }` question needed a sharper
+         test than the one first used. The env var IS restored after the
+         test via an RAII guard regardless (the valid half of the
+         original finding — the mutation was never being undone, which
+         could pollute a future test added to this same file).
+       - **Round 4** (closing round, all CI green): (a) the two
+         `pipe-tagged == single-spec` `assert_eq!`s from round 3 could
+         themselves abort the test — a legitimate new seed shape (round
+         3's own `zero_specs_after_filter`: `has_pipe = true`, `n_specs =
+         0`, so NOT single-spec) trips `pipe_tagged_but_not_single_spec`
+         by construction, meaning the census would crash exactly when it
+         found something worth reporting. Demoted both to printed
+         diagnostics with a loud `⚠ UNEXPECTED` marker; the ONE remaining
+         hard assertion is `bucket_sum == total_seeds`, a true tautology
+         (the match is exhaustive) rather than a data-dependent
+         correlation a real corpus shape could trip. (b) `resolve_item`
+         was missing the `feeder:{item}:{x}:{y}` prefix (ghost_router.rs
+         1935) — added, and the raw-key absolute-last-resort now carries
+         an explicit comment fence naming its own residual bias (two
+         specs sharing an item under some future unrecognized key format
+         would each read as "distinct" there, hiding rather than
+         fabricating a same-item pair — the opposite direction from the
+         round-1/round-2 bugs, and, like the merge-tap case, unobserved
+         in every corpus run to date). (c) reworded "exact firing
+         predicate" to "necessary superset" throughout (see above) — the
+         zero conclusion survives the correction; the wording claiming
+         precision it didn't have does not. (d) added an explicit note
+         that the `has_pipe` computation is O(sum of every routed path's
+         length) per cluster when the census is on, not O(1) — cheap
+         enough for an opt-in diagnostic, but not free, and not a pattern
+         to reach for in an always-on path. (e) fixed a misleading print:
+         "pipe-tagged seeds ... expected 0 by construction" contradicted
+         the very next line reporting 11 — corrected to "expected to
+         equal the single-spec bypass count; any excess is the signal."
+         (f) **the round-3 refutation of the `unsafe` finding was itself
+         wrong, and is corrected here.** Round 3 tested only whether
+         wrapping the call in `unsafe {}` triggered `unused_unsafe` (it
+         didn't) and concluded the wrapper was therefore required — but
+         that test doesn't distinguish "required" from "tolerated by a
+         special lint carve-out." The decisive test is whether the BARE,
+         unwrapped call compiles: at `--edition 2021` it does, with zero
+         errors or warnings; at `--edition 2024` the same bare call fails
+         to compile with `E0133` ("call to unsafe function"). `crates/
+         core/Cargo.toml` pins `edition = "2021"` (checked directly, not
+         assumed). So on this crate's actual edition, `std::env::set_var`
+         is a plain safe function, and wrapping it in `unsafe {}` was
+         genuinely unnecessary — round 3's "confirmation" was an artifact
+         of `set_var`/`remove_var` carrying a `#[rustc_deprecated_safe_
+         2024]`-style attribute that specifically suppresses
+         `unused_unsafe` for pre-emptive wrapping, to ease the migration
+         to edition 2024 (where the functions become genuinely unsafe)
+         without warning either style of caller in the meantime. The
+         `unsafe` blocks are removed; a corrected comment explains the
+         edition-conditional truth and flags that a future edition-2024
+         bump would need them back.
        **Corrected, reconciled result — 111 seeds partition as:** 11
        single-spec pipe-bypass seeds, 31 single-tile 2-different-item
        crossings (the shape point 1's item-conflict-gate finding is
        about), 0 single-tile clusters with >2 specs, 3 multi-tile
        clusters with all-distinct items, and 66 multi-tile clusters with
        an item-sharing pair somewhere in their participant union.
-       **Zero seeds match the rung's exact predicate**
-       (`cluster_tile_count == 1 && n_specs == 2 && n_distinct_items == 1`).
+       **Zero seeds fall in the necessary-superset bucket for the rung's
+       firing conditions**
+       (`cluster_tile_count == 1 && n_specs == 2 && n_distinct_items == 1`
+       — see above for why this is a superset, not the exact predicate,
+       and why the zero conclusion holds regardless).
        The 66 multi-tile figure is a separate, explicitly weaker signal —
        round 2 review flagged it as likely dominated by the mundane case
        of a trunk column and its own non-last tap-off sharing an item

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -251,54 +251,83 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
        reworked to let the cheap template actually fire. Don't delete on
        this note alone; run the census.
     3. **Census run 2026-08-21 (#689 W1d, `crates/core/tests/
-       junction_seed_census.rs`) — zero single-tile same-item crossings
-       observed; multi-tile item-sharing is common but is a different
-       question.** New behavior-neutral `TraceEvent::JunctionSeedCensus`
-       (`trace.rs`, gated behind `SPAGHETTIO_JUNCTION_SEED_CENSUS`, off by
-       default — the shipped web path always has a trace collector *and*
-       sink active, so an `is_active()`-only gate would not have made
-       this zero-cost in production) fires once per `ghost_router`
-       cluster seed, right where `keys_at_tile` is built, recording
-       `cluster_tile_count`/`n_specs`/`n_distinct_items`/`has_pipe`.
-       Corpus: the same six tier-ladder fixtures
-       `check_firing_census.rs` uses, plus the six e2e "from-ore"
-       fixtures listed in the test's module doc (12 fixtures total,
-       default `LayoutOptions` + each fixture's own belt-tier constraint;
-       SAT zone cache pinned to `sat-zones-ci.bin`).
-       **Round 1 review caught a methodology gap the first version of
-       this entry got wrong**: `n_specs`/`n_distinct_items` are the union
-       of every spec touching ANY tile in a cluster, and a cluster can
-       already span multiple tiles at seed time (before
-       `solve_crossing`'s own growth) — so `n_specs > n_distinct_items`
-       on a multi-tile cluster means "an item-sharing pair exists
-       somewhere in this cluster's participants", not "one tile has two
-       same-item specs", which is the rung's actual `tile_count == 1`
-       predicate. The test was fixed to record `cluster_tile_count` and
-       split the result on it. Corrected result: **111 seeds; 31 are
-       single-tile 2-different-item crossings (the shape point 1's
-       item-conflict-gate finding is about), 11 are single-spec
-       pipe-bypass seeds, and 66 are multi-tile clusters with an
-       item-sharing pair somewhere in the union — but of those 66,
-       cluster_tile_count is NEVER 1. Zero single-tile same-item seeds
-       were observed in this corpus** (no `(cluster_tile_count=1,
-       n_specs≥2, n_distinct<n_specs)` row in the full table). This is
-       the precise answer to the G1 question, and it's a stronger,
-       cleaner null than the first (wrong) pass reported — but it is
-       still one 12-fixture corpus, not a proof of universal
-       non-occurrence, so it does not by itself clear the rung for
-       deletion. Also recorded: 11 seeds have `has_pipe = true` (measured
-       on the raw spec set BEFORE the pipe filter) — corroborating point
-       1's pipe×belt finding rather than contradicting it (these are
-       exactly the corpus's 11 single-spec seeds, the
-       belt-crosses-a-placed-pipe bypass path; the pipe itself never
-       reaches `keys_at_tile`). Net: **this corpus found no reachable
-       instance of the rung's predicate anywhere in the pipeline — not a
-       universal proof, but real, corpus-wide, zero-based evidence for
-       the "never occurs" branch of point 1's either/or.** Widening the
-       corpus (more fixtures, or a fuzz/property sweep over crossing
-       shapes) would raise confidence further; this alone still isn't
-       sufficient for the owner-reviewed deletion call. CENSUS-ONLY per
-       its own charter: no gate or control flow changed.
+       junction_seed_census.rs`, two rounds of adversarial review
+       absorbed) — zero seeds matching the rung's exact firing predicate
+       observed; a separate, weaker multi-tile signal is common but
+       doesn't bear on reachability.** New behavior-neutral
+       `TraceEvent::JunctionSeedCensus` (`trace.rs`, gated behind
+       `SPAGHETTIO_JUNCTION_SEED_CENSUS`, off by default — the shipped web
+       path always has a trace collector *and* sink active, so an
+       `is_active()`-only gate would not have made this zero-cost in
+       production) fires once per `ghost_router` cluster seed, right
+       where `keys_at_tile` is built, recording `cluster_tile_count`/
+       `n_specs`/`n_distinct_items`/`has_pipe`. Corpus: the same six
+       tier-ladder fixtures `check_firing_census.rs` uses, plus the six
+       e2e "from-ore" fixtures listed in the test's module doc (12
+       fixtures total, default `LayoutOptions` + each fixture's own
+       belt-tier constraint; SAT zone cache pinned to `sat-zones-ci.bin`).
+       **The rung's exact firing predicate**
+       (`PerpendicularTemplateStrategy::try_solve`, ghost_router.rs
+       ~6166-6171): `region.tile_count() == 1` AND `specs.len() == 2`.
+       Two review rounds found real methodology gaps in earlier passes of
+       this census, both now fixed:
+       - **Round 1**: `n_specs`/`n_distinct_items` are the union of every
+         spec touching ANY tile in a cluster, and a cluster can already
+         span multiple tiles at seed time — so `n_specs > n_distinct_items`
+         on a multi-tile cluster means "an item-sharing pair exists
+         somewhere in the cluster", not "one tile has two same-item
+         specs". Fixed by recording `cluster_tile_count` and splitting on
+         it — the rung structurally cannot act on `tile_count > 1`
+         (returns `None` immediately), so multi-tile clusters are outside
+         its domain regardless of what any one tile inside them looks
+         like.
+       - **Round 2**: (a) the single-tile bucket still didn't check
+         `specs.len() == 2` exactly — a single-tile cluster with 3+ specs
+         and an item-sharing pair would have counted as a "hit" even
+         though the rung refuses whenever `specs.len() != 2` (this
+         corpus has zero such clusters, so the number didn't change, but
+         the metric needed tightening); (b) the `n_distinct_items`
+         fallback for a `spec_items`-map miss used the spec's raw key
+         (unique by construction), which HIDES same-item pairs instead of
+         manufacturing false ones — not hypothetical, since the fluid
+         catch-up sweep (ghost_router.rs ~2648-2667) only tags a synth key
+         when its path is entirely on pipe tiles, leaving some fluid synth
+         keys untagged; fixed by recovering the item from the key's own
+         `trunk:`/`tap:`/`flow:` prefix convention before falling back to
+         the raw key; (c) the doc's arithmetic didn't reconcile (31+11+66
+         = 108 of 111 — a 4th "multi-tile, all-distinct" bucket of 3 was
+         missing from the prose) and the headline numbers were
+         hand-transcribed rather than computed and cross-checked by the
+         test itself. The test now buckets exhaustively (`assert_eq!` on
+         the partition, not just prose) and prints a cross-check that
+         "pipe-tagged" and "single-spec" seeds are the same 11 (measured:
+         they are, exactly).
+       **Corrected, reconciled result — 111 seeds partition as:** 11
+       single-spec pipe-bypass seeds, 31 single-tile 2-different-item
+       crossings (the shape point 1's item-conflict-gate finding is
+       about), 0 single-tile clusters with >2 specs, 3 multi-tile
+       clusters with all-distinct items, and 66 multi-tile clusters with
+       an item-sharing pair somewhere in their participant union.
+       **Zero seeds match the rung's exact predicate**
+       (`cluster_tile_count == 1 && n_specs == 2 && n_distinct_items == 1`).
+       The 66 multi-tile figure is a separate, explicitly weaker signal —
+       round 2 review flagged it as likely dominated by the mundane case
+       of a trunk column and its own non-last tap-off sharing an item
+       (`docs/rfc-unified-belt-specs.md` Phase 2), which is a parent/child
+       relationship within one logical flow, not two independent specs
+       crossing — so read it as an upper bound on "same-item adjacency
+       exists somewhere nearby", not evidence of a same-item crossing.
+       Net: **this corpus found no reachable instance of the rung's exact
+       predicate anywhere in the pipeline — not a universal proof (one
+       12-fixture corpus, and `build_bus_layout`'s candidate search +
+       retry machinery means "111 seeds" counts every `route_bus_ghost`
+       invocation across all evaluated candidates and retries, not
+       deduplicated physical crossings), but real, corpus-wide, zero-based
+       evidence for the "never occurs" branch of point 1's either/or.**
+       Widening the corpus (more fixtures, or a fuzz/property sweep over
+       crossing shapes) would raise confidence further; this alone still
+       isn't sufficient for the owner-reviewed deletion call. CENSUS-ONLY
+       per its own charter: no gate or control flow changed.
     2. **The fixture replay's strategy ladder had drifted** from
        production (pre-native `sat-1ug`/Relaxed-reach list vs production's
        `sat-1ug-native` core). #687 lifted the pinned-tier core into a

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -250,6 +250,41 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
        production and deletable — or the conflict/dispatch gates get
        reworked to let the cheap template actually fire. Don't delete on
        this note alone; run the census.
+    3. **Census run 2026-08-21 (#689 W1d, `crates/core/tests/
+       junction_seed_census.rs`) — same-item crossings DO occur; rung
+       reachability is still NOT established.** New behavior-neutral
+       `TraceEvent::JunctionSeedCensus` (`trace.rs`) fires once per
+       `ghost_router` cluster seed, right where `keys_at_tile` is built,
+       recording `n_specs`/`n_distinct_items`/`has_pipe`. Corpus: the
+       same six tier-ladder fixtures `check_firing_census.rs` uses, plus
+       the six e2e "from-ore" fixtures listed in the test's module doc
+       (12 fixtures total, default `LayoutOptions` + each fixture's own
+       belt-tier constraint; SAT zone cache pinned to
+       `sat-zones-ci.bin`). Result: **111 seeds; 66 have `n_specs >
+       n_distinct_items`** (a same-item pair among the seed's specs) —
+       far from zero, so the "never occurs" branch of point 1's
+       either/or does NOT hold. But the qualifier matters: **every one of
+       the 66 is a 3-or-more-spec cluster** (the full table has no
+       `(n_specs=2, n_distinct=1)` row at all — zero instances of the
+       rung's own narrow shape, an isolated 2-spec single-tile crossing
+       where both specs share an item). This census measures the SEED as
+       formed at cluster construction, not what `junction_solver`'s
+       growth/strategy-dispatch loop does with it afterward — it cannot
+       say whether the rung's `tile_count == 1` / 2-spec predicate is
+       ever met by a subset of one of these larger clusters mid-growth.
+       So: item-sharing at seed time is common, but the rung's specific
+       firing precondition remains unobserved in this corpus. Also
+       recorded: 11 seeds have `has_pipe = true` (measured on the raw
+       spec set BEFORE the pipe filter) — corroborating point 1's
+       pipe×belt finding rather than contradicting it (these are exactly
+       the corpus's 11 single-spec seeds, the belt-crosses-a-placed-pipe
+       bypass path; the pipe itself never reaches `keys_at_tile`). Net:
+       **neither deletion nor a gate rework is justified by this census
+       alone** — the open question narrows to "does the item-conflict
+       gate or the rung's tile_count==1 guard ever see a same-item pair
+       in isolation," which needs growth-loop instrumentation, not a
+       seed-level census. CENSUS-ONLY per its own charter: no gate or
+       control flow changed.
     2. **The fixture replay's strategy ladder had drifted** from
        production (pre-native `sat-1ug`/Relaxed-reach list vs production's
        `sat-1ug-native` core). #687 lifted the pinned-tier core into a

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -251,40 +251,54 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
        reworked to let the cheap template actually fire. Don't delete on
        this note alone; run the census.
     3. **Census run 2026-08-21 (#689 W1d, `crates/core/tests/
-       junction_seed_census.rs`) — same-item crossings DO occur; rung
-       reachability is still NOT established.** New behavior-neutral
-       `TraceEvent::JunctionSeedCensus` (`trace.rs`) fires once per
-       `ghost_router` cluster seed, right where `keys_at_tile` is built,
-       recording `n_specs`/`n_distinct_items`/`has_pipe`. Corpus: the
-       same six tier-ladder fixtures `check_firing_census.rs` uses, plus
-       the six e2e "from-ore" fixtures listed in the test's module doc
-       (12 fixtures total, default `LayoutOptions` + each fixture's own
-       belt-tier constraint; SAT zone cache pinned to
-       `sat-zones-ci.bin`). Result: **111 seeds; 66 have `n_specs >
-       n_distinct_items`** (a same-item pair among the seed's specs) —
-       far from zero, so the "never occurs" branch of point 1's
-       either/or does NOT hold. But the qualifier matters: **every one of
-       the 66 is a 3-or-more-spec cluster** (the full table has no
-       `(n_specs=2, n_distinct=1)` row at all — zero instances of the
-       rung's own narrow shape, an isolated 2-spec single-tile crossing
-       where both specs share an item). This census measures the SEED as
-       formed at cluster construction, not what `junction_solver`'s
-       growth/strategy-dispatch loop does with it afterward — it cannot
-       say whether the rung's `tile_count == 1` / 2-spec predicate is
-       ever met by a subset of one of these larger clusters mid-growth.
-       So: item-sharing at seed time is common, but the rung's specific
-       firing precondition remains unobserved in this corpus. Also
-       recorded: 11 seeds have `has_pipe = true` (measured on the raw
-       spec set BEFORE the pipe filter) — corroborating point 1's
-       pipe×belt finding rather than contradicting it (these are exactly
-       the corpus's 11 single-spec seeds, the belt-crosses-a-placed-pipe
-       bypass path; the pipe itself never reaches `keys_at_tile`). Net:
-       **neither deletion nor a gate rework is justified by this census
-       alone** — the open question narrows to "does the item-conflict
-       gate or the rung's tile_count==1 guard ever see a same-item pair
-       in isolation," which needs growth-loop instrumentation, not a
-       seed-level census. CENSUS-ONLY per its own charter: no gate or
-       control flow changed.
+       junction_seed_census.rs`) — zero single-tile same-item crossings
+       observed; multi-tile item-sharing is common but is a different
+       question.** New behavior-neutral `TraceEvent::JunctionSeedCensus`
+       (`trace.rs`, gated behind `SPAGHETTIO_JUNCTION_SEED_CENSUS`, off by
+       default — the shipped web path always has a trace collector *and*
+       sink active, so an `is_active()`-only gate would not have made
+       this zero-cost in production) fires once per `ghost_router`
+       cluster seed, right where `keys_at_tile` is built, recording
+       `cluster_tile_count`/`n_specs`/`n_distinct_items`/`has_pipe`.
+       Corpus: the same six tier-ladder fixtures
+       `check_firing_census.rs` uses, plus the six e2e "from-ore"
+       fixtures listed in the test's module doc (12 fixtures total,
+       default `LayoutOptions` + each fixture's own belt-tier constraint;
+       SAT zone cache pinned to `sat-zones-ci.bin`).
+       **Round 1 review caught a methodology gap the first version of
+       this entry got wrong**: `n_specs`/`n_distinct_items` are the union
+       of every spec touching ANY tile in a cluster, and a cluster can
+       already span multiple tiles at seed time (before
+       `solve_crossing`'s own growth) — so `n_specs > n_distinct_items`
+       on a multi-tile cluster means "an item-sharing pair exists
+       somewhere in this cluster's participants", not "one tile has two
+       same-item specs", which is the rung's actual `tile_count == 1`
+       predicate. The test was fixed to record `cluster_tile_count` and
+       split the result on it. Corrected result: **111 seeds; 31 are
+       single-tile 2-different-item crossings (the shape point 1's
+       item-conflict-gate finding is about), 11 are single-spec
+       pipe-bypass seeds, and 66 are multi-tile clusters with an
+       item-sharing pair somewhere in the union — but of those 66,
+       cluster_tile_count is NEVER 1. Zero single-tile same-item seeds
+       were observed in this corpus** (no `(cluster_tile_count=1,
+       n_specs≥2, n_distinct<n_specs)` row in the full table). This is
+       the precise answer to the G1 question, and it's a stronger,
+       cleaner null than the first (wrong) pass reported — but it is
+       still one 12-fixture corpus, not a proof of universal
+       non-occurrence, so it does not by itself clear the rung for
+       deletion. Also recorded: 11 seeds have `has_pipe = true` (measured
+       on the raw spec set BEFORE the pipe filter) — corroborating point
+       1's pipe×belt finding rather than contradicting it (these are
+       exactly the corpus's 11 single-spec seeds, the
+       belt-crosses-a-placed-pipe bypass path; the pipe itself never
+       reaches `keys_at_tile`). Net: **this corpus found no reachable
+       instance of the rung's predicate anywhere in the pipeline — not a
+       universal proof, but real, corpus-wide, zero-based evidence for
+       the "never occurs" branch of point 1's either/or.** Widening the
+       corpus (more fixtures, or a fuzz/property sweep over crossing
+       shapes) would raise confidence further; this alone still isn't
+       sufficient for the owner-reviewed deletion call. CENSUS-ONLY per
+       its own charter: no gate or control flow changed.
     2. **The fixture replay's strategy ladder had drifted** from
        production (pre-native `sat-1ug`/Relaxed-reach list vs production's
        `sat-1ug-native` core). #687 lifted the pinned-tier core into a

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -268,8 +268,8 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
        belt-tier constraint; SAT zone cache pinned to `sat-zones-ci.bin`).
        **The rung's exact firing predicate**
        (`PerpendicularTemplateStrategy::try_solve`, ghost_router.rs
-       ~6166-6171): `region.tile_count() == 1` AND `specs.len() == 2`.
-       Two review rounds found real methodology gaps in earlier passes of
+       6177/6183/6186): `region.tile_count() == 1` AND `specs.len() == 2`.
+       Three review rounds found real methodology gaps in earlier passes of
        this census, both now fixed:
        - **Round 1**: `n_specs`/`n_distinct_items` are the union of every
          spec touching ANY tile in a cluster, and a cluster can already
@@ -290,7 +290,7 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
          fallback for a `spec_items`-map miss used the spec's raw key
          (unique by construction), which HIDES same-item pairs instead of
          manufacturing false ones — not hypothetical, since the fluid
-         catch-up sweep (ghost_router.rs ~2648-2667) only tags a synth key
+         catch-up sweep (ghost_router.rs 2643-2667) only tags a synth key
          when its path is entirely on pipe tiles, leaving some fluid synth
          keys untagged; fixed by recovering the item from the key's own
          `trunk:`/`tap:`/`flow:` prefix convention before falling back to
@@ -302,6 +302,44 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
          the partition, not just prose) and prints a cross-check that
          "pipe-tagged" and "single-spec" seeds are the same 11 (measured:
          they are, exactly).
+       - **Round 3**: (a) the bucket match's trailing `_ =>
+         unreachable!()` arm was reachable for `n_specs == 0` (a seed
+         whose only participants were pipes, all filtered out of
+         `keys_at_tile`) — precisely a case this census exists to
+         surface, and crashing on it would have destroyed the data
+         instead of reporting it; fixed with its own `zero_specs_after_
+         filter` bucket, checked first, making every remaining arm
+         genuinely exhaustive rather than resting on a data-dependent
+         catch-all. (b) the env-var gate was presence-based
+         (`var_os(..).is_some()`), so a shop-wide diagnostics block
+         setting every `SPAGHETTIO_*` var to `"0"` to disable them would
+         have accidentally enabled this one — fixed to require the value
+         be `"1"` or case-insensitive `"true"`. (c) the `resolve_item`
+         prefix fallback checked bare `"tap:"` before a more specific
+         case: a merge-tap feed key is literally `"tap:mergetap:{item}:
+         {x}:{y}"` (`format!("tap{MERGE_TAP_SEGMENT_TAG}...")`,
+         `ghost_router.rs:1635`), so the generic `"tap:"` strip would have
+         recovered the literal string `"mergetap"` as the item — currently
+         inert (merge-tap keys are always registered as regular
+         `BeltSpec`s, so `spec_items.get(key)` already resolves them
+         before the fallback is ever consulted), but fixed by checking the
+         merge-tap-specific prefix first so it can't matter later either.
+         (d) the "pipe-tagged == single-spec" identity was prose-only —
+         now `assert_eq!`-enforced, so corpus drift fails the test instead
+         of quietly rotting this doc. (e) one claim in round 2's
+         absorption was refuted rather than applied: the bot's assertion
+         that the `unsafe { std::env::set_var(...) }` wrapper is
+         "unnecessary under edition 2021" does not hold on this repo's
+         pinned toolchain (rustc 1.95.0) — verified directly:
+         `unsafe { std::env::set_var(...) }` under
+         `#[deny(unused_unsafe)]` compiles with zero warnings, while the
+         same experiment on an ordinary safe call (`unsafe {
+         println!(...) }`) correctly fires `unused_unsafe` — so the
+         wrapper is required, not vestigial, on this toolchain regardless
+         of edition. The env var IS now restored after the test via an
+         RAII guard (the valid half of that finding — the mutation was
+         never being undone, which could pollute a future test added to
+         this same file).
        **Corrected, reconciled result — 111 seeds partition as:** 11
        single-spec pipe-bypass seeds, 31 single-tile 2-different-item
        crossings (the shape point 1's item-conflict-gate finding is

--- a/docs/offpath-code-followups.md
+++ b/docs/offpath-code-followups.md
@@ -395,6 +395,43 @@ code); netflow's `allow_voiding` branch (parked pending UI hookup).
          `unsafe` blocks are removed; a corrected comment explains the
          edition-conditional truth and flags that a future edition-2024
          bump would need them back.
+       - **Round 5** (final pass before merge, no blocking findings — 3
+         metric-integrity caveats): (a) the only hard assertion was the
+         tautological `bucket_sum == total_seeds`; the load-bearing
+         conclusion (`single_tile_same_item == 0`) was only printed.
+         Added `assert_eq!(single_tile_same_item, 0, ...)` with a message
+         naming exactly what a failure means: the reachability conclusion
+         changed, update this G1 entry before trusting any deletion call.
+         This does NOT contradict round 4's "never abort on discovery"
+         principle — that principle was about EXPLORATORY tallies (the
+         pipe-tagged/single-spec correlation checks) where an unexpected
+         value is itself the interesting finding; `single_tile_same_item`
+         IS the conclusion this census exists to check, and re-running it
+         is exactly the deliberate moment to be loud if it ever changes.
+         (b) the module doc's "counts every route_bus_ghost invocation"
+         claim overstated: `run_layout_with_retry_inner` calls
+         `trace::truncate_events` on a junction-cap/substation retry,
+         discarding that candidate's pass-1 census events (including any
+         `JunctionSeedCensus`) before pass 2 runs — so this census counts
+         the SHIPPED pass per candidate, not literally every invocation.
+         Fixed the sentence, and the test now directly tallies
+         `TraceEvent::LayoutRetried` occurrences (emitted right after the
+         truncate, so it survives) and prints the count next to the
+         summary line — measured, not just caveated. This cannot flip the
+         zero to a false positive: truncation only removes observations,
+         never fabricates one; the zero is therefore a lower bound on
+         this corpus, not a certainty that no truncated pass-1 ever hit
+         the rung's shape. (c) added an explicit caveat where the
+         11-pipe-bypass corroboration is discussed: the fluid catch-up
+         sweep only tags a synth key as Pipe when its path sits entirely
+         on pipe tiles, and `resolve_item`'s absolute-last-resort (raw
+         key as pseudo-item) can make two specs that truly share an item
+         read as "distinct" under an unrecognized key format — both
+         biases HIDE a same-item pair rather than fabricate one, so the
+         zero conclusion inherits this same residual risk. Neither bias
+         has been observed firing in any run to date. Any deletion
+         follow-up citing this census's zero should carry this caveat
+         forward.
        **Corrected, reconciled result — 111 seeds partition as:** 11
        single-spec pipe-bypass seeds, 31 single-tile 2-different-item
        crossings (the shape point 1's item-conflict-gate finding is


### PR DESCRIPTION
## Intent

Part of RFC-070 track W1d (tracking #689). #687 established the
~795-line perpendicular-template rung (`crates/core/src/bus/ghost_router.rs`,
`solve_perpendicular_template` area) appears production-unreachable on
both shapes it handles, leaving one open hypothesis: do same-item belt
crossings ever seed junctions? This PR is a census answering exactly
that, nothing else.

**Four rounds of review absorbed** (full adjudication in PR comments).
Rounds 1-2 fixed real methodology gaps (never changing the zero
conclusion's direction). Round 3 fixed a genuine crash risk and several
hardening issues. Round 4 (closing) fixed a bug introduced by round 3's
own fix, tightened the predicate's precision claim, and corrected a
refutation from round 3 that was itself wrong (see the round-4 comment
for the full receipt).

## Scope

- **In:** a behavior-neutral `TraceEvent::JunctionSeedCensus`
  (`crates/core/src/trace.rs`), emitted once per `ghost_router` cluster
  seed right where `keys_at_tile` is built
  (`crates/core/src/bus/ghost_router.rs`), recording `cluster_tile_count`
  / `n_specs` / `n_distinct_items` / `has_pipe`, gated behind a
  value-checked `SPAGHETTIO_JUNCTION_SEED_CENSUS` (off by default); an
  `#[ignore]`d `crates/core/tests/junction_seed_census.rs` with an
  exhaustive, `assert_eq!`-checked bucket partition; the G1 entry in
  `docs/offpath-code-followups.md` updated with the reconciled result.
- **Out:** any change to `junction_solver`'s item-conflict gate, the
  rung's `tile_count == 1` / `specs.len() == 2` / `is_perpendicular`
  guards, or any other control flow. CENSUS-ONLY per the campaign brief.
- **Size:** ~750 lines net across five commits (initial diagnostic +
  four review-absorption passes), mostly the test file + doc updates.

## Census result (final, four rounds verified)

Corpus: the six tier-ladder fixtures `check_firing_census.rs` uses, plus
the six e2e "from-ore" fixtures (`tier1_iron_gear_wheel_from_ore`,
`tier2_electronic_circuit_from_ore`, `tier2_electronic_circuit_20s_from_ore`,
`tier3_plastic_bar_from_crude`, `tier4_advanced_circuit_from_ore_am2`,
`tier5_processing_unit_from_ore_am3`) that differ in belt-tier
constraint and/or rate/machine. 12 fixtures, `SPAGHETTIO_ZONE_CACHE_PATH`
pinned to `sat-zones-ci.bin`, `SPAGHETTIO_JUNCTION_SEED_CENSUS=1`.

**The rung's firing gate is threefold** (`PerpendicularTemplateStrategy::
try_solve`, ghost_router.rs 6177/6183/6186): `region.tile_count() == 1`
AND `specs.len() == 2` AND `is_perpendicular(da, db)`. This census's
event schema records neither direction, so its bucket is a NECESSARY
condition for firing (a superset), not the exact predicate — sufficient
for the zero conclusion (any firing must land in the bucket) but not the
tightest possible bucket.

```
=== junction seed census: 111 seeds across 12 fixtures ===

--- bucket breakdown (sums to 111, assert_eq!-checked) ---
n_specs == 0 after the pipe filter (never a crash):    0
single-tile, 1 spec (belt-over-forbidden-tile bypass): 11
single-tile, 2 specs, different items:                 31
single-tile, 2 specs, SAME item (necessary-superset):  0
single-tile, >2 specs (outside rung's specs.len()==2): 0
multi-tile,  all participants distinct items:          3
multi-tile,  item-sharing pair somewhere in union:     66

cross-check (printed, not asserted — see round 4 note): pipe-tagged &
single-spec = 11, pipe-tagged but NOT single-spec = 0, single-spec but
NOT pipe-tagged = 0
```

**Headline: 0 seeds fall in the necessary-superset bucket for the
rung's firing conditions.** All 111 seeds partition exhaustively into 7
buckets (assert_eq!-checked): 0 zero-spec-after-filter, 11 single-spec
pipe-bypass, 31 single-tile 2-different-item crossings, 0 single-tile
>2-spec, 3 multi-tile all-distinct, 66 multi-tile with an item-sharing
pair somewhere in the cluster's union.

The 66 is a separate, explicitly weaker signal — likely dominated by
the mundane trunk-owns-its-own-non-last-tap same-item adjacency
(`rfc-unified-belt-specs.md` Phase 2), not evidence of a crossing.

**Net: this corpus found no reachable instance of the rung's necessary
firing conditions anywhere in the pipeline.** Not a universal proof —
one 12-fixture corpus, seeds counted across every `route_bus_ghost`
invocation (candidates + retries), not deduplicated — but real,
corpus-wide, zero-based evidence for the "never occurs" branch. Still
not sufficient alone for the owner-reviewed deletion call.

## Review rounds absorbed (full receipts in PR comments)

- **Round 1** (2 major): cluster-wide vs per-tile conflation (fixed via
  `cluster_tile_count`); unconditional hot-path cost (fixed via an
  opt-in env gate).
- **Round 2** (4): missing `specs.len()==2` check; `spec_items`-miss
  fallback hid same-item pairs (fixed via key-prefix recovery); doc
  arithmetic didn't reconcile; headline was hand-transcribed (fixed via
  test-computed, exhaustive buckets).
- **Round 3** (6, one applied only in part): a crash risk
  (`unreachable!()` reachable for `n_specs==0`, fixed); presence- vs
  value-based env gate; merge-tap key-parsing trap; prose-only
  cross-check; drifted line refs — all fixed. One claim
  ("unsafe { set_var } unnecessary under edition 2021") was refuted at
  the time — **that refutation turned out to be wrong** (see round 4).
- **Round 4, closing** (7, one a self-correction): a real bug from
  round 3's own fix (the new `zero_specs_after_filter` bucket tripped
  round 2's correlation assert by construction) — fixed by demoting
  both correlation asserts to diagnostics; missing `feeder:` prefix;
  "exact predicate" overclaimed precision, reworded to "necessary
  superset"; misleading "expected 0" prose; undisclosed O(n) cost.
  **And: round 3's refutation of the `unsafe` finding was itself
  wrong** — the decisive test is whether the bare, unwrapped call
  compiles (it does, at this crate's actual edition 2021; it doesn't at
  edition 2024, confirmed with `rustc` directly), not whether wrapping
  it triggers `unused_unsafe` (it doesn't, at either edition, because
  `set_var`/`remove_var` carry a lint-suppressing attribute during the
  edition-2024 migration). The `unsafe` blocks are now removed.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml --no-fail-fast` (unpiped) — exit 0, full suite green, re-run clean after all four review rounds
- [x] `cargo clippy --workspace -- -D warnings` (the exact `ci.yml` invocation) — exit 0, clean, all five rounds
- [x] `cargo clippy --manifest-path crates/core/Cargo.toml --test junction_seed_census -- -D warnings` — exit 0 (confirms no `unused_unsafe` fallout either with or without the wrapper)
- [x] WASM rebuild: `wasm-pack build crates/wasm-bindings --target web --out-dir <abs path>/web/src/wasm-pkg` — exit 0, all five rounds
- [x] Census run (final): `SPAGHETTIO_ZONE_CACHE_PATH=<abs path>/crates/core/data/sat-zones-ci.bin cargo test --manifest-path crates/core/Cargo.toml --test junction_seed_census -- --ignored --nocapture`, then `git checkout -- crates/core/data/sat-zones-ci.bin` immediately after every run — the pin file never appears in this branch's diff. Numbers confirmed unchanged across all four review rounds.
- [ ] Snapshot inspection — not applicable, no layout-engine behavior change (diagnostic-only)

## Deviations from intent

None beyond the review-driven corrections described above — including
one finding refuted with receipts (later found wrong and corrected) and
one bug introduced by absorbing a prior round's finding (also caught and
fixed). All part of the review process working as intended.

## Models / contracts touched

`docs/offpath-code-followups.md`'s G1 entry — updated with the final
reconciled census result across four review rounds, per the
followups-doc contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>