### PR TITLE
diag(w1b): selection scoreboard — per-candidate verdicts and the deciding precedence stage

### DIFF
--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -937,6 +937,12 @@ struct CandidateRun {
     /// the unactionable "no decomposition candidate produced a layout"
     /// (observability gap found debugging rfc-build-quality Phase 2).
     error: Option<String>,
+    /// `produce()` panicked and `catch_unwind` swallowed it. Read only by
+    /// the RFC-070 scoreboard, which must not conflate a panic with an
+    /// ordinary refusal — `error` carries a sentinel string in that case
+    /// and string-matching it would be a latent bug the moment the tag is
+    /// reworded.
+    panicked: bool,
     events: Vec<crate::trace::TraceEvent>,
 }
 
@@ -944,7 +950,7 @@ impl CandidateRun {
     /// A candidate that wasn't tried (e.g. gating predicate was false).
     /// No outcome, no events; the winner-selection code skips it.
     fn skipped(_name: &str) -> Self {
-        Self { outcome: None, events: Vec::new(), error: None }
+        Self { outcome: None, events: Vec::new(), error: None, panicked: false }
     }
 }
 
@@ -984,7 +990,7 @@ where
             None
         }
     };
-    CandidateRun { outcome, events, error }
+    CandidateRun { outcome, events, error, panicked: false }
 }
 
 /// Like `run_candidate` but wraps the produce call in `catch_unwind`.
@@ -1002,6 +1008,7 @@ where
     let mut events = crate::trace::peek_events_since(start);
     crate::trace::truncate_events(start);
     let mut error = None;
+    let mut panicked = false;
     let outcome = match result {
         Ok(Ok(layout)) => {
             let score = score_layout(&layout, solver_result);
@@ -1022,6 +1029,7 @@ where
         }
         Err(_) => {
             error = Some("panicked (caught)".to_string());
+            panicked = true;
             events.push(crate::trace::TraceEvent::DecompositionCandidateScored {
                 name: name.to_string(),
                 density: 0.0,
@@ -1034,7 +1042,122 @@ where
             None
         }
     };
-    CandidateRun { outcome, events, error }
+    CandidateRun { outcome, events, error, panicked }
+}
+
+/// RFC-070 Phase 0b (#689 W1b): one candidate's row on the selection
+/// scoreboard.
+///
+/// Purely observational — no decision reads it. A row starts from the
+/// candidate's `CandidateRun` (outcome + soft score, mechanism 1) and is
+/// then FILLED IN by whichever verdict mechanism happens to touch that
+/// candidate, **at the site where the decision path already computed the
+/// number**. Nothing here recomputes: a scoreboard that re-ran
+/// `validate()` on its own could disagree with the value the decision
+/// actually used, and an oracle that disagrees with the thing it is
+/// oracling is worse than no oracle.
+///
+/// The price of that discipline is `None`s — a candidate that no
+/// comparison needed carries no issue counts at all, because on that call
+/// nothing computed any. That is a genuine hole in what this can see, and
+/// it is recorded as a hole rather than papered over with a fresh
+/// validation pass.
+struct CandidateVerdict {
+    name: &'static str,
+    outcome: crate::trace::SelectionCandidateOutcome,
+    reason: Option<String>,
+    score: Option<f64>,
+    accepted: Option<bool>,
+    accepted_reason: Option<String>,
+    counts: Option<IssueCounts>,
+    counts_source: Option<&'static str>,
+    kinds: Option<ErrorKinds>,
+}
+
+impl CandidateVerdict {
+    fn from_run(name: &'static str, run: &CandidateRun) -> Self {
+        use crate::trace::SelectionCandidateOutcome as Outcome;
+        // `panicked` is a field, not a string match on `error` — see its
+        // doc on `CandidateRun`. Order matters: a panic also sets `error`.
+        let outcome = match (&run.outcome, run.panicked, &run.error) {
+            (Some(_), _, _) => Outcome::Produced,
+            (None, true, _) => Outcome::Panicked,
+            (None, false, Some(_)) => Outcome::Refused,
+            (None, false, None) => Outcome::NotRun,
+        };
+        Self {
+            name,
+            outcome,
+            reason: run.error.clone(),
+            score: run.outcome.as_ref().map(|(_, s)| s.score),
+            accepted: run.outcome.as_ref().map(|(_, s)| s.accepted),
+            accepted_reason: run
+                .outcome
+                .as_ref()
+                .and_then(|(_, s)| s.accepted_reason.clone()),
+            counts: None,
+            counts_source: None,
+            kinds: None,
+        }
+    }
+}
+
+/// The seven candidate rows, **indexed exactly like the `candidates`
+/// array** in `select_best_decomposition` (`NATIVE_IDX` = 0 through
+/// `H_IDX` = 6), so a recorder can key off the same index constants the
+/// decision uses.
+struct Scoreboard([CandidateVerdict; 7]);
+
+impl Scoreboard {
+    /// Record the `IssueCounts` a comparison site just computed.
+    ///
+    /// FIRST WRITE WINS. Native's counts are computed by both pairwise
+    /// comparisons and DI's by both `di_choice` and `scoped_choice`; the
+    /// repeats are the same deterministic `count_issues` call on the same
+    /// layout, so keeping the first preserves the provenance of the site
+    /// that first needed the number instead of overwriting it with a
+    /// later duplicate.
+    fn record_counts(&mut self, idx: usize, counts: IssueCounts, source: &'static str) {
+        let row = &mut self.0[idx];
+        if row.counts.is_none() {
+            row.counts = Some(counts);
+            row.counts_source = Some(source);
+        }
+    }
+
+    /// Record the `ErrorKinds` the merge-tap decision just computed.
+    /// First write wins, for the same reason as `record_counts`.
+    fn record_kinds(&mut self, idx: usize, kinds: ErrorKinds) {
+        let row = &mut self.0[idx];
+        if row.kinds.is_none() {
+            row.kinds = Some(kinds);
+        }
+    }
+
+    /// Emit one event per candidate — all seven, including the ones that
+    /// never ran. "Which candidates were even eligible" is half the
+    /// question RFC-070 asks, and a row that is absent from the stream
+    /// cannot answer it (`docs/validator-reporting.md`: one positioned
+    /// record per instance, never a count in a message).
+    fn emit(&self) {
+        for row in &self.0 {
+            crate::trace::emit(crate::trace::TraceEvent::SelectionCandidateEvaluated {
+                name: row.name.to_string(),
+                outcome: row.outcome,
+                reason: row.reason.clone(),
+                score: row.score,
+                accepted: row.accepted,
+                accepted_reason: row.accepted_reason.clone(),
+                errors: row.counts.map(|c| c.errors),
+                selection_warnings: row.counts.map(|c| c.warnings),
+                layout_warnings: row.counts.map(|c| c.layout_warnings),
+                counts_source: row.counts_source.map(str::to_string),
+                contamination_errors: row.kinds.map(|k| k.contamination),
+                starvation_errors: row.kinds.map(|k| k.starvation),
+                structural_errors: row.kinds.map(|k| k.structural),
+            });
+        }
+    }
 }
 
 /// Run candidates and pick the winner.
@@ -1212,6 +1335,21 @@ pub fn select_best_decomposition(
     // applies unchanged (every non-Pooled and every Native-clean case).
     const NATIVE_IDX: usize = 0;
     const MERGE_TAP_IDX: usize = 3;
+
+    // RFC-070 Phase 0b scoreboard. Built here — after every candidate has
+    // run, before the first verdict mechanism fires — so the mechanism
+    // sites below can record into it as they compute. Index-aligned with
+    // the `candidates` array further down.
+    let mut board = Scoreboard([
+        CandidateVerdict::from_run("native", &native_run),
+        CandidateVerdict::from_run("k1-shape-fix", &k1_run),
+        CandidateVerdict::from_run("size-split-2", &split_run),
+        CandidateVerdict::from_run("merge-tap", &merge_tap_run),
+        CandidateVerdict::from_run("cell-composed", &cells_run),
+        CandidateVerdict::from_run("direct-insertion", &di_run),
+        CandidateVerdict::from_run("horizontal-stack", &horizontal_run),
+    ]);
+
     let merge_tap_choice: Option<usize> = merge_tap_run.outcome.as_ref().map(|(mt_layout, _)| {
         let start = crate::trace::peek_events_len();
         let mergetap_kinds = classify_errors(mt_layout, solver_result);
@@ -1220,6 +1358,10 @@ pub fn select_best_decomposition(
             .as_ref()
             .map(|(l, _)| classify_errors(l, solver_result));
         crate::trace::truncate_events(start);
+        board.record_kinds(MERGE_TAP_IDX, mergetap_kinds);
+        if let Some(n) = native_kinds {
+            board.record_kinds(NATIVE_IDX, n);
+        }
         match native_kinds {
             Some(n) if mergetap_kinds.quality_key() < n.quality_key() => MERGE_TAP_IDX,
             Some(_) => NATIVE_IDX,
@@ -1264,6 +1406,8 @@ pub fn select_best_decomposition(
         let di_counts = count_issues(di_layout, solver_result);
         let nat_counts = count_issues(nat_layout, solver_result);
         crate::trace::truncate_events(start);
+        board.record_counts(DI_IDX, di_counts, "di-vs-native");
+        board.record_counts(NATIVE_IDX, nat_counts, "di-vs-native");
         // Component-wise, NOT lexicographic — see `IssueCounts`.
         let strictly_better_issues = di_counts.strictly_better_than(&nat_counts);
         // Equal on every issue channel: DI must then be strictly denser
@@ -1296,6 +1440,8 @@ pub fn select_best_decomposition(
             let hs_counts = count_issues(hs_layout, solver_result);
             let nat_counts = count_issues(nat_layout, solver_result);
             crate::trace::truncate_events(start);
+            board.record_counts(H_IDX, hs_counts, "horizontal-vs-native");
+            board.record_counts(NATIVE_IDX, nat_counts, "horizontal-vs-native");
             let strictly_better_issues = hs_counts.strictly_better_than(&nat_counts);
             // v1 deliberately has NO equal-issues-and-denser arm (unlike
             // `di_choice`): measured on the first full-suite run, that
@@ -1369,8 +1515,11 @@ pub fn select_best_decomposition(
         && n_layouts > 1
     {
         let start = crate::trace::peek_events_len();
-        let flags = tier_outcomes.map(|o| {
-            o.map(|(l, score)| {
+        // `from_fn` rather than `[T; N]::map` only so the RFC-070
+        // scoreboard can key the row it records by the same index the
+        // flag lands on; the traversal and its result are identical.
+        let flags: [Option<(bool, usize)>; 7] = std::array::from_fn(|idx| {
+            tier_outcomes[idx].map(|(l, score)| {
                 // (error-free, warning key). The key orders the
                 // error-free tier below: RFC-060 made the refusal path
                 // multi-candidate (cells, DI, horizontal), and a
@@ -1391,12 +1540,44 @@ pub fn select_best_decomposition(
                         // Selection-scoped count — see
                         // `validate::selection_warning_count`.
                         let warnings = crate::validate::selection_warning_count(&issues);
+                        board.record_counts(
+                            idx,
+                            IssueCounts {
+                                errors,
+                                warnings,
+                                layout_warnings: l.warnings.len(),
+                            },
+                            "clean-flags",
+                        );
                         (
                             score.accepted && errors == 0,
                             warnings + l.warnings.len(),
                         )
                     }
-                    Err(_) => (false, usize::MAX),
+                    Err(e) => {
+                        // `validate()` returns `Err` CARRYING the issues, and
+                        // this arm is reached iff at least one is an Error.
+                        // The decision reads only "not clean" — but throwing
+                        // the counts away here would have the scoreboard
+                        // report a blank row for precisely the candidates
+                        // that failed hardest. Same issue list, same
+                        // predicates as the `Ok` arm; the source tag records
+                        // that the decision itself did not read them.
+                        board.record_counts(
+                            idx,
+                            IssueCounts {
+                                errors: e
+                                    .issues
+                                    .iter()
+                                    .filter(|i| i.severity == crate::validate::Severity::Error)
+                                    .count(),
+                                warnings: crate::validate::selection_warning_count(&e.issues),
+                                layout_warnings: l.warnings.len(),
+                            },
+                            "clean-flags(unclean)",
+                        );
+                        (false, usize::MAX)
+                    }
                 }
             })
         });
@@ -1586,20 +1767,42 @@ pub fn select_best_decomposition(
     // the DI/horizontal pairwise resolution — so neither scoped
     // candidate can shadow the other; the merge-tap non-shadowing
     // structure is unchanged.)
-    let winner_idx = match merge_tap_choice {
-        Some(MERGE_TAP_IDX) => Some(MERGE_TAP_IDX),
-        Some(_) => scoped_choice.or(Some(NATIVE_IDX)),
-        None => scoped_choice,
+    //
+    // RFC-070 Phase 0b: each arm is TAGGED with the `SelectionStage` that
+    // produced it. The chain is unchanged — `Some(_) => scoped_choice
+    // .or(Some(NATIVE_IDX))` is spelled as a match on `scoped_choice`
+    // purely so the two answers get different stage tags (a scoped
+    // candidate displacing native is a different decision from native
+    // surviving merge-tap, and the oracle must not merge them).
+    use crate::trace::SelectionStage;
+    let winner_idx: Option<(usize, SelectionStage)> = match merge_tap_choice {
+        Some(MERGE_TAP_IDX) => Some((MERGE_TAP_IDX, SelectionStage::MergeTap)),
+        Some(_) => match scoped_choice {
+            Some(i) => Some((i, SelectionStage::ScopedPairwise)),
+            None => Some((NATIVE_IDX, SelectionStage::MergeTap)),
+        },
+        None => scoped_choice.map(|i| (i, SelectionStage::ScopedPairwise)),
     }
-    .or(best_error_free_idx)
-    .or(best_accepted_idx)
+    .or(best_error_free_idx.map(|i| (i, SelectionStage::BestErrorFree)))
+    .or(best_accepted_idx.map(|i| (i, SelectionStage::BestAccepted)))
     // DI IS admitted here, deliberately: `di_choice` returns `None` when
     // native produced nothing (see its guard), precisely so `cell-composed`
     // and DI compete in this ranking rather than DI auto-winning a refusal.
     // `ranking_len` is what excludes DI in the native-SUCCEEDED case.
-    .or_else(|| candidates[..ranking_len].iter().position(|(o, _, _)| o.is_some()));
+    .or_else(|| {
+        candidates[..ranking_len]
+            .iter()
+            .position(|(o, _, _)| o.is_some())
+            .map(|i| (i, SelectionStage::FirstProduced))
+    });
 
-    let Some(idx) = winner_idx else {
+    let Some((idx, stage)) = winner_idx else {
+        // Every candidate failed. The scoreboard still goes out — WHY each
+        // of the seven produced nothing is exactly what a refusal
+        // investigation needs — but no `SelectionDecided` follows it,
+        // because there is no winner and the stage enum is deliberately
+        // closed over the five ways a winner CAN be picked.
+        board.emit();
         let details: Vec<String> = candidates
             .iter()
             .map(|(_, _, name)| name.to_string())
@@ -1630,6 +1833,18 @@ pub fn select_best_decomposition(
     crate::trace::emit(crate::trace::TraceEvent::DecompositionChosen {
         name: name.to_string(),
         score: score.score,
+    });
+    // RFC-070 Phase 0b: the scoreboard and its terminal event go out LAST
+    // and ADJACENTLY, after the winner's replayed stream. A candidate's
+    // `produce` can run its own nested selection whose events are replayed
+    // above; emitting the outer block here keeps each selection's
+    // candidates contiguous with their own `SelectionDecided`, so a reader
+    // pairs them by flushing on the terminal event without a nested block
+    // splicing into the outer one.
+    board.emit();
+    crate::trace::emit(crate::trace::TraceEvent::SelectionDecided {
+        winner: name.to_string(),
+        stage,
     });
     Ok(layout)
 }

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -1114,12 +1114,18 @@ struct Scoreboard([CandidateVerdict; 7]);
 impl Scoreboard {
     /// Record the `IssueCounts` a comparison site just computed.
     ///
-    /// FIRST WRITE WINS. Native's counts are computed by both pairwise
-    /// comparisons and DI's by both `di_choice` and `scoped_choice`; the
-    /// repeats are the same deterministic `count_issues` call on the same
-    /// layout, so keeping the first preserves the provenance of the site
-    /// that first needed the number instead of overwriting it with a
-    /// later duplicate.
+    /// FIRST WRITE WINS, and `source` therefore names the site that FIRST
+    /// computed this candidate's counts — **not** necessarily the site
+    /// that went on to decide. `count_issues` runs at five places: both
+    /// pairwise comparisons (which is why native is computed twice) and
+    /// again inside `scoped_choice`'s DI-vs-horizontal arm, which does
+    /// not record at all because both its inputs are already on the board
+    /// by construction. Every repeat is the same deterministic call on
+    /// the same layout, so the recorded VALUE is identical whichever site
+    /// wrote it; only the label differs. Read `source` as provenance of
+    /// the number, and the terminal event's stage as the deciding site
+    /// (#692 review, 3/3 — the two are not the same question and the
+    /// earlier wording let them be read as one).
     fn record_counts(&mut self, idx: usize, counts: IssueCounts, source: &'static str) {
         let row = &mut self.0[idx];
         if row.counts.is_none() {

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -974,9 +974,14 @@ impl CandidateRun {
 /// silently recording one candidate's verdicts against another's row
 /// (#692 review round 2, 3/3).
 ///
-/// The assertions compare compile-time constants, so they cannot fire
-/// for some inputs and not others: either every call panics — in the
-/// first test that runs — or none can.
+/// The checks are `debug_assert`s: they compare compile-time constants,
+/// so a violation cannot depend on the input — it is caught by the first
+/// debug-built call, which every `cargo test` run and every CI job is
+/// (tests build in debug), while release and WASM pay nothing and cannot
+/// panic a browser solve over a code-level ordering mistake. Coverage is
+/// unchanged; the blast radius is not (#692 review round 3, 1/3, which
+/// noted the unconditional form inverted the degradation philosophy used
+/// twenty lines away, where candidates run under `catch_unwind`).
 const CANDIDATE_ORDER: [&str; 7] = [
     "native",
     "k1-shape-fix",
@@ -1155,7 +1160,7 @@ impl Scoreboard {
     /// review round 2, 3/3).
     fn from_runs(runs: [&CandidateRun; 7]) -> Self {
         Self(std::array::from_fn(|i| {
-            assert_eq!(
+            debug_assert_eq!(
                 runs[i].name, CANDIDATE_ORDER[i],
                 "candidate slot {i} holds `{}` but CANDIDATE_ORDER says `{}` — a \
                  candidate was added or reordered without updating every \
@@ -1170,11 +1175,12 @@ impl Scoreboard {
     ///
     /// FIRST WRITE WINS, and `source` therefore names the site that FIRST
     /// computed this candidate's counts — **not** necessarily the site
-    /// that went on to decide. `count_issues` runs at five places: both
-    /// pairwise comparisons (which is why native is computed twice) and
-    /// again inside `scoped_choice`'s DI-vs-horizontal arm, which does
-    /// not record at all because both its inputs are already on the board
-    /// by construction. Every repeat is the same deterministic call on
+    /// that went on to decide. `count_issues` runs at SIX call sites — two
+    /// in `di_choice`, two in `horizontal_choice` (which is why native is
+    /// computed twice), and two in `scoped_choice`'s DI-vs-horizontal arm,
+    /// which records at none of them because both its inputs are already
+    /// on the board by construction. (The doc said "five places" until
+    /// #692 review round 3 counted them.) Every repeat is the same deterministic call on
     /// the same layout, so the recorded VALUE is identical whichever site
     /// wrote it; only the label differs. Read `source` as provenance of
     /// the number, and the terminal event's stage as the deciding site
@@ -1677,15 +1683,14 @@ pub fn select_best_decomposition(
     // layout — same behaviour as today's pipeline when shape-fix can't
     // resolve a (n, m) trap).
     // Index order MUST match NATIVE_IDX (0) / MERGE_TAP_IDX (3) above.
-    let (native_err, k1_err, split_err, merge_tap_err, cells_err, di_err, horizontal_err) = (
-        native_run.error.clone(),
-        k1_run.error.clone(),
-        split_run.error.clone(),
-        merge_tap_run.error.clone(),
-        cells_run.error.clone(),
-        di_run.error.clone(),
-        horizontal_run.error.clone(),
-    );
+    // Refusal reasons for the all-candidates-failed message, taken from
+    // the same checked list everything else is keyed by. This was a
+    // hand-typed 7-slot tuple zipped positionally against the candidate
+    // names — every element the same type, so a reorder compiled silently
+    // and glued the wrong reason to the wrong candidate, which is the
+    // misattribution class the rest of this function retired (#692 review
+    // round 3, 1/3). Cloned here, before `candidates` moves the runs.
+    let refusal_reasons: [Option<String>; 7] = run_refs.map(|r| r.error.clone());
     // Whether DI may enter the generic ranking at all. It may ONLY when
     // native produced nothing: then there is no bit-identity to protect
     // and DI competes fairly with `cell-composed` on the error-free tier.
@@ -1724,7 +1729,7 @@ pub fn select_best_decomposition(
         (horizontal_run.outcome, horizontal_run.events, horizontal_run.name),
     ];
     for (i, (_, _, name)) in candidates.iter().enumerate() {
-        assert_eq!(
+        debug_assert_eq!(
             *name, CANDIDATE_ORDER[i],
             "candidates[{i}] holds `{name}` but CANDIDATE_ORDER says `{}` — the \
              winner index would name the wrong candidate",
@@ -1874,10 +1879,14 @@ pub fn select_best_decomposition(
         // because there is no winner and the stage enum is deliberately
         // closed over the five ways a winner CAN be picked.
         board.emit();
-        let details: Vec<String> = candidates
+        // Both sides keyed by `CANDIDATE_ORDER`: the names from the list
+        // itself and the reasons from `run_refs`, whose slots are checked
+        // against it. Nothing here is positional against a separately
+        // typed literal any more, so the message cannot glue one
+        // candidate's reason onto another's name.
+        let details: Vec<String> = CANDIDATE_ORDER
             .iter()
-            .map(|(_, _, name)| name.to_string())
-            .zip([&native_err, &k1_err, &split_err, &merge_tap_err, &cells_err, &di_err, &horizontal_err])
+            .zip(refusal_reasons.iter())
             .map(|(name, err)| {
                 format!("{name}: {}", err.as_deref().unwrap_or("did not run"))
             })

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -211,12 +211,15 @@ impl DecompositionCandidate for DirectInsertionCandidate {
             Ok::<_, String>((l, n_warn))
         };
 
-        // Two arms only under `Search`, which is NOT the default — `Upstream`
-        // is (RFC-059: the search is measured better on every validator channel
-        // and ships a 0/s factory on one target, so it waits on #520). Every
-        // other value pins a single arm, and that is also how the corpus sweep
-        // measures the search against the pre-RFC status quo rather than
-        // asserting that picking the better arm cannot be worse.
+        // Two arms only under `Search`, which is NOT the default —
+        // `Downstream` is (`DiClaimOrder`'s `#[default]`, reached here via
+        // `LayoutOptions::default()`; RFC-059's sim close-out flipped it from
+        // `Upstream`, and this comment said `Upstream` until 2026-08-21).
+        // `Search` waits on #520: it is better on every validator channel and
+        // ships a 0/s factory on one target. Every other value pins a single
+        // arm, and that is also how the corpus sweep measures the search
+        // against the pre-RFC status quo rather than asserting that picking
+        // the better arm cannot be worse.
         if opts.di_claim_order != crate::bus::di_cell::DiClaimOrder::Search {
             return arm(opts.di_claim_order.clone()).map(|(l, _)| l);
         }

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -934,6 +934,14 @@ pub fn score_layout(layout: &LayoutResult, solver_result: &SolverResult) -> Cand
 /// dropped instead of overlapping the winner's in the web UI's live
 /// renderer (which surfaces the streaming sink).
 struct CandidateRun {
+    /// The candidate's own name, captured at the call that ran it. A run
+    /// is self-identifying so the index-keyed arrays below can be CHECKED
+    /// against [`CANDIDATE_ORDER`] rather than trusted (#692 review round
+    /// 2, 3/3: four hand-maintained same-order lists bound only by
+    /// comments is the "two definitions that disagree" bug class, and a
+    /// silent misalignment would attribute one candidate's verdicts to
+    /// another with nothing failing).
+    name: &'static str,
     outcome: Option<(LayoutResult, CandidateScore)>,
     /// The candidate's layout error when it produced no outcome — kept so
     /// the all-candidates-failed terminal message can say WHY instead of
@@ -952,16 +960,45 @@ struct CandidateRun {
 impl CandidateRun {
     /// A candidate that wasn't tried (e.g. gating predicate was false).
     /// No outcome, no events; the winner-selection code skips it.
-    fn skipped(_name: &str) -> Self {
-        Self { outcome: None, events: Vec::new(), error: None, panicked: false }
+    fn skipped(name: &'static str) -> Self {
+        Self { name, outcome: None, events: Vec::new(), error: None, panicked: false }
     }
 }
+
+/// The canonical candidate order. Every index-keyed structure in
+/// [`select_best_decomposition`] — the `*_IDX` constants, the scoreboard
+/// rows, `tier_outcomes`, `clean_flags` and `candidates` — is keyed by
+/// THIS list, and each of those is checked against it at construction
+/// using each run's own [`CandidateRun::name`]. Adding or reordering a
+/// candidate without updating the list therefore fails loudly instead of
+/// silently recording one candidate's verdicts against another's row
+/// (#692 review round 2, 3/3).
+///
+/// The assertions compare compile-time constants, so they cannot fire
+/// for some inputs and not others: either every call panics — in the
+/// first test that runs — or none can.
+const CANDIDATE_ORDER: [&str; 7] = [
+    "native",
+    "k1-shape-fix",
+    "size-split-2",
+    "merge-tap",
+    "cell-composed",
+    "direct-insertion",
+    "horizontal-stack",
+];
+
+/// Indices into [`CANDIDATE_ORDER`]. Named because several decisions
+/// below are scoped to specific candidates.
+const NATIVE_IDX: usize = 0;
+const MERGE_TAP_IDX: usize = 3;
+const DI_IDX: usize = 5;
+const H_IDX: usize = 6;
 
 /// Run a candidate, score it, and capture every trace event it emitted.
 /// The events are removed from the global collector so they don't bleed
 /// into other candidates' runs or into the final result; the caller
 /// replays only the winner's events at the end.
-fn run_candidate<F>(name: &str, solver_result: &SolverResult, f: F) -> CandidateRun
+fn run_candidate<F>(name: &'static str, solver_result: &SolverResult, f: F) -> CandidateRun
 where
     F: FnOnce(&SolverResult) -> Result<LayoutResult, String>,
 {
@@ -993,7 +1030,7 @@ where
             None
         }
     };
-    CandidateRun { outcome, events, error, panicked: false }
+    CandidateRun { name, outcome, events, error, panicked: false }
 }
 
 /// Like `run_candidate` but wraps the produce call in `catch_unwind`.
@@ -1002,7 +1039,7 @@ where
 /// configurations the multi-stage balancer doesn't yet handle). Captures
 /// the panic so the search degrades to whichever earlier candidate had
 /// a layout instead of bringing the whole call down.
-fn run_candidate_catch_unwind<F>(name: &str, solver_result: &SolverResult, f: F) -> CandidateRun
+fn run_candidate_catch_unwind<F>(name: &'static str, solver_result: &SolverResult, f: F) -> CandidateRun
 where
     F: FnOnce() -> Result<LayoutResult, String> + std::panic::UnwindSafe,
 {
@@ -1045,7 +1082,7 @@ where
             None
         }
     };
-    CandidateRun { outcome, events, error, panicked }
+    CandidateRun { name, outcome, events, error, panicked }
 }
 
 /// RFC-070 Phase 0b (#689 W1b): one candidate's row on the selection
@@ -1078,7 +1115,9 @@ struct CandidateVerdict {
 }
 
 impl CandidateVerdict {
-    fn from_run(name: &'static str, run: &CandidateRun) -> Self {
+    /// The row's name comes from the RUN, not from a parallel list — see
+    /// `CandidateRun::name`.
+    fn from_run(run: &CandidateRun) -> Self {
         use crate::trace::SelectionCandidateOutcome as Outcome;
         // `panicked` is a field, not a string match on `error` — see its
         // doc on `CandidateRun`. Order matters: a panic also sets `error`.
@@ -1089,7 +1128,7 @@ impl CandidateVerdict {
             (None, false, None) => Outcome::NotRun,
         };
         Self {
-            name,
+            name: run.name,
             outcome,
             reason: run.error.clone(),
             score: run.outcome.as_ref().map(|(_, s)| s.score),
@@ -1105,13 +1144,28 @@ impl CandidateVerdict {
     }
 }
 
-/// The seven candidate rows, **indexed exactly like the `candidates`
-/// array** in `select_best_decomposition` (`NATIVE_IDX` = 0 through
-/// `H_IDX` = 6), so a recorder can key off the same index constants the
-/// decision uses.
+/// The seven candidate rows, indexed by [`CANDIDATE_ORDER`] — the same
+/// keying the `*_IDX` constants and the `candidates` array use, so a
+/// recorder can key off the index constants the decision uses.
 struct Scoreboard([CandidateVerdict; 7]);
 
 impl Scoreboard {
+    /// Build the board from the runs, CHECKING each run's own name
+    /// against its slot rather than trusting the literal order (#692
+    /// review round 2, 3/3).
+    fn from_runs(runs: [&CandidateRun; 7]) -> Self {
+        Self(std::array::from_fn(|i| {
+            assert_eq!(
+                runs[i].name, CANDIDATE_ORDER[i],
+                "candidate slot {i} holds `{}` but CANDIDATE_ORDER says `{}` — a \
+                 candidate was added or reordered without updating every \
+                 index-keyed list in select_best_decomposition, which would \
+                 record this candidate's verdicts against another's row",
+                runs[i].name, CANDIDATE_ORDER[i]
+            );
+            CandidateVerdict::from_run(runs[i])
+        }))
+    }
     /// Record the `IssueCounts` a comparison site just computed.
     ///
     /// FIRST WRITE WINS, and `source` therefore names the site that FIRST
@@ -1342,22 +1396,25 @@ pub fn select_best_decomposition(
     // peek/truncate drops both so they never reach the winner's replayed
     // stream. `None` when merge-tap didn't run — the generic selection then
     // applies unchanged (every non-Pooled and every Native-clean case).
-    const NATIVE_IDX: usize = 0;
-    const MERGE_TAP_IDX: usize = 3;
+    // THE index-keyed list of runs. `tier_outcomes` and the RFC-070
+    // scoreboard are both derived from this one array, and
+    // `Scoreboard::from_runs` checks each run's own name against
+    // `CANDIDATE_ORDER`, so the three lists cannot drift apart silently
+    // (#692 review round 2, 3/3).
+    let run_refs: [&CandidateRun; 7] = [
+        &native_run,
+        &k1_run,
+        &split_run,
+        &merge_tap_run,
+        &cells_run,
+        &di_run,
+        &horizontal_run,
+    ];
 
     // RFC-070 Phase 0b scoreboard. Built here — after every candidate has
     // run, before the first verdict mechanism fires — so the mechanism
-    // sites below can record into it as they compute. Index-aligned with
-    // the `candidates` array further down.
-    let mut board = Scoreboard([
-        CandidateVerdict::from_run("native", &native_run),
-        CandidateVerdict::from_run("k1-shape-fix", &k1_run),
-        CandidateVerdict::from_run("size-split-2", &split_run),
-        CandidateVerdict::from_run("merge-tap", &merge_tap_run),
-        CandidateVerdict::from_run("cell-composed", &cells_run),
-        CandidateVerdict::from_run("direct-insertion", &di_run),
-        CandidateVerdict::from_run("horizontal-stack", &horizontal_run),
-    ]);
+    // sites below can record into it as they compute.
+    let mut board = Scoreboard::from_runs(run_refs);
 
     let merge_tap_choice: Option<usize> = merge_tap_run.outcome.as_ref().map(|(mt_layout, _)| {
         let start = crate::trace::peek_events_len();
@@ -1401,7 +1458,6 @@ pub fn select_best_decomposition(
     // `count_issues` runs `validate()`, which emits a
     // `ValidationCompleted` event; peek/truncate drops those so they
     // never reach the winner's replayed stream (#396).
-    const DI_IDX: usize = 5;
     let di_choice: Option<usize> = di_run.outcome.as_ref().and_then(|(di_layout, di_score)| {
         let Some((nat_layout, nat_score)) = native_run.outcome.as_ref() else {
             // Native produced nothing (a hard bus refusal). DI does NOT
@@ -1441,7 +1497,6 @@ pub fn select_best_decomposition(
     // generic ranking (which admits horizontal exactly then, via
     // `ranking_len`) weighs it against `cell-composed` and DI instead of
     // it auto-winning a refusal.
-    const H_IDX: usize = 6;
     let horizontal_choice: Option<usize> =
         horizontal_run.outcome.as_ref().and_then(|(hs_layout, hs_score)| {
             let (nat_layout, _nat_score) = native_run.outcome.as_ref()?;
@@ -1509,15 +1564,9 @@ pub fn select_best_decomposition(
     // Removing it as redundant would silently re-admit the
     // density-wins-over-warnings regression that ranking cannot see — the
     // failure `tier2_electronic_circuit` hit before `ranking_len` existed.
-    let tier_outcomes = [
-        native_run.outcome.as_ref(),
-        k1_run.outcome.as_ref(),
-        split_run.outcome.as_ref(),
-        merge_tap_run.outcome.as_ref(),
-        cells_run.outcome.as_ref(),
-        di_run.outcome.as_ref(),
-        horizontal_run.outcome.as_ref(),
-    ];
+    // Derived from `run_refs`, whose order is checked against
+    // `CANDIDATE_ORDER` — one list, not a fourth hand-maintained copy.
+    let tier_outcomes = run_refs.map(|r| r.outcome.as_ref());
     let n_layouts = tier_outcomes.iter().filter(|o| o.is_some()).count();
     let clean_flags: [Option<(bool, usize)>; 7] = if merge_tap_choice.is_none()
         && scoped_choice.is_none()
@@ -1660,15 +1709,28 @@ pub fn select_best_decomposition(
     // `clean_flags[DI_IDX]` is simply never read. That slice is the whole
     // mechanism; there is no `None` pin (`tier_outcomes` populates DI like
     // any other candidate).
+    // Each entry's name comes from its own run, not from a literal, so
+    // the check below actually discriminates: swapping two runs here
+    // moves their names with them and trips the assert, where hardcoded
+    // labels would have silently mislabelled the winner (#692 review
+    // round 2, 3/3).
     let candidates: [(Option<(LayoutResult, CandidateScore)>, Vec<crate::trace::TraceEvent>, &str); 7] = [
-        (native_run.outcome, native_run.events, "native"),
-        (k1_run.outcome, k1_run.events, "k1-shape-fix"),
-        (split_run.outcome, split_run.events, "size-split-2"),
-        (merge_tap_run.outcome, merge_tap_run.events, "merge-tap"),
-        (cells_run.outcome, cells_run.events, "cell-composed"),
-        (di_run.outcome, di_run.events, "direct-insertion"),
-        (horizontal_run.outcome, horizontal_run.events, "horizontal-stack"),
+        (native_run.outcome, native_run.events, native_run.name),
+        (k1_run.outcome, k1_run.events, k1_run.name),
+        (split_run.outcome, split_run.events, split_run.name),
+        (merge_tap_run.outcome, merge_tap_run.events, merge_tap_run.name),
+        (cells_run.outcome, cells_run.events, cells_run.name),
+        (di_run.outcome, di_run.events, di_run.name),
+        (horizontal_run.outcome, horizontal_run.events, horizontal_run.name),
     ];
+    for (i, (_, _, name)) in candidates.iter().enumerate() {
+        assert_eq!(
+            *name, CANDIDATE_ORDER[i],
+            "candidates[{i}] holds `{name}` but CANDIDATE_ORDER says `{}` — the \
+             winner index would name the wrong candidate",
+            CANDIDATE_ORDER[i]
+        );
+    }
 
     // Find best accepted candidate (highest score). The candidates
     // array is a PREFERENCE ranking (native first, cell-composed

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1452,6 +1452,12 @@ pub enum TraceEvent {
         counts_source: Option<String>,
         /// `ErrorKinds` (mechanism 3) — computed ONLY by the merge-tap
         /// decision, so `None` on every call where merge-tap did not run.
+        /// One row can therefore carry counts from one mechanism and kinds
+        /// from another (a Pooled solve where DI also ran gives native
+        /// `di-vs-native` counts AND merge-tap kinds): a row is a
+        /// per-candidate summary of everything any mechanism computed
+        /// about it, not the record of one decision. The decision is
+        /// `SelectionDecided::stage`, and only that.
         contamination_errors: Option<usize>,
         starvation_errors: Option<usize>,
         structural_errors: Option<usize>,

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1401,6 +1401,62 @@ pub enum TraceEvent {
         score: f64,
     },
 
+    // RFC-070 Phase 0b (#689 W1b): the SELECTION SCOREBOARD. One
+    // `SelectionCandidateEvaluated` per candidate slot of
+    // `select_best_decomposition` (all seven, every call — including the
+    // ones that never ran), then one `SelectionDecided` naming the winner
+    // and the precedence stage that picked it. The two are emitted
+    // adjacently at the very end of the selection, so a stream walker can
+    // pair them by "flush the pending candidates when a `SelectionDecided`
+    // arrives" without a nested selection (a candidate whose `produce`
+    // runs its own search, replayed inside the winner's events) splicing
+    // itself into the outer block.
+    //
+    // Purely observational: the fields RECORD what each verdict mechanism
+    // already computed on the decision path, never a recomputation, which
+    // is why so many are `Option`. A `None` means "no mechanism computed
+    // this for this candidate on this call" — an oracle GAP, not a zero.
+    // Reading one as 0 is the `unwrap_or(0)` trap that has silently
+    // reported "no findings" here before.
+    SelectionCandidateEvaluated {
+        /// Candidate name, matching `DecompositionCandidate::name`.
+        name: String,
+        outcome: SelectionCandidateOutcome,
+        /// `produce()`'s own error text when `outcome` is `Refused`, or the
+        /// caught-panic tag when `Panicked`. `None` otherwise — a candidate
+        /// that was never run carries no reason string, because the gating
+        /// predicate lives at the call site, not in `produce`.
+        reason: Option<String>,
+        /// Soft score (`score_layout`) and its acceptance verdict — `Some`
+        /// iff the candidate produced a layout (mechanism 1). `accepted`
+        /// carries only the `missing-balancer-template` hard gate; it is
+        /// NOT a validation verdict.
+        score: Option<f64>,
+        accepted: Option<bool>,
+        accepted_reason: Option<String>,
+        /// `IssueCounts` (mechanism 2) as computed by whichever comparison
+        /// site ran first — `errors` / `selection_warning_count` /
+        /// `LayoutResult.warnings.len()`. All three are `None` together
+        /// when no comparison needed this candidate's counts.
+        errors: Option<usize>,
+        selection_warnings: Option<usize>,
+        layout_warnings: Option<usize>,
+        /// Which decision site produced the counts above (`"di-vs-native"`,
+        /// `"horizontal-vs-native"`, `"clean-flags"`). Provenance matters:
+        /// the counts are only as authoritative as the site that needed
+        /// them.
+        counts_source: Option<String>,
+        /// `ErrorKinds` (mechanism 3) — computed ONLY by the merge-tap
+        /// decision, so `None` on every call where merge-tap did not run.
+        contamination_errors: Option<usize>,
+        starvation_errors: Option<usize>,
+        structural_errors: Option<usize>,
+    },
+    SelectionDecided {
+        winner: String,
+        stage: SelectionStage,
+    },
+
     // `ModuleSizeSplit` candidate (see `docs/rfc-decomposition-search.md`)
     // applied a k-way split to one module of the partition plan. Fires
     // once per split module per `produce()` call. With Phase 1's k=2,
@@ -1632,6 +1688,49 @@ pub struct MachineTrace {
     pub count: f64,
     /// Total output rate of this machine group (items/s)
     pub rate: f64,
+}
+
+/// What happened to one candidate slot of `select_best_decomposition`.
+/// `NotRun` and `Refused` are DIFFERENT facts: `NotRun` means the call
+/// site's gating predicate was false so `produce` was never called (no
+/// layout pass was paid for), while `Refused` means `produce` ran and
+/// returned `Err` — including the three arms that self-validate and
+/// refuse their own error-carrying layout.
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SelectionCandidateOutcome {
+    Produced,
+    Refused,
+    Panicked,
+    NotRun,
+}
+
+/// The precedence stage of `select_best_decomposition` that picked the
+/// winner — a CLOSED enum of the five arms of the `winner_idx` chain, in
+/// precedence order. Exhaustive by construction: every return path of
+/// that chain maps to exactly one variant, so a future stage that is
+/// added without a variant here fails to compile.
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SelectionStage {
+    /// The scoped Pooled merge-tap decision (`ErrorKinds::quality_key`).
+    /// Covers BOTH of its answers: merge-tap won, or native beat merge-tap
+    /// and no scoped-pairwise choice displaced it.
+    MergeTap,
+    /// The DI / horizontal-stack pairwise `IssueCounts` comparison
+    /// (`scoped_choice`) — reached either directly or through the
+    /// merge-tap chain's native arm.
+    ScopedPairwise,
+    /// `best_error_free_idx` — the validation tier (#392).
+    BestErrorFree,
+    /// `best_accepted_idx` — best soft score among accepted candidates.
+    BestAccepted,
+    /// The positional fallback: first candidate that produced anything.
+    FirstProduced,
 }
 
 #[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1441,10 +1441,14 @@ pub enum TraceEvent {
         errors: Option<usize>,
         selection_warnings: Option<usize>,
         layout_warnings: Option<usize>,
-        /// Which decision site produced the counts above (`"di-vs-native"`,
-        /// `"horizontal-vs-native"`, `"clean-flags"`). Provenance matters:
-        /// the counts are only as authoritative as the site that needed
-        /// them.
+        /// Which site FIRST computed the counts above (`"di-vs-native"`,
+        /// `"horizontal-vs-native"`, `"clean-flags"`) — provenance of the
+        /// number, **not** the site that decided. Recording is
+        /// first-write-wins and several sites compute the same candidate's
+        /// counts, so a later deciding tier can inherit an earlier tag;
+        /// the value is identical either way (same deterministic call on
+        /// the same layout). For "who decided", read `SelectionDecided`'s
+        /// stage.
         counts_source: Option<String>,
         /// `ErrorKinds` (mechanism 3) — computed ONLY by the merge-tap
         /// decision, so `None` on every call where merge-tap did not run.

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -29,6 +29,15 @@
 //! printed header (round 3, #686) so a table-skimmer sees it without
 //! reading down to the Interpretation paragraph.
 //!
+//! TWO diagnostics live here, over the same `FIXTURES` slice and running
+//! in opposite directions. `check_firing_census` (this one) approximates
+//! the candidate field from OUTSIDE via option toggles and reports
+//! validator CATEGORIES. `selection_scoreboard_census` (RFC-070 Phase 0b,
+//! bottom of the file) reads the REAL internal loop under default options
+//! and reports candidates, verdicts and the deciding precedence stage —
+//! it closes the "which candidate" approximation named just above while
+//! saying nothing about categories, so neither replaces the other.
+//!
 //! Run: cargo test --test check_firing_census -- --ignored --nocapture
 
 use std::collections::BTreeSet;

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -454,9 +454,14 @@ fn check_firing_census() {
          fixture's own default; round 6, #686) ==="
     );
     println!(
-        "  (denominator counts COMPARABLE builds only — a build whose \
-         fixture's own default refused has no baseline and is reported \
-         separately, never as a difference; #675 follow-up)"
+        "  (denominator counts COMPARABLE builds only: ones that SUCCEEDED \
+         and whose fixture's own default also built. \"+N with no default\" \
+         counts successful builds whose fixture's default did NOT build — \
+         they have no baseline, so they are neither identical nor \
+         different. It is NOT a count of builds with a failing default in \
+         general: a variant's OWN refusals never reach this tally at all, \
+         they are in the `refusals:` summary at the top; #675 follow-up, \
+         wording per #692 review round 3)"
     );
     println!(
         "  (\"identical\" = tiles AND stamps — name/x/y/direction/recipe/\
@@ -885,9 +890,15 @@ fn selection_scoreboard_contract() {
     let names: Vec<&str> = rows.iter().map(|(n, _)| *n).collect();
     assert_eq!(
         names, EXPECTED_ORDER,
-        "the scoreboard must emit one row per candidate SLOT, in canonical order — \
-         a missing row means a candidate became unobservable, and a reordered one \
-         means every recorded verdict is attributed to the wrong candidate"
+        "the scoreboard must emit one row per candidate SLOT, in canonical order. \
+         TWO readings, and they need different fixes: (1) the ENGINE legitimately \
+         gained, lost or renamed a candidate — check `CANDIDATE_ORDER` in \
+         decomposition_search.rs; if it changed, this list is merely stale, update \
+         it and re-take the RFC-070 Phase-0 baseline, since the candidate field \
+         moved. (2) The INSTRUMENTATION broke — `CANDIDATE_ORDER` is unchanged but \
+         `Scoreboard::emit` stopped emitting a slot or the index alignment slipped, \
+         in which case every recorded verdict is now attributed to the wrong \
+         candidate and the fix is here, not in the baseline"
     );
 
     let decided: Vec<(&str, SelectionStage)> = events
@@ -900,7 +911,15 @@ fn selection_scoreboard_contract() {
     assert_eq!(
         decided.len(),
         1,
-        "exactly one selection must terminate for this fixture; got {decided:?}"
+        "exactly one selection must terminate for this fixture; got {decided:?}. \
+         TWO readings: (1) the ENGINE legitimately nested a selection — some \
+         candidate's `produce` now runs its own search on this fixture, which is a \
+         correct engine that this pin does not cover; confirm by checking whether \
+         the extra terminal is preceded by its own full block of seven rows (the \
+         census's block walker renders exactly that) and, if so, re-point this test \
+         at the OUTER block instead of assuming one. (2) The INSTRUMENTATION broke — \
+         terminals are duplicated or emitted somewhere other than once per \
+         selection, which would regroup every census table"
     );
 
     let last_row = events
@@ -914,8 +933,14 @@ fn selection_scoreboard_contract() {
     assert!(
         last_row < terminal,
         "all rows must precede their `SelectionDecided` — the census pairs a block \
-         to its verdict by flushing on the terminal event, so emitting a row after \
-         it would silently regroup the table"
+         to its verdict by flushing on the terminal event, so a row after it \
+         silently regroups the table. TWO readings: (1) the ENGINE nested a \
+         selection whose block now lands after the outer terminal (the ordering \
+         contract in `select_best_decomposition` puts the board immediately before \
+         `SelectionDecided`, so this means that ordering changed and the walker \
+         needs revisiting); (2) the INSTRUMENTATION broke — `board.emit()` moved \
+         relative to the terminal event. `decided.len()` above discriminates: a \
+         nested selection adds a terminal, a misplaced emit does not"
     );
 
     // --- the winner is one of this block's own rows, and it produced ---

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -554,9 +554,12 @@ fn selection_scoreboard_census() {
 
     println!("\n=== RFC-070 selection scoreboard (default options, one build per fixture) ===");
     println!(
-        "(err/selw/laww are the counts the DECISION computed, sourced in \
-         the `from` column; `-` means no mechanism computed one — a gap, \
-         not a zero. `reason` is produce()'s refusal text, or the \
+        "(err/selw/laww are counts a decision mechanism computed; `-` means \
+         no mechanism computed one — a gap, not a zero. `from` names the \
+         site that FIRST computed them, which is not necessarily the site \
+         that decided: recording is first-write-wins and the value is the \
+         same either way, so read the deciding stage below the table for \
+         WHO decided. `reason` is produce()'s refusal text, or the \
          accepted=no tag for a candidate that built but failed the hard \
          gate.)"
     );
@@ -565,8 +568,14 @@ fn selection_scoreboard_census() {
     for &(item, rate, machine, inputs) in FIXTURES {
         let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
         let fixture_key = format!("{item}@{rate}:{machine}");
+        // Every fixture contributes exactly one summary row, including the
+        // ones that never reach a decision (#692 review, 2/3: the header
+        // claimed "one row per fixture" while a no-winner or unsolvable
+        // fixture silently contributed none — a summary that drops its
+        // failures is the shape this repo keeps getting bitten by).
         let Ok(sr) = solver::solve(item, rate, &input_set, machine) else {
             println!("\n-- {fixture_key}\n   SKIP (no solve)");
+            stage_tally.push((fixture_key, "—".to_string(), "SKIP (no solve)".to_string()));
             continue;
         };
         // Collect this fixture's whole event stream, then walk it. The
@@ -600,7 +609,20 @@ fn selection_scoreboard_census() {
         let mut pending: Vec<&TraceEvent> = Vec::new();
         for ev in &events {
             match ev {
-                TraceEvent::SelectionCandidateEvaluated { .. } => pending.push(ev),
+                TraceEvent::SelectionCandidateEvaluated { name, .. } => {
+                    // A block that ended WITHOUT a `SelectionDecided` (the
+                    // all-candidates-failed path) would otherwise stay open
+                    // and absorb the next block's rows — flushing only on
+                    // the terminal event has no defense against that
+                    // (#692 review, 3/3). `Scoreboard::emit` walks its rows
+                    // in index order and index 0 is always `native`, so a
+                    // `native` row arriving with rows already pending marks
+                    // the start of a new block, terminated or not.
+                    if name == "native" && !pending.is_empty() {
+                        blocks.push((std::mem::take(&mut pending), None));
+                    }
+                    pending.push(ev);
+                }
                 TraceEvent::SelectionDecided { winner, stage } => {
                     blocks.push((std::mem::take(&mut pending), Some((winner.as_str(), *stage))));
                 }
@@ -613,6 +635,11 @@ fn selection_scoreboard_census() {
         }
         if blocks.is_empty() {
             println!("   (no selection events — build never reached the search)");
+            stage_tally.push((
+                fixture_key,
+                "—".to_string(),
+                "no selection events".to_string(),
+            ));
             continue;
         }
 
@@ -689,12 +716,24 @@ fn selection_scoreboard_census() {
                         ));
                     }
                 }
-                None => println!("   => NO WINNER (every candidate failed; see reasons above)"),
+                None => {
+                    println!("   => NO WINNER (every candidate failed; see reasons above)");
+                    if n == blocks.len() - 1 {
+                        stage_tally.push((
+                            fixture_key.clone(),
+                            "—".to_string(),
+                            "NO WINNER (all candidates failed)".to_string(),
+                        ));
+                    }
+                }
             }
         }
     }
 
-    println!("\n=== outer-selection summary (one row per fixture) ===");
+    println!(
+        "\n=== outer-selection summary (one row per fixture, including the \
+         ones that reached no decision) ==="
+    );
     println!("{:<44} {:<18} deciding stage", "fixture", "winner");
     for (fixture, winner, stage) in &stage_tally {
         println!("{fixture:<44} {winner:<18} {stage}");
@@ -710,14 +749,14 @@ fn selection_scoreboard_census() {
          buy a worse `laww`. `kinds` is the lexicographic `ErrorKinds` \
          key, computed only by the Pooled merge-tap decision. A blank \
          column is a candidate NO mechanism examined, and the blanks are \
-         structural rather than incidental: the merge-tap decision \
-         short-circuits the `clean_flags` tier entirely, so on a \
-         merge-tap-decided fixture neither native nor merge-tap carries \
-         issue counts at all even though both produced layouts — the \
-         kinds key is the whole of what that decision looked at, so it is \
-         the whole of what this can report. That is also why the deciding \
-         STAGE is the load-bearing column: it says which question was \
-         actually asked, where the counts only say what the answer was \
-         made of."
+         structural rather than incidental: a merge-tap decision \
+         short-circuits the `clean_flags` tier entirely, so the only \
+         counts such a fixture can show are ones a scoped pairwise \
+         already computed — and where DI and horizontal both refused, \
+         that is none, leaving the kinds key as the whole of what the \
+         decision looked at and the whole of what this can report. That \
+         is also why the deciding STAGE is the load-bearing column: it \
+         says which question was actually asked, where the counts only \
+         say what the answer was made of."
     );
 }

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -577,6 +577,12 @@ fn selection_scoreboard_census() {
         // nested selection (cell composition builds per-cell layouts),
         // and each such block is contiguous and complete, so this
         // separates them instead of merging them into the outer one.
+        //
+        // Only the WINNER's nested blocks are visible: `run_candidate`
+        // truncates every candidate's events out of the collector and
+        // replays only the winner's, so a losing candidate's inner
+        // selection is dropped before anything can read it. Absence of a
+        // nested block is therefore not evidence that none ran.
         /// One selection's candidate rows plus its terminal verdict —
         /// `None` when the selection ended with every candidate failing,
         /// which emits rows but no `SelectionDecided`.

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -577,7 +577,11 @@ fn selection_scoreboard_census() {
         // nested selection (cell composition builds per-cell layouts),
         // and each such block is contiguous and complete, so this
         // separates them instead of merging them into the outer one.
-        let mut blocks: Vec<(Vec<&TraceEvent>, Option<(&str, SelectionStage)>)> = Vec::new();
+        /// One selection's candidate rows plus its terminal verdict —
+        /// `None` when the selection ended with every candidate failing,
+        /// which emits rows but no `SelectionDecided`.
+        type SelectionBlock<'a> = (Vec<&'a TraceEvent>, Option<(&'a str, SelectionStage)>);
+        let mut blocks: Vec<SelectionBlock> = Vec::new();
         let mut pending: Vec<&TraceEvent> = Vec::new();
         for ev in &events {
             match ev {
@@ -609,9 +613,8 @@ fn selection_scoreboard_census() {
                 );
             }
             println!(
-                "   {:<18} {:<9} {:>9} {:>4} {:>5} {:>5} {:>5}  {:<21} {:<9} {}",
-                "candidate", "outcome", "score", "acc", "err", "selw", "laww", "from", "kinds",
-                "reason"
+                "   {:<18} {:<9} {:>9} {:>4} {:>5} {:>5} {:>5}  {:<21} {:<9} reason",
+                "candidate", "outcome", "score", "acc", "err", "selw", "laww", "from", "kinds"
             );
             for ev in rows {
                 let TraceEvent::SelectionCandidateEvaluated {
@@ -677,7 +680,7 @@ fn selection_scoreboard_census() {
     }
 
     println!("\n=== outer-selection summary (one row per fixture) ===");
-    println!("{:<44} {:<18} {}", "fixture", "winner", "deciding stage");
+    println!("{:<44} {:<18} deciding stage", "fixture", "winner");
     for (fixture, winner, stage) in &stage_tally {
         println!("{fixture:<44} {winner:<18} {stage}");
     }

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -547,7 +547,9 @@ fn selection_scoreboard_census() {
     println!(
         "(err/selw/laww are the counts the DECISION computed, sourced in \
          the `from` column; `-` means no mechanism computed one — a gap, \
-         not a zero)"
+         not a zero. `reason` is produce()'s refusal text, or the \
+         accepted=no tag for a candidate that built but failed the hard \
+         gate.)"
     );
 
     let mut stage_tally: Vec<(String, String, String)> = Vec::new();
@@ -618,6 +620,7 @@ fn selection_scoreboard_census() {
                     reason,
                     score,
                     accepted,
+                    accepted_reason,
                     errors,
                     selection_warnings,
                     layout_warnings,
@@ -648,7 +651,11 @@ fn selection_scoreboard_census() {
                     num(layout_warnings),
                     counts_source.as_deref().unwrap_or("-"),
                     kinds,
-                    reason.as_deref().unwrap_or("-"),
+                    // `produce()`'s refusal text, or — for a candidate
+                    // that produced but failed the hard gate — the
+                    // `accepted=no` tag, which is the only place the
+                    // missing-balancer-template count surfaces.
+                    reason.as_deref().or(accepted_reason.as_deref()).unwrap_or("-"),
                 );
             }
             match decided {

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -29,8 +29,17 @@
 //! printed header (round 3, #686) so a table-skimmer sees it without
 //! reading down to the Interpretation paragraph.
 //!
-//! TWO diagnostics live here, over the same `FIXTURES` slice and running
-//! in opposite directions. `check_firing_census` (this one) approximates
+//! THREE tests live here. Two are `#[ignore]`d diagnostics over the same
+//! `FIXTURES` slice, running in opposite directions; the third,
+//! `selection_scoreboard_contract`, is NOT ignored and is the only thing
+//! in this file a build depends on — it pins the Phase-0b oracle's
+//! contract (every candidate slot emits a row, in canonical order, before
+//! its terminal event; the winner is one of its own block's rows; the
+//! deciding stage is the one this fixture reaches) so that a broken stage
+//! tag or a row that stops being emitted fails CI instead of quietly
+//! printing wrong output to a human who may never run it.
+//!
+//! Of the two diagnostics: `check_firing_census` (this one) approximates
 //! the candidate field from OUTSIDE via option toggles and reports
 //! validator CATEGORIES. `selection_scoreboard_census` (RFC-070 Phase 0b,
 //! bottom of the file) reads the REAL internal loop under default options
@@ -51,14 +60,15 @@ use spaghettio_core::{solver, validate};
 
 /// A structural signature of a built layout's entities, sorted so
 /// emission order doesn't matter. Used only to
-/// detect when a variant's build is bit-identical to the same fixture's
+/// detect when a variant's build is identical to the same fixture's
 /// default (round 6, #686): `cells-off`/`hs-off` are gated internally
 /// (`decomposition_search.rs`'s `try_cells`/`try_horizontal`) on
 /// conditions this hardcoded fixture list may not satisfy for every
 /// fixture (chain eligibility, a `DualInput` row), so a variant can be a
-/// silent no-op — bit-identical to default — for some or all fixtures,
-/// which would otherwise look like a genuinely evaluated, merely-quiet
-/// candidate.
+/// silent no-op — producing the same layout as default — for some or all
+/// fixtures, which would otherwise look like a genuinely evaluated,
+/// merely-quiet candidate. What "identical" means here is defined
+/// precisely below, and it is NOT "validates the same".
 ///
 /// Field order: name, x, y, direction, recipe, carries, mirror, rate-bits.
 /// The last three joined in as the #675 follow-up recorded on #686's
@@ -68,15 +78,27 @@ use spaghettio_core::{solver, validate};
 ///   (`validate/*.rs` reads `e.carries` across nine check modules;
 ///   `fluids.rs` passes `e.mirror` into `fluid_ports`), so two layouts
 ///   differing only there genuinely validate differently — omitting them
-///   let "bit-identical" mean less than it claimed.
-/// - `rate` is NOT read by any validator or engine decision
-///   (`docs/rate-stamp-semantics.md`; the `PlacedEntity::rate` doc says so
-///   outright, and the round-7 review's claim that `belt_flow` reads it
-///   is wrong — those sites read `ItemFlow::rate` off the solver). It is
-///   in the signature anyway because a differing stamp means the pipeline
-///   made a different lane-family decision on the way to the same tiles,
-///   which is worth not calling "identical" — a provenance difference,
-///   not a validation-visible one.
+///   let the "identical" label mean less than it claimed.
+/// - `rate` is NOT read by any validator or engine decision. Receipts,
+///   since two reviews have now claimed opposite things: all 21 `.rate`
+///   reads across `validate/` and `connectivity.rs` are on solver
+///   `ItemFlow`s (`o`/`i`/`f`/`out`/`inp`/`sur`/`flow`/`ext`), none on a
+///   `PlacedEntity`; the three `belt_flow.rs` lines #686 round 7 cited as
+///   proof (`:684`, `:1675`, `:3286`) read `e.carries`, `e.carries` and
+///   `build_ug_pairs` respectively. `docs/rate-stamp-semantics.md` and
+///   the `PlacedEntity::rate` doc say the same. It is in the signature
+///   anyway because a differing stamp means the pipeline made a different
+///   lane-family decision on the way to the same tiles — which is worth
+///   not calling "identical" — and that choice REDEFINES the label:
+///
+/// **A "no-op" here means tiles AND stamps identical, not
+/// validator-identical.** The two differ only if `rate` can vary
+/// independently of geometry; where it does, this reports the variant as
+/// doing something when the validator would not care (#692 review round
+/// 2, 1/3). Measured on the current fixture set the redefinition changes
+/// nothing — the ratios are identical to the pre-`rate` run (di-off 5/6,
+/// di-forced 5/6, cells-off 6/6, hs-off 5/6, partitioned 4/6) — so
+/// nothing here is currently reported noisy on a stamp alone.
 ///
 /// `f64` has no `Ord`, so the rate travels as `to_bits`: exact equality
 /// is all this needs, and the sort only wants a total order, not a
@@ -428,13 +450,19 @@ fn check_firing_census() {
         );
     }
     println!(
-        "\n=== per-variant no-op check (bit-identical entities vs that \
+        "\n=== per-variant no-op check (entities identical to that \
          fixture's own default; round 6, #686) ==="
     );
     println!(
         "  (denominator counts COMPARABLE builds only — a build whose \
          fixture's own default refused has no baseline and is reported \
          separately, never as a difference; #675 follow-up)"
+    );
+    println!(
+        "  (\"identical\" = tiles AND stamps — name/x/y/direction/recipe/\
+         carries/mirror/rate. `rate` is not validator-visible, so this is \
+         a stricter test than \"validates the same\": a variant differing \
+         only in its rate stamp counts as NOT identical)"
     );
     for &(vname, _, native_adjacent) in variants.iter().filter(|t| t.0 != "default") {
         let total = comparable_builds.get(vname).copied().unwrap_or(0);
@@ -488,7 +516,10 @@ fn check_firing_census() {
          apply before concluding a quiet category is inert). A firing on \
          a variant identical to default carries no selection evidence, \
          and a variant that is no-op across all fixtures measures \
-         nothing here — see the per-variant no-op check above. That rule \
+         nothing here — see the per-variant no-op check above, and note \
+         that its \"identical\" is tiles-and-stamps, a STRICTER test than \
+         validator-identical, so it can only under-report no-ops, never \
+         over-report them. That rule \
          is enforced by the PAIRING, not by the no-op flag: a genuinely \
          identical variant validates identically, so its firings also \
          land on the same fixture's default side and cannot set either \
@@ -644,13 +675,20 @@ fn selection_scoreboard_census() {
         }
 
         for (n, (rows, decided)) in blocks.iter().enumerate() {
-            if blocks.len() > 1 {
-                // More than one selection ran for this fixture: an inner
-                // one belongs to a candidate whose `produce` recursed.
+            let is_outer = n == blocks.len() - 1;
+            if blocks.len() > 1 && !is_outer {
+                // An inner block belongs to a candidate whose `produce`
+                // recursed. The OUTER block is the last one and must not
+                // wear this banner — it is the row a reader is sent to
+                // (#692 review round 2, 1/3: the banner previously
+                // labelled "selection 2/2" as nested, which is exactly
+                // the load-bearing one).
                 println!(
-                    "   [selection {}/{} — a nested block comes from a \
-                     candidate's own search]",
+                    "   [selection {}/{} — nested, from a candidate's own \
+                     search; the outer selection is {}/{}]",
                     n + 1,
+                    blocks.len(),
+                    blocks.len(),
                     blocks.len()
                 );
             }
@@ -706,7 +744,28 @@ fn selection_scoreboard_census() {
             match decided {
                 Some((winner, stage)) => {
                     println!("   => winner: {winner}   deciding stage: {}", stage_name(*stage));
-                    if n == blocks.len() - 1 {
+                    // The block-pairing invariant, checked rather than
+                    // assumed (#692 review round 2, 3/3): a selection's
+                    // winner must be one of ITS OWN rows. If grouping ever
+                    // breaks — a reorder, or a nested selection emitted
+                    // after the outer terminal — this fires instead of the
+                    // table quietly attributing the wrong block's verdicts.
+                    // A diagnostic prints its failures loudly rather than
+                    // panicking; the CI-enforced version of this invariant
+                    // is `selection_scoreboard_contract` below.
+                    let winner_in_block = rows.iter().any(|ev| {
+                        matches!(ev, TraceEvent::SelectionCandidateEvaluated { name, .. }
+                                 if name == winner)
+                    });
+                    if !winner_in_block {
+                        println!(
+                            "   !! BLOCK PAIRING BROKEN: winner `{winner}` is not among \
+                             this block's {} rows — the summary row below is not \
+                             trustworthy",
+                            rows.len()
+                        );
+                    }
+                    if is_outer {
                         // The OUTER selection is the last block: nested
                         // ones close while the outer is still running.
                         stage_tally.push((
@@ -718,7 +777,7 @@ fn selection_scoreboard_census() {
                 }
                 None => {
                     println!("   => NO WINNER (every candidate failed; see reasons above)");
-                    if n == blocks.len() - 1 {
+                    if is_outer {
                         stage_tally.push((
                             fixture_key.clone(),
                             "—".to_string(),
@@ -758,5 +817,152 @@ fn selection_scoreboard_census() {
          is also why the deciding STAGE is the load-bearing column: it \
          says which question was actually asked, where the counts only \
          say what the answer was made of."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RFC-070 Phase 0b: the CI contract (NOT #[ignore]d)
+// ---------------------------------------------------------------------------
+
+/// The one non-ignored test in this file, and deliberately so.
+///
+/// Everything else here is a print-only diagnostic a human runs with
+/// `--ignored`. That is fine for a table nobody's build depends on — but
+/// the Phase-0b scoreboard is the oracle every later RFC-070 phase diffs
+/// its shadow loop against, and an oracle whose only reader is a human
+/// running a diagnostic by hand has no failure mode: a broken stage tag,
+/// a row that stops being emitted, or an `from_run` outcome deduced
+/// backwards would all ship green (#692 review round 2, 3/3). The repo's
+/// own doctrine names this exactly — "a check going quiet is not evidence
+/// the problem is fixed" (`docs/validator-reporting.md`).
+///
+/// So this pins the CONTRACT, not the layout: every candidate slot emits
+/// a row, the rows arrive in the canonical order and before the terminal
+/// event, the winner is one of that block's own rows, and the deciding
+/// stage is the one this fixture actually reaches. Tile geometry is the
+/// golden-hash tests' job and is deliberately not asserted here.
+///
+/// The expected candidate order is written out longhand rather than
+/// imported from `CANDIDATE_ORDER`: a test that reads the same constant
+/// the code reads cannot detect a wrong reorder, because both move
+/// together. This list is the independent second opinion.
+#[test]
+#[ntest::timeout(120_000)]
+fn selection_scoreboard_contract() {
+    use spaghettio_core::trace::{self, SelectionCandidateOutcome, SelectionStage, TraceEvent};
+
+    /// Slot order asserted independently of the engine's own constant.
+    const EXPECTED_ORDER: [&str; 7] = [
+        "native",
+        "k1-shape-fix",
+        "size-split-2",
+        "merge-tap",
+        "cell-composed",
+        "direct-insertion",
+        "horizontal-stack",
+    ];
+
+    let inputs: FxHashSet<String> = ["iron-plate"].iter().map(|s| s.to_string()).collect();
+    let sr = solver::solve("iron-gear-wheel", 10.0, &inputs, "assembling-machine-1")
+        .expect("tier-1 fixture must solve");
+
+    let guard = trace::start_trace();
+    let layout = layout::build_bus_layout(&sr, LayoutOptions::default());
+    let events = trace::drain_events();
+    drop(guard);
+    layout.expect("tier-1 fixture must build");
+
+    // --- every slot emits a row, in order, before the terminal event ---
+    let rows: Vec<(&str, SelectionCandidateOutcome)> = events
+        .iter()
+        .filter_map(|e| match e {
+            TraceEvent::SelectionCandidateEvaluated { name, outcome, .. } => {
+                Some((name.as_str(), *outcome))
+            }
+            _ => None,
+        })
+        .collect();
+    let names: Vec<&str> = rows.iter().map(|(n, _)| *n).collect();
+    assert_eq!(
+        names, EXPECTED_ORDER,
+        "the scoreboard must emit one row per candidate SLOT, in canonical order — \
+         a missing row means a candidate became unobservable, and a reordered one \
+         means every recorded verdict is attributed to the wrong candidate"
+    );
+
+    let decided: Vec<(&str, SelectionStage)> = events
+        .iter()
+        .filter_map(|e| match e {
+            TraceEvent::SelectionDecided { winner, stage } => Some((winner.as_str(), *stage)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        decided.len(),
+        1,
+        "exactly one selection must terminate for this fixture; got {decided:?}"
+    );
+
+    let last_row = events
+        .iter()
+        .rposition(|e| matches!(e, TraceEvent::SelectionCandidateEvaluated { .. }))
+        .expect("rows asserted present above");
+    let terminal = events
+        .iter()
+        .position(|e| matches!(e, TraceEvent::SelectionDecided { .. }))
+        .expect("terminal asserted present above");
+    assert!(
+        last_row < terminal,
+        "all rows must precede their `SelectionDecided` — the census pairs a block \
+         to its verdict by flushing on the terminal event, so emitting a row after \
+         it would silently regroup the table"
+    );
+
+    // --- the winner is one of this block's own rows, and it produced ---
+    let (winner, stage) = decided[0];
+    let winner_row = rows
+        .iter()
+        .find(|(n, _)| *n == winner)
+        .unwrap_or_else(|| panic!("winner `{winner}` is not among the emitted rows {names:?}"));
+    assert_eq!(
+        winner_row.1,
+        SelectionCandidateOutcome::Produced,
+        "the winner's own row must say it produced a layout"
+    );
+
+    // --- `from_run`'s outcome deduction, across two live variants ---
+    let outcome_of = |name: &str| {
+        rows.iter().find(|(n, _)| *n == name).unwrap_or_else(|| panic!("no row for {name}")).1
+    };
+    assert_eq!(
+        outcome_of("cell-composed"),
+        SelectionCandidateOutcome::Produced,
+        "cell-composition is a live candidate under `LayoutOptions::default()` \
+         (`cell_composition: Candidate`) and produces on this chain-eligible fixture; \
+         if this flips, the candidate FIELD changed, and the stage assertion below \
+         will move with it"
+    );
+    assert_eq!(
+        outcome_of("k1-shape-fix"),
+        SelectionCandidateOutcome::NotRun,
+        "k1-shape-fix is gated on PartitionedDecomposed + an unaccepted native, \
+         neither true here — `not-run` and `refused` are different facts and must \
+         not collapse"
+    );
+
+    // --- the deciding stage ---
+    assert_eq!(winner, "native", "native must win this clean tier-1 fixture; got {winner}");
+    assert_eq!(
+        stage,
+        SelectionStage::BestErrorFree,
+        "expected the error-free tier to decide: native and cell-composed both \
+         produce here, so `clean_flags` runs (its gate is `n_layouts > 1`) and the \
+         validation tier picks before `best-accepted` is reached. If this fails, \
+         read it as one of TWO different things — the stage TAGGING broke (an \
+         instrumentation bug, fix here), or the CANDIDATE SET for this fixture \
+         changed so only one candidate now produces (an engine change, in which \
+         case the expected stage is `best-accepted` and the RFC-070 Phase-0 \
+         baseline needs re-taking). The `cell-composed` assertion above \
+         discriminates between them."
     );
 }

--- a/crates/core/tests/check_firing_census.rs
+++ b/crates/core/tests/check_firing_census.rs
@@ -40,8 +40,8 @@ use spaghettio_core::bus::layout::{self, LayoutOptions, LayoutStrategy};
 use spaghettio_core::models::LayoutResult;
 use spaghettio_core::{solver, validate};
 
-/// A structural signature of a built layout's entities — name/x/y/
-/// direction/recipe, sorted so emission order doesn't matter. Used only to
+/// A structural signature of a built layout's entities, sorted so
+/// emission order doesn't matter. Used only to
 /// detect when a variant's build is bit-identical to the same fixture's
 /// default (round 6, #686): `cells-off`/`hs-off` are gated internally
 /// (`decomposition_search.rs`'s `try_cells`/`try_horizontal`) on
@@ -50,13 +50,46 @@ use spaghettio_core::{solver, validate};
 /// silent no-op — bit-identical to default — for some or all fixtures,
 /// which would otherwise look like a genuinely evaluated, merely-quiet
 /// candidate.
-type EntitySignature = Vec<(String, i32, i32, u8, Option<String>)>;
+///
+/// Field order: name, x, y, direction, recipe, carries, mirror, rate-bits.
+/// The last three joined in as the #675 follow-up recorded on #686's
+/// closing comment, and they are NOT equally load-bearing:
+///
+/// - `carries` and `mirror` are read by the validator directly
+///   (`validate/*.rs` reads `e.carries` across nine check modules;
+///   `fluids.rs` passes `e.mirror` into `fluid_ports`), so two layouts
+///   differing only there genuinely validate differently — omitting them
+///   let "bit-identical" mean less than it claimed.
+/// - `rate` is NOT read by any validator or engine decision
+///   (`docs/rate-stamp-semantics.md`; the `PlacedEntity::rate` doc says so
+///   outright, and the round-7 review's claim that `belt_flow` reads it
+///   is wrong — those sites read `ItemFlow::rate` off the solver). It is
+///   in the signature anyway because a differing stamp means the pipeline
+///   made a different lane-family decision on the way to the same tiles,
+///   which is worth not calling "identical" — a provenance difference,
+///   not a validation-visible one.
+///
+/// `f64` has no `Ord`, so the rate travels as `to_bits`: exact equality
+/// is all this needs, and the sort only wants a total order, not a
+/// numerically meaningful one.
+type EntitySignature = Vec<(String, i32, i32, u8, Option<String>, Option<String>, bool, Option<u64>)>;
 
 fn layout_signature(l: &LayoutResult) -> EntitySignature {
     let mut sig: Vec<_> = l
         .entities
         .iter()
-        .map(|e| (e.name.clone(), e.x, e.y, e.direction as u8, e.recipe.clone()))
+        .map(|e| {
+            (
+                e.name.clone(),
+                e.x,
+                e.y,
+                e.direction as u8,
+                e.recipe.clone(),
+                e.carries.clone(),
+                e.mirror,
+                e.rate.map(f64::to_bits),
+            )
+        })
         .collect();
     sig.sort();
     sig
@@ -175,27 +208,34 @@ impl CatRow {
     }
 }
 
+/// The hardcoded tier-ladder slice both diagnostics in this file run
+/// over. Shared so the check-firing census and the RFC-070 selection
+/// scoreboard describe THE SAME six solves — a scoreboard taken over a
+/// different fixture set could not be read against the census rows.
+/// Fields: item, rate, machine, external inputs.
+const FIXTURES: &[(&str, f64, &str, &[&str])] = &[
+    ("iron-gear-wheel", 10.0, "assembling-machine-1", &["iron-plate"]),
+    ("electronic-circuit", 10.0, "assembling-machine-1", &["iron-ore", "copper-ore"]),
+    ("electronic-circuit", 30.0, "assembling-machine-2", &["iron-ore", "copper-ore"]),
+    ("plastic-bar", 5.0, "chemical-plant", &["coal", "water", "crude-oil"]),
+    (
+        "advanced-circuit",
+        5.0,
+        "assembling-machine-2",
+        &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+    ),
+    (
+        "processing-unit",
+        2.0,
+        "assembling-machine-3",
+        &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+    ),
+];
+
 #[test]
 #[ignore = "G2 diagnostic census — run with --ignored --nocapture"]
 fn check_firing_census() {
-    let fixtures: &[(&str, f64, &str, &[&str])] = &[
-        ("iron-gear-wheel", 10.0, "assembling-machine-1", &["iron-plate"]),
-        ("electronic-circuit", 10.0, "assembling-machine-1", &["iron-ore", "copper-ore"]),
-        ("electronic-circuit", 30.0, "assembling-machine-2", &["iron-ore", "copper-ore"]),
-        ("plastic-bar", 5.0, "chemical-plant", &["coal", "water", "crude-oil"]),
-        (
-            "advanced-circuit",
-            5.0,
-            "assembling-machine-2",
-            &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
-        ),
-        (
-            "processing-unit",
-            2.0,
-            "assembling-machine-3",
-            &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
-        ),
-    ];
+    let fixtures = FIXTURES;
     // Third field: `native_adjacent` — is this a shape the native
     // `Candidate`-mode search evaluates as one of its own baseline/
     // competing arms (round 3's receipts: decomposition_search.rs's
@@ -234,9 +274,20 @@ fn check_firing_census() {
     // `try_horizontal`'s DualInput-row requirement — decomposition_
     // search.rs), so a variant can be bit-identical to default for some or
     // all fixtures without that being visible anywhere in the table above.
-    // Per-variant: how many non-default builds succeeded, and how many of
-    // those were structurally identical to that SAME fixture's default.
-    let mut nondefault_builds: FxHashMap<&'static str, usize> = FxHashMap::default();
+    // Per-variant: how many non-default builds were COMPARABLE (their
+    // fixture's own default also built), and how many of those were
+    // structurally identical to it.
+    //
+    // #675 follow-up (round-7 minor, recorded on #686's closing comment):
+    // the denominator used to count every successful non-default build,
+    // including ones from fixtures whose default REFUSED. Those can never
+    // be flagged identical — there is nothing to compare against, and the
+    // code scores "unknown" as "not identical" — so they silently pushed
+    // the printed ratio toward 0/N and invited a skimmer to read a real
+    // difference where there was only a missing baseline. Non-comparable
+    // builds are counted separately and printed as their own column.
+    let mut comparable_builds: FxHashMap<&'static str, usize> = FxHashMap::default();
+    let mut noncomparable_builds: FxHashMap<&'static str, usize> = FxHashMap::default();
     let mut noop_count: FxHashMap<&'static str, usize> = FxHashMap::default();
 
     for &(item, rate, machine, inputs) in fixtures {
@@ -270,10 +321,18 @@ fn check_firing_census() {
                 defaults_built.insert(fixture_key.clone());
                 default_sig = Some(layout_signature(&l));
             } else {
-                *nondefault_builds.entry(*vname).or_insert(0) += 1;
-                let is_noop = default_sig.as_ref().is_some_and(|d| *d == layout_signature(&l));
-                if is_noop {
-                    *noop_count.entry(*vname).or_insert(0) += 1;
+                match default_sig.as_ref() {
+                    Some(d) => {
+                        *comparable_builds.entry(*vname).or_insert(0) += 1;
+                        if *d == layout_signature(&l) {
+                            *noop_count.entry(*vname).or_insert(0) += 1;
+                        }
+                    }
+                    // This fixture's default refused (or the variant order
+                    // ever changes so default isn't first): no baseline,
+                    // so this build is not evidence either way and stays
+                    // out of the ratio.
+                    None => *noncomparable_builds.entry(*vname).or_insert(0) += 1,
                 }
             }
             let issues = match validate::validate(&l, Some(&sr)) {
@@ -363,11 +422,20 @@ fn check_firing_census() {
         "\n=== per-variant no-op check (bit-identical entities vs that \
          fixture's own default; round 6, #686) ==="
     );
+    println!(
+        "  (denominator counts COMPARABLE builds only — a build whose \
+         fixture's own default refused has no baseline and is reported \
+         separately, never as a difference; #675 follow-up)"
+    );
     for &(vname, _, native_adjacent) in variants.iter().filter(|t| t.0 != "default") {
-        let total = nondefault_builds.get(vname).copied().unwrap_or(0);
+        let total = comparable_builds.get(vname).copied().unwrap_or(0);
         let noop = noop_count.get(vname).copied().unwrap_or(0);
+        let uncomparable = noncomparable_builds.get(vname).copied().unwrap_or(0);
         let tag = if native_adjacent { "native-adjacent" } else { "user-elected" };
-        println!("  {vname:<12} {noop}/{total} builds identical to default  ({tag})");
+        println!(
+            "  {vname:<12} {noop}/{total} comparable builds identical to default \
+             (+{uncomparable} with no default to compare)  ({tag})"
+        );
     }
     println!(
         "\nInterpretation: `loser-only`/`err-loser` are computed per \
@@ -411,6 +479,220 @@ fn check_firing_census() {
          apply before concluding a quiet category is inert). A firing on \
          a variant identical to default carries no selection evidence, \
          and a variant that is no-op across all fixtures measures \
-         nothing here — see the per-variant no-op check above."
+         nothing here — see the per-variant no-op check above. That rule \
+         is enforced by the PAIRING, not by the no-op flag: a genuinely \
+         identical variant validates identically, so its firings also \
+         land on the same fixture's default side and cannot set either \
+         flag. The flag is a label on the table, and the signature it \
+         rests on now covers carries/mirror/rate so the label is worth \
+         roughly what it claims."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RFC-070 Phase 0b (#689 W1b): the selection scoreboard
+// ---------------------------------------------------------------------------
+
+/// Render `select_best_decomposition`'s own scoreboard for each fixture:
+/// which of the seven candidates were evaluated, what each of the THREE
+/// verdict mechanisms said about them, who won, and which precedence
+/// stage did the deciding.
+///
+/// Relationship to the census above: same fixtures, opposite direction.
+/// The census approximates the candidate field from OUTSIDE, by
+/// re-running the whole pipeline under option toggles (its stated v1
+/// scope: "k1-shape-fix and size-split members only exist inside
+/// `select_best_decomposition` and are not re-enacted here"). This one
+/// reads the real internal loop, once, under DEFAULT options — the
+/// production configuration, not a toggled one — and reports what it
+/// actually did. It therefore closes the census's "which candidate" gap
+/// while saying nothing about categories, and the census still closes
+/// the "which categories fire" gap this says nothing about.
+///
+/// What it CANNOT show, by construction: the instrumentation records only
+/// what the decision path already computed, never a fresh `validate()`
+/// call. A candidate that no comparison mechanism needed carries no issue
+/// counts at all, and those blanks print as `-`. A `-` is "nothing
+/// computed this", NOT "zero" — reading it as zero is the `unwrap_or(0)`
+/// mistake this instrument exists to avoid making at scale.
+///
+/// Run: cargo test --test check_firing_census -- --ignored --nocapture
+#[test]
+#[ignore = "RFC-070 Phase 0b diagnostic — run with --ignored --nocapture"]
+fn selection_scoreboard_census() {
+    use spaghettio_core::trace::{self, SelectionCandidateOutcome, SelectionStage, TraceEvent};
+
+    fn outcome_name(o: SelectionCandidateOutcome) -> &'static str {
+        // Exhaustive on purpose: the enum is closed, so a new outcome
+        // fails to compile here rather than printing as something else.
+        match o {
+            SelectionCandidateOutcome::Produced => "produced",
+            SelectionCandidateOutcome::Refused => "refused",
+            SelectionCandidateOutcome::Panicked => "PANICKED",
+            SelectionCandidateOutcome::NotRun => "not-run",
+        }
+    }
+
+    fn stage_name(s: SelectionStage) -> &'static str {
+        match s {
+            SelectionStage::MergeTap => "merge-tap",
+            SelectionStage::ScopedPairwise => "scoped-pairwise",
+            SelectionStage::BestErrorFree => "best-error-free",
+            SelectionStage::BestAccepted => "best-accepted",
+            SelectionStage::FirstProduced => "first-produced",
+        }
+    }
+
+    println!("\n=== RFC-070 selection scoreboard (default options, one build per fixture) ===");
+    println!(
+        "(err/selw/laww are the counts the DECISION computed, sourced in \
+         the `from` column; `-` means no mechanism computed one — a gap, \
+         not a zero)"
+    );
+
+    let mut stage_tally: Vec<(String, String, String)> = Vec::new();
+    for &(item, rate, machine, inputs) in FIXTURES {
+        let input_set: FxHashSet<String> = inputs.iter().map(|s| s.to_string()).collect();
+        let fixture_key = format!("{item}@{rate}:{machine}");
+        let Ok(sr) = solver::solve(item, rate, &input_set, machine) else {
+            println!("\n-- {fixture_key}\n   SKIP (no solve)");
+            continue;
+        };
+        // Collect this fixture's whole event stream, then walk it. The
+        // guard must outlive the drain.
+        let guard = trace::start_trace();
+        let built = layout::build_bus_layout(&sr, LayoutOptions::default());
+        let events = trace::drain_events();
+        drop(guard);
+
+        println!("\n-- {fixture_key}");
+        if let Err(e) = &built {
+            println!("   build REFUSED: {e}");
+        }
+
+        // Pair candidates with their terminal event by flushing on
+        // `SelectionDecided`. A candidate's `produce` can run its own
+        // nested selection (cell composition builds per-cell layouts),
+        // and each such block is contiguous and complete, so this
+        // separates them instead of merging them into the outer one.
+        let mut blocks: Vec<(Vec<&TraceEvent>, Option<(&str, SelectionStage)>)> = Vec::new();
+        let mut pending: Vec<&TraceEvent> = Vec::new();
+        for ev in &events {
+            match ev {
+                TraceEvent::SelectionCandidateEvaluated { .. } => pending.push(ev),
+                TraceEvent::SelectionDecided { winner, stage } => {
+                    blocks.push((std::mem::take(&mut pending), Some((winner.as_str(), *stage))));
+                }
+                _ => {}
+            }
+        }
+        if !pending.is_empty() {
+            // Candidates with no terminal event: the all-refused path.
+            blocks.push((pending, None));
+        }
+        if blocks.is_empty() {
+            println!("   (no selection events — build never reached the search)");
+            continue;
+        }
+
+        for (n, (rows, decided)) in blocks.iter().enumerate() {
+            if blocks.len() > 1 {
+                // More than one selection ran for this fixture: an inner
+                // one belongs to a candidate whose `produce` recursed.
+                println!(
+                    "   [selection {}/{} — a nested block comes from a \
+                     candidate's own search]",
+                    n + 1,
+                    blocks.len()
+                );
+            }
+            println!(
+                "   {:<18} {:<9} {:>9} {:>4} {:>5} {:>5} {:>5}  {:<21} {:<9} {}",
+                "candidate", "outcome", "score", "acc", "err", "selw", "laww", "from", "kinds",
+                "reason"
+            );
+            for ev in rows {
+                let TraceEvent::SelectionCandidateEvaluated {
+                    name,
+                    outcome,
+                    reason,
+                    score,
+                    accepted,
+                    errors,
+                    selection_warnings,
+                    layout_warnings,
+                    counts_source,
+                    contamination_errors,
+                    starvation_errors,
+                    structural_errors,
+                    ..
+                } = ev
+                else {
+                    continue;
+                };
+                let num = |v: &Option<usize>| v.map_or("-".to_string(), |n| n.to_string());
+                let kinds = match (contamination_errors, starvation_errors, structural_errors) {
+                    (Some(c), Some(s), Some(x)) => format!("c{c}/s{s}/x{x}"),
+                    _ => "-".to_string(),
+                };
+                let won = decided.is_some_and(|(w, _)| w == name);
+                println!(
+                    "  {}{:<18} {:<9} {:>9} {:>4} {:>5} {:>5} {:>5}  {:<21} {:<9} {}",
+                    if won { "*" } else { " " },
+                    name,
+                    outcome_name(*outcome),
+                    score.map_or("-".to_string(), |s| format!("{s:.4}")),
+                    accepted.map_or("-", |a| if a { "yes" } else { "no" }),
+                    num(errors),
+                    num(selection_warnings),
+                    num(layout_warnings),
+                    counts_source.as_deref().unwrap_or("-"),
+                    kinds,
+                    reason.as_deref().unwrap_or("-"),
+                );
+            }
+            match decided {
+                Some((winner, stage)) => {
+                    println!("   => winner: {winner}   deciding stage: {}", stage_name(*stage));
+                    if n == blocks.len() - 1 {
+                        // The OUTER selection is the last block: nested
+                        // ones close while the outer is still running.
+                        stage_tally.push((
+                            fixture_key.clone(),
+                            (*winner).to_string(),
+                            stage_name(*stage).to_string(),
+                        ));
+                    }
+                }
+                None => println!("   => NO WINNER (every candidate failed; see reasons above)"),
+            }
+        }
+    }
+
+    println!("\n=== outer-selection summary (one row per fixture) ===");
+    println!("{:<44} {:<18} {}", "fixture", "winner", "deciding stage");
+    for (fixture, winner, stage) in &stage_tally {
+        println!("{fixture:<44} {winner:<18} {stage}");
+    }
+    println!(
+        "\nInterpretation: the three verdict mechanisms are not \
+         commensurable and the columns must not be read as one ranking. \
+         `score`/`acc` is the soft score (`score_layout`), whose `acc` \
+         carries ONLY the missing-balancer-template hard gate and is not \
+         a validation verdict. `err`/`selw`/`laww` are the component-wise \
+         `IssueCounts` floor used by the DI and horizontal pairwise \
+         comparisons — never lexicographic, so a better `selw` does NOT \
+         buy a worse `laww`. `kinds` is the lexicographic `ErrorKinds` \
+         key, computed only by the Pooled merge-tap decision. A blank \
+         column is a candidate NO mechanism examined, and the blanks are \
+         structural rather than incidental: the merge-tap decision \
+         short-circuits the `clean_flags` tier entirely, so on a \
+         merge-tap-decided fixture neither native nor merge-tap carries \
+         issue counts at all even though both produced layouts — the \
+         kinds key is the whole of what that decision looked at, so it is \
+         the whole of what this can report. That is also why the deciding \
+         STAGE is the load-bearing column: it says which question was \
+         actually asked, where the counts only say what the answer was \
+         made of."
     );
 }

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -329,4 +329,10 @@ fixtures / docs split per the churn norm).
   inside `produce()`; the scoreboard sees one DI row, not two arms (moot
   under the default `Upstream`). (f) The scoreboard is per selection
   CALL — a candidate whose `produce` runs its own search emits its own
-  block; none occurred on the census slice.*
+  block; none occurred on the census slice. (g) …and only the WINNER's
+  nested blocks survive at all: `run_candidate` truncates each
+  candidate's events out of the collector and replays only the winner's,
+  so a LOSING candidate's inner selection is dropped before any reader
+  sees it. Absence of a nested block is not evidence that none ran — a
+  shadow-loop diff assuming otherwise would be comparing against a stream
+  the production loop deliberately edits.*

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -279,3 +279,54 @@ fixtures / docs split per the churn norm).
   gen-1 runs; shadow's 2× cost excluded by construction); (d) the
   parity corpus is a named Phase-0c deliverable, not an assumption;
   (e) line-anchor nits fixed with an as-of note.*
+- *2026-08-21 — **Phase 0b landed** (#689 track W1b): two trace events —
+  `SelectionCandidateEvaluated`, one per candidate SLOT (all seven, every
+  call, including the ones a gate excluded before they cost a layout
+  pass) and `SelectionDecided` (winner + deciding stage). Design call,
+  and the one the later phases depend on: the events **record what each
+  verdict mechanism already computed at its own site, and never
+  recompute**. A scoreboard that re-ran `validate()` on the side could
+  disagree with the number the decision actually used, and Phase 2a
+  diffs the shadow loop against these records — an oracle that disagrees
+  with the thing it is oracling is worse than none. The price is
+  structural holes (below); Phase 1b's offline policy replay must treat
+  a missing count as "nothing computed this", never as zero.*
+- *2026-08-21 — **the precedence chain is named as FIVE stages**, where
+  Motivation above calls it four. The first `.or()` link answers with two
+  different mechanisms: merge-tap's `ErrorKinds::quality_key` verdict
+  (which can name merge-tap OR native) and the DI/horizontal pairwise
+  `IssueCounts` resolution that may displace it. Collapsing them into one
+  tag would lose which question was asked, which is the column K70-1
+  turns on. Measured over the #686 census slice (six fixtures, default
+  options): `best-error-free` ×4, `merge-tap` ×1, `scoped-pairwise` ×1;
+  `best-accepted` and `first-produced` never fired. Note that
+  `best-accepted` — the "generic soft score" mechanism the Summary
+  treats as one of the three — decided **nothing** on this slice; if
+  Phase 0c's wider corpus repeats that, the soft score's real role is
+  the `accepted` hard gate, not the ranking.*
+- *2026-08-21 — **Phase-0b oracle gaps**, recorded so no later phase
+  assumes the baseline says more than it does. (a) Issue counts exist
+  only where a comparison needed them: a merge-tap-decided selection
+  short-circuits the `clean_flags` tier entirely, so on such a fixture
+  neither native nor merge-tap carries ANY `IssueCounts` — the kinds key
+  is all that decision looked at. Likewise a scoped-pairwise-decided
+  selection leaves every non-participant countless. (b) `ErrorKinds` is
+  computed only by the merge-tap decision, so no candidate on a
+  non-Pooled or native-clean solve has one. (c) A `not-run` row has no
+  reason: the gates (`try_cells` / `try_di` / `try_horizontal` /
+  `try_k1_shape_fix` / `try_size_split` / `try_merge_tap`) are
+  conjunctions of booleans at the call site, so the scoreboard can say a
+  candidate was not tried but not WHICH conjunct excluded it — Phase 1b's
+  uniform loop should make the gate a first-class reportable predicate.
+  (d) **The refusal-attribution gap #686 named is NOT closed**: DI,
+  horizontal-stack and cell-composed stringify their own validation
+  failure as `e.to_string().lines().next()`, which yields
+  "…failed validation: Validation failed:" and discards the issue list
+  before anything can record it. Which CATEGORIES fire inside a
+  self-refused candidate therefore remains invisible; recovering it means
+  changing what `produce()` keeps, which is not additive and was kept out
+  of 0b. (e) DI's internal `DiClaimOrder::Search` two-arm race lives
+  inside `produce()`; the scoreboard sees one DI row, not two arms (moot
+  under the default `Upstream`). (f) The scoreboard is per selection
+  CALL — a candidate whose `produce` runs its own search emits its own
+  block; none occurred on the census slice.*

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -407,3 +407,32 @@ fixtures / docs split per the churn norm).
   run). Dropping `rate` was the alternative and was rejected: it would make
   the label mean less while matching neither the recorded #675 follow-up nor
   the provenance question the counter exists to answer.*
+- *2026-08-21 — **#692 review round 3 adjudicated** (6 minors, no majors;
+  closing round). Absorbed: the all-refused message's refusal reasons now come
+  from the checked `run_refs`/`CANDIDATE_ORDER` pair instead of a hand-typed
+  7-slot tuple zipped positionally against candidate names — the same
+  misattribution class round 2 retired elsewhere, and the last positional
+  literal in the function; the two alignment checks became `debug_assert_eq!`,
+  so the tripwire fires in every debug build (which is what `cargo test` and
+  CI run — coverage unchanged) while release and WASM cannot panic a browser
+  solve over a code-level ordering mistake, restoring the degradation
+  philosophy the `catch_unwind` arms twenty lines away already follow; the
+  contract test's `decided.len()`, row-order and event-order assertions now
+  each name BOTH readings of a failure (engine legitimately changed vs.
+  instrumentation broke) and say which sibling assertion discriminates,
+  extending what the stage assertion already did; the no-op denominator
+  header now states that "+N with no default" counts SUCCESSFUL builds
+  lacking a baseline and that a variant's own refusals never reach that tally
+  (they are in the refusals summary), so it cannot be read as "all builds with
+  a failing default"; and a doc said `count_issues` runs at five sites when it
+  runs at six. Adjudicated as designed, no code change: a single scoreboard row
+  can carry counts sourced to one mechanism and kinds to another — that is what
+  a per-candidate summary across three mechanisms IS, and the decision
+  authority is `SelectionDecided::stage`, which the row does not duplicate; one
+  clarifying sentence added at the field doc. Incidental finding, NOT fixed and
+  out of scope: `ghost_occupancy::is_claimed` is dead code in RELEASE builds
+  because its only non-test uses are inside `debug_assert!`s in
+  `ghost_router.rs` — pre-existing, and invisible to CI because the clippy job
+  is debug-only. It surfaced here because the same hazard applied to
+  `CANDIDATE_ORDER`, which is why the refusal message now uses it for real
+  rather than only inside assertions.*

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -367,3 +367,43 @@ fixtures / docs split per the churn norm).
   sees it. Absence of a nested block is not evidence that none ran — a
   shadow-loop diff assuming otherwise would be comparing against a stream
   the production loop deliberately edits.*
+- *2026-08-21 — **#692 review round 2 adjudicated** (7 findings). Absorbed:
+  (a) the Phase-0b oracle had NO CI assertion coverage — everything was
+  `#[ignore]`d, so a broken stage tag or a dropped row shipped green. Added
+  `selection_scoreboard_contract`, a non-ignored test pinning the contract
+  (every slot emits a row, canonical order, rows before the terminal event,
+  winner ∈ its own block's rows, `not-run` ≠ `refused`, and the fixture's
+  deciding stage). **Discrimination check executed, not assumed**: mis-tagging
+  the error-free stage, dropping the `native` row, and swapping two runs in
+  the index list each made it fail with a message naming the right cause;
+  restored and re-verified green. (b) The four hand-maintained same-order
+  candidate lists are now one: `CandidateRun` carries its own name, a
+  `CANDIDATE_ORDER` const is the single source, and `Scoreboard::from_runs`
+  plus a `candidates` post-check assert each run's own name against its slot,
+  so a reorder panics instead of recording one candidate's verdicts against
+  another's row. (c) The census's nested-block banner no longer labels the
+  OUTER block, and the block walker now checks that a winner is among its own
+  block's rows, printing a loud marker if not. Refuted with receipts:
+  (d) "the failure path emits with the sink detached" — the sink is
+  re-attached at `decomposition_search.rs:1604` and the failure-path
+  `board.emit()` is at `:1814`, 210 lines later with no intervening
+  `swap_sink`; failure-path rows reach a streaming consumer exactly like
+  success-path ones, so no doc note was added for a behaviour that does not
+  exist. (e) "the e2e cells-off gap is left unfixed" — correct and
+  deliberate, recorded in the entry above and on #689.*
+- *2026-08-21 — **`PlacedEntity::rate` is NOT validator-visible; the no-op
+  label is redefined accordingly.** Two reviews claimed opposite things, so
+  it was settled by count: all 21 `.rate` reads across `validate/` and
+  `connectivity.rs` are on solver `ItemFlow`s, none on a `PlacedEntity`, and
+  the three `belt_flow.rs` lines #686 round 7 cited as proof read `e.carries`,
+  `e.carries` and `build_ug_pairs`. #686's adjudication was therefore wrong
+  about `rate` (right about `carries`). Decision: KEEP `rate` in
+  `EntitySignature` — a differing stamp means a different lane-family decision
+  reached the same tiles, which is worth not calling identical — and redefine
+  the label at every site that states it: **a no-op is "tiles AND stamps
+  identical", not "validator-identical"**. That is a strictly stricter test,
+  so it can only under-report no-ops, never over-report them; measured, it
+  changes nothing on the current slice (ratios identical to the pre-`rate`
+  run). Dropping `rate` was the alternative and was rejected: it would make
+  the label mean less while matching neither the recorded #675 follow-up nor
+  the provenance question the counter exists to answer.*

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -326,8 +326,10 @@ fixtures / docs split per the churn norm).
   self-refused candidate therefore remains invisible; recovering it means
   changing what `produce()` keeps, which is not additive and was kept out
   of 0b. (e) DI's internal `DiClaimOrder::Search` two-arm race lives
-  inside `produce()`; the scoreboard sees one DI row, not two arms (moot
-  under the default `Upstream`). (f) The scoreboard is per selection
+  inside `produce()`; the scoreboard sees one DI row, not two arms —
+  moot under the default, which is `Downstream` (checking this turned up
+  a stale in-code comment claiming the default was `Upstream`, corrected
+  in the same PR; RFC-059's sim close-out had flipped it). (f) The scoreboard is per selection
   CALL — a candidate whose `produce` runs its own search emits its own
   block; none occurred on the census slice. (g) …and only the WINNER's
   nested blocks survive at all: `run_candidate` truncates each

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -299,11 +299,32 @@ fixtures / docs split per the churn norm).
   tag would lose which question was asked, which is the column K70-1
   turns on. Measured over the #686 census slice (six fixtures, default
   options): `best-error-free` ×4, `merge-tap` ×1, `scoped-pairwise` ×1;
-  `best-accepted` and `first-produced` never fired. Note that
-  `best-accepted` — the "generic soft score" mechanism the Summary
-  treats as one of the three — decided **nothing** on this slice; if
-  Phase 0c's wider corpus repeats that, the soft score's real role is
-  the `accepted` hard gate, not the ranking.*
+  `best-accepted` and `first-produced` never fired **on that slice** —
+  see the next entry, which found `best-accepted` deciding as soon as the
+  option set changes. The stage distribution is a function of the OPTIONS,
+  not just the fixture.*
+- *2026-08-21 — **the e2e harness does not run production's candidate
+  set**, found by decoding a `tier1_iron_gear_wheel` snapshot and getting
+  a different deciding stage than the census reported for the same
+  fixture (`best-accepted` vs `best-error-free`). Cause:
+  `LayoutOptions::default()` sets `cell_composition: Candidate`
+  (`bus/layout.rs:241`), but `run_e2e` spells the field explicitly as
+  `cell_composition: Default::default()` (`tests/e2e.rs:355`) — the
+  ENUM's default, which is `Off` (`bus/cells/mod.rs:24`) — next to a
+  `..Default::default()` that would have given `Candidate`. The line
+  dates to RFC-051 Phase A when Off WAS the struct default (`5090da99`);
+  Phase B flipped the struct and the harness kept resolving to the enum.
+  Consequence for the mechanism: with cells off, only native produces,
+  `clean_flags` is skipped by its own `n_layouts > 1` guard, the
+  error-free tier is empty, and `best-accepted` decides — which is why
+  the whole e2e suite exercises a stage the census slice never reaches.
+  **Not fixed here**: flipping it changes the candidate set under every
+  regression test, i.e. a selection change, which is a campaign call and
+  not an additive Phase-0b one. Two obligations fall out: (1) the
+  Phase-0c parity corpus must be defined over fixture × MACHINE TIER ×
+  OPTION SET, since "same fixture" does not pin the candidate field; (2)
+  suite greenness is not evidence about the cell-composed arm, whose
+  production exposure the e2e corpus does not cover at all.*
 - *2026-08-21 — **Phase-0b oracle gaps**, recorded so no later phase
   assumes the baseline says more than it does. (a) Issue counts exist
   only where a comparison needed them: a merge-tap-decided selection

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -328,10 +328,18 @@ fixtures / docs split per the churn norm).
 - *2026-08-21 — **Phase-0b oracle gaps**, recorded so no later phase
   assumes the baseline says more than it does. (a) Issue counts exist
   only where a comparison needed them: a merge-tap-decided selection
-  short-circuits the `clean_flags` tier entirely, so on such a fixture
-  neither native nor merge-tap carries ANY `IssueCounts` — the kinds key
-  is all that decision looked at. Likewise a scoped-pairwise-decided
-  selection leaves every non-participant countless. (b) `ErrorKinds` is
+  short-circuits the `clean_flags` tier entirely, so the only counts such
+  a fixture can carry are whatever a scoped pairwise already computed —
+  and on `ec@30`, where DI and horizontal both refused, that is NOTHING
+  for either native or merge-tap, leaving the kinds key as the whole of
+  what that decision looked at. (Corrected after #692 review, 2/3: the
+  first wording said a merge-tap decision means no counts, full stop.
+  It does not — native's counts DO get recorded whenever DI or
+  horizontal produced, since `di_choice`/`horizontal_choice` run on the
+  produced-but-unaccepted native that merge-tap's own gate requires. The
+  `ec@30` observation was true; the generalisation from it was not.)
+  Likewise a scoped-pairwise-decided selection leaves every
+  non-participant countless. (b) `ErrorKinds` is
   computed only by the merge-tap decision, so no candidate on a
   non-Pooled or native-clean solve has one. (c) A `not-run` row has no
   reason: the gates (`try_cells` / `try_di` / `try_horizontal` /


### PR DESCRIPTION
## Intent

RFC-070 Phase 0b (campaign #689, track W1b): make `select_best_decomposition`'s
own verdicts observable. The RFC names the Phase-0 baseline as the oracle every
later phase diffs against — "per corpus fixture: candidate set, per-candidate
verdicts under each mechanism, winner, and *which precedence-chain stage decided
it*" — and today the trace stream says only which name won. This adds the events
and renders them.

## Scope

- **In:** two trace events (`SelectionCandidateEvaluated`, `SelectionDecided`)
  plus the recording plumbing at each existing decision site; a
  `selection_scoreboard_census` diagnostic beside #686's check-firing census;
  `selection_scoreboard_contract`, a NON-ignored CI test pinning the oracle's
  contract (review round 2), and the single-source `CANDIDATE_ORDER` with
  construction-time alignment asserts that back it;
  the two #675 follow-ups recorded on #686's closing comment
  (`layout_signature` enrichment, no-op denominator); RFC decision-log entries.
- **Out:** Phase 0c — the committed baseline data, the machine-tier axis
  widening, the named parity corpus. This PR builds the instrument and runs it
  once; freezing a baseline belongs with the corpus definition, not ahead of it.
- **Out:** closing the refusal-attribution gap. `produce()` stringifies its own
  validation failure as `e.to_string().lines().next()` and drops the issue list,
  so *which categories* fire inside a self-refused candidate is still invisible
  (#686's stated gap). Recovering it changes what production code keeps — not
  additive, so not Phase 0b.
- **Size:** 756 added lines, over the ~400 norm. ~250 of them are comment lines
  and a further large share is the two diagnostics' printed interpretation
  prose. It *is* splittable — events / census / docs — and I chose not to: the
  event field set was designed backwards from what the census needed to print,
  so landing the schema alone would ship an unexercised contract, and the census
  run below is the only receipt that the events carry what the RFC asked for.
  Judgement call, stated rather than hidden.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml --no-fail-fast` —
      **exit 0**, unpiped (redirected to a file, exit captured from the run
      itself). **1183 passed, 0 failed, 74 ignored** across 27 test binaries —
      1182 before review round 2, +1 for the new non-ignored contract test.
      Run four times across the PR's life; identical counts each time.
- [x] **The contract test discriminates** — verified by breaking the code three
      ways and watching it fail, then restoring: mis-tag the error-free stage
      (fails the stage assertion), emit `&self.0[1..]` (fails the order
      assertion), swap two runs in the index list (fails the alignment assert,
      naming slot 4).
- [x] Snapshot round-trip: `SPAGHETTIO_DUMP_SNAPSHOTS=1 … tier1_iron_gear_wheel`
      then decode — all 7 `SelectionCandidateEvaluated` rows and the
      `SelectionDecided` survive the `.fls` serde encoding. This is also where
      the e2e/production candidate-set divergence surfaced (below).
- [x] `cargo clippy --workspace -- -D warnings` (CI's exact invocation) — exit 0.
      Also `cargo clippy --test check_firing_census -- -D warnings` — exit 0
      (CI lints libs only; this is new-file hygiene).
- [x] `wasm-pack build crates/wasm-bindings --target web --out-dir "$(pwd)/web/src/wasm-pkg"`
      — exit 0. Generated TS carries both closed enums as string unions
      (`SelectionStage = "merge-tap" | … | "first-produced"`). Two TS switches
      dispatch on `evt.phase`: the streaming renderer's has a permissive
      `default`, and `junctionTrace`'s is guarded by an `isJunctionEvent` type
      predicate over a fixed phase set, so neither sees a new variant. Nothing
      builds an exhaustive `Record` over the phase union. (`tsc` itself was not
      run — `web/node_modules` is not installed in this worktree; CI's web job
      covers it.)
- [x] Both diagnostics run under
      `SPAGHETTIO_ZONE_CACHE_PATH=crates/core/data/sat-zones-ci.bin`; the pin
      file is untouched in every commit (`git status` clean after each run).
- [ ] Browser eyeball — N/A, no geometry change.

**Byte-identity evidence** (the property this PR rests on). The full suite is
green untouched, including the selection pins that would catch a precedence
change — `merge_tap_does_not_shadow_di_on_pooled_yellow`,
`decomposition_search_picks_native_on_clean_partitioned_case`,
`cell_candidate_resolves_ec15_refusal` — and every golden hash. Independently:
the check-firing census's category table over 36 builds is unchanged from the
#686 run (belt-flow-reachability 240, input-rate-delivery 179, belt-flow-path
60, belt-detour 33, belt-dead-end 18, row-input-belt-margin 18), which is 36
layouts' worth of validator output agreeing to the issue.

### The scoreboard (six census fixtures, default options)

```
=== RFC-070 selection scoreboard (default options, one build per fixture) ===
(err/selw/laww are the counts the DECISION computed, sourced in the `from` column; `-` means no mechanism computed one — a gap, not a zero. `reason` is produce()'s refusal text, or the accepted=no tag for a candidate that built but failed the hard gate.)

-- iron-gear-wheel@10:assembling-machine-1
   candidate          outcome       score  acc   err  selw  laww  from                  kinds     reason
  *native             produced     0.1518  yes     0     0     0  clean-flags           -         -
   k1-shape-fix       not-run           -    -     -     -     -  -                     -         -
   size-split-2       not-run           -    -     -     -     -  -                     -         -
   merge-tap          not-run           -    -     -     -     -  -                     -         -
   cell-composed      produced     0.1472  yes     0     0     1  clean-flags           -         -
   direct-insertion   not-run           -    -     -     -     -  -                     -         -
   horizontal-stack   not-run           -    -     -     -     -  -                     -         -
   => winner: native   deciding stage: best-error-free

-- electronic-circuit@10:assembling-machine-1
   candidate          outcome       score  acc   err  selw  laww  from                  kinds     reason
   native             refused           -    -     -     -     -  -                     -         lane-aware delivery: item copper-cable rate 30.00/s exceeds per-lane capacity 22.50/s on a sideload-fed single trunk (2 producers, no balancer)
   k1-shape-fix       not-run           -    -     -     -     -  -                     -         -
   size-split-2       not-run           -    -     -     -     -  -                     -         -
   merge-tap          not-run           -    -     -     -     -  -                     -         -
   cell-composed      produced    -0.0442  yes     0     0     1  clean-flags           -         -
  *direct-insertion   produced     0.0368  yes     0     0     0  clean-flags           -         -
   horizontal-stack   produced     0.1273  yes     0     1     0  clean-flags           -         -
   => winner: direct-insertion   deciding stage: best-error-free

-- electronic-circuit@30:assembling-machine-2
   candidate          outcome       score  acc   err  selw  laww  from                  kinds     reason
  *native             produced    -0.1334   no     -     -     -  -                     c0/s3/x0  1 missing-balancer-template warning(s)
   k1-shape-fix       not-run           -    -     -     -     -  -                     -         -
   size-split-2       not-run           -    -     -     -     -  -                     -         -
   merge-tap          produced    -0.1378  yes     -     -     -  -                     c0/s65/x0 -
   cell-composed      refused           -    -     -     -     -  -                     -         cells: copper-cable has 2 in-ports for copper-plate across 2 rows (multi-row corridor fan not implemented, #433)
   direct-insertion   refused           -    -     -     -     -  -                     -         direct insertion failed validation: Validation failed:
   horizontal-stack   refused           -    -     -     -     -  -                     -         horizontal-stack failed validation: Validation failed:
   => winner: native   deciding stage: merge-tap

-- plastic-bar@5:chemical-plant
   candidate          outcome       score  acc   err  selw  laww  from                  kinds     reason
  *native             produced     0.2624  yes     0     0     0  clean-flags           -         -
   k1-shape-fix       not-run           -    -     -     -     -  -                     -         -
   size-split-2       not-run           -    -     -     -     -  -                     -         -
   merge-tap          not-run           -    -     -     -     -  -                     -         -
   cell-composed      produced     0.1597  yes     0     0     1  clean-flags           -         -
   direct-insertion   not-run           -    -     -     -     -  -                     -         -
   horizontal-stack   not-run           -    -     -     -     -  -                     -         -
   => winner: native   deciding stage: best-error-free

-- advanced-circuit@5:assembling-machine-2
   candidate          outcome       score  acc   err  selw  laww  from                  kinds     reason
   native             produced    -0.0279  yes     0     2     0  di-vs-native          -         -
   k1-shape-fix       not-run           -    -     -     -     -  -                     -         -
   size-split-2       not-run           -    -     -     -     -  -                     -         -
   merge-tap          not-run           -    -     -     -     -  -                     -         -
   cell-composed      produced    -0.2549  yes     -     -     -  -                     -         -
   direct-insertion   produced    -0.0279  yes     0     2     0  di-vs-native          -         -
  *horizontal-stack   produced    -0.0283  yes     0     0     0  horizontal-vs-native  -         -
   => winner: horizontal-stack   deciding stage: scoped-pairwise

-- processing-unit@2:assembling-machine-3
   candidate          outcome       score  acc   err  selw  laww  from                  kinds     reason
  *native             produced    -0.3878  yes     0     7     0  di-vs-native          -         -
   k1-shape-fix       not-run           -    -     -     -     -  -                     -         -
   size-split-2       not-run           -    -     -     -     -  -                     -         -
   merge-tap          not-run           -    -     -     -     -  -                     -         -
   cell-composed      produced    -1.3728  yes     0     0     1  clean-flags           -         -
   direct-insertion   produced    -0.3878  yes     0     7     0  di-vs-native          -         -
   horizontal-stack   produced    -0.3645  yes     0    12     0  horizontal-vs-native  -         -
   => winner: native   deciding stage: best-error-free

=== outer-selection summary (one row per fixture) ===
fixture                                      winner             deciding stage
iron-gear-wheel@10:assembling-machine-1      native             best-error-free
electronic-circuit@10:assembling-machine-1   direct-insertion   best-error-free
electronic-circuit@30:assembling-machine-2   native             merge-tap
plastic-bar@5:chemical-plant                 native             best-error-free
advanced-circuit@5:assembling-machine-2      horizontal-stack   scoped-pairwise
processing-unit@2:assembling-machine-3       native             best-error-free
```

Three of the five stages fire on this slice. **`best-accepted` decides nothing**
— the generic soft score, one of the three mechanisms the RFC's Summary names,
never picked a winner here; its live role was the `accepted` hard gate
(`ec@30` native, `acc=no`). Worth re-checking at Phase 0c's wider corpus before
anyone treats it as a ranking. `first-produced` also never fired.

The blanks are the other finding. A merge-tap decision short-circuits the
`clean_flags` tier, so the only counts such a fixture can carry are ones a
scoped pairwise already computed — and on `ec@30` DI and horizontal both
refused, so there are none: the kinds key (`c0/s3/x0` vs `c0/s65/x0`) is the
whole of what that decision looked at, and so the whole of what any oracle can
report about it. (The first version of this claim generalised it to every
merge-tap decision, which is wrong — native's counts do get recorded whenever
DI or horizontal produced. Caught by the review bot, 2/3.)

### No-op check, with the enriched signature

```
  di-off       5/6 comparable builds identical to default (+0 with no default to compare)  (native-adjacent)
  di-forced    5/6 comparable builds identical to default (+0 with no default to compare)  (user-elected)
  cells-off    6/6 comparable builds identical to default (+0 with no default to compare)  (native-adjacent)
  hs-off       5/6 comparable builds identical to default (+0 with no default to compare)  (native-adjacent)
  partitioned  4/6 comparable builds identical to default (+0 with no default to compare)  (user-elected)
```

Identical ratios to #686's round-6 run, and zero non-comparable builds — **both
follow-ups are measurably inert on this fixture set**. No layout here differs
from its default only in `carries`/`mirror`/`rate`, and no fixture's default
refused. They harden the instrument for a future run, exactly like the
`defaults_built` guard before them. Said plainly rather than presented as a fix
that fixed something.

## Deviations from intent

- **Five stages, not four.** The RFC's Motivation calls the precedence chain
  four-stage; the scoreboard names five. The first `.or()` link answers with two
  different mechanisms — merge-tap's `quality_key` verdict (which can name
  merge-tap *or* native) and the DI/horizontal pairwise `IssueCounts` resolution
  that may displace it — so one tag would lose which question was asked, which
  is the column K70-1 turns on. Recorded in the RFC decision log.
- **Not absorbed**, per the owner's recorded call on #686: gating
  `fixtures_*_nondefault` on `!is_noop`. The pairing already neutralises a true
  no-op; only the label needed the richer signature. The Interpretation now says
  which of the two does that work.
- `rate` is in the enriched signature even though **no validator reads it** —
  the round-7 review's `belt_flow` citation is wrong, those sites read
  `ItemFlow::rate` off the solver, and `PlacedEntity::rate`'s own doc says so.
  It is in as a provenance signal (a different stamp means a different
  lane-family decision) and is documented as that, not as a validation
  difference.
- **One out-of-scope comment fix**, taken because it is a trap in the file being
  instrumented: the comment above `DirectInsertionCandidate`'s `Search` guard
  claimed the default claim order is `Upstream`. It is `Downstream` —
  `DiClaimOrder`'s `#[default]`, flipped at RFC-059's sim close-out and never
  updated here. Comment-only; found while writing oracle gap (e), which stands
  either way.
- Seven **oracle gaps** are recorded in the RFC decision log rather than fixed
  here. The load-bearing one is the refusal-attribution gap above; the others
  are the missing counts where no mechanism ran, `ErrorKinds` existing only on
  the merge-tap path, `not-run` rows carrying no reason (the gates are
  conjunctions of booleans at the call site), DI's internal claim-order race
  being invisible, the scoreboard being per selection *call*, and — the one
  that bites a shadow diff — a LOSING candidate's nested selection being
  truncated out of the stream before any reader sees it, so "no nested block"
  is not evidence that none ran.

### Finding: the e2e harness does not run production's candidate set

Decoding the snapshot gave a *different deciding stage* than the census
reported for the same fixture — `best-accepted` from the suite,
`best-error-free` from default options. Cause: `LayoutOptions::default()` sets
`cell_composition: Candidate` (`bus/layout.rs:241`), but `run_e2e` spells the
field as `cell_composition: Default::default()` (`tests/e2e.rs:355`) — the
*enum's* default, `Off` (`bus/cells/mod.rs:24`) — sitting next to a
`..Default::default()` that would have given `Candidate`. The line dates to
RFC-051 Phase A (`5090da99`), when `Off` *was* the struct default; Phase B
flipped the struct and the harness kept resolving to the enum.

With cells off only native produces, so `clean_flags` is skipped by its own
`n_layouts > 1` guard and `best-accepted` decides — the suite exercises a
precedence stage the census slice never reaches, and vice versa.

**Not fixed here.** Flipping it changes the candidate set under every
regression test — a selection change, not an additive Phase-0b one. Recorded in
the RFC decision log with both consequences: the Phase-0c parity corpus must
range over fixture × machine tier × **option set**, and suite greenness says
nothing about the cell-composed arm's production exposure.

## Models / contracts touched

`crates/core/src/trace.rs` gains two events and two closed enums (both cross the
WASM boundary as string unions). `docs/rfc-070-one-selection-loop.md` decision
log gains the Phase-0b entries. No validator severity, category or
selection-participation change, so `docs/validator-trust.md` is deliberately
untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
