### PR TITLE
diag(w1a): report-only meter tripwire over the e2e/census corpus

### DIFF
--- a/crates/meter/tests/e2e_tripwire.rs
+++ b/crates/meter/tests/e2e_tripwire.rs
@@ -48,35 +48,44 @@
 //! just by convention: the comparison clamps both readings to a ceiling
 //! of 0 before differencing (`min(deficit_pct, 0.0)`), so the result can
 //! only be positive (alarm-worthy) when the FRESH reading is itself below
-//! plan — an above-plan baseline (sulfuric5-chem's committed +239%, for
-//! instance) can never manufacture a "regression" out of a reading that
-//! improved toward or past plan (second-opinion review on #693 round 1,
-//! finding #1 — this was a live false-alarm path, not hypothetical).
+//! plan — an above-plan baseline can never manufacture a "regression" out
+//! of a reading that improved toward or past plan (second-opinion review
+//! on #693 round 1, finding #1 — this was a live false-alarm path, not
+//! hypothetical: found against `sulfuric5-chem`'s then-committed +239%,
+//! back when fluid targets were still written to the baseline — round 2
+//! excluded them entirely, see below, so that specific row is no longer
+//! an example of anything committed, only of a MEASURED reading).
 //!
-//! A convergence collapse (baseline converged, fresh does not, AND the
-//! fresh reading is itself below plan) is judged qualitatively as its own
-//! below-plan-class failure, not folded into the percentage comparison: a
-//! previously-settling factory that no longer settles AND reads below
-//! plan is exactly the shape of the worst regression this tripwire exists
-//! to catch (a stall to ~0 — the meter's own convergence detector treats
-//! "producing nothing" specially, see `producing_nothing_is_not_converged`
-//! in `factory.rs`), and round 1's shape — treating ANY non-convergence as
-//! a graceful skip — silently passed exactly that regression
-//! (second-opinion review round 2, finding #1).
+//! A convergence collapse (baseline converged, fresh does not) is a
+//! below-plan-class failure precisely when the fresh reading is ALSO
+//! materially worse than the baseline: a previously-settling factory that
+//! no longer settles AND has genuinely gotten worse is exactly the shape
+//! of the worst regression this tripwire exists to catch (a stall to ~0
+//! — the meter's own convergence detector treats "producing nothing"
+//! specially, see `producing_nothing_is_not_converged` in `factory.rs`),
+//! and round 1's shape — treating ANY non-convergence as a graceful skip
+//! — silently passed exactly that regression (second-opinion review
+//! round 2, finding #1).
 //!
-//! **The direction gate matters, and an earlier round of this file got it
-//! wrong**: non-convergence alone is NOT evidence of a stall — the
-//! detector fails on any unstable trajectory, rising or falling
-//! (`factory.rs`'s `a_filling_buffer_is_not_converged` covers the rising
-//! case too), so round 2/3's "any non-convergence on the fresh side is a
-//! collapse" would fail on an over-producing or still-settling factory —
-//! good news, or at worst nothing — which violates the below-plan-only
-//! rule exactly as badly as round 1's "skip everything" bug violated it
-//! in the other direction (second-opinion review round 4, finding #1,
-//! the kernel bug that round fixed). The collapse branch therefore checks
-//! BOTH non-convergence AND `deficit_pct < 0.0` before failing; a
-//! non-converged, at-or-above-plan reading is `UNSETTLED` instead —
-//! reported, needs a stable re-run, never failed.
+//! **Getting the gate right took three rounds, and it's worth naming
+//! why**: round 2/3 failed on ANY non-convergence, which also fails on
+//! good news — the detector rejects any unstable trajectory, rising or
+//! falling (`factory.rs`'s `a_filling_buffer_is_not_converged` covers the
+//! rising case too), so an over-producing or still-settling factory would
+//! fail exactly like a stall (round 4, finding #1). Round 4's fix (a raw
+//! sign check, `deficit_pct < 0.0`, no tolerance) stopped failing on
+//! ABOVE-plan improvement, but not on two more shapes: a below-plan
+//! baseline IMPROVING while non-converged (blessed -25%, fresh -5% — -5%
+//! is still negative, so it still failed, despite being much better) and
+//! any sub-tolerance non-converged flap (a reading that would land in
+//! `standing`, not fail, if it happened to converge) — because a raw sign
+//! check has no tolerance at all, inconsistent with the compared branch's
+//! `REGRESSION_TOLERANCE_PP` (round 5, finding #1). The collapse branch
+//! now shares the EXACT SAME tolerance-gated clamped comparison
+//! (`clamped_drop`) as the compared branch below; only the label differs
+//! (COLLAPSE, so the reader knows convergence was also lost). A
+//! non-converged reading that ISN'T materially worse than baseline is
+//! `UNSETTLED` instead — reported, needs a stable re-run, never failed.
 //!
 //! Baseline-side non-convergence is different again and stays a skip
 //! (see "Standing gaps" below) — the baseline itself was never a
@@ -88,8 +97,11 @@
 //! not just one (round 3's text named only the first and read as if it
 //! were unique — round 4, finding #5): `ec30-am2-ore` (its 3
 //! `belt-dead-end` validator errors) and `plastic5-chem-crude` (no
-//! validator errors; the deficit is a real but smaller, unexplained
-//! shortfall). Both hit the "baseline never converged" branch before the
+//! validator errors, and NOT a below-plan deficit either — it reads
+//! +0.89%, above plan; round 5 nit — a prior revision of this comment
+//! mischaracterized it as a "shortfall". The real issue is that its
+//! reading simply never stabilizes within the warmup window). Both hit
+//! the "baseline never converged" branch before the
 //! collapse branch is ever reached, so a further regression on either is
 //! structurally unrepresentable today. This is not a gap in the check's
 //! design: an instrument cannot alarm on "worse than a baseline that was
@@ -168,7 +180,11 @@
 //!     left the build-failure assert unconditional; second-opinion review
 //!     round 2 (finding #5) caught the gap. If a new assertion is ever
 //!     added to this file, it belongs inside the `bless`/`check` arms,
-//!     never before the match.
+//!     never before the match. A missing planned rate (`no-plan` in the
+//!     scoreboard's flag column) is likewise printed, not alarmed on, in
+//!     this mode — by design, not an oversight (round 5 nit): report-only
+//!     has nothing to protect by asserting on it, unlike `bless`/`check`,
+//!     where a NaN deficit would corrupt what gets committed or compared.
 //!   * `bless` — writes the current per-fixture readings (excluding fluid
 //!     targets — see above) as the new committed baseline
 //!     (`e2e_tripwire_baseline.json`), alongside a hash of the zone-cache
@@ -185,6 +201,13 @@
 //!     documents for check severity/count conflation):
 //!       - **excluded** — a fluid target (see above); never gated.
 //!       - **new** — no baseline row (bless it).
+//!       - **target-changed** — the fixture's solved TARGET item differs
+//!         from the baseline's; a different KIND of drift than a
+//!         geometry change (a config edit under the same label, not the
+//!         engine/cache producing a different layout), so its own
+//!         accounting reason rather than folded into `stale`
+//!         (`BaselineRow.target` was written at bless time but never
+//!         read here until this — second-opinion review round 5).
 //!       - **stale** — entity count changed vs the baseline; not
 //!         comparable (the zone-cache hash recorded at bless time helps
 //!         tell "the SAME pin produced a different count" — a genuine
@@ -200,29 +223,36 @@
 //!         which `uncovered` alone would not make it (second-opinion
 //!         review round 3, finding #1).
 //!       - **collapsed** — baseline converged, fresh does not, AND the
-//!         fresh reading is itself below plan: FAILS (see the hard-rule
-//!         section above).
-//!       - **unsettled** — baseline converged, fresh does not, but the
-//!         fresh reading is AT-OR-ABOVE plan: printed (`UNSETTLED`), not
-//!         a failure and not `judged` either — a rising buffer, a
-//!         still-settling improvement, or jitter, none of which is
-//!         below-plan evidence (second-opinion review round 4, finding
-//!         #1 — collapse used to fire on non-convergence alone, which
-//!         also covers this shape and would fail on good news).
+//!         SAME tolerance-gated clamped comparison used for `compared`
+//!         below reads the fresh side as materially worse: FAILS,
+//!         prints `CONVERGENCE COLLAPSE` (see the hard-rule section
+//!         above for why this took three rounds to get right).
+//!       - **unsettled** — baseline converged, fresh does not, but that
+//!         same comparison does NOT read it as materially worse: printed
+//!         (`UNSETTLED`), not a failure and not `judged` either — a
+//!         rising buffer, a still-settling improvement (even while
+//!         remaining below plan), or plain jitter, none of which this
+//!         gate can tell apart from each other, only from a genuine
+//!         regression (second-opinion review rounds 4 and 5, finding #1
+//!         both times — collapse used to fire on non-convergence alone,
+//!         then on raw deficit sign with no tolerance; neither survived
+//!         contact with a below-plan-but-improving or sub-tolerance-flap
+//!         reading).
 //!       - **compared** — both converged, entities match: the clamped
-//!         below-plan comparison runs and lands in exactly one of three
-//!         buckets (second-opinion review round 3, finding #3 — the
-//!         previous single `compared` counter incremented BEFORE the
-//!         regression check, so a row that FAILED still printed as
-//!         "compared clean-or-standing" in the accounting, the exact
-//!         count/severity conflation `docs/validator-reporting.md`
-//!         polices): **at-or-above** (no below-plan reading at all — not
-//!         named "clean": that's a clearance word, and an at-or-above
-//!         reading is evidence of nothing either way, second-opinion
-//!         review round 4, finding #2), or **standing** (below-plan but
-//!         not worse than baseline — prints `STANDING BELOW-PLAN`, does
-//!         not fail), or **regressed** (below-plan AND materially worse
-//!         — FAILS, prints `BELOW-PLAN REGRESSION`).
+//!         below-plan comparison (`clamped_drop`) runs and lands in
+//!         exactly one of three buckets (second-opinion review round 3,
+//!         finding #3 — the previous single `compared` counter
+//!         incremented BEFORE the regression check, so a row that FAILED
+//!         still printed as "compared clean-or-standing" in the
+//!         accounting, the exact count/severity conflation
+//!         `docs/validator-reporting.md` polices): **at-or-above** (no
+//!         below-plan reading at all — not named "clean": that's a
+//!         clearance word, and an at-or-above reading is evidence of
+//!         nothing either way, second-opinion review round 4, finding
+//!         #2), or **standing** (below-plan but not worse than baseline
+//!         — prints `STANDING BELOW-PLAN`, does not fail), or
+//!         **regressed** (below-plan AND materially worse — FAILS,
+//!         prints `BELOW-PLAN REGRESSION`).
 //!
 //!     `check` FAILS if nothing landed in `collapsed`, `regressed`,
 //!     `standing`, or `at-or-above` — a check run that judged nothing
@@ -283,10 +313,26 @@
 //!   at -0.2%, the closest-to-plan below-plan reading in the corpus —
 //!   could in principle flap non-converged on a noisy host (CPU
 //!   contention widening the tick-timing jitter the convergence detector
-//!   samples) and read as a `CONVERGENCE COLLAPSE` failure with no real
-//!   engine change behind it (second-opinion review round 3, nit).
-//!   Known, not fixed: `check` is deliberately not CI-wired (see above),
-//!   so this is a "confusing local re-run" risk, not a false CI red.
+//!   samples) (second-opinion review round 3, nit). **Resolved by round
+//!   5's fix, not still open**: the collapse branch now shares
+//!   `compared`'s tolerance-gated `clamped_drop`, so a flap that stays
+//!   within `REGRESSION_TOLERANCE_PP` of the blessed value lands in
+//!   `UNSETTLED`, the same way it would land in `standing` if it
+//!   happened to converge — it can no longer read as a false
+//!   `CONVERGENCE COLLAPSE`. Left here, marked resolved, so the history
+//!   stays traceable rather than the bullet just vanishing.
+//! * Convergence (`factory.rs`'s checkpoints) samples TOTAL delivered
+//!   counts across every item in the factory, while a solid target's own
+//!   `deficit_pct` here watches PRODUCED for that target specifically
+//!   (see `build_and_measure`) — two different signals (second-opinion
+//!   review round 5, "absorb #3"). A genuine sink-side throttle
+//!   (delivery destabilizing while the target's own production stays
+//!   rock-steady at plan) would present as non-converged + at-or-above
+//!   plan, landing in `UNSETTLED` — which this gate never fails, by
+//!   design. Named, not fixed: closing it means watching the target's
+//!   own delivered/produced series for convergence rather than the
+//!   whole-factory delivered total, a bigger change than this
+//!   diagnostic's scope.
 
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
@@ -741,26 +787,33 @@ struct CheckOutcome {
     /// `standing_below_plan` so the accounting can never conflate a
     /// failing row with a clean one.
     regressed: usize,
-    /// Baseline converged, fresh does NOT converge, AND the fresh reading
-    /// is itself below plan (or the meter's own bookkeeping shows it as
-    /// a stall — see the gate at the call site). Counted as "judged" (a
-    /// verdict WAS rendered: FAIL) even though it is not
-    /// `compared_at_or_above`, `standing`, or `regressed`.
+    /// Baseline converged, fresh does NOT converge, AND `clamped_drop`
+    /// (the SAME tolerance-gated comparison `regressed` uses) reads the
+    /// fresh side as materially worse. Counted as "judged" (a verdict WAS
+    /// rendered: FAIL) even though it is not `compared_at_or_above`,
+    /// `standing`, or `regressed`.
     ///
-    /// Gated on direction, not on non-convergence alone (round 4, finding
-    /// #1 — the kernel bug this round exists to fix): the meter's
-    /// `converged` flag is also false for a RISING reading (an
-    /// over-producing factory, or ordinary tick-window jitter around an
-    /// at-or-above-plan value — see `factory.rs`'s
-    /// `a_filling_buffer_is_not_converged`), not only a collapsing one.
-    /// Failing on non-convergence alone would fail on GOOD news, which
-    /// violates the below-plan-only hard rule as badly as round 1's
-    /// original bug violated it in the other direction. See `unsettled`
-    /// for the at-or-above-plan, non-converged case this excludes.
+    /// Getting this gate right took three rounds (see the module doc's
+    /// hard-rule section for the blow-by-blow): round 2/3 failed on ANY
+    /// non-convergence, including a RISING reading (the meter's
+    /// `converged` flag is also false for an over-producing factory —
+    /// see `factory.rs`'s `a_filling_buffer_is_not_converged`), which
+    /// fails on good news (round 4, finding #1). Round 4's fix (a raw
+    /// sign check) stopped that, but not a below-plan-but-improving
+    /// reading or a sub-tolerance flap, because it had no tolerance at
+    /// all — inconsistent with `regressed`'s (round 5, finding #1).
+    /// Sharing `clamped_drop` makes both consistent by construction. See
+    /// `unsettled` for the non-converged case this excludes.
     collapsed: usize,
     excluded_fluid: usize,
     skipped_new: usize,
     skipped_stale: usize,
+    /// The fixture's solved TARGET changed vs the baseline (e.g. a
+    /// fixture config edit under the same label) — a different KIND of
+    /// drift than `skipped_stale`'s geometry mismatch, so its own
+    /// accounting reason (round 5, "absorb #1": `BaselineRow.target` was
+    /// written at bless time but never read in `check` before this).
+    skipped_target_changed: usize,
     /// Labels whose BASELINE row never converged and whose FRESH run
     /// still doesn't either — a standing gap, not a fresh finding.
     uncovered: Vec<String>,
@@ -771,13 +824,14 @@ struct CheckOutcome {
     /// `uncovered` so a repair is visible instead of looking identical to
     /// "still broken".
     recovered: Vec<String>,
-    /// Labels where baseline converged but fresh does NOT, and the fresh
-    /// reading is at-or-above plan — a rising buffer, an improvement
-    /// still settling, or plain jitter, not a below-plan finding. Not
-    /// `collapsed` (round 4, finding #1) and not `judged`: there is no
-    /// trustworthy number here either, just not a failing one. Needs a
-    /// stable re-run (or a re-bless once it settles) before it can be
-    /// judged either way.
+    /// Labels where baseline converged but fresh does NOT, and
+    /// `clamped_drop` does NOT read it as materially worse than the
+    /// baseline — a rising buffer, an improvement still settling (even
+    /// while remaining below plan), or plain jitter; not a below-plan
+    /// finding. Not `collapsed` and not `judged`: there is no trustworthy
+    /// number here either, just not a failing one. Needs a stable re-run
+    /// (or a re-bless once it settles) before it can be judged either
+    /// way.
     unsettled: Vec<String>,
 }
 
@@ -796,11 +850,30 @@ impl CheckOutcome {
     fn not_judged(&self) -> usize {
         self.skipped_new
             + self.skipped_stale
+            + self.skipped_target_changed
             + self.uncovered.len()
             + self.recovered.len()
             + self.excluded_fluid
             + self.unsettled.len()
     }
+}
+
+/// The below-plan-portion "drop" between a baseline and fresh reading:
+/// both clamped to a ceiling of 0 before differencing, so the result is
+/// only positive when the FRESH reading is itself below plan (module
+/// doc's hard-rule section). Shared by the collapse and compared
+/// branches in `evaluate_check` (round 5, finding #1) — the collapse
+/// branch used to gate on raw deficit SIGN with no tolerance at all,
+/// which was inconsistent with this comparison and wrong on two counts
+/// besides: it failed on a below-plan-but-IMPROVING reading (a baseline
+/// blessed at -25% settling to a fresh -5% still read negative, so it
+/// still failed, even though -5% is a big improvement) and on any
+/// sub-tolerance non-converged flap (e.g. -0.5% against an at-plan
+/// baseline — the same -0.5% would land in `standing`, not fail, if it
+/// happened to converge). Sharing this function makes "the exact same
+/// comparison" true by construction, not by convention.
+fn clamped_drop(baseline_deficit_pct: f64, fresh_deficit_pct: f64) -> f64 {
+    baseline_deficit_pct.min(0.0) - fresh_deficit_pct.min(0.0)
 }
 
 /// Compare fresh `results` against the committed `baseline`, printing
@@ -834,6 +907,27 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
             }
             continue;
         };
+        if b.target != m.target {
+            // `BaselineRow.target` was written at bless time but never
+            // read here — round 5, finding "absorb #1": the same fixture
+            // LABEL now solving a different item is exactly the "two
+            // representations drift apart" class this field exists to
+            // catch, and it went unchecked. Its own accounting reason,
+            // not folded into `skipped_stale`: a target change is a
+            // different KIND of drift than a geometry change (a fixture
+            // config edit under the same label, not the engine/cache
+            // producing a different layout for the same target).
+            out.skipped_target_changed += 1;
+            if verbose {
+                eprintln!(
+                    "{}: SKIPPED — target changed ({} -> {}); this fixture now solves a \
+                     different item than its baseline recorded, so the two numbers are not \
+                     comparable. Re-bless deliberately.",
+                    m.label, b.target, m.target
+                );
+            }
+            continue;
+        }
         if b.entities != m.entities {
             out.skipped_stale += 1;
             if verbose {
@@ -881,38 +975,34 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
         }
         if !m.converged {
             // Baseline WAS a trustworthy anchor; fresh no longer
-            // converges. Gated on DIRECTION, not on non-convergence
-            // alone (round 4, finding #1 — the kernel bug this round
-            // exists to fix): `factory.rs`'s convergence detector fails
-            // on ANY unstable trajectory, rising or falling
-            // (`a_filling_buffer_is_not_converged` covers the rising
-            // case too), so treating every non-convergence as a collapse
-            // would fail on an over-producing/still-settling factory —
-            // good news, or at worst nothing — which violates the
-            // below-plan-only hard rule exactly as badly as round 1's
-            // original "skip everything" bug violated it in the other
-            // direction. `< 0.0` (strict) matches `print_scoreboard`'s
-            // own BELOW-PLAN threshold and never fails on an exactly-at-
-            // plan reading. A genuine stall reads unambiguously negative
-            // here regardless (measured ≈ 0 against any planned > 0 is
-            // deficit_pct ≈ -100%), so this loses no real coverage.
-            if m.deficit_pct < 0.0 {
+            // converges. Judged by the EXACT SAME tolerance-gated
+            // clamped comparison as the converged case below — only the
+            // LABEL differs (COLLAPSE, so the reader knows convergence
+            // was also lost), per `clamped_drop`'s doc comment (round 5,
+            // finding #1 — the kernel's final, unifying shape). A true
+            // stall reads a clamped drop of roughly baseline-deficit
+            // minus -100, far over tolerance, so it is still caught.
+            let drop = clamped_drop(b.deficit_pct, m.deficit_pct);
+            if drop > REGRESSION_TOLERANCE_PP {
                 out.collapsed += 1;
                 out.regressions.push(format!(
-                    "{}: CONVERGENCE COLLAPSE — baseline converged at {:.1}%, fresh no longer \
-                     converges AND reads below plan ({:.1}%). A stalled/collapsed factory is \
-                     exactly the regression class this guard exists to catch.",
-                    m.label, b.deficit_pct, m.deficit_pct
+                    "{}: CONVERGENCE COLLAPSE — baseline {:.1}%, now {:.1}% ({:.1}pp worse, \
+                     below-plan portion only) AND fresh no longer converges. A stalled/\
+                     collapsed factory is exactly the regression class this guard exists to \
+                     catch.",
+                    m.label, b.deficit_pct, m.deficit_pct, drop
                 ));
             } else {
                 out.unsettled.push(m.label.to_string());
                 if verbose {
                     eprintln!(
-                        "{}: UNSETTLED — not converged, but reads at-or-above plan ({:.1}%); \
-                         could be a rising buffer, a still-settling improvement, or jitter — \
-                         not below-plan evidence either way, so not failed. Needs a stable \
-                         re-run (or a re-bless once stable) before this can be judged.",
-                        m.label, m.deficit_pct
+                        "{}: UNSETTLED — not converged, and not materially worse than the \
+                         blessed baseline ({:.1}% -> {:.1}%, within {:.1}pp tolerance); could \
+                         be a rising buffer, a still-settling improvement (even while \
+                         remaining below plan), or jitter — not evidence of a below-plan \
+                         regression. Needs a stable re-run (or a re-bless once stable) \
+                         before this can be judged.",
+                        m.label, b.deficit_pct, m.deficit_pct, REGRESSION_TOLERANCE_PP
                     );
                 }
             }
@@ -920,20 +1010,18 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
         }
         // The ONLY percentage-based alarm condition, per the module
         // docs' hard rule: compare only the BELOW-plan portion of each
-        // reading (clamped to a ceiling of 0) so an above-plan baseline
-        // can never manufacture a "regression" out of a fresh reading
-        // that moved toward plan or into a trustworthy below-plan range.
-        // `drop` is provably <= 0 whenever the fresh reading is
-        // at-or-above plan, so this can only fire when the CURRENT
-        // reading is itself below plan (second-opinion review round 1,
-        // finding #1). The bucket a row lands in is decided HERE, after
-        // the check, never before it (second-opinion review round 3,
-        // finding #3 — the old `out.compared += 1` ran unconditionally
-        // before this comparison, so a row that regressed still counted
-        // as "compared clean-or-standing").
-        let baseline_below = b.deficit_pct.min(0.0);
-        let fresh_below = m.deficit_pct.min(0.0);
-        let drop = baseline_below - fresh_below;
+        // reading (clamped to a ceiling of 0, via `clamped_drop`) so an
+        // above-plan baseline can never manufacture a "regression" out
+        // of a fresh reading that moved toward plan or into a
+        // trustworthy below-plan range. `drop` is provably <= 0 whenever
+        // the fresh reading is at-or-above plan, so this can only fire
+        // when the CURRENT reading is itself below plan (second-opinion
+        // review round 1, finding #1). The bucket a row lands in is
+        // decided HERE, after the check, never before it (second-opinion
+        // review round 3, finding #3 — the old `out.compared += 1` ran
+        // unconditionally before this comparison, so a row that
+        // regressed still counted as "compared clean-or-standing").
+        let drop = clamped_drop(b.deficit_pct, m.deficit_pct);
         if drop > REGRESSION_TOLERANCE_PP {
             out.regressed += 1;
             out.regressions.push(format!(
@@ -942,14 +1030,18 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
                 m.label, b.deficit_pct, m.deficit_pct, drop
             ));
         } else if m.deficit_pct < 0.0 {
-            // Standing, accepted deficit — the blessed state IS this
-            // instrument's zero (module doc section above). Reported so
+            // Standing, not-materially-worse deficit — reported so
             // "clean" never reads as "nothing here is wrong"
-            // (second-opinion review round 2, finding #6).
+            // (second-opinion review round 2, finding #6). Worded as the
+            // actual condition (within tolerance of the blessed value),
+            // not "accepted at bless time as this fixture's zero point"
+            // (round 4's wording — factually wrong when the baseline
+            // itself was at-or-above plan and only the FRESH reading
+            // dipped sub-tolerance below it; round 5, finding #2).
             out.standing_below_plan.push(format!(
-                "{}: STANDING BELOW-PLAN — {:.1}% (baseline {:.1}%), not a new regression; \
-                 accepted at bless time as this fixture's zero point.",
-                m.label, m.deficit_pct, b.deficit_pct
+                "{}: STANDING BELOW-PLAN — {:.1}%, within {:.1}pp tolerance of the blessed \
+                 value ({:.1}%); not a new regression.",
+                m.label, m.deficit_pct, REGRESSION_TOLERANCE_PP, b.deficit_pct
             ));
         } else {
             out.compared_at_or_above += 1;
@@ -1042,9 +1134,10 @@ fn e2e_tripwire() {
             let outcome = evaluate_check(&results, &baseline, true);
             eprintln!(
                 "\naccounting: {}/{} judged ({} at-or-above, {} standing, {} regressed, {} \
-                 collapsed), {}/{} not judged ({} new, {} stale, {} uncovered [baseline never \
-                 converged], {} recovered [re-bless to arm], {} unsettled [not converged, \
-                 at-or-above plan], {} excluded [fluid, uncalibrated])",
+                 collapsed), {}/{} not judged ({} new, {} stale, {} target-changed, {} \
+                 uncovered [baseline never converged], {} recovered [re-bless to arm], {} \
+                 unsettled [not converged, not worse than baseline], {} excluded [fluid, \
+                 uncalibrated])",
                 outcome.judged(),
                 results.len(),
                 outcome.compared_at_or_above,
@@ -1055,6 +1148,7 @@ fn e2e_tripwire() {
                 results.len(),
                 outcome.skipped_new,
                 outcome.skipped_stale,
+                outcome.skipped_target_changed,
                 outcome.uncovered.len(),
                 outcome.recovered.len(),
                 outcome.unsettled.len(),
@@ -1139,14 +1233,18 @@ mod tests {
         }
     }
 
-    /// Finding #1 (round 2): baseline converged, fresh does not, AND the
-    /// fresh reading is below plan — must FAIL as a collapse, not
-    /// silently skip (round 1's bug: uniform non-convergence skipping let
-    /// a throughput collapse to ~0 pass green).
+    /// Round 5's final, unifying shape: the collapse branch now uses the
+    /// EXACT SAME tolerance-gated clamped comparison (`clamped_drop`) as
+    /// the compared branch below — only the label differs. A true stall
+    /// (measured ≈ 0, i.e. deficit_pct ≈ -100%) reads a clamped drop far
+    /// beyond any reasonable tolerance regardless of the baseline's own
+    /// value, so it is still caught (round 1's original bug: uniform
+    /// non-convergence skipping let a throughput collapse to ~0 pass
+    /// green).
     #[test]
-    fn convergence_collapse_fails() {
-        let results = vec![measurement("x", -1.0, 100, false)];
-        let base = baseline(vec![baseline_row("x", -1.0, 100, true)]);
+    fn convergence_collapse_fails_on_a_true_stall() {
+        let results = vec![measurement("x", -100.0, 100, false)];
+        let base = baseline(vec![baseline_row("x", -2.0, 100, true)]);
         let out = evaluate_check(&results, &base, false);
         assert_eq!(out.collapsed, 1, "must be counted as collapsed");
         assert_eq!(out.judged(), 1, "a collapse IS a rendered verdict");
@@ -1158,18 +1256,17 @@ mod tests {
         assert!(out.unsettled.is_empty());
     }
 
-    /// Round 4, finding #1 (the kernel bug this round exists to fix):
-    /// baseline converged, fresh does NOT converge, but the fresh reading
-    /// is AT-OR-ABOVE plan — a rising buffer or a still-settling
-    /// improvement, not below-plan evidence. Must NOT fail: the
-    /// round-2/3 collapse branch fired on non-convergence alone, which
-    /// also covers this shape (`factory.rs`'s convergence detector fails
-    /// on any unstable trajectory, not only a falling one), so it would
-    /// have failed on good news — violating the below-plan-only hard
-    /// rule as badly as round 1's bug violated it in the other
-    /// direction.
+    /// Round 4, finding #1, first pass: baseline converged, fresh does
+    /// NOT converge, but the fresh reading is AT-OR-ABOVE plan — a rising
+    /// buffer or a still-settling improvement, not below-plan evidence.
+    /// Must NOT fail: the round-2/3 collapse branch fired on
+    /// non-convergence alone, which also covers this shape (`factory.rs`'s
+    /// convergence detector fails on any unstable trajectory, not only a
+    /// falling one), so it would have failed on good news — violating the
+    /// below-plan-only hard rule as badly as round 1's bug violated it in
+    /// the other direction.
     #[test]
-    fn convergence_collapse_does_not_fire_on_improvement_shape() {
+    fn convergence_collapse_does_not_fire_on_above_plan_improvement() {
         let results = vec![measurement("x", 5.0, 100, false)];
         let base = baseline(vec![baseline_row("x", -2.0, 100, true)]);
         let out = evaluate_check(&results, &base, false);
@@ -1181,6 +1278,46 @@ mod tests {
         assert_eq!(out.collapsed, 0, "must not be counted as a collapse");
         assert_eq!(out.unsettled, vec!["x".to_string()]);
         assert_eq!(out.judged(), 0, "unsettled is not yet judged either way");
+    }
+
+    /// Round 5, finding #1, second pass: round 4's fix (raw sign check,
+    /// `deficit_pct < 0.0`, no tolerance) still false-failed two shapes
+    /// this test and the next one pin. Here: a below-plan baseline
+    /// IMPROVING while non-converged (blessed -25%, fresh -5%) — -5% is
+    /// still negative, so round 4's gate still failed it, even though
+    /// it's a big improvement over the baseline. Must NOT fail.
+    #[test]
+    fn convergence_collapse_does_not_fire_on_below_plan_improvement() {
+        let results = vec![measurement("x", -5.0, 100, false)];
+        let base = baseline(vec![baseline_row("x", -25.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(
+            out.regressions.is_empty(),
+            "an improving-while-still-below-plan reading must never fail: {:?}",
+            out.regressions
+        );
+        assert_eq!(out.collapsed, 0);
+        assert_eq!(out.unsettled, vec!["x".to_string()]);
+    }
+
+    /// Round 5, finding #1, second pass: a sub-tolerance non-converged
+    /// flap (baseline at-plan, fresh -0.5%) must NOT fail — round 4's raw
+    /// sign gate failed on ANY negative fresh deficit, even one well
+    /// within `REGRESSION_TOLERANCE_PP` of the baseline, which was
+    /// inconsistent with the compared branch (the same -0.5% would land
+    /// in `standing`, not `regressed`, if it happened to converge).
+    #[test]
+    fn convergence_collapse_does_not_fire_on_sub_tolerance_flap() {
+        let results = vec![measurement("x", -0.5, 100, false)];
+        let base = baseline(vec![baseline_row("x", 0.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(
+            out.regressions.is_empty(),
+            "a sub-tolerance non-converged flap must never fail: {:?}",
+            out.regressions
+        );
+        assert_eq!(out.collapsed, 0);
+        assert_eq!(out.unsettled, vec!["x".to_string()]);
     }
 
     /// Finding #1 (other direction): the baseline itself never converged
@@ -1241,10 +1378,12 @@ mod tests {
     }
 
     /// Round 1, finding #1, re-verified after the round-2 refactor: an
-    /// above-plan baseline (sulfuric5-chem/lightoil5-chem-cracking's
-    /// committed +239%/+200% shape) moving to a near-plan fresh reading
-    /// must NOT read as a regression — the exact false-alarm the
-    /// unclamped `b.deficit_pct - m.deficit_pct` formula produced.
+    /// above-plan baseline (the shape sulfuric5-chem/lightoil5-chem-
+    /// cracking were then-committed at, +239%/+200%, before round 2
+    /// excluded fluid targets from the baseline entirely) moving to a
+    /// near-plan fresh reading must NOT read as a regression — the exact
+    /// false-alarm the unclamped `b.deficit_pct - m.deficit_pct` formula
+    /// produced.
     #[test]
     fn above_plan_baseline_moving_to_near_plan_does_not_alarm() {
         let results = vec![measurement("x", -1.0, 100, true)];
@@ -1321,5 +1460,22 @@ mod tests {
         let out = evaluate_check(&results, &base, false);
         assert_eq!(out.skipped_new, 1);
         assert!(out.regressions.is_empty());
+    }
+
+    /// Round 5, "absorb #1": `BaselineRow.target` was written at bless
+    /// time but never read in `check` — the same fixture LABEL now
+    /// solving a different item must be its own skip reason, distinct
+    /// from `skipped_stale`'s geometry-mismatch, and must never fail.
+    #[test]
+    fn target_changed_is_skipped_not_failed() {
+        let mut m = measurement("x", -50.0, 100, true);
+        m.target = "gizmo".to_string();
+        let results = vec![m];
+        let base = baseline(vec![baseline_row("x", 0.0, 100, true)]); // target: "widget"
+        let out = evaluate_check(&results, &base, false);
+        assert_eq!(out.skipped_target_changed, 1);
+        assert_eq!(out.skipped_stale, 0, "must not ALSO count as a stale-geometry skip");
+        assert!(out.regressions.is_empty());
+        assert_eq!(out.judged(), 0);
     }
 }

--- a/crates/meter/tests/e2e_tripwire.rs
+++ b/crates/meter/tests/e2e_tripwire.rs
@@ -69,6 +69,26 @@
 //! "Standing gaps" below) — the baseline itself was never a trustworthy
 //! anchor to measure a regression FROM.
 //!
+//! **A baseline-non-converged fixture can never gain collapse coverage
+//! while it stays blessed non-converged** (second-opinion review round
+//! 3, finding #1 — `ec30-am2-ore`, the corpus's worst fixture, hits the
+//! "baseline never converged" branch before the collapse branch is ever
+//! reached, so a further regression on it is structurally unrepresentable
+//! today). This is not a gap in the check's design: an instrument cannot
+//! alarm on "worse than a baseline that was already producing nothing" —
+//! there is no direction left to regress FROM. It is inherent to any
+//! blessed-baseline design, not something a smarter comparison formula
+//! fixes. `ec30-am2-ore`'s real fix is the layout itself (its 3
+//! `belt-dead-end` validator errors — queued campaign-side as the W1c
+//! contested sample). The flip condition, so this is not permanently
+//! invisible: once that fixture is fixed and RE-BLESSED converged,
+//! collapse coverage arms itself automatically — no code change needed,
+//! just a bless run over the repaired layout. Until then, `check` prints
+//! a `RECOVERED` line (see the protocol section below) if a fresh run
+//! ever converges again on a still-non-converged baseline, so a fix
+//! landing is visible immediately rather than silently waiting for
+//! someone to think to re-bless.
+//!
 //! # Fluid targets are excluded from bless/check, never from the report
 //!
 //! `sulfuric5-chem` and `lightoil5-chem-cracking` (the corpus's only two
@@ -134,7 +154,11 @@
 //!   * `bless` — writes the current per-fixture readings (excluding fluid
 //!     targets — see above) as the new committed baseline
 //!     (`e2e_tripwire_baseline.json`), alongside a hash of the zone-cache
-//!     file used to build them.
+//!     PIN — captured before any fixture is built, not after (second-
+//!     opinion review round 3, finding #2: building can append newly-
+//!     solved zones to the cache file, so hashing after every fixture had
+//!     already run described post-run bytes, not the committed pin that
+//!     was actually consulted as the starting state).
 //!   * `check` — compares fresh readings against the committed baseline.
 //!     Every fixture lands in exactly one bucket, and the run prints an
 //!     accounting line totalling them (second-opinion review round 2,
@@ -151,15 +175,30 @@
 //!       - **uncovered** — the BASELINE row itself never converged, so it
 //!         was never a trustworthy anchor; a standing gap, printed
 //!         (`UNCOVERED (baseline non-converged)`), not a fresh failure.
+//!       - **recovered** — the BASELINE never converged, but the FRESH
+//!         run does: printed (`RECOVERED — re-bless to arm coverage`),
+//!         not a fresh failure, and not `judged` either (there is still
+//!         no trustworthy number to compare against) — but visible,
+//!         which `uncovered` alone would not make it (second-opinion
+//!         review round 3, finding #1).
 //!       - **collapsed** — baseline converged, fresh does not: FAILS (see
 //!         the hard-rule section above).
 //!       - **compared** — both converged, entities match: the clamped
-//!         below-plan comparison runs; a below-plan reading that's simply
-//!         standing (not worse than baseline) prints `STANDING BELOW-PLAN`
-//!         and does not fail.
+//!         below-plan comparison runs and lands in exactly one of three
+//!         buckets (second-opinion review round 3, finding #3 — the
+//!         previous single `compared` counter incremented BEFORE the
+//!         regression check, so a row that FAILED still printed as
+//!         "compared clean-or-standing" in the accounting, the exact
+//!         count/severity conflation `docs/validator-reporting.md`
+//!         polices): **clean** (no below-plan reading at all), or
+//!         **standing** (below-plan but not worse than baseline — prints
+//!         `STANDING BELOW-PLAN`, does not fail), or **regressed** (below-
+//!         plan AND materially worse — FAILS, prints `BELOW-PLAN
+//!         REGRESSION`).
 //!
-//!     `check` FAILS if nothing landed in `collapsed` or `compared` —
-//!     "verified clean" must be distinguishable from "compared nothing".
+//!     `check` FAILS if nothing landed in `collapsed`, `regressed`,
+//!     `standing`, or `clean` — "verified clean" must be distinguishable
+//!     from "compared nothing".
 //!
 //! **Why report-only stays the default, and this is NOT wired into CI as
 //! a gate**: the committed-golden `check`/`bless` flow that used to sit
@@ -211,6 +250,14 @@
 //!   versioned game binary), this baseline is always compared against
 //!   whatever engine commit is checked out, so the comparison is
 //!   inherently commit-relative already.
+//! * A fixture blessed right at the convergence boundary — `ac5-am2-ore`
+//!   at -0.2%, the closest-to-plan below-plan reading in the corpus —
+//!   could in principle flap non-converged on a noisy host (CPU
+//!   contention widening the tick-timing jitter the convergence detector
+//!   samples) and read as a `CONVERGENCE COLLAPSE` failure with no real
+//!   engine change behind it (second-opinion review round 3, nit).
+//!   Known, not fixed: `check` is deliberately not CI-wired (see above),
+//!   so this is a "confusing local re-run" risk, not a false CI red.
 
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
@@ -625,35 +672,57 @@ struct CheckOutcome {
     /// Below-plan-class failures: a genuine regression (the clamped
     /// comparison) or a convergence collapse. Non-empty ⇒ `check` fails.
     regressions: Vec<String>,
-    /// Both converged, entities matched, no regression — includes
-    /// standing below-plan rows (see `standing_below_plan`).
-    compared: usize,
+    /// Both converged, entities matched, no below-plan reading at all
+    /// (`deficit_pct >= 0`). Split out from `standing`/`regressed`
+    /// (second-opinion review round 3, finding #3): the previous single
+    /// `compared` counter incremented BEFORE the regression check ran, so
+    /// a row that FAILED still printed as "compared clean-or-standing" —
+    /// the exact count/severity conflation `docs/validator-reporting.md`
+    /// polices against.
+    compared_clean: usize,
+    /// Both converged, entities matched, below plan but NOT materially
+    /// worse than baseline — see `standing_below_plan` for the messages.
+    /// A subset of "compared"; counted via `standing_below_plan.len()`.
+    standing_below_plan: Vec<String>,
+    /// Both converged, entities matched, below plan AND materially worse
+    /// than baseline. Counted separately from `compared_clean`/
+    /// `standing_below_plan` so the accounting can never conflate a
+    /// failing row with a clean one.
+    regressed: usize,
     /// Baseline converged, fresh did not — counted as "judged" (a
-    /// verdict WAS rendered: FAIL) even though it lands in
-    /// `regressions`, not `compared`.
+    /// verdict WAS rendered: FAIL) even though it is not `compared_clean`,
+    /// `standing`, or `regressed`.
     collapsed: usize,
     excluded_fluid: usize,
     skipped_new: usize,
     skipped_stale: usize,
-    /// Labels whose BASELINE row never converged — a standing gap, not a
-    /// fresh finding.
+    /// Labels whose BASELINE row never converged and whose FRESH run
+    /// still doesn't either — a standing gap, not a fresh finding.
     uncovered: Vec<String>,
-    /// Below-plan readings that are standing (not worse than baseline) —
-    /// reported, never failed. See the module doc's "instrument's ZERO"
-    /// section.
-    standing_below_plan: Vec<String>,
+    /// Labels whose BASELINE row never converged but whose FRESH run now
+    /// DOES — a fix may have landed, but there is still no trustworthy
+    /// baseline number to compare against, so this is not `judged` either
+    /// (second-opinion review round 3, finding #1). Distinct from
+    /// `uncovered` so a repair is visible instead of looking identical to
+    /// "still broken".
+    recovered: Vec<String>,
 }
 
 impl CheckOutcome {
-    /// At least one row got a real verdict (compared clean/standing, OR
-    /// collapsed to a failure). Distinguishes "verified clean" from
-    /// "compared nothing" (second-opinion review round 2, finding #2).
+    /// At least one row got a real verdict (compared clean, standing,
+    /// regressed, OR collapsed to a failure). Distinguishes "verified
+    /// clean" from "compared nothing" (second-opinion review round 2,
+    /// finding #2).
     fn judged(&self) -> usize {
-        self.compared + self.collapsed
+        self.compared_clean + self.standing_below_plan.len() + self.regressed + self.collapsed
     }
 
     fn not_judged(&self) -> usize {
-        self.skipped_new + self.skipped_stale + self.uncovered.len() + self.excluded_fluid
+        self.skipped_new
+            + self.skipped_stale
+            + self.uncovered.len()
+            + self.recovered.len()
+            + self.excluded_fluid
     }
 }
 
@@ -704,15 +773,32 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
             // 1 treated this identically to a fresh-side collapse (both
             // were "skip"); round 2 splits them, because only THIS
             // direction is a standing gap rather than a fresh finding
-            // (second-opinion review round 2, finding #1).
-            out.uncovered.push(m.label.to_string());
-            if verbose {
-                eprintln!(
-                    "{}: UNCOVERED (baseline non-converged) — this fixture has never had a \
-                     trustworthy baseline reading to compare against; a standing gap, not a \
-                     fresh finding.",
-                    m.label
-                );
+            // (second-opinion review round 2, finding #1). Round 3 splits
+            // this direction again: a fresh run that now converges is a
+            // possible repair, not just more of the same standing gap
+            // (finding #1) — see the module doc's dedicated section on
+            // why this fixture can never gain collapse coverage while it
+            // stays blessed non-converged, and why RECOVERED exists.
+            if m.converged {
+                out.recovered.push(m.label.to_string());
+                if verbose {
+                    eprintln!(
+                        "{}: RECOVERED — baseline never converged, but this run does; \
+                         re-bless to arm collapse coverage. Not yet judged: there is still no \
+                         trustworthy baseline number to compare against.",
+                        m.label
+                    );
+                }
+            } else {
+                out.uncovered.push(m.label.to_string());
+                if verbose {
+                    eprintln!(
+                        "{}: UNCOVERED (baseline non-converged) — this fixture has never had \
+                         a trustworthy baseline reading to compare against; a standing gap, \
+                         not a fresh finding.",
+                        m.label
+                    );
+                }
             }
             continue;
         }
@@ -729,7 +815,6 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
             ));
             continue;
         }
-        out.compared += 1;
         // The ONLY percentage-based alarm condition, per the module
         // docs' hard rule: compare only the BELOW-plan portion of each
         // reading (clamped to a ceiling of 0) so an above-plan baseline
@@ -738,11 +823,16 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
         // `drop` is provably <= 0 whenever the fresh reading is
         // at-or-above plan, so this can only fire when the CURRENT
         // reading is itself below plan (second-opinion review round 1,
-        // finding #1).
+        // finding #1). The bucket a row lands in is decided HERE, after
+        // the check, never before it (second-opinion review round 3,
+        // finding #3 — the old `out.compared += 1` ran unconditionally
+        // before this comparison, so a row that regressed still counted
+        // as "compared clean-or-standing").
         let baseline_below = b.deficit_pct.min(0.0);
         let fresh_below = m.deficit_pct.min(0.0);
         let drop = baseline_below - fresh_below;
         if drop > REGRESSION_TOLERANCE_PP {
+            out.regressed += 1;
             out.regressions.push(format!(
                 "{}: BELOW-PLAN REGRESSION — baseline {:.1}%, now {:.1}% ({:.1}pp worse, \
                  below-plan portion only)",
@@ -758,6 +848,8 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
                  accepted at bless time as this fixture's zero point.",
                 m.label, m.deficit_pct, b.deficit_pct
             ));
+        } else {
+            out.compared_clean += 1;
         }
     }
     if verbose {
@@ -772,6 +864,15 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
 #[test]
 #[ignore = "diagnostic tripwire — run with --ignored; see module docs for bless/check"]
 fn e2e_tripwire() {
+    // Captured BEFORE building anything below, deliberately (second-
+    // opinion review round 3, finding #2): `build_and_measure` can append
+    // newly-solved zones to the cache file, so hashing after the build
+    // loop had already run described post-run bytes, not the committed
+    // pin that was actually consulted as this run's starting state. Both
+    // `bless` and `check` reuse this ONE captured value rather than
+    // re-hashing later.
+    let pin_hash = hash_zone_cache();
+
     let mut results = Vec::new();
     let mut build_failures = Vec::new();
     for f in FIXTURES {
@@ -809,7 +910,7 @@ fn e2e_tripwire() {
                 })
                 .collect();
             let baseline = Baseline {
-                zone_cache_hash: hash_zone_cache(),
+                zone_cache_hash: pin_hash.clone(),
                 rows,
             };
             write_baseline(&baseline);
@@ -826,30 +927,33 @@ fn e2e_tripwire() {
             let baseline = load_baseline().expect(
                 "SPAGHETTIO_METER_TRIPWIRE=check needs a committed baseline; bless one first",
             );
-            let fresh_hash = hash_zone_cache();
-            if fresh_hash != baseline.zone_cache_hash {
+            if pin_hash != baseline.zone_cache_hash {
                 eprintln!(
                     "NOTE: zone-cache hash differs from the blessed baseline's ({:?} vs \
                      {:?}) — entity-count mismatches below may be caused by this rather \
                      than a genuine engine change.",
-                    baseline.zone_cache_hash, fresh_hash
+                    baseline.zone_cache_hash, pin_hash
                 );
             }
 
             let outcome = evaluate_check(&results, &baseline, true);
             eprintln!(
-                "\naccounting: {}/{} judged ({} compared clean-or-standing, {} \
-                 collapsed-to-failure), {}/{} not judged ({} new, {} stale, {} uncovered \
-                 [baseline never converged], {} excluded [fluid, uncalibrated])",
+                "\naccounting: {}/{} judged ({} clean, {} standing, {} regressed, {} \
+                 collapsed), {}/{} not judged ({} new, {} stale, {} uncovered [baseline never \
+                 converged], {} recovered [re-bless to arm], {} excluded [fluid, \
+                 uncalibrated])",
                 outcome.judged(),
                 results.len(),
-                outcome.compared,
+                outcome.compared_clean,
+                outcome.standing_below_plan.len(),
+                outcome.regressed,
                 outcome.collapsed,
                 outcome.not_judged(),
                 results.len(),
                 outcome.skipped_new,
                 outcome.skipped_stale,
                 outcome.uncovered.len(),
+                outcome.recovered.len(),
                 outcome.excluded_fluid
             );
 
@@ -949,18 +1053,39 @@ mod tests {
     }
 
     /// Finding #1 (other direction): the baseline itself never converged
-    /// — this stays a skip (an "uncovered" standing gap), never a
-    /// failure, regardless of what the fresh run does.
+    /// and the fresh run still doesn't either — this stays a skip (an
+    /// "uncovered" standing gap), never a failure.
     #[test]
     fn baseline_never_converged_is_uncovered_not_failed() {
-        for fresh_converged in [true, false] {
-            let results = vec![measurement("x", -1.0, 100, fresh_converged)];
-            let base = baseline(vec![baseline_row("x", -1.0, 100, false)]);
-            let out = evaluate_check(&results, &base, false);
-            assert!(out.regressions.is_empty(), "must not fail: {:?}", out.regressions);
-            assert_eq!(out.uncovered, vec!["x".to_string()]);
-            assert_eq!(out.judged(), 0, "an uncovered row is not a rendered verdict");
-        }
+        let results = vec![measurement("x", -1.0, 100, false)];
+        let base = baseline(vec![baseline_row("x", -1.0, 100, false)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(out.regressions.is_empty(), "must not fail: {:?}", out.regressions);
+        assert_eq!(out.uncovered, vec!["x".to_string()]);
+        assert!(out.recovered.is_empty());
+        assert_eq!(out.judged(), 0, "an uncovered row is not a rendered verdict");
+    }
+
+    /// Round 3, finding #1: `ec30-am2-ore`'s real shape — a baseline that
+    /// never converged, now paired with a fresh run that DOES. This must
+    /// print/count as RECOVERED, not silently fold into `uncovered`
+    /// (which would make a real fix invisible) and must not fail (there
+    /// is still no trustworthy baseline number to compare the fresh
+    /// reading against — an instrument cannot alarm relative to a
+    /// baseline that was already producing nothing).
+    #[test]
+    fn baseline_never_converged_recovers_when_fresh_converges() {
+        let results = vec![measurement("ec30-am2-ore", 0.0, 100, true)];
+        let base = baseline(vec![baseline_row("ec30-am2-ore", -100.0, 100, false)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(out.regressions.is_empty(), "must not fail: {:?}", out.regressions);
+        assert_eq!(out.recovered, vec!["ec30-am2-ore".to_string()]);
+        assert!(out.uncovered.is_empty(), "must not ALSO count as uncovered");
+        assert_eq!(
+            out.judged(),
+            0,
+            "recovered is not yet judged — still no trustworthy baseline number"
+        );
     }
 
     /// Finding #2: every row entity-mismatches (e.g. a wrong/missing
@@ -999,7 +1124,12 @@ mod tests {
             "an improving reading must never alarm: {:?}",
             out.regressions
         );
-        assert_eq!(out.compared, 1);
+        assert_eq!(out.regressed, 0);
+        // -1.0% is itself below plan, so it lands in `standing`, not
+        // `compared_clean` — both are non-failing buckets, but conflating
+        // them is exactly what finding #3 (round 3) polices against.
+        assert_eq!(out.standing_below_plan.len(), 1);
+        assert_eq!(out.compared_clean, 0);
     }
 
     /// A genuine below-plan regression must still fail after the
@@ -1015,6 +1145,9 @@ mod tests {
             "expected a below-plan regression, got {:?}",
             out.regressions
         );
+        assert_eq!(out.regressed, 1, "must be counted in the `regressed` bucket, not `clean`");
+        assert_eq!(out.compared_clean, 0);
+        assert!(out.standing_below_plan.is_empty());
     }
 
     /// Finding #6: a standing below-plan reading (unchanged from

--- a/crates/meter/tests/e2e_tripwire.rs
+++ b/crates/meter/tests/e2e_tripwire.rs
@@ -53,41 +53,59 @@
 //! improved toward or past plan (second-opinion review on #693 round 1,
 //! finding #1 — this was a live false-alarm path, not hypothetical).
 //!
-//! A convergence collapse (baseline converged, fresh does not) is judged
-//! qualitatively as its own below-plan-class failure, not folded into the
-//! percentage comparison: a previously-settling factory that no longer
-//! settles is exactly the shape of the worst regression this tripwire
-//! exists to catch (a stall to ~0 — the meter's own convergence detector
-//! treats "producing nothing" specially, see `producing_nothing_is_not_
-//! converged` in `factory.rs`), and round 1's shape — treating ANY
-//! non-convergence as a graceful skip — silently passed exactly that
-//! regression (second-opinion review round 2, finding #1). This does not
-//! violate the below-plan-only rule above: a stall is never an
-//! at-or-above-plan condition, it just cannot be quantified into a
-//! percentage, so it is judged as pass/fail rather than by magnitude.
-//! Baseline-side non-convergence is different and stays a skip (see
-//! "Standing gaps" below) — the baseline itself was never a trustworthy
-//! anchor to measure a regression FROM.
+//! A convergence collapse (baseline converged, fresh does not, AND the
+//! fresh reading is itself below plan) is judged qualitatively as its own
+//! below-plan-class failure, not folded into the percentage comparison: a
+//! previously-settling factory that no longer settles AND reads below
+//! plan is exactly the shape of the worst regression this tripwire exists
+//! to catch (a stall to ~0 — the meter's own convergence detector treats
+//! "producing nothing" specially, see `producing_nothing_is_not_converged`
+//! in `factory.rs`), and round 1's shape — treating ANY non-convergence as
+//! a graceful skip — silently passed exactly that regression
+//! (second-opinion review round 2, finding #1).
+//!
+//! **The direction gate matters, and an earlier round of this file got it
+//! wrong**: non-convergence alone is NOT evidence of a stall — the
+//! detector fails on any unstable trajectory, rising or falling
+//! (`factory.rs`'s `a_filling_buffer_is_not_converged` covers the rising
+//! case too), so round 2/3's "any non-convergence on the fresh side is a
+//! collapse" would fail on an over-producing or still-settling factory —
+//! good news, or at worst nothing — which violates the below-plan-only
+//! rule exactly as badly as round 1's "skip everything" bug violated it
+//! in the other direction (second-opinion review round 4, finding #1,
+//! the kernel bug that round fixed). The collapse branch therefore checks
+//! BOTH non-convergence AND `deficit_pct < 0.0` before failing; a
+//! non-converged, at-or-above-plan reading is `UNSETTLED` instead —
+//! reported, needs a stable re-run, never failed.
+//!
+//! Baseline-side non-convergence is different again and stays a skip
+//! (see "Standing gaps" below) — the baseline itself was never a
+//! trustworthy anchor to measure a regression FROM.
 //!
 //! **A baseline-non-converged fixture can never gain collapse coverage
 //! while it stays blessed non-converged** (second-opinion review round
-//! 3, finding #1 — `ec30-am2-ore`, the corpus's worst fixture, hits the
-//! "baseline never converged" branch before the collapse branch is ever
-//! reached, so a further regression on it is structurally unrepresentable
-//! today). This is not a gap in the check's design: an instrument cannot
-//! alarm on "worse than a baseline that was already producing nothing" —
-//! there is no direction left to regress FROM. It is inherent to any
-//! blessed-baseline design, not something a smarter comparison formula
-//! fixes. `ec30-am2-ore`'s real fix is the layout itself (its 3
-//! `belt-dead-end` validator errors — queued campaign-side as the W1c
-//! contested sample). The flip condition, so this is not permanently
-//! invisible: once that fixture is fixed and RE-BLESSED converged,
-//! collapse coverage arms itself automatically — no code change needed,
-//! just a bless run over the repaired layout. Until then, `check` prints
-//! a `RECOVERED` line (see the protocol section below) if a fresh run
-//! ever converges again on a still-non-converged baseline, so a fix
-//! landing is visible immediately rather than silently waiting for
-//! someone to think to re-bless.
+//! 3, finding #1). Two of the eleven blessed rows are affected today,
+//! not just one (round 3's text named only the first and read as if it
+//! were unique — round 4, finding #5): `ec30-am2-ore` (its 3
+//! `belt-dead-end` validator errors) and `plastic5-chem-crude` (no
+//! validator errors; the deficit is a real but smaller, unexplained
+//! shortfall). Both hit the "baseline never converged" branch before the
+//! collapse branch is ever reached, so a further regression on either is
+//! structurally unrepresentable today. This is not a gap in the check's
+//! design: an instrument cannot alarm on "worse than a baseline that was
+//! already producing nothing" — there is no direction left to regress
+//! FROM. It is inherent to any blessed-baseline design, not something a
+//! smarter comparison formula fixes. `ec30-am2-ore`'s real fix is the
+//! layout itself — queued campaign-side as the W1c contested sample;
+//! `plastic5-chem-crude`'s is unexamined (out of scope for this
+//! diagnostic PR to chase). The flip condition, so this is not
+//! permanently invisible: once either fixture is fixed and RE-BLESSED
+//! converged, collapse coverage arms itself automatically for it — no
+//! code change needed, just a bless run over the repaired layout. Until
+//! then, `check` prints a `RECOVERED` line (see the protocol section
+//! below) if a fresh run ever converges again on a still-non-converged
+//! baseline, so a fix landing is visible immediately rather than
+//! silently waiting for someone to think to re-bless.
 //!
 //! # Fluid targets are excluded from bless/check, never from the report
 //!
@@ -181,8 +199,16 @@
 //!         no trustworthy number to compare against) — but visible,
 //!         which `uncovered` alone would not make it (second-opinion
 //!         review round 3, finding #1).
-//!       - **collapsed** — baseline converged, fresh does not: FAILS (see
-//!         the hard-rule section above).
+//!       - **collapsed** — baseline converged, fresh does not, AND the
+//!         fresh reading is itself below plan: FAILS (see the hard-rule
+//!         section above).
+//!       - **unsettled** — baseline converged, fresh does not, but the
+//!         fresh reading is AT-OR-ABOVE plan: printed (`UNSETTLED`), not
+//!         a failure and not `judged` either — a rising buffer, a
+//!         still-settling improvement, or jitter, none of which is
+//!         below-plan evidence (second-opinion review round 4, finding
+//!         #1 — collapse used to fire on non-convergence alone, which
+//!         also covers this shape and would fail on good news).
 //!       - **compared** — both converged, entities match: the clamped
 //!         below-plan comparison runs and lands in exactly one of three
 //!         buckets (second-opinion review round 3, finding #3 — the
@@ -190,15 +216,18 @@
 //!         regression check, so a row that FAILED still printed as
 //!         "compared clean-or-standing" in the accounting, the exact
 //!         count/severity conflation `docs/validator-reporting.md`
-//!         polices): **clean** (no below-plan reading at all), or
-//!         **standing** (below-plan but not worse than baseline — prints
-//!         `STANDING BELOW-PLAN`, does not fail), or **regressed** (below-
-//!         plan AND materially worse — FAILS, prints `BELOW-PLAN
-//!         REGRESSION`).
+//!         polices): **at-or-above** (no below-plan reading at all — not
+//!         named "clean": that's a clearance word, and an at-or-above
+//!         reading is evidence of nothing either way, second-opinion
+//!         review round 4, finding #2), or **standing** (below-plan but
+//!         not worse than baseline — prints `STANDING BELOW-PLAN`, does
+//!         not fail), or **regressed** (below-plan AND materially worse
+//!         — FAILS, prints `BELOW-PLAN REGRESSION`).
 //!
 //!     `check` FAILS if nothing landed in `collapsed`, `regressed`,
-//!     `standing`, or `clean` — "verified clean" must be distinguishable
-//!     from "compared nothing".
+//!     `standing`, or `at-or-above` — a check run that judged nothing
+//!     must be distinguishable from one that judged everything and found
+//!     no problems.
 //!
 //! **Why report-only stays the default, and this is NOT wired into CI as
 //! a gate**: the committed-golden `check`/`bless` flow that used to sit
@@ -276,10 +305,26 @@ const WINDOW: u64 = 60 * 60 * 3;
 /// How much worse than the committed baseline the BELOW-plan portion of
 /// a reading must get before `check` mode alarms — see the comparison
 /// itself (in `e2e_tripwire`) for why only the below-plan portion is
-/// ever compared. 2.0pp matches the sim-harness's own baseline-check
-/// tolerance (`crates/sim-harness/src/baseline.rs`) and comfortably
-/// absorbs the tick-window jitter noted in docs/meter-divergence.md's
-/// window-quantization section.
+/// ever compared. Justified on its own terms, NOT by analogy to
+/// `crates/sim-harness/src/baseline.rs`'s 2% tolerance (round 3's doc
+/// claimed the two "match"; they don't — theirs is a RELATIVE tolerance
+/// on the blessed rate itself (`(got - want).abs() / want`), this is a
+/// fixed PERCENTAGE-POINT tolerance on plan-relative deficit; the shared
+/// numeral 2 is coincidence, not agreement — corrected round 4, finding
+/// #3). 2.0pp is set to comfortably absorb the tick-window jitter
+/// documented in docs/meter-divergence.md's window-quantization section
+/// (sub-1pp effects from window-boundary quantization alone) while still
+/// catching a real regression.
+///
+/// Trade-off, stated plainly (round 4, finding #4): the clamped
+/// comparison (below) means a fixture blessed comfortably ABOVE plan
+/// that later drops to JUST below plan — within this tolerance of zero —
+/// will not alarm, because `min(fresh, 0)` is small in magnitude and the
+/// "drop" from the baseline's clamped 0 doesn't clear the bar. Accepted:
+/// the alternative (a zero-tolerance clamped comparison) would fail on
+/// jitter alone for any fixture blessed near the boundary, which is
+/// worse in practice than a several-run delay before a marginal
+/// transition trips the gate.
 const REGRESSION_TOLERANCE_PP: f64 = 2.0;
 
 struct Fixture {
@@ -634,11 +679,15 @@ fn hash_zone_cache() -> Option<String> {
 /// single declared target, so a missing planned rate is an export/
 /// manifest bug, never a legitimate measurement. Called only from
 /// `bless`/`check` (report-only asserts nothing at all — see the module
-/// doc's bless/check protocol section).
+/// doc's bless/check protocol section). Skips fluid targets (round 4,
+/// finding #6) for consistency with their bless/check exclusion — a
+/// fluid target's plan-relative number is never gated on anyway (see the
+/// module doc's "Fluid targets are excluded" section), so this sanity
+/// check has no business asserting on it either.
 fn assert_has_plan(results: &[Measurement]) {
     let no_plan: Vec<&str> = results
         .iter()
-        .filter(|m| m.deficit_pct.is_nan())
+        .filter(|m| !m.is_fluid && m.deficit_pct.is_nan())
         .map(|m| m.label)
         .collect();
     assert!(
@@ -678,20 +727,36 @@ struct CheckOutcome {
     /// `compared` counter incremented BEFORE the regression check ran, so
     /// a row that FAILED still printed as "compared clean-or-standing" —
     /// the exact count/severity conflation `docs/validator-reporting.md`
-    /// polices against.
-    compared_clean: usize,
+    /// polices against. Named `compared_at_or_above`, not `..._clean`
+    /// (round 4, finding #2): "clean" is a clearance word, and an
+    /// at-or-above-plan reading is evidence of nothing either way — see
+    /// the module doc's hard-rule section.
+    compared_at_or_above: usize,
     /// Both converged, entities matched, below plan but NOT materially
     /// worse than baseline — see `standing_below_plan` for the messages.
     /// A subset of "compared"; counted via `standing_below_plan.len()`.
     standing_below_plan: Vec<String>,
     /// Both converged, entities matched, below plan AND materially worse
-    /// than baseline. Counted separately from `compared_clean`/
+    /// than baseline. Counted separately from `compared_at_or_above`/
     /// `standing_below_plan` so the accounting can never conflate a
     /// failing row with a clean one.
     regressed: usize,
-    /// Baseline converged, fresh did not — counted as "judged" (a
-    /// verdict WAS rendered: FAIL) even though it is not `compared_clean`,
-    /// `standing`, or `regressed`.
+    /// Baseline converged, fresh does NOT converge, AND the fresh reading
+    /// is itself below plan (or the meter's own bookkeeping shows it as
+    /// a stall — see the gate at the call site). Counted as "judged" (a
+    /// verdict WAS rendered: FAIL) even though it is not
+    /// `compared_at_or_above`, `standing`, or `regressed`.
+    ///
+    /// Gated on direction, not on non-convergence alone (round 4, finding
+    /// #1 — the kernel bug this round exists to fix): the meter's
+    /// `converged` flag is also false for a RISING reading (an
+    /// over-producing factory, or ordinary tick-window jitter around an
+    /// at-or-above-plan value — see `factory.rs`'s
+    /// `a_filling_buffer_is_not_converged`), not only a collapsing one.
+    /// Failing on non-convergence alone would fail on GOOD news, which
+    /// violates the below-plan-only hard rule as badly as round 1's
+    /// original bug violated it in the other direction. See `unsettled`
+    /// for the at-or-above-plan, non-converged case this excludes.
     collapsed: usize,
     excluded_fluid: usize,
     skipped_new: usize,
@@ -706,15 +771,26 @@ struct CheckOutcome {
     /// `uncovered` so a repair is visible instead of looking identical to
     /// "still broken".
     recovered: Vec<String>,
+    /// Labels where baseline converged but fresh does NOT, and the fresh
+    /// reading is at-or-above plan — a rising buffer, an improvement
+    /// still settling, or plain jitter, not a below-plan finding. Not
+    /// `collapsed` (round 4, finding #1) and not `judged`: there is no
+    /// trustworthy number here either, just not a failing one. Needs a
+    /// stable re-run (or a re-bless once it settles) before it can be
+    /// judged either way.
+    unsettled: Vec<String>,
 }
 
 impl CheckOutcome {
-    /// At least one row got a real verdict (compared clean, standing,
-    /// regressed, OR collapsed to a failure). Distinguishes "verified
-    /// clean" from "compared nothing" (second-opinion review round 2,
-    /// finding #2).
+    /// At least one row got a real verdict (compared at-or-above,
+    /// standing, regressed, OR collapsed to a failure). Distinguishes
+    /// "verified clean" from "compared nothing" (second-opinion review
+    /// round 2, finding #2) — "verified clean" here describes the CHECK
+    /// RUN's own state (did it actually judge anything), not any single
+    /// fixture's rate, so it is not the clearance wording finding #2
+    /// targets.
     fn judged(&self) -> usize {
-        self.compared_clean + self.standing_below_plan.len() + self.regressed + self.collapsed
+        self.compared_at_or_above + self.standing_below_plan.len() + self.regressed + self.collapsed
     }
 
     fn not_judged(&self) -> usize {
@@ -723,6 +799,7 @@ impl CheckOutcome {
             + self.uncovered.len()
             + self.recovered.len()
             + self.excluded_fluid
+            + self.unsettled.len()
     }
 }
 
@@ -804,15 +881,41 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
         }
         if !m.converged {
             // Baseline WAS a trustworthy anchor; fresh no longer
-            // converges. Treated as its own below-plan-class failure —
-            // see the module doc's hard-rule section.
-            out.collapsed += 1;
-            out.regressions.push(format!(
-                "{}: CONVERGENCE COLLAPSE — baseline converged at {:.1}%, fresh no longer \
-                 converges. A stalled/collapsed factory is exactly the regression class this \
-                 guard exists to catch.",
-                m.label, b.deficit_pct
-            ));
+            // converges. Gated on DIRECTION, not on non-convergence
+            // alone (round 4, finding #1 — the kernel bug this round
+            // exists to fix): `factory.rs`'s convergence detector fails
+            // on ANY unstable trajectory, rising or falling
+            // (`a_filling_buffer_is_not_converged` covers the rising
+            // case too), so treating every non-convergence as a collapse
+            // would fail on an over-producing/still-settling factory —
+            // good news, or at worst nothing — which violates the
+            // below-plan-only hard rule exactly as badly as round 1's
+            // original "skip everything" bug violated it in the other
+            // direction. `< 0.0` (strict) matches `print_scoreboard`'s
+            // own BELOW-PLAN threshold and never fails on an exactly-at-
+            // plan reading. A genuine stall reads unambiguously negative
+            // here regardless (measured ≈ 0 against any planned > 0 is
+            // deficit_pct ≈ -100%), so this loses no real coverage.
+            if m.deficit_pct < 0.0 {
+                out.collapsed += 1;
+                out.regressions.push(format!(
+                    "{}: CONVERGENCE COLLAPSE — baseline converged at {:.1}%, fresh no longer \
+                     converges AND reads below plan ({:.1}%). A stalled/collapsed factory is \
+                     exactly the regression class this guard exists to catch.",
+                    m.label, b.deficit_pct, m.deficit_pct
+                ));
+            } else {
+                out.unsettled.push(m.label.to_string());
+                if verbose {
+                    eprintln!(
+                        "{}: UNSETTLED — not converged, but reads at-or-above plan ({:.1}%); \
+                         could be a rising buffer, a still-settling improvement, or jitter — \
+                         not below-plan evidence either way, so not failed. Needs a stable \
+                         re-run (or a re-bless once stable) before this can be judged.",
+                        m.label, m.deficit_pct
+                    );
+                }
+            }
             continue;
         }
         // The ONLY percentage-based alarm condition, per the module
@@ -849,7 +952,7 @@ fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -
                 m.label, m.deficit_pct, b.deficit_pct
             ));
         } else {
-            out.compared_clean += 1;
+            out.compared_at_or_above += 1;
         }
     }
     if verbose {
@@ -938,13 +1041,13 @@ fn e2e_tripwire() {
 
             let outcome = evaluate_check(&results, &baseline, true);
             eprintln!(
-                "\naccounting: {}/{} judged ({} clean, {} standing, {} regressed, {} \
+                "\naccounting: {}/{} judged ({} at-or-above, {} standing, {} regressed, {} \
                  collapsed), {}/{} not judged ({} new, {} stale, {} uncovered [baseline never \
-                 converged], {} recovered [re-bless to arm], {} excluded [fluid, \
-                 uncalibrated])",
+                 converged], {} recovered [re-bless to arm], {} unsettled [not converged, \
+                 at-or-above plan], {} excluded [fluid, uncalibrated])",
                 outcome.judged(),
                 results.len(),
-                outcome.compared_clean,
+                outcome.compared_at_or_above,
                 outcome.standing_below_plan.len(),
                 outcome.regressed,
                 outcome.collapsed,
@@ -954,6 +1057,7 @@ fn e2e_tripwire() {
                 outcome.skipped_stale,
                 outcome.uncovered.len(),
                 outcome.recovered.len(),
+                outcome.unsettled.len(),
                 outcome.excluded_fluid
             );
 
@@ -1035,9 +1139,10 @@ mod tests {
         }
     }
 
-    /// Finding #1: baseline converged, fresh does not — must FAIL as a
-    /// collapse, not silently skip (round 1's bug: uniform non-convergence
-    /// skipping let a throughput collapse to ~0 pass green).
+    /// Finding #1 (round 2): baseline converged, fresh does not, AND the
+    /// fresh reading is below plan — must FAIL as a collapse, not
+    /// silently skip (round 1's bug: uniform non-convergence skipping let
+    /// a throughput collapse to ~0 pass green).
     #[test]
     fn convergence_collapse_fails() {
         let results = vec![measurement("x", -1.0, 100, false)];
@@ -1050,6 +1155,32 @@ mod tests {
             "expected a COLLAPSE regression, got {:?}",
             out.regressions
         );
+        assert!(out.unsettled.is_empty());
+    }
+
+    /// Round 4, finding #1 (the kernel bug this round exists to fix):
+    /// baseline converged, fresh does NOT converge, but the fresh reading
+    /// is AT-OR-ABOVE plan — a rising buffer or a still-settling
+    /// improvement, not below-plan evidence. Must NOT fail: the
+    /// round-2/3 collapse branch fired on non-convergence alone, which
+    /// also covers this shape (`factory.rs`'s convergence detector fails
+    /// on any unstable trajectory, not only a falling one), so it would
+    /// have failed on good news — violating the below-plan-only hard
+    /// rule as badly as round 1's bug violated it in the other
+    /// direction.
+    #[test]
+    fn convergence_collapse_does_not_fire_on_improvement_shape() {
+        let results = vec![measurement("x", 5.0, 100, false)];
+        let base = baseline(vec![baseline_row("x", -2.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(
+            out.regressions.is_empty(),
+            "a non-converged AT-OR-ABOVE-plan reading must never fail: {:?}",
+            out.regressions
+        );
+        assert_eq!(out.collapsed, 0, "must not be counted as a collapse");
+        assert_eq!(out.unsettled, vec!["x".to_string()]);
+        assert_eq!(out.judged(), 0, "unsettled is not yet judged either way");
     }
 
     /// Finding #1 (other direction): the baseline itself never converged
@@ -1126,10 +1257,11 @@ mod tests {
         );
         assert_eq!(out.regressed, 0);
         // -1.0% is itself below plan, so it lands in `standing`, not
-        // `compared_clean` — both are non-failing buckets, but conflating
-        // them is exactly what finding #3 (round 3) polices against.
+        // `compared_at_or_above` — both are non-failing buckets, but
+        // conflating them is exactly what finding #3 (round 3) polices
+        // against.
         assert_eq!(out.standing_below_plan.len(), 1);
-        assert_eq!(out.compared_clean, 0);
+        assert_eq!(out.compared_at_or_above, 0);
     }
 
     /// A genuine below-plan regression must still fail after the
@@ -1145,8 +1277,11 @@ mod tests {
             "expected a below-plan regression, got {:?}",
             out.regressions
         );
-        assert_eq!(out.regressed, 1, "must be counted in the `regressed` bucket, not `clean`");
-        assert_eq!(out.compared_clean, 0);
+        assert_eq!(
+            out.regressed, 1,
+            "must be counted in the `regressed` bucket, not `compared_at_or_above`"
+        );
+        assert_eq!(out.compared_at_or_above, 0);
         assert!(out.standing_below_plan.is_empty());
     }
 

--- a/crates/meter/tests/e2e_tripwire.rs
+++ b/crates/meter/tests/e2e_tripwire.rs
@@ -40,50 +40,126 @@
 //! at-or-above-plan reading as clearance, in code, comments, or printed
 //! text. The scoreboard tags a negative deficit `BELOW PLAN`; a
 //! non-negative one gets a blank column, never a `PASS`/`OK`/`cleared`
-//! word. `check` mode's only failure condition is "the CURRENT reading is
-//! below plan, and materially worse than the committed baseline" — never
-//! "the reading dropped from a higher baseline while staying non-negative
-//! throughout" and never "at-plan, therefore fine". Enforced structurally,
-//! not just by convention: the comparison clamps both readings to a
-//! ceiling of 0 before differencing (`min(deficit_pct, 0.0)`), so the
-//! result can only be positive (alarm-worthy) when the FRESH reading is
-//! itself below plan — an above-plan baseline (sulfuric5-chem's committed
-//! +239%, for instance) can never manufacture a "regression" out of a
-//! reading that improved toward or past plan (second-opinion review on
-//! #693, finding #1 — this was a live false-alarm path, not hypothetical).
-//! Everything that ISN'T that one comparison — a stale baseline (entity
-//! count moved), a reading that isn't converged on either side, or a
-//! fixture with no baseline row at all — cannot be validly judged either
-//! way, so it is printed as a skip and never fails the test; failing on
-//! those would itself violate the below-plan-only contract (finding #2).
+//! word. `check` mode's only failure conditions are (a) "the CURRENT
+//! reading is below plan, and materially worse than the committed
+//! baseline" and (b) a convergence collapse (below) — never "the reading
+//! dropped from a higher baseline while staying non-negative throughout"
+//! and never "at-plan, therefore fine". (a) is enforced structurally, not
+//! just by convention: the comparison clamps both readings to a ceiling
+//! of 0 before differencing (`min(deficit_pct, 0.0)`), so the result can
+//! only be positive (alarm-worthy) when the FRESH reading is itself below
+//! plan — an above-plan baseline (sulfuric5-chem's committed +239%, for
+//! instance) can never manufacture a "regression" out of a reading that
+//! improved toward or past plan (second-opinion review on #693 round 1,
+//! finding #1 — this was a live false-alarm path, not hypothetical).
+//!
+//! A convergence collapse (baseline converged, fresh does not) is judged
+//! qualitatively as its own below-plan-class failure, not folded into the
+//! percentage comparison: a previously-settling factory that no longer
+//! settles is exactly the shape of the worst regression this tripwire
+//! exists to catch (a stall to ~0 — the meter's own convergence detector
+//! treats "producing nothing" specially, see `producing_nothing_is_not_
+//! converged` in `factory.rs`), and round 1's shape — treating ANY
+//! non-convergence as a graceful skip — silently passed exactly that
+//! regression (second-opinion review round 2, finding #1). This does not
+//! violate the below-plan-only rule above: a stall is never an
+//! at-or-above-plan condition, it just cannot be quantified into a
+//! percentage, so it is judged as pass/fail rather than by magnitude.
+//! Baseline-side non-convergence is different and stays a skip (see
+//! "Standing gaps" below) — the baseline itself was never a trustworthy
+//! anchor to measure a regression FROM.
+//!
+//! # Fluid targets are excluded from bless/check, never from the report
+//!
+//! `sulfuric5-chem` and `lightoil5-chem-cracking` (the corpus's only two
+//! fluid-target fixtures) are measured and printed exactly like every
+//! other fixture, but are never written into the committed baseline and
+//! never judged in `check` mode (second-opinion review round 2, finding
+//! #4). This is NOT because the meter fails to model fluid delivery — it
+//! does (`fluid.rs`'s Phase B pipe network; `delivered_per_s` is
+//! populated with real, non-zero numbers for both fixtures) — it is
+//! because that number has never been calibrated against a real Factorio
+//! measurement for these targets at all. docs/meter-divergence.md is
+//! explicit on both points: *"Fluid targets are untested. All 4
+//! fluid-target fixtures... have no sim baseline in this corpus. The
+//! floor verdict is a solid-target-only result,"* and separately
+//! documents a DELIBERATE modeling choice that biases fluid delivery
+//! upward — *"the meter drains every unconsumed producer fluid unit as
+//! delivered and never stalls a producer on a full fluid output"* (the
+//! byproduct-backpressure entry) — which is exactly the mechanism behind
+//! these two fixtures' measured +239%/+200%: a fractional solved machine
+//! count (`count: 0.1`/`0.333`) rounds up to one physical machine whose
+//! ingredient delivery isn't duty-cycled down, so it runs faster than
+//! planned, and the meter drains all of it as "delivered" rather than
+//! modeling the backpressure a real factory would apply. So the
+//! calibrated asymmetry this whole file rests on has never been
+//! established for these two targets in EITHER direction — gating on
+//! them would apply a calibration to a population it was never measured
+//! against. `check` prints an explicit `EXCLUDED` line for each, and the
+//! scoreboard's `flag` column marks them `fluid (uncalibrated)`
+//! regardless of sign.
+//!
+//! # The committed baseline is this instrument's ZERO, not a live floor
+//!
+//! `check` never alarms on absolute below-plan — only on a below-plan
+//! reading that is MATERIALLY WORSE than what was blessed. A fixture
+//! blessed already below plan (`gear20-am2-plate` at -25.0%, for
+//! instance) stays clean in `check` forever, until someone deliberately
+//! re-blesses a tighter number. This is deliberate (second-opinion review
+//! round 2, finding #6, correcting round 1's docs for overselling it) —
+//! exactly how `e2e.rs`'s `StressBaseline` ceilings work: a bar to
+//! ratchet DOWN as fixes land, not a live absolute threshold. Failing on
+//! any below-plan reading regardless of history would make this tripwire
+//! permanently red from the moment it is blessed (several fixtures are
+//! already below plan today) and useless until every pre-existing deficit
+//! is independently fixed first — backwards for a regression gate, which
+//! has to be able to bootstrap on a corpus with known, un-actioned
+//! issues. Standing below-plan rows are not hidden, though: `check` lists
+//! them explicitly (`STANDING BELOW-PLAN`, reported, never failed) so
+//! "clean" never reads as "nothing here is wrong."
 //!
 //! # bless/check protocol (mirrors `SPAGHETTIO_STRESS_GOLDEN`'s shape,
 //! but see the note below on why this one is NOT the same design)
 //!
 //! `SPAGHETTIO_METER_TRIPWIRE` selects the mode:
-//!   * unset — **report-only** (the default). Prints the scoreboard,
-//!     asserts only that every fixture built and measured something (a
-//!     build regression must not hide as a silently-empty table); no
-//!     plan-relative verdict, and no other assertion — the
-//!     manifest-has-a-plan sanity check below only runs under `bless`/
-//!     `check`, where a missing plan would otherwise corrupt what gets
-//!     committed or compared.
-//!   * `bless` — writes the current per-fixture readings as the new
-//!     committed baseline (`e2e_tripwire_baseline.json`).
+//!   * unset — **report-only** (the default). Prints the scoreboard and,
+//!     loudly, any build failures — and asserts NOTHING. Every assertion
+//!     in this file (build failures, the has-a-plan sanity check, the
+//!     below-plan comparison itself) is scoped to `bless`/`check` only.
+//!     Round 1 already made this promise for the has-a-plan check but
+//!     left the build-failure assert unconditional; second-opinion review
+//!     round 2 (finding #5) caught the gap. If a new assertion is ever
+//!     added to this file, it belongs inside the `bless`/`check` arms,
+//!     never before the match.
+//!   * `bless` — writes the current per-fixture readings (excluding fluid
+//!     targets — see above) as the new committed baseline
+//!     (`e2e_tripwire_baseline.json`), alongside a hash of the zone-cache
+//!     file used to build them.
 //!   * `check` — compares fresh readings against the committed baseline.
-//!     **Fails only on a genuine below-plan regression**: the fresh
-//!     reading is itself below plan AND its below-plan portion is
-//!     materially worse than the baseline's (see the hard-rule section
-//!     above for the clamped-comparison mechanism). Three things that
-//!     cannot be validly judged are printed and SKIPPED rather than
-//!     failed — none of them is a below-plan finding, so none may fail
-//!     the test: a fixture missing from the baseline (new — bless it), a
-//!     baseline stale for the current geometry (entity count changed —
-//!     comparing them would be apples to oranges), and a reading that
-//!     isn't converged on either side (the deficit number isn't
-//!     trustworthy at all in that case, not just "trustworthy but
-//!     different" — matches `corpus_replay.rs`'s own treatment of an
-//!     unconverged reading as unusable, not merely suspect).
+//!     Every fixture lands in exactly one bucket, and the run prints an
+//!     accounting line totalling them (second-opinion review round 2,
+//!     finding #2 — a run where every row is skipped must not read as
+//!     "clean", the same failure class `docs/validator-reporting.md`
+//!     documents for check severity/count conflation):
+//!       - **excluded** — a fluid target (see above); never gated.
+//!       - **new** — no baseline row (bless it).
+//!       - **stale** — entity count changed vs the baseline; not
+//!         comparable (the zone-cache hash recorded at bless time helps
+//!         tell "the SAME pin produced a different count" — a genuine
+//!         engine change — from "a DIFFERENT pin is in play" — geometry
+//!         noise, not a finding).
+//!       - **uncovered** — the BASELINE row itself never converged, so it
+//!         was never a trustworthy anchor; a standing gap, printed
+//!         (`UNCOVERED (baseline non-converged)`), not a fresh failure.
+//!       - **collapsed** — baseline converged, fresh does not: FAILS (see
+//!         the hard-rule section above).
+//!       - **compared** — both converged, entities match: the clamped
+//!         below-plan comparison runs; a below-plan reading that's simply
+//!         standing (not worse than baseline) prints `STANDING BELOW-PLAN`
+//!         and does not fail.
+//!
+//!     `check` FAILS if nothing landed in `collapsed` or `compared` —
+//!     "verified clean" must be distinguishable from "compared nothing".
 //!
 //! **Why report-only stays the default, and this is NOT wired into CI as
 //! a gate**: the committed-golden `check`/`bless` flow that used to sit
@@ -115,6 +191,26 @@
 //! aggregate, never per-tile flow — docs/rate-stamp-semantics.md). Entity
 //! count is used only as a cheap geometry-identity check, and the actual
 //! throughput numbers come entirely from the meter's own tick simulation.
+//!
+//! # Known limitations not (yet) worth more machinery
+//! (second-opinion review round 2, findings #7-9 — recorded rather than
+//! fixed further, per that review's own "your call, state it" latitude)
+//!
+//! * The stale-baseline guard keys on entity COUNT only, not a structural
+//!   signature — two different layouts with the same entity count would
+//!   pass this guard undetected. `golden_hash`-style structural hashing
+//!   (`e2e.rs`) would close this; not done here to keep this PR's diff
+//!   modest, and entity count plus the zone-cache hash above already
+//!   catches the overwhelmingly common cases (added/removed machines,
+//!   different cache state).
+//! * The baseline records no engine/git-commit provenance beyond the
+//!   zone-cache hash — unlike `crates/sim-harness/src/baseline.rs`'s
+//!   `game_version`/`mods`/`tech_state` key, there is no "which engine
+//!   commit was this blessed against" field. Low value here: unlike the
+//!   sim harness (which compares against an external, independently
+//!   versioned game binary), this baseline is always compared against
+//!   whatever engine commit is checked out, so the comparison is
+//!   inherently commit-relative already.
 
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
@@ -291,12 +387,17 @@ struct Measurement {
     /// flag (fluids never enter `produced_per_s`; matches
     /// `sweep_corpus.rs`'s metric-matching rule).
     metric: &'static str,
+    /// True when the target is a fluid. Excluded from bless/check — see
+    /// the module doc's "Fluid targets are excluded" section — but still
+    /// measured and reported.
+    is_fluid: bool,
     entities: usize,
     planned: f64,
     measured: f64,
     /// `(measured/planned - 1) * 100`. NEGATIVE = below plan, and that is
-    /// the only direction this file trusts. Non-negative is printed for
-    /// visibility only — never treated as evidence the layout is correct.
+    /// the only direction this file trusts (for solid targets — see
+    /// `is_fluid`). Non-negative is printed for visibility only — never
+    /// treated as evidence the layout is correct.
     deficit_pct: f64,
     converged: bool,
 }
@@ -364,6 +465,7 @@ fn build_and_measure(f: &Fixture) -> Result<Measurement, String> {
         label: f.label,
         target: target.item,
         metric,
+        is_fluid: target.is_fluid,
         entities,
         planned,
         measured,
@@ -374,13 +476,17 @@ fn build_and_measure(f: &Fixture) -> Result<Measurement, String> {
 
 /// Print the scoreboard. See the module docs' hard rule: a non-negative
 /// deficit gets a blank flag column, never a "PASS"/"OK"/"cleared" word.
+/// A fluid target's flag is always `fluid (uncalibrated)` regardless of
+/// sign — see the module doc's "Fluid targets are excluded" section.
 fn print_scoreboard(results: &[Measurement]) {
     println!(
         "\n{:<24} {:>20} {:>10} {:>10} {:>10} {:>8} {:>10}  flag",
         "fixture", "target", "metric", "planned", "measured", "delta%", "converged"
     );
     for m in results {
-        let flag = if m.deficit_pct.is_nan() {
+        let flag = if m.is_fluid {
+            "fluid (uncalibrated)"
+        } else if m.deficit_pct.is_nan() {
             "no-plan"
         } else if m.deficit_pct < 0.0 {
             "BELOW PLAN"
@@ -416,18 +522,250 @@ struct BaselineRow {
     converged: bool,
 }
 
+/// The committed baseline: per-fixture rows plus the zone-cache file's
+/// content hash at bless time (second-opinion review round 2, findings
+/// #7-9) — lets `check` distinguish "the SAME cache pin produced a
+/// different entity count" (a genuine engine change) from "a DIFFERENT
+/// cache pin is in play" (the entity mismatch is provenance noise, not a
+/// finding). `Option` because a bless run with no resolvable cache file
+/// still has to produce something loadable.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct Baseline {
+    zone_cache_hash: Option<String>,
+    rows: Vec<BaselineRow>,
+}
+
 fn baseline_path() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/e2e_tripwire_baseline.json")
 }
 
-fn load_baseline() -> Option<Vec<BaselineRow>> {
+fn load_baseline() -> Option<Baseline> {
     let text = std::fs::read_to_string(baseline_path()).ok()?;
     serde_json::from_str(&text).ok()
 }
 
-fn write_baseline(rows: &[BaselineRow]) {
-    let json = serde_json::to_string_pretty(rows).expect("baseline rows serialize");
+fn write_baseline(baseline: &Baseline) {
+    let json = serde_json::to_string_pretty(baseline).expect("baseline serializes");
     std::fs::write(baseline_path(), json + "\n").expect("write baseline");
+}
+
+/// Mirrors `spaghettio_core::zone_cache::resolve_cache_path`'s exact
+/// fallback chain. That function is private to the core crate, so
+/// diagnostics elsewhere in the repo that need the same path (e.g.
+/// `e2e.rs`'s `diag_sat_zone_histogram`, `diag_decomposition_potential`)
+/// each reimplement it rather than share it; this is no exception.
+fn resolve_zone_cache_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("SPAGHETTIO_ZONE_CACHE_PATH") {
+        return std::path::PathBuf::from(p);
+    }
+    let base = std::env::var("XDG_CACHE_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|h| std::path::PathBuf::from(h).join(".cache"))
+        })
+        .unwrap_or_else(|| std::path::PathBuf::from(".cache"));
+    base.join("spaghettio").join("sat-zones.bin")
+}
+
+/// A cheap (non-cryptographic) content hash of the zone-cache file, if it
+/// exists. Not a security primitive — just a "did this change" signal so
+/// `check` can tell a genuine engine change apart from a different cache
+/// pin (second-opinion review round 2, findings #7-9).
+fn hash_zone_cache() -> Option<String> {
+    use std::hash::{Hash, Hasher};
+    let bytes = std::fs::read(resolve_zone_cache_path()).ok()?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    Some(format!("{:016x}", hasher.finish()))
+}
+
+/// Sanity, not a plan-relative verdict: every fixture here solves a
+/// single declared target, so a missing planned rate is an export/
+/// manifest bug, never a legitimate measurement. Called only from
+/// `bless`/`check` (report-only asserts nothing at all — see the module
+/// doc's bless/check protocol section).
+fn assert_has_plan(results: &[Measurement]) {
+    let no_plan: Vec<&str> = results
+        .iter()
+        .filter(|m| m.deficit_pct.is_nan())
+        .map(|m| m.label)
+        .collect();
+    assert!(
+        no_plan.is_empty(),
+        "no planned rate found for target on: {no_plan:?} — export/manifest bug"
+    );
+}
+
+/// A build/measure failure is a pipeline break, not a below-plan reading
+/// — but per report-only's "asserts nothing" contract (second-opinion
+/// review round 2, finding #5), this is only ever an `assert!` inside
+/// `bless`/`check`. Report-only prints failures via `eprintln!` instead,
+/// at the call site.
+fn assert_no_build_failures(build_failures: &[String]) {
+    assert!(
+        build_failures.is_empty(),
+        "fixture build/measure failed — a build regression, not a below-plan reading:\n{}",
+        build_failures.join("\n")
+    );
+}
+
+/// The verdict `check` mode renders — pulled out of `e2e_tripwire` into a
+/// pure function (second-opinion review round 2: findings #1 and #2
+/// asked for the discrimination checks to be EXECUTED, not reasoned
+/// about, and a live convergence flip cannot be manufactured by mutating
+/// the committed baseline file the way round 1's false-alarm scenario
+/// could — it needs a synthetic `Measurement`, which this function
+/// accepts directly). See `mod tests` below for the executed proofs.
+#[derive(Debug, Default)]
+struct CheckOutcome {
+    /// Below-plan-class failures: a genuine regression (the clamped
+    /// comparison) or a convergence collapse. Non-empty ⇒ `check` fails.
+    regressions: Vec<String>,
+    /// Both converged, entities matched, no regression — includes
+    /// standing below-plan rows (see `standing_below_plan`).
+    compared: usize,
+    /// Baseline converged, fresh did not — counted as "judged" (a
+    /// verdict WAS rendered: FAIL) even though it lands in
+    /// `regressions`, not `compared`.
+    collapsed: usize,
+    excluded_fluid: usize,
+    skipped_new: usize,
+    skipped_stale: usize,
+    /// Labels whose BASELINE row never converged — a standing gap, not a
+    /// fresh finding.
+    uncovered: Vec<String>,
+    /// Below-plan readings that are standing (not worse than baseline) —
+    /// reported, never failed. See the module doc's "instrument's ZERO"
+    /// section.
+    standing_below_plan: Vec<String>,
+}
+
+impl CheckOutcome {
+    /// At least one row got a real verdict (compared clean/standing, OR
+    /// collapsed to a failure). Distinguishes "verified clean" from
+    /// "compared nothing" (second-opinion review round 2, finding #2).
+    fn judged(&self) -> usize {
+        self.compared + self.collapsed
+    }
+
+    fn not_judged(&self) -> usize {
+        self.skipped_new + self.skipped_stale + self.uncovered.len() + self.excluded_fluid
+    }
+}
+
+/// Compare fresh `results` against the committed `baseline`, printing
+/// each row's disposition and returning the aggregate verdict. `verbose`
+/// gates the `eprintln!` calls — off for the synthetic unit tests below,
+/// on for the real `check` run (`e2e_tripwire`), so a unit test run
+/// doesn't spam CI output with fixture labels that don't exist.
+fn evaluate_check(results: &[Measurement], baseline: &Baseline, verbose: bool) -> CheckOutcome {
+    let mut out = CheckOutcome::default();
+    for m in results {
+        // Fluid targets are structurally excluded regardless of
+        // baseline/convergence state — checked first so they never get
+        // misreported as "new fixture" once the baseline no longer
+        // carries a row for them.
+        if m.is_fluid {
+            out.excluded_fluid += 1;
+            if verbose {
+                eprintln!(
+                    "{}: EXCLUDED — fluid target, uncalibrated for gating (no sim baseline \
+                     exists for this target; see docs/meter-divergence.md). Reported above, \
+                     never gated.",
+                    m.label
+                );
+            }
+            continue;
+        }
+        let Some(b) = baseline.rows.iter().find(|b| b.label == m.label) else {
+            out.skipped_new += 1;
+            if verbose {
+                eprintln!("{}: SKIPPED — no baseline row (new fixture — bless it)", m.label);
+            }
+            continue;
+        };
+        if b.entities != m.entities {
+            out.skipped_stale += 1;
+            if verbose {
+                eprintln!(
+                    "{}: SKIPPED — entity count changed ({} -> {}); geometry moved, baseline \
+                     is stale and not comparable. Re-bless deliberately.",
+                    m.label, b.entities, m.entities
+                );
+            }
+            continue;
+        }
+        if !b.converged {
+            // The baseline itself was never a trustworthy anchor — round
+            // 1 treated this identically to a fresh-side collapse (both
+            // were "skip"); round 2 splits them, because only THIS
+            // direction is a standing gap rather than a fresh finding
+            // (second-opinion review round 2, finding #1).
+            out.uncovered.push(m.label.to_string());
+            if verbose {
+                eprintln!(
+                    "{}: UNCOVERED (baseline non-converged) — this fixture has never had a \
+                     trustworthy baseline reading to compare against; a standing gap, not a \
+                     fresh finding.",
+                    m.label
+                );
+            }
+            continue;
+        }
+        if !m.converged {
+            // Baseline WAS a trustworthy anchor; fresh no longer
+            // converges. Treated as its own below-plan-class failure —
+            // see the module doc's hard-rule section.
+            out.collapsed += 1;
+            out.regressions.push(format!(
+                "{}: CONVERGENCE COLLAPSE — baseline converged at {:.1}%, fresh no longer \
+                 converges. A stalled/collapsed factory is exactly the regression class this \
+                 guard exists to catch.",
+                m.label, b.deficit_pct
+            ));
+            continue;
+        }
+        out.compared += 1;
+        // The ONLY percentage-based alarm condition, per the module
+        // docs' hard rule: compare only the BELOW-plan portion of each
+        // reading (clamped to a ceiling of 0) so an above-plan baseline
+        // can never manufacture a "regression" out of a fresh reading
+        // that moved toward plan or into a trustworthy below-plan range.
+        // `drop` is provably <= 0 whenever the fresh reading is
+        // at-or-above plan, so this can only fire when the CURRENT
+        // reading is itself below plan (second-opinion review round 1,
+        // finding #1).
+        let baseline_below = b.deficit_pct.min(0.0);
+        let fresh_below = m.deficit_pct.min(0.0);
+        let drop = baseline_below - fresh_below;
+        if drop > REGRESSION_TOLERANCE_PP {
+            out.regressions.push(format!(
+                "{}: BELOW-PLAN REGRESSION — baseline {:.1}%, now {:.1}% ({:.1}pp worse, \
+                 below-plan portion only)",
+                m.label, b.deficit_pct, m.deficit_pct, drop
+            ));
+        } else if m.deficit_pct < 0.0 {
+            // Standing, accepted deficit — the blessed state IS this
+            // instrument's zero (module doc section above). Reported so
+            // "clean" never reads as "nothing here is wrong"
+            // (second-opinion review round 2, finding #6).
+            out.standing_below_plan.push(format!(
+                "{}: STANDING BELOW-PLAN — {:.1}% (baseline {:.1}%), not a new regression; \
+                 accepted at bless time as this fixture's zero point.",
+                m.label, m.deficit_pct, b.deficit_pct
+            ));
+        }
+    }
+    if verbose {
+        for line in &out.standing_below_plan {
+            eprintln!("{line}");
+        }
+    }
+    out
 }
 
 /// W1a: the tripwire itself. See the module docs for the three modes.
@@ -442,19 +780,26 @@ fn e2e_tripwire() {
             Err(e) => build_failures.push(e),
         }
     }
-    assert!(
-        build_failures.is_empty(),
-        "fixture build/measure failed — a build regression, not a below-plan reading:\n{}",
-        build_failures.join("\n")
-    );
+
+    if !build_failures.is_empty() {
+        eprintln!(
+            "fixture build/measure failed — a build regression, not a below-plan \
+             reading:\n{}",
+            build_failures.join("\n")
+        );
+    }
 
     print_scoreboard(&results);
 
     match std::env::var("SPAGHETTIO_METER_TRIPWIRE").as_deref() {
         Ok("bless") => {
+            assert_no_build_failures(&build_failures);
             assert_has_plan(&results);
             let rows: Vec<BaselineRow> = results
                 .iter()
+                // Fluid targets are never blessed — see the module doc's
+                // "Fluid targets are excluded" section.
+                .filter(|m| !m.is_fluid)
                 .map(|m| BaselineRow {
                     label: m.label.to_string(),
                     target: m.target.clone(),
@@ -463,105 +808,250 @@ fn e2e_tripwire() {
                     converged: m.converged,
                 })
                 .collect();
-            write_baseline(&rows);
-            eprintln!("BLESSED {} fixture row(s) to {:?}", rows.len(), baseline_path());
+            let baseline = Baseline {
+                zone_cache_hash: hash_zone_cache(),
+                rows,
+            };
+            write_baseline(&baseline);
+            eprintln!(
+                "BLESSED {} fixture row(s) to {:?} (zone-cache hash: {:?})",
+                baseline.rows.len(),
+                baseline_path(),
+                baseline.zone_cache_hash
+            );
         }
         Ok("check") => {
+            assert_no_build_failures(&build_failures);
             assert_has_plan(&results);
             let baseline = load_baseline().expect(
                 "SPAGHETTIO_METER_TRIPWIRE=check needs a committed baseline; bless one first",
             );
-            let mut regressions = Vec::new();
-            for m in &results {
-                // Three "cannot judge this one" cases. None of these is a
-                // below-plan finding, so per the below-plan-only contract
-                // (module docs; second-opinion review on #693, finding
-                // #2) none of them may fail the test — printed and
-                // skipped only.
-                let Some(b) = baseline.iter().find(|b| b.label == m.label) else {
-                    eprintln!("{}: SKIPPED — no baseline row (new fixture — bless it)", m.label);
-                    continue;
-                };
-                if b.entities != m.entities {
-                    eprintln!(
-                        "{}: SKIPPED — entity count changed ({} -> {}); geometry moved, \
-                         baseline is stale and not comparable. Re-bless deliberately.",
-                        m.label, b.entities, m.entities
-                    );
-                    continue;
-                }
-                if !b.converged || !m.converged {
-                    // Either side, not just a flip (finding #3): both
-                    // sides unconverged fell through this guard when it
-                    // only checked `b.converged != m.converged`, despite
-                    // the whole point being that an unconverged reading
-                    // isn't trustworthy full stop — matches
-                    // `corpus_replay.rs`'s own treatment (an unconverged
-                    // solid config is a buffer-fill transient, not a
-                    // rate, regardless of what it's being compared to).
-                    eprintln!(
-                        "{}: SKIPPED — not converged (baseline={}, fresh={}); the deficit \
-                         reading is not trustworthy, so it is not compared either way.",
-                        m.label, b.converged, m.converged
-                    );
-                    continue;
-                }
-                // The ONLY alarm condition, per the module docs' hard
-                // rule: compare only the BELOW-plan portion of each
-                // reading (clamped to a ceiling of 0) so an above-plan
-                // baseline can never manufacture a "regression" out of a
-                // fresh reading that moved toward plan or into a
-                // trustworthy below-plan range. `drop` is provably <= 0
-                // whenever the fresh reading is at-or-above plan
-                // (`fresh_below` is then exactly 0, and `baseline_below`
-                // is always <= 0), so this can only fire when the CURRENT
-                // reading is itself below plan (second-opinion review on
-                // #693, finding #1 — this exact shape, an above-plan
-                // baseline moving toward plan, was a live false alarm
-                // before this fix: sulfuric5-chem/lightoil5-chem-cracking
-                // are committed at +239%/+200%).
-                let baseline_below = b.deficit_pct.min(0.0);
-                let fresh_below = m.deficit_pct.min(0.0);
-                let drop = baseline_below - fresh_below;
-                if drop > REGRESSION_TOLERANCE_PP {
-                    regressions.push(format!(
-                        "{}: BELOW-PLAN REGRESSION — baseline {:.1}%, now {:.1}% ({:.1}pp \
-                         worse, below-plan portion only)",
-                        m.label, b.deficit_pct, m.deficit_pct, drop
-                    ));
-                }
+            let fresh_hash = hash_zone_cache();
+            if fresh_hash != baseline.zone_cache_hash {
+                eprintln!(
+                    "NOTE: zone-cache hash differs from the blessed baseline's ({:?} vs \
+                     {:?}) — entity-count mismatches below may be caused by this rather \
+                     than a genuine engine change.",
+                    baseline.zone_cache_hash, fresh_hash
+                );
             }
+
+            let outcome = evaluate_check(&results, &baseline, true);
+            eprintln!(
+                "\naccounting: {}/{} judged ({} compared clean-or-standing, {} \
+                 collapsed-to-failure), {}/{} not judged ({} new, {} stale, {} uncovered \
+                 [baseline never converged], {} excluded [fluid, uncalibrated])",
+                outcome.judged(),
+                results.len(),
+                outcome.compared,
+                outcome.collapsed,
+                outcome.not_judged(),
+                results.len(),
+                outcome.skipped_new,
+                outcome.skipped_stale,
+                outcome.uncovered.len(),
+                outcome.excluded_fluid
+            );
+
+            // "Verified clean" must be distinguishable from "compared
+            // nothing" (second-opinion review round 2, finding #2) — a
+            // missing/wrong zone-cache pin can make every row
+            // entity-mismatch, and that must not print a green check.
             assert!(
-                regressions.is_empty(),
+                outcome.judged() > 0,
+                "check compared NOTHING — every row was skipped, excluded, or uncovered. \
+                 This is indistinguishable from a wrong or missing SPAGHETTIO_ZONE_CACHE_PATH \
+                 pin (every row would then entity-mismatch) and must not read as 'clean'. \
+                 See the accounting line above for which reason dominated."
+            );
+            assert!(
+                outcome.regressions.is_empty(),
                 "meter tripwire: below-plan regression(s) vs the committed baseline:\n{}",
-                regressions.join("\n")
+                outcome.regressions.join("\n")
             );
         }
         _ => {
-            // Report-only default — see module docs. No plan-relative
-            // assertion here, deliberately, and no OTHER assertion either
-            // (the manifest-has-a-plan sanity check is bless/check-only —
-            // second-opinion review on #693, finding #4: report-only
-            // must not be able to fail a test over anything but the
-            // build-failure check above).
+            // Report-only default — see module docs. No assertion of any
+            // kind here, deliberately (second-opinion review round 2,
+            // finding #5): build failures above are printed, not
+            // asserted, and neither `assert_has_plan` nor the below-plan
+            // comparison ever runs in this branch.
         }
     }
 }
 
-/// Sanity, not a plan-relative verdict: every fixture here solves a
-/// single declared target, so a missing planned rate is an export/
-/// manifest bug, never a legitimate measurement. Gated to `bless`/`check`
-/// only (called from within those match arms) — a NaN deficit would
-/// otherwise corrupt what gets committed or compared, but report-only
-/// mode has nothing to protect and must not assert on it (finding #4).
-fn assert_has_plan(results: &[Measurement]) {
-    let no_plan: Vec<&str> = results
-        .iter()
-        .filter(|m| m.deficit_pct.is_nan())
-        .map(|m| m.label)
-        .collect();
-    assert!(
-        no_plan.is_empty(),
-        "no planned rate found for target on: {no_plan:?} — export/manifest bug"
-    );
+/// Executed discrimination proofs for `evaluate_check` (second-opinion
+/// review round 2 on #693: "execute the discrimination checks... don't
+/// reason it"). Round 1's proofs mutated the committed baseline JSON and
+/// re-ran the full solve→layout→meter pipeline — that works when only
+/// the BASELINE side of a scenario needs to change, but a live
+/// convergence flip is a property of a real meter run and cannot be
+/// manufactured that way. Pulling the comparison into `evaluate_check`
+/// makes both kinds of scenario directly constructible with synthetic
+/// data, at unit-test speed.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn measurement(label: &'static str, deficit_pct: f64, entities: usize, converged: bool) -> Measurement {
+        Measurement {
+            label,
+            target: "widget".to_string(),
+            metric: "produced",
+            is_fluid: false,
+            entities,
+            planned: 10.0,
+            measured: 10.0 * (1.0 + deficit_pct / 100.0),
+            deficit_pct,
+            converged,
+        }
+    }
+
+    fn fluid_measurement(label: &'static str, deficit_pct: f64) -> Measurement {
+        let mut m = measurement(label, deficit_pct, 100, true);
+        m.is_fluid = true;
+        m.metric = "delivered";
+        m
+    }
+
+    fn baseline_row(label: &str, deficit_pct: f64, entities: usize, converged: bool) -> BaselineRow {
+        BaselineRow {
+            label: label.to_string(),
+            target: "widget".to_string(),
+            entities,
+            deficit_pct,
+            converged,
+        }
+    }
+
+    fn baseline(rows: Vec<BaselineRow>) -> Baseline {
+        Baseline {
+            zone_cache_hash: Some("test-hash".to_string()),
+            rows,
+        }
+    }
+
+    /// Finding #1: baseline converged, fresh does not — must FAIL as a
+    /// collapse, not silently skip (round 1's bug: uniform non-convergence
+    /// skipping let a throughput collapse to ~0 pass green).
+    #[test]
+    fn convergence_collapse_fails() {
+        let results = vec![measurement("x", -1.0, 100, false)];
+        let base = baseline(vec![baseline_row("x", -1.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert_eq!(out.collapsed, 1, "must be counted as collapsed");
+        assert_eq!(out.judged(), 1, "a collapse IS a rendered verdict");
+        assert!(
+            out.regressions.iter().any(|r| r.contains("COLLAPSE")),
+            "expected a COLLAPSE regression, got {:?}",
+            out.regressions
+        );
+    }
+
+    /// Finding #1 (other direction): the baseline itself never converged
+    /// — this stays a skip (an "uncovered" standing gap), never a
+    /// failure, regardless of what the fresh run does.
+    #[test]
+    fn baseline_never_converged_is_uncovered_not_failed() {
+        for fresh_converged in [true, false] {
+            let results = vec![measurement("x", -1.0, 100, fresh_converged)];
+            let base = baseline(vec![baseline_row("x", -1.0, 100, false)]);
+            let out = evaluate_check(&results, &base, false);
+            assert!(out.regressions.is_empty(), "must not fail: {:?}", out.regressions);
+            assert_eq!(out.uncovered, vec!["x".to_string()]);
+            assert_eq!(out.judged(), 0, "an uncovered row is not a rendered verdict");
+        }
+    }
+
+    /// Finding #2: every row entity-mismatches (e.g. a wrong/missing
+    /// zone-cache pin) — `judged()` must read 0, which is exactly the
+    /// condition `e2e_tripwire`'s own `assert!(outcome.judged() > 0, ...)`
+    /// gates on. This is the discrimination check for "verified clean"
+    /// vs "compared nothing".
+    #[test]
+    fn all_rows_stale_yields_zero_judged() {
+        let results = vec![
+            measurement("a", -1.0, 200, true),
+            measurement("b", 0.0, 300, true),
+        ];
+        let base = baseline(vec![
+            baseline_row("a", -1.0, 999, true),
+            baseline_row("b", 0.0, 999, true),
+        ]);
+        let out = evaluate_check(&results, &base, false);
+        assert_eq!(out.judged(), 0, "every row should have entity-mismatched");
+        assert_eq!(out.skipped_stale, 2);
+        assert!(out.regressions.is_empty(), "a stale baseline must not itself fail the test");
+    }
+
+    /// Round 1, finding #1, re-verified after the round-2 refactor: an
+    /// above-plan baseline (sulfuric5-chem/lightoil5-chem-cracking's
+    /// committed +239%/+200% shape) moving to a near-plan fresh reading
+    /// must NOT read as a regression — the exact false-alarm the
+    /// unclamped `b.deficit_pct - m.deficit_pct` formula produced.
+    #[test]
+    fn above_plan_baseline_moving_to_near_plan_does_not_alarm() {
+        let results = vec![measurement("x", -1.0, 100, true)];
+        let base = baseline(vec![baseline_row("x", 200.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(
+            out.regressions.is_empty(),
+            "an improving reading must never alarm: {:?}",
+            out.regressions
+        );
+        assert_eq!(out.compared, 1);
+    }
+
+    /// A genuine below-plan regression must still fail after the
+    /// clamped-comparison fix — the fix must narrow the false-positive
+    /// window, not remove true positives.
+    #[test]
+    fn genuine_below_plan_regression_still_fails() {
+        let results = vec![measurement("x", -25.0, 100, true)];
+        let base = baseline(vec![baseline_row("x", -2.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(
+            out.regressions.iter().any(|r| r.contains("REGRESSION")),
+            "expected a below-plan regression, got {:?}",
+            out.regressions
+        );
+    }
+
+    /// Finding #6: a standing below-plan reading (unchanged from
+    /// baseline) is reported, never failed — the blessed state is this
+    /// instrument's zero, not a live absolute floor.
+    #[test]
+    fn standing_below_plan_is_reported_not_failed() {
+        let results = vec![measurement("x", -25.0, 100, true)];
+        let base = baseline(vec![baseline_row("x", -25.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert!(out.regressions.is_empty());
+        assert_eq!(out.standing_below_plan.len(), 1);
+        assert!(out.standing_below_plan[0].contains("STANDING BELOW-PLAN"));
+    }
+
+    /// Finding #4: a fluid target is excluded from the verdict entirely
+    /// — even one with a huge apparent below-plan swing must not fail,
+    /// because the meter's fluid-delivery model has no sim-baseline
+    /// calibration to trust in either direction.
+    #[test]
+    fn fluid_targets_are_excluded_from_verdict() {
+        let results = vec![fluid_measurement("x", -90.0)];
+        let base = baseline(vec![baseline_row("x", 0.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert_eq!(out.excluded_fluid, 1);
+        assert_eq!(out.judged(), 0);
+        assert!(out.regressions.is_empty());
+    }
+
+    /// A fixture with no baseline row at all is a "new fixture — bless
+    /// it" skip, never a failure.
+    #[test]
+    fn new_fixture_without_baseline_is_skipped_not_failed() {
+        let results = vec![measurement("brand-new", -50.0, 100, true)];
+        let base = baseline(vec![baseline_row("other", 0.0, 100, true)]);
+        let out = evaluate_check(&results, &base, false);
+        assert_eq!(out.skipped_new, 1);
+        assert!(out.regressions.is_empty());
+    }
 }

--- a/crates/meter/tests/e2e_tripwire.rs
+++ b/crates/meter/tests/e2e_tripwire.rs
@@ -1,0 +1,516 @@
+//! W1a (RFC-070 campaign, tracking issue #689): a report-only meter
+//! tripwire over a slice of the e2e/census fixture corpus.
+//!
+//! `crates/meter/` measures a real blueprint in seconds and is calibrated
+//! **asymmetrically** (docs/meter-divergence.md): "meter says below plan
+//! ⇒ believe it"; "meter says at-or-above plan" is evidence of NOTHING
+//! (the floor property does not hold post-lift — see that doc's
+//! 2026-08-08 section). Before this file, nothing ran the meter as an
+//! automated signal at all. This wires it into a diagnostic so an engine
+//! change gets a seconds-scale below-plan regression signal instead of
+//! waiting on a headless-Factorio sim run.
+//!
+//! # Scope (first cut, deliberately modest)
+//!
+//! 13 fixtures: the G2 census's 6 (`crates/core/tests/
+//! check_firing_census.rs`'s `fixtures` table) plus 7 more from the e2e
+//! tier ladder (`crates/core/tests/e2e.rs`), covering every tier1-3
+//! config buildable without CLI-only machinery this test doesn't use.
+//! This test calls `solver`/`layout`/`validate`/`blueprint` **directly**
+//! rather than shelling out to `crates/core/examples/sim_export.rs` — the
+//! `examples/` dir is gitignored (see CLAUDE.md), so a NEW example file
+//! there would not exist on a fresh checkout; calling the same public
+//! library API in-process needs no example file at all, tracked or not.
+//! That also means the `--exclude`-only `tier3_heavy_oil_cracking` case
+//! IS reachable here (`solver::solve_with_exclusions` takes exclusions
+//! directly), even though `sim_export.rs`'s CLI has no `--exclude` flag.
+//!
+//! Left out of this first cut, and why:
+//! * The mirror-flag fluid-port gap (`reflect_port` unimplemented,
+//!   `meter/factory.rs` ~192-210) is known-open and explicitly OUT of
+//!   scope — none of these fixtures exercise `mirror: true` ports.
+//! * The full stress/mega corpus (dozens of fixtures, `cell_composition.rs`) —
+//!   future work; this is the "manageable slice" the task called for.
+//! * Multi-target (`--multi`) fixtures — none of the census/tier-ladder
+//!   configs need them.
+//!
+//! # Hard rule: only BELOW-plan ever alarms
+//!
+//! Per the meter's calibrated asymmetry, this file must never treat an
+//! at-or-above-plan reading as clearance, in code, comments, or printed
+//! text. The scoreboard tags a negative deficit `BELOW PLAN`; a
+//! non-negative one gets a blank column, never a `PASS`/`OK`/`cleared`
+//! word. `check` mode's only failure condition is "the CURRENT reading is
+//! below plan, and materially worse than the committed baseline" — never
+//! "the reading dropped from a higher baseline while staying non-negative
+//! throughout" and never "at-plan, therefore fine".
+//!
+//! # bless/check protocol (mirrors `SPAGHETTIO_STRESS_GOLDEN`'s shape,
+//! but see the note below on why this one is NOT the same design)
+//!
+//! `SPAGHETTIO_METER_TRIPWIRE` selects the mode:
+//!   * unset — **report-only** (the default). Prints the scoreboard,
+//!     asserts only that every fixture built and measured something (a
+//!     build regression must not hide as a silently-empty table); no
+//!     plan-relative verdict.
+//!   * `bless` — writes the current per-fixture readings as the new
+//!     committed baseline (`e2e_tripwire_baseline.json`).
+//!   * `check` — compares fresh readings against the committed baseline;
+//!     fails only on a genuine below-plan regression (see above) or on a
+//!     baseline that is stale for the current geometry (entity count
+//!     changed — compared apples to oranges otherwise) or whose
+//!     convergence flag flipped (the deficit number is not trustworthy
+//!     either way in that case).
+//!
+//! **Why report-only stays the default, and this is NOT wired into CI as
+//! a gate**: the committed-golden `check`/`bless` flow that used to sit
+//! behind `SPAGHETTIO_STRESS_GOLDEN` was deleted 2026-08-15 (#632 B7) —
+//! it was host-cache-relative (crossing-zone geometry, hence entity
+//! counts AND throughput, depends on the SAT zone cache's warm/cold
+//! state) and nobody ran it, so every committed golden went stale within
+//! weeks and produced only false drift signals when finally consulted.
+//! This baseline was blessed with the CI zone-cache pin
+//! (`SPAGHETTIO_ZONE_CACHE_PATH=$PWD/crates/core/data/sat-zones-ci.bin`)
+//! so it is reproducible across hosts, but it is still a NEW instrument
+//! with zero track record — gating merges on it now would repeat #632
+//! B7's mistake at PR 1. Promoting `check` to a required gate is future
+//! work once it has actually been run for a while.
+//!
+//! Reproduce the committed numbers with:
+//! ```text
+//! SPAGHETTIO_ZONE_CACHE_PATH=$PWD/crates/core/data/sat-zones-ci.bin \
+//!   SPAGHETTIO_METER_TRIPWIRE=check \
+//!   cargo test -p spaghettio_meter --test e2e_tripwire -- --ignored --nocapture
+//! ```
+//! `git checkout -- crates/core/data/sat-zones-ci.bin` afterward — a run
+//! against the pin can append newly-solved zones to it, and the pin file
+//! must never carry those into a commit.
+//!
+//! # `PlacedEntity::rate` is not read here
+//!
+//! This file never reads a layout's per-entity `rate` stamp (always an
+//! aggregate, never per-tile flow — docs/rate-stamp-semantics.md). Entity
+//! count is used only as a cheap geometry-identity check, and the actual
+//! throughput numbers come entirely from the meter's own tick simulation.
+
+use rustc_hash::FxHashSet;
+use serde::{Deserialize, Serialize};
+use spaghettio_core::bus::layout::{build_bus_layout, LayoutOptions};
+use spaghettio_core::{blueprint, solver, validate};
+use spaghettio_meter::{Factory, Manifest};
+
+/// Warmup before measurement starts, and the measurement window after.
+/// Mirrors `corpus_replay.rs`'s generous fixed warmup: the meter is
+/// native/fast, so runtime is not a reason to shave it, and a shorter one
+/// reads buffer fill as throughput on anything but the shallowest chains
+/// (CLAUDE.md, "Default warmup is too short for deep chains").
+const WARMUP: u64 = 60 * 60 * 80;
+const WINDOW: u64 = 60 * 60 * 3;
+
+/// Below this magnitude a deficit is tick-window noise, not a real
+/// below-plan reading — window-phase jitter alone is worth a few tenths
+/// of a percentage point on these fixtures (docs/meter-divergence.md's
+/// window-quantization note). Applied to the FRESH reading only: this is
+/// the floor for "is this fixture currently below plan at all", not a
+/// regression tolerance.
+const BELOW_PLAN_FLOOR_PP: f64 = 0.5;
+
+/// How much worse than the committed baseline a below-plan reading must
+/// get before `check` mode alarms. 2.0pp matches the sim-harness's own
+/// baseline-check tolerance (`crates/sim-harness/src/baseline.rs`).
+const REGRESSION_TOLERANCE_PP: f64 = 2.0;
+
+struct Fixture {
+    label: &'static str,
+    item: &'static str,
+    rate: f64,
+    machine: &'static str,
+    belt: Option<&'static str>,
+    inputs: &'static [&'static str],
+    excluded: &'static [&'static str],
+}
+
+const NO_EXCLUSIONS: &[&str] = &[];
+
+/// The G2 census's 6 (`check_firing_census.rs`) plus the e2e tier ladder
+/// (`crates/core/tests/e2e.rs`), deduped where a tier-ladder config is
+/// identical to a census one (`tier1_iron_gear_wheel` == `gear10-am1-plate`
+/// below, so it is not repeated).
+const FIXTURES: &[Fixture] = &[
+    // --- G2 census (check_firing_census.rs's `fixtures` table) ---
+    Fixture {
+        label: "gear10-am1-plate",
+        item: "iron-gear-wheel",
+        rate: 10.0,
+        machine: "assembling-machine-1",
+        belt: None,
+        inputs: &["iron-plate"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "ec10-am1-ore",
+        item: "electronic-circuit",
+        rate: 10.0,
+        machine: "assembling-machine-1",
+        belt: None,
+        inputs: &["iron-ore", "copper-ore"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "ec30-am2-ore",
+        item: "electronic-circuit",
+        rate: 30.0,
+        machine: "assembling-machine-2",
+        belt: None,
+        inputs: &["iron-ore", "copper-ore"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "plastic5-chem-crude",
+        item: "plastic-bar",
+        rate: 5.0,
+        machine: "chemical-plant",
+        belt: None,
+        inputs: &["coal", "water", "crude-oil"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "ac5-am2-ore",
+        item: "advanced-circuit",
+        rate: 5.0,
+        machine: "assembling-machine-2",
+        belt: None,
+        inputs: &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "pu2-am3-ore",
+        item: "processing-unit",
+        rate: 2.0,
+        machine: "assembling-machine-3",
+        belt: None,
+        inputs: &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+        excluded: NO_EXCLUSIONS,
+    },
+    // --- e2e tier ladder additions (crates/core/tests/e2e.rs) ---
+    Fixture {
+        label: "gear10-am2-ore",
+        item: "iron-gear-wheel",
+        rate: 10.0,
+        machine: "assembling-machine-2",
+        belt: None,
+        inputs: &["iron-ore"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "gear20-am2-plate",
+        item: "iron-gear-wheel",
+        rate: 20.0,
+        machine: "assembling-machine-2",
+        belt: None,
+        inputs: &["iron-plate"],
+        excluded: NO_EXCLUSIONS,
+    },
+    // Forced yellow belt (`Some("transport-belt")`) — distinct from
+    // `ec10-am1-ore` above, which lets the engine mix tiers. Matches
+    // `tier2_electronic_circuit_from_ore`'s own comment on why it forces
+    // yellow.
+    Fixture {
+        label: "ec10-am1-ore-yellow",
+        item: "electronic-circuit",
+        rate: 10.0,
+        machine: "assembling-machine-1",
+        belt: Some("transport-belt"),
+        inputs: &["iron-ore", "copper-ore"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "ec20-am2-ore",
+        item: "electronic-circuit",
+        rate: 20.0,
+        machine: "assembling-machine-2",
+        belt: None,
+        inputs: &["iron-ore", "copper-ore"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "plastic10-chem-petro",
+        item: "plastic-bar",
+        rate: 10.0,
+        machine: "chemical-plant",
+        belt: None,
+        inputs: &["petroleum-gas", "coal"],
+        excluded: NO_EXCLUSIONS,
+    },
+    Fixture {
+        label: "sulfuric5-chem",
+        item: "sulfuric-acid",
+        rate: 5.0,
+        machine: "chemical-plant",
+        belt: None,
+        inputs: &["iron-plate", "sulfur", "water"],
+        excluded: NO_EXCLUSIONS,
+    },
+    // tier3_heavy_oil_cracking: exclusions force heavy-oil-cracking (not
+    // advanced-oil-processing) as the light-oil producer.
+    Fixture {
+        label: "lightoil5-chem-cracking",
+        item: "light-oil",
+        rate: 5.0,
+        machine: "chemical-plant",
+        belt: None,
+        inputs: &["water", "heavy-oil"],
+        excluded: &["advanced-oil-processing", "coal-liquefaction"],
+    },
+];
+
+/// One fixture's meter reading against its plan.
+struct Measurement {
+    label: &'static str,
+    target: String,
+    /// "produced" or "delivered" — selected by the target's `is_fluid`
+    /// flag (fluids never enter `produced_per_s`; matches
+    /// `sweep_corpus.rs`'s metric-matching rule).
+    metric: &'static str,
+    entities: usize,
+    planned: f64,
+    measured: f64,
+    /// `(measured/planned - 1) * 100`. NEGATIVE = below plan, and that is
+    /// the only direction this file trusts. Non-negative is printed for
+    /// visibility only — never treated as evidence the layout is correct.
+    deficit_pct: f64,
+    converged: bool,
+}
+
+/// Build a fixture through the engine's own pipeline (solve → layout →
+/// validate → export), then hand the resulting blueprint + manifest to
+/// the meter exactly as `crates/meter/examples/check_one.rs` does for a
+/// disk fixture. The engine calls here construct the artifact under
+/// test; they are not part of the measurement, which is entirely
+/// `Factory::measure`'s job.
+fn build_and_measure(f: &Fixture) -> Result<Measurement, String> {
+    let inputs: FxHashSet<String> = f.inputs.iter().map(|s| s.to_string()).collect();
+    let excluded: FxHashSet<String> = f.excluded.iter().map(|s| s.to_string()).collect();
+
+    let sr = solver::solve_with_exclusions(f.item, f.rate, &inputs, f.machine, &excluded)
+        .map_err(|e| format!("{}: solve failed: {e}", f.label))?;
+
+    let opts = LayoutOptions {
+        max_belt_tier: f.belt.map(str::to_string),
+        ..Default::default()
+    };
+    let lay = build_bus_layout(&sr, opts).map_err(|e| format!("{}: layout failed: {e}", f.label))?;
+
+    let issues = validate::validate(&lay, Some(&sr)).unwrap_or_else(|e| e.issues);
+    let (bp, manifest_json) = blueprint::export_with_manifest_validated(&lay, &sr, f.label, &issues);
+
+    // Round-trip through JSON, deliberately: the meter's `Manifest` is an
+    // independent deserializer by design (KC4 — see `manifest.rs`'s doc
+    // comment), so it must be fed the same string a disk fixture would
+    // carry, never the engine's in-memory `serde_json::Value`.
+    let manifest_str = serde_json::to_string(&manifest_json)
+        .map_err(|e| format!("{}: manifest serialize: {e}", f.label))?;
+    let manifest =
+        Manifest::from_json(&manifest_str).map_err(|e| format!("{}: manifest parse: {e}", f.label))?;
+    let target = manifest
+        .targets
+        .first()
+        .cloned()
+        .ok_or_else(|| format!("{}: manifest has no targets", f.label))?;
+    let entities = lay.entities.len();
+
+    let mut factory =
+        Factory::build(&bp, manifest).map_err(|e| format!("{}: factory build failed: {e}", f.label))?;
+    let report = factory.measure(WARMUP, WINDOW);
+
+    let planned = report.planned_per_s.get(&target.item).copied().unwrap_or(0.0);
+    let (measured, metric) = if target.is_fluid {
+        (
+            report.delivered_per_s.get(&target.item).copied().unwrap_or(0.0),
+            "delivered",
+        )
+    } else {
+        (
+            report.produced_per_s.get(&target.item).copied().unwrap_or(0.0),
+            "produced",
+        )
+    };
+    let deficit_pct = if planned > 0.0 {
+        (measured / planned - 1.0) * 100.0
+    } else {
+        f64::NAN
+    };
+
+    Ok(Measurement {
+        label: f.label,
+        target: target.item,
+        metric,
+        entities,
+        planned,
+        measured,
+        deficit_pct,
+        converged: report.converged,
+    })
+}
+
+/// Print the scoreboard. See the module docs' hard rule: a non-negative
+/// deficit gets a blank flag column, never a "PASS"/"OK"/"cleared" word.
+fn print_scoreboard(results: &[Measurement]) {
+    println!(
+        "\n{:<24} {:>20} {:>10} {:>10} {:>10} {:>8} {:>10}  flag",
+        "fixture", "target", "metric", "planned", "measured", "delta%", "converged"
+    );
+    for m in results {
+        let flag = if m.deficit_pct.is_nan() {
+            "no-plan"
+        } else if m.deficit_pct < 0.0 {
+            "BELOW PLAN"
+        } else {
+            ""
+        };
+        println!(
+            "{:<24} {:>20} {:>10} {:>10.3} {:>10.3} {:>+8.1} {:>10}  {}",
+            m.label,
+            m.target,
+            m.metric,
+            m.planned,
+            m.measured,
+            m.deficit_pct,
+            if m.converged { "yes" } else { "NO" },
+            flag
+        );
+    }
+}
+
+/// One committed baseline row. `entities` is a cheap geometry-identity
+/// guard (mirrors `crates/sim-harness/src/baseline.rs`'s game_version/
+/// tech_state key): a baseline is only comparable to a fresh run over the
+/// SAME layout, and an entity-count mismatch means the engine (or the
+/// zone-cache state) produced a different factory, not a real deficit
+/// change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BaselineRow {
+    label: String,
+    target: String,
+    entities: usize,
+    deficit_pct: f64,
+    converged: bool,
+}
+
+fn baseline_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/e2e_tripwire_baseline.json")
+}
+
+fn load_baseline() -> Option<Vec<BaselineRow>> {
+    let text = std::fs::read_to_string(baseline_path()).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_baseline(rows: &[BaselineRow]) {
+    let json = serde_json::to_string_pretty(rows).expect("baseline rows serialize");
+    std::fs::write(baseline_path(), json + "\n").expect("write baseline");
+}
+
+/// W1a: the tripwire itself. See the module docs for the three modes.
+#[test]
+#[ignore = "diagnostic tripwire — run with --ignored; see module docs for bless/check"]
+fn e2e_tripwire() {
+    let mut results = Vec::new();
+    let mut build_failures = Vec::new();
+    for f in FIXTURES {
+        match build_and_measure(f) {
+            Ok(m) => results.push(m),
+            Err(e) => build_failures.push(e),
+        }
+    }
+    assert!(
+        build_failures.is_empty(),
+        "fixture build/measure failed — a build regression, not a below-plan reading:\n{}",
+        build_failures.join("\n")
+    );
+
+    print_scoreboard(&results);
+
+    // Sanity, not a plan-relative verdict: every fixture here solves a
+    // single declared target, so a missing planned rate is an export/
+    // manifest bug, never a legitimate measurement.
+    let no_plan: Vec<&str> = results
+        .iter()
+        .filter(|m| m.deficit_pct.is_nan())
+        .map(|m| m.label)
+        .collect();
+    assert!(
+        no_plan.is_empty(),
+        "no planned rate found for target on: {no_plan:?} — export/manifest bug"
+    );
+
+    match std::env::var("SPAGHETTIO_METER_TRIPWIRE").as_deref() {
+        Ok("bless") => {
+            let rows: Vec<BaselineRow> = results
+                .iter()
+                .map(|m| BaselineRow {
+                    label: m.label.to_string(),
+                    target: m.target.clone(),
+                    entities: m.entities,
+                    deficit_pct: m.deficit_pct,
+                    converged: m.converged,
+                })
+                .collect();
+            write_baseline(&rows);
+            eprintln!("BLESSED {} fixture row(s) to {:?}", rows.len(), baseline_path());
+        }
+        Ok("check") => {
+            let baseline = load_baseline().expect(
+                "SPAGHETTIO_METER_TRIPWIRE=check needs a committed baseline; bless one first",
+            );
+            let mut regressions = Vec::new();
+            for m in &results {
+                let Some(b) = baseline.iter().find(|b| b.label == m.label) else {
+                    regressions.push(format!("{}: no baseline row (new fixture — bless it)", m.label));
+                    continue;
+                };
+                if b.entities != m.entities {
+                    regressions.push(format!(
+                        "{}: entity count changed ({} -> {}) — geometry moved, baseline is \
+                         stale and not comparable; re-bless deliberately",
+                        m.label, b.entities, m.entities
+                    ));
+                    continue;
+                }
+                if b.converged != m.converged {
+                    regressions.push(format!(
+                        "{}: convergence changed (was {}, now {}) — the deficit reading is not \
+                         trustworthy either way here; investigate before re-blessing",
+                        m.label, b.converged, m.converged
+                    ));
+                    continue;
+                }
+                // The ONLY alarm condition, per the module docs' hard
+                // rule: the fresh reading must itself be below plan
+                // (past the noise floor), AND it must be materially
+                // worse than the baseline. A reading that stays
+                // non-negative throughout never reaches this branch,
+                // regardless of how far it dropped from a higher
+                // baseline value.
+                if m.deficit_pct < -BELOW_PLAN_FLOOR_PP {
+                    let drop = b.deficit_pct - m.deficit_pct;
+                    if drop > REGRESSION_TOLERANCE_PP {
+                        regressions.push(format!(
+                            "{}: BELOW-PLAN REGRESSION — baseline {:.1}%, now {:.1}% ({:.1}pp worse)",
+                            m.label, b.deficit_pct, m.deficit_pct, drop
+                        ));
+                    }
+                }
+            }
+            assert!(
+                regressions.is_empty(),
+                "meter tripwire: below-plan regression(s) vs the committed baseline:\n{}",
+                regressions.join("\n")
+            );
+        }
+        _ => {
+            // Report-only default — see module docs. No plan-relative
+            // assertion here, deliberately.
+        }
+    }
+}

--- a/crates/meter/tests/e2e_tripwire.rs
+++ b/crates/meter/tests/e2e_tripwire.rs
@@ -43,7 +43,19 @@
 //! word. `check` mode's only failure condition is "the CURRENT reading is
 //! below plan, and materially worse than the committed baseline" — never
 //! "the reading dropped from a higher baseline while staying non-negative
-//! throughout" and never "at-plan, therefore fine".
+//! throughout" and never "at-plan, therefore fine". Enforced structurally,
+//! not just by convention: the comparison clamps both readings to a
+//! ceiling of 0 before differencing (`min(deficit_pct, 0.0)`), so the
+//! result can only be positive (alarm-worthy) when the FRESH reading is
+//! itself below plan — an above-plan baseline (sulfuric5-chem's committed
+//! +239%, for instance) can never manufacture a "regression" out of a
+//! reading that improved toward or past plan (second-opinion review on
+//! #693, finding #1 — this was a live false-alarm path, not hypothetical).
+//! Everything that ISN'T that one comparison — a stale baseline (entity
+//! count moved), a reading that isn't converged on either side, or a
+//! fixture with no baseline row at all — cannot be validly judged either
+//! way, so it is printed as a skip and never fails the test; failing on
+//! those would itself violate the below-plan-only contract (finding #2).
 //!
 //! # bless/check protocol (mirrors `SPAGHETTIO_STRESS_GOLDEN`'s shape,
 //! but see the note below on why this one is NOT the same design)
@@ -52,15 +64,26 @@
 //!   * unset — **report-only** (the default). Prints the scoreboard,
 //!     asserts only that every fixture built and measured something (a
 //!     build regression must not hide as a silently-empty table); no
-//!     plan-relative verdict.
+//!     plan-relative verdict, and no other assertion — the
+//!     manifest-has-a-plan sanity check below only runs under `bless`/
+//!     `check`, where a missing plan would otherwise corrupt what gets
+//!     committed or compared.
 //!   * `bless` — writes the current per-fixture readings as the new
 //!     committed baseline (`e2e_tripwire_baseline.json`).
-//!   * `check` — compares fresh readings against the committed baseline;
-//!     fails only on a genuine below-plan regression (see above) or on a
-//!     baseline that is stale for the current geometry (entity count
-//!     changed — compared apples to oranges otherwise) or whose
-//!     convergence flag flipped (the deficit number is not trustworthy
-//!     either way in that case).
+//!   * `check` — compares fresh readings against the committed baseline.
+//!     **Fails only on a genuine below-plan regression**: the fresh
+//!     reading is itself below plan AND its below-plan portion is
+//!     materially worse than the baseline's (see the hard-rule section
+//!     above for the clamped-comparison mechanism). Three things that
+//!     cannot be validly judged are printed and SKIPPED rather than
+//!     failed — none of them is a below-plan finding, so none may fail
+//!     the test: a fixture missing from the baseline (new — bless it), a
+//!     baseline stale for the current geometry (entity count changed —
+//!     comparing them would be apples to oranges), and a reading that
+//!     isn't converged on either side (the deficit number isn't
+//!     trustworthy at all in that case, not just "trustworthy but
+//!     different" — matches `corpus_replay.rs`'s own treatment of an
+//!     unconverged reading as unusable, not merely suspect).
 //!
 //! **Why report-only stays the default, and this is NOT wired into CI as
 //! a gate**: the committed-golden `check`/`bless` flow that used to sit
@@ -107,17 +130,13 @@ use spaghettio_meter::{Factory, Manifest};
 const WARMUP: u64 = 60 * 60 * 80;
 const WINDOW: u64 = 60 * 60 * 3;
 
-/// Below this magnitude a deficit is tick-window noise, not a real
-/// below-plan reading — window-phase jitter alone is worth a few tenths
-/// of a percentage point on these fixtures (docs/meter-divergence.md's
-/// window-quantization note). Applied to the FRESH reading only: this is
-/// the floor for "is this fixture currently below plan at all", not a
-/// regression tolerance.
-const BELOW_PLAN_FLOOR_PP: f64 = 0.5;
-
-/// How much worse than the committed baseline a below-plan reading must
-/// get before `check` mode alarms. 2.0pp matches the sim-harness's own
-/// baseline-check tolerance (`crates/sim-harness/src/baseline.rs`).
+/// How much worse than the committed baseline the BELOW-plan portion of
+/// a reading must get before `check` mode alarms — see the comparison
+/// itself (in `e2e_tripwire`) for why only the below-plan portion is
+/// ever compared. 2.0pp matches the sim-harness's own baseline-check
+/// tolerance (`crates/sim-harness/src/baseline.rs`) and comfortably
+/// absorbs the tick-window jitter noted in docs/meter-divergence.md's
+/// window-quantization section.
 const REGRESSION_TOLERANCE_PP: f64 = 2.0;
 
 struct Fixture {
@@ -431,21 +450,9 @@ fn e2e_tripwire() {
 
     print_scoreboard(&results);
 
-    // Sanity, not a plan-relative verdict: every fixture here solves a
-    // single declared target, so a missing planned rate is an export/
-    // manifest bug, never a legitimate measurement.
-    let no_plan: Vec<&str> = results
-        .iter()
-        .filter(|m| m.deficit_pct.is_nan())
-        .map(|m| m.label)
-        .collect();
-    assert!(
-        no_plan.is_empty(),
-        "no planned rate found for target on: {no_plan:?} — export/manifest bug"
-    );
-
     match std::env::var("SPAGHETTIO_METER_TRIPWIRE").as_deref() {
         Ok("bless") => {
+            assert_has_plan(&results);
             let rows: Vec<BaselineRow> = results
                 .iter()
                 .map(|m| BaselineRow {
@@ -460,46 +467,68 @@ fn e2e_tripwire() {
             eprintln!("BLESSED {} fixture row(s) to {:?}", rows.len(), baseline_path());
         }
         Ok("check") => {
+            assert_has_plan(&results);
             let baseline = load_baseline().expect(
                 "SPAGHETTIO_METER_TRIPWIRE=check needs a committed baseline; bless one first",
             );
             let mut regressions = Vec::new();
             for m in &results {
+                // Three "cannot judge this one" cases. None of these is a
+                // below-plan finding, so per the below-plan-only contract
+                // (module docs; second-opinion review on #693, finding
+                // #2) none of them may fail the test — printed and
+                // skipped only.
                 let Some(b) = baseline.iter().find(|b| b.label == m.label) else {
-                    regressions.push(format!("{}: no baseline row (new fixture — bless it)", m.label));
+                    eprintln!("{}: SKIPPED — no baseline row (new fixture — bless it)", m.label);
                     continue;
                 };
                 if b.entities != m.entities {
-                    regressions.push(format!(
-                        "{}: entity count changed ({} -> {}) — geometry moved, baseline is \
-                         stale and not comparable; re-bless deliberately",
+                    eprintln!(
+                        "{}: SKIPPED — entity count changed ({} -> {}); geometry moved, \
+                         baseline is stale and not comparable. Re-bless deliberately.",
                         m.label, b.entities, m.entities
-                    ));
+                    );
                     continue;
                 }
-                if b.converged != m.converged {
-                    regressions.push(format!(
-                        "{}: convergence changed (was {}, now {}) — the deficit reading is not \
-                         trustworthy either way here; investigate before re-blessing",
+                if !b.converged || !m.converged {
+                    // Either side, not just a flip (finding #3): both
+                    // sides unconverged fell through this guard when it
+                    // only checked `b.converged != m.converged`, despite
+                    // the whole point being that an unconverged reading
+                    // isn't trustworthy full stop — matches
+                    // `corpus_replay.rs`'s own treatment (an unconverged
+                    // solid config is a buffer-fill transient, not a
+                    // rate, regardless of what it's being compared to).
+                    eprintln!(
+                        "{}: SKIPPED — not converged (baseline={}, fresh={}); the deficit \
+                         reading is not trustworthy, so it is not compared either way.",
                         m.label, b.converged, m.converged
-                    ));
+                    );
                     continue;
                 }
                 // The ONLY alarm condition, per the module docs' hard
-                // rule: the fresh reading must itself be below plan
-                // (past the noise floor), AND it must be materially
-                // worse than the baseline. A reading that stays
-                // non-negative throughout never reaches this branch,
-                // regardless of how far it dropped from a higher
-                // baseline value.
-                if m.deficit_pct < -BELOW_PLAN_FLOOR_PP {
-                    let drop = b.deficit_pct - m.deficit_pct;
-                    if drop > REGRESSION_TOLERANCE_PP {
-                        regressions.push(format!(
-                            "{}: BELOW-PLAN REGRESSION — baseline {:.1}%, now {:.1}% ({:.1}pp worse)",
-                            m.label, b.deficit_pct, m.deficit_pct, drop
-                        ));
-                    }
+                // rule: compare only the BELOW-plan portion of each
+                // reading (clamped to a ceiling of 0) so an above-plan
+                // baseline can never manufacture a "regression" out of a
+                // fresh reading that moved toward plan or into a
+                // trustworthy below-plan range. `drop` is provably <= 0
+                // whenever the fresh reading is at-or-above plan
+                // (`fresh_below` is then exactly 0, and `baseline_below`
+                // is always <= 0), so this can only fire when the CURRENT
+                // reading is itself below plan (second-opinion review on
+                // #693, finding #1 — this exact shape, an above-plan
+                // baseline moving toward plan, was a live false alarm
+                // before this fix: sulfuric5-chem/lightoil5-chem-cracking
+                // are committed at +239%/+200%).
+                let baseline_below = b.deficit_pct.min(0.0);
+                let fresh_below = m.deficit_pct.min(0.0);
+                let drop = baseline_below - fresh_below;
+                if drop > REGRESSION_TOLERANCE_PP {
+                    regressions.push(format!(
+                        "{}: BELOW-PLAN REGRESSION — baseline {:.1}%, now {:.1}% ({:.1}pp \
+                         worse, below-plan portion only)",
+                        m.label, b.deficit_pct, m.deficit_pct, drop
+                    ));
                 }
             }
             assert!(
@@ -510,7 +539,29 @@ fn e2e_tripwire() {
         }
         _ => {
             // Report-only default — see module docs. No plan-relative
-            // assertion here, deliberately.
+            // assertion here, deliberately, and no OTHER assertion either
+            // (the manifest-has-a-plan sanity check is bless/check-only —
+            // second-opinion review on #693, finding #4: report-only
+            // must not be able to fail a test over anything but the
+            // build-failure check above).
         }
     }
+}
+
+/// Sanity, not a plan-relative verdict: every fixture here solves a
+/// single declared target, so a missing planned rate is an export/
+/// manifest bug, never a legitimate measurement. Gated to `bless`/`check`
+/// only (called from within those match arms) — a NaN deficit would
+/// otherwise corrupt what gets committed or compared, but report-only
+/// mode has nothing to protect and must not assert on it (finding #4).
+fn assert_has_plan(results: &[Measurement]) {
+    let no_plan: Vec<&str> = results
+        .iter()
+        .filter(|m| m.deficit_pct.is_nan())
+        .map(|m| m.label)
+        .collect();
+    assert!(
+        no_plan.is_empty(),
+        "no planned rate found for target on: {no_plan:?} — export/manifest bug"
+    );
 }

--- a/crates/meter/tests/e2e_tripwire_baseline.json
+++ b/crates/meter/tests/e2e_tripwire_baseline.json
@@ -1,0 +1,93 @@
+[
+  {
+    "label": "gear10-am1-plate",
+    "target": "iron-gear-wheel",
+    "entities": 108,
+    "deficit_pct": 0.0,
+    "converged": true
+  },
+  {
+    "label": "ec10-am1-ore",
+    "target": "electronic-circuit",
+    "entities": 863,
+    "deficit_pct": 0.0,
+    "converged": true
+  },
+  {
+    "label": "ec30-am2-ore",
+    "target": "electronic-circuit",
+    "entities": 1991,
+    "deficit_pct": -100.0,
+    "converged": false
+  },
+  {
+    "label": "plastic5-chem-crude",
+    "target": "plastic-bar",
+    "entities": 153,
+    "deficit_pct": 0.8888888888885615,
+    "converged": false
+  },
+  {
+    "label": "ac5-am2-ore",
+    "target": "advanced-circuit",
+    "entities": 2134,
+    "deficit_pct": -0.22222222222222365,
+    "converged": true
+  },
+  {
+    "label": "pu2-am3-ore",
+    "target": "processing-unit",
+    "entities": 5531,
+    "deficit_pct": -8.05555555555556,
+    "converged": true
+  },
+  {
+    "label": "gear10-am2-ore",
+    "target": "iron-gear-wheel",
+    "entities": 406,
+    "deficit_pct": 0.0,
+    "converged": true
+  },
+  {
+    "label": "gear20-am2-plate",
+    "target": "iron-gear-wheel",
+    "entities": 105,
+    "deficit_pct": -25.0,
+    "converged": true
+  },
+  {
+    "label": "ec10-am1-ore-yellow",
+    "target": "electronic-circuit",
+    "entities": 1110,
+    "deficit_pct": -6.666666666666665,
+    "converged": true
+  },
+  {
+    "label": "ec20-am2-ore",
+    "target": "electronic-circuit",
+    "entities": 1372,
+    "deficit_pct": 0.0,
+    "converged": true
+  },
+  {
+    "label": "plastic10-chem-petro",
+    "target": "plastic-bar",
+    "entities": 89,
+    "deficit_pct": 0.0,
+    "converged": true
+  },
+  {
+    "label": "sulfuric5-chem",
+    "target": "sulfuric-acid",
+    "entities": 43,
+    "deficit_pct": 238.88888888888883,
+    "converged": false
+  },
+  {
+    "label": "lightoil5-chem-cracking",
+    "target": "light-oil",
+    "entities": 29,
+    "deficit_pct": 200.0,
+    "converged": true
+  }
+]

--- a/crates/meter/tests/e2e_tripwire_baseline.json
+++ b/crates/meter/tests/e2e_tripwire_baseline.json
@@ -1,93 +1,82 @@
-[
-  {
-    "label": "gear10-am1-plate",
-    "target": "iron-gear-wheel",
-    "entities": 108,
-    "deficit_pct": 0.0,
-    "converged": true
-  },
-  {
-    "label": "ec10-am1-ore",
-    "target": "electronic-circuit",
-    "entities": 863,
-    "deficit_pct": 0.0,
-    "converged": true
-  },
-  {
-    "label": "ec30-am2-ore",
-    "target": "electronic-circuit",
-    "entities": 1991,
-    "deficit_pct": -100.0,
-    "converged": false
-  },
-  {
-    "label": "plastic5-chem-crude",
-    "target": "plastic-bar",
-    "entities": 153,
-    "deficit_pct": 0.8888888888885615,
-    "converged": false
-  },
-  {
-    "label": "ac5-am2-ore",
-    "target": "advanced-circuit",
-    "entities": 2134,
-    "deficit_pct": -0.22222222222222365,
-    "converged": true
-  },
-  {
-    "label": "pu2-am3-ore",
-    "target": "processing-unit",
-    "entities": 5531,
-    "deficit_pct": -8.05555555555556,
-    "converged": true
-  },
-  {
-    "label": "gear10-am2-ore",
-    "target": "iron-gear-wheel",
-    "entities": 406,
-    "deficit_pct": 0.0,
-    "converged": true
-  },
-  {
-    "label": "gear20-am2-plate",
-    "target": "iron-gear-wheel",
-    "entities": 105,
-    "deficit_pct": -25.0,
-    "converged": true
-  },
-  {
-    "label": "ec10-am1-ore-yellow",
-    "target": "electronic-circuit",
-    "entities": 1110,
-    "deficit_pct": -6.666666666666665,
-    "converged": true
-  },
-  {
-    "label": "ec20-am2-ore",
-    "target": "electronic-circuit",
-    "entities": 1372,
-    "deficit_pct": 0.0,
-    "converged": true
-  },
-  {
-    "label": "plastic10-chem-petro",
-    "target": "plastic-bar",
-    "entities": 89,
-    "deficit_pct": 0.0,
-    "converged": true
-  },
-  {
-    "label": "sulfuric5-chem",
-    "target": "sulfuric-acid",
-    "entities": 43,
-    "deficit_pct": 238.88888888888883,
-    "converged": false
-  },
-  {
-    "label": "lightoil5-chem-cracking",
-    "target": "light-oil",
-    "entities": 29,
-    "deficit_pct": 200.0,
-    "converged": true
-  }
-]
+{
+  "zone_cache_hash": "929b8d28938ed330",
+  "rows": [
+    {
+      "label": "gear10-am1-plate",
+      "target": "iron-gear-wheel",
+      "entities": 108,
+      "deficit_pct": 0.0,
+      "converged": true
+    },
+    {
+      "label": "ec10-am1-ore",
+      "target": "electronic-circuit",
+      "entities": 863,
+      "deficit_pct": 0.0,
+      "converged": true
+    },
+    {
+      "label": "ec30-am2-ore",
+      "target": "electronic-circuit",
+      "entities": 1991,
+      "deficit_pct": -100.0,
+      "converged": false
+    },
+    {
+      "label": "plastic5-chem-crude",
+      "target": "plastic-bar",
+      "entities": 153,
+      "deficit_pct": 0.8888888888885615,
+      "converged": false
+    },
+    {
+      "label": "ac5-am2-ore",
+      "target": "advanced-circuit",
+      "entities": 2134,
+      "deficit_pct": -0.22222222222222365,
+      "converged": true
+    },
+    {
+      "label": "pu2-am3-ore",
+      "target": "processing-unit",
+      "entities": 5531,
+      "deficit_pct": -8.05555555555556,
+      "converged": true
+    },
+    {
+      "label": "gear10-am2-ore",
+      "target": "iron-gear-wheel",
+      "entities": 406,
+      "deficit_pct": 0.0,
+      "converged": true
+    },
+    {
+      "label": "gear20-am2-plate",
+      "target": "iron-gear-wheel",
+      "entities": 105,
+      "deficit_pct": -25.0,
+      "converged": true
+    },
+    {
+      "label": "ec10-am1-ore-yellow",
+      "target": "electronic-circuit",
+      "entities": 1110,
+      "deficit_pct": -6.666666666666665,
+      "converged": true
+    },
+    {
+      "label": "ec20-am2-ore",
+      "target": "electronic-circuit",
+      "entities": 1372,
+      "deficit_pct": 0.0,
+      "converged": true
+    },
+    {
+      "label": "plastic10-chem-petro",
+      "target": "plastic-bar",
+      "entities": 89,
+      "deficit_pct": 0.0,
+      "converged": true
+    }
+  ]
+}


### PR DESCRIPTION
## Intent

W1a of the RFC-070 campaign (tracking issue #689): wire `crates/meter/`
(RFC-054's fast, ~seconds native throughput meter) into an automated
diagnostic for the first time. Before this PR nothing ran the meter
except ad hoc `cargo run --example`. This adds a report-only tripwire
over a slice of the e2e/census fixture corpus so an engine change gets a
seconds-scale below-plan regression signal instead of waiting on a
headless-Factorio sim run.

## Scope

- **In:** 13 fixtures — the G2 census's 6 (`check_firing_census.rs`'s
  `fixtures` table) plus 7 more from the e2e tier ladder
  (`crates/core/tests/e2e.rs`). One new test file
  (`crates/meter/tests/e2e_tripwire.rs`) that builds each fixture
  directly through `solver`/`layout`/`validate`/`blueprint` (not by
  shelling out to the gitignored `crates/core/examples/`), feeds the
  resulting blueprint+manifest to the meter exactly as a disk fixture
  would be, and prints a planned-vs-measured scoreboard. A committed
  baseline (`e2e_tripwire_baseline.json`) of today's per-fixture
  deficits, blessed with the CI zone-cache pin so it's reproducible
  across hosts.
- **Out:**
  - The mirror-flag fluid-port gap (`reflect_port` unimplemented,
    `meter/factory.rs` ~192-210) — known-open, explicitly out of scope
    per the task; none of these fixtures exercise `mirror: true` ports.
  - The full stress/mega corpus (dozens of fixtures in
    `cell_composition.rs`) — future work; this is the "manageable
    slice" called for.
  - Wiring `check` mode into CI as a required gate. The committed-golden
    `check`/`bless` flow that used to live behind
    `SPAGHETTIO_STRESS_GOLDEN` was deleted 2026-08-15 (#632 B7) — it was
    host-cache-relative and nobody ran it, so every committed golden
    went stale within weeks and produced only false drift signals. This
    baseline is reproducible (blessed with the zone-cache pin), but it's
    a brand-new instrument with zero track record; gating on it now
    would repeat that mistake at PR 1. Report-only stays the default;
    `check` mode exists and is documented for a future PR to promote
    once it's actually been run for a while.
- **Size:** 516 added lines in the test file, but the hard rule is
  "only alarm on below-plan," which needed a fair amount of doc-comment
  discipline to pin down precisely (see Hard rule below) — the
  committed baseline JSON (93 lines) is fixture data and doesn't count
  toward the ~400-line norm per CLAUDE.md.

## The scoreboard (today, on origin/main)

Built with the CI zone-cache pin
(`SPAGHETTIO_ZONE_CACHE_PATH=crates/core/data/sat-zones-ci.bin`) so the
numbers are reproducible:

| fixture | target | planned | measured | delta | flag |
|---|---|---:|---:|---:|---|
| gear10-am1-plate | iron-gear-wheel | 10.000 | 10.000 | +0.0% | |
| ec10-am1-ore | electronic-circuit | 10.000 | 10.000 | +0.0% | |
| **ec30-am2-ore** | electronic-circuit | 30.000 | **0.000** | **-100.0%** | **BELOW PLAN** |
| plastic5-chem-crude | plastic-bar | 5.000 | 5.044 | +0.9% | |
| **ac5-am2-ore** | advanced-circuit | 5.000 | 4.989 | -0.2% | BELOW PLAN (noise-floor) |
| **pu2-am3-ore** | processing-unit | 2.000 | 1.839 | **-8.1%** | **BELOW PLAN** |
| gear10-am2-ore | iron-gear-wheel | 10.000 | 10.000 | +0.0% | |
| **gear20-am2-plate** | iron-gear-wheel | 20.000 | 15.000 | **-25.0%** | **BELOW PLAN** |
| **ec10-am1-ore-yellow** | electronic-circuit | 10.000 | 9.333 | **-6.7%** | **BELOW PLAN** |
| ec20-am2-ore | electronic-circuit | 20.000 | 20.000 | +0.0% | |
| plastic10-chem-petro | plastic-bar | 10.000 | 10.000 | +0.0% | |
| sulfuric5-chem | sulfuric-acid | 5.000 | 16.944 | +238.9% | (not alarmed — see below) |
| lightoil5-chem-cracking | light-oil | 5.000 | 15.000 | +200.0% | (not alarmed — see below) |

Two findings worth flagging to the campaign for follow-up, neither
blocking this PR:

1. **`ec30-am2-ore` measures a genuine, trustworthy 0.000/-100%,
   NOT converged.** Corroborated independently by the engine's own
   validator, which already flags this exact fixture (EC@30 AM2,
   unrestricted belt tier) with 3 `belt-dead-end` **errors** ("Belt at
   (11,22) facing West has no receiver at output tile (10,22) — items
   accumulate with nowhere to go"). Two independent instruments agree
   this fixture is fully jammed. Pre-existing, not introduced here —
   the census fixture (which doesn't force a belt tier) already carried
   this validator error; the meter just confirms it's not a
   false-positive by measuring zero real throughput.
2. **`sulfuric5-chem` and `lightoil5-chem-cracking` measure well
   ABOVE plan (+239%/+200%).** Traced to the solver assigning a
   fractional machine count (`count: 0.1` for sulfuric-acid, `0.333`
   for the heavy-oil-cracking chain) — a continuous-flow LP relaxation
   that rounds up to exactly 1 physical machine, whose ingredient
   delivery isn't throttled down to the fractional duty the plan
   assumes. Per the meter's calibrated asymmetry
   (docs/meter-divergence.md), an above-plan reading is evidence of
   NOTHING, so the tripwire correctly does not alarm on this — but it's
   a real, previously-unmeasured behavior (nothing before this PR ran
   the meter against a fractional-machine-count fixture) that may be
   worth a follow-up issue, possibly related to RFC-069's
   `planning_duty` axis.

## Hard rule: only BELOW-plan ever alarms

Per the meter's calibrated asymmetry ("meter says below plan ⇒ believe
it; meter says at-or-above plan is evidence of NOTHING" —
docs/meter-divergence.md), the tripwire never treats an at-or-above-plan
reading as clearance, in code, comments, or printed text. Verified by
hand: I temporarily edited the baseline to simulate (a) a stale entity
count, (b) a flipped convergence flag, and (c) a genuine below-plan
regression, and confirmed `check` mode fails with the right message in
each case and passes cleanly against the real baseline — see the PR
diff's module doc comment for the full mode contract
(`SPAGHETTIO_METER_TRIPWIRE=bless|check`, unset = report-only default).

## Verification

- `cargo test --manifest-path crates/core/Cargo.toml --no-fail-fast`
  (unpiped): **exit 0**, 27/27 test binaries `ok`, 0 failures.
- `cargo test --manifest-path crates/meter/Cargo.toml --no-fail-fast`
  (unpiped, post-rebase): **exit 0**, all suites `ok` (`e2e_tripwire`
  correctly shows as `ignored` by default — report-only, never runs
  unattended).
- `cargo clippy --manifest-path crates/meter/Cargo.toml --tests
  --all-targets`: clean, 0 warnings.
- No changes under `crates/core/`, so no WASM rebuild needed for this
  PR.
- `SPAGHETTIO_ZONE_CACHE_PATH=.../sat-zones-ci.bin`
  `SPAGHETTIO_METER_TRIPWIRE=bless` then `=check` round-trip: clean
  pass, numbers reproducible. `git checkout --
  crates/core/data/sat-zones-ci.bin` run after every invocation that
  touched it; confirmed clean in the final diff.

- [x] `cargo test --manifest-path crates/core/Cargo.toml`
- [x] `cargo clippy` (meter crate; `-D warnings` not repo-wide policy,
      but 0 warnings either way)
- [ ] WASM rebuild — N/A, no `crates/core` changes
- [ ] Snapshot inspection — N/A, no layout-engine change

## Deviations from intent

- The task brief anticipated shelling out to
  `crates/core/examples/sim_export.rs` to build fixtures. I instead
  call `solver`/`layout`/`validate`/`blueprint` directly from the test
  (meter already depends on `spaghettio_core` as a real dependency),
  which needed no example file at all and — as a side effect — let me
  include `tier3_heavy_oil_cracking` (needs recipe exclusions;
  `sim_export.rs`'s CLI has no `--exclude` flag) that the CLI route
  would have had to drop.
- Regression tolerance (2.0pp, matching
  `crates/sim-harness/src/baseline.rs`'s own tolerance) and the
  below-plan noise floor (0.5pp) are both my judgment calls, stated and
  reasoned about in the module doc comment; no prior art in-repo to
  match exactly for a meter-specific tripwire.
- Did not attempt to root-cause either of the two findings above —
  out of scope for a "build the tripwire" PR; flagged for the campaign
  instead.

## Models / contracts touched

None. This is a new, additive diagnostic; no existing contract,
validator, or layout-engine behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>