### PR TITLE
sim: belt name/direction/ug_type in the state dump + scripts/sim-localize.py

### DIFF
--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1079,6 +1079,19 @@ local function stn(st)
   return tostring(st)
 end
 
+-- Sentinel for a JSON `null` in the belts array. Lua cannot hold a
+-- `nil` in the middle (or at the tail) of an otherwise-sequential table --
+-- assigning `nil` just removes the key, so `helpers.table_to_json` would
+-- see a shorter array border and silently emit a 6-element tuple instead
+-- of 7 for a plain (non-underground) belt. There is no documented null
+-- sentinel `table_to_json` recognizes (checked against the Factorio forums
+-- and the 2.0 LuaHelpers docs), so this dump builds the JSON normally with
+-- this unique placeholder string in `ug_type`'s slot, then string-replaces
+-- the quoted placeholder with a literal `null` in the finished JSON text.
+-- The placeholder can never collide with a real value in this array
+-- (item/entity names never contain it).
+local SIM_STATE_NULL = "__spaghettio_sim_state_null__"
+
 local function dump_sim_state(s)
   local belts, machines, inserters, pipes = {}, {}, {}, {}
   for _, b in pairs(s.find_entities_filtered{type = {"transport-belt", "underground-belt", "splitter"}}) do
@@ -1101,10 +1114,21 @@ local function dump_sim_state(s)
       end
       det[li] = lane
     end
-    if n > 0 then
-      table.insert(belts, {math.floor(b.position.x - storage.offx) + LX0,
-                           math.floor(b.position.y - storage.offy) + LY0, n, det})
+    -- Name + direction (belts never carried these, unlike pipes which got
+    -- them for the same reason in #364 a few lines below) and, for
+    -- underground belts, which end of the pair this is. `direction` is the
+    -- raw 2.0 16-way `defines.direction` integer, unremapped (0=north,
+    -- 4=east, 8=south, 12=west) -- see docs/sim-harness.md for the
+    -- encoding note. Every belt is now emitted, including `n == 0`: an
+    -- empty belt is the primary localization signal for a dried-up lane,
+    -- and the old `if n > 0` guard hid exactly those tiles.
+    local ug_type = SIM_STATE_NULL
+    if b.type == "underground-belt" then
+      ug_type = b.belt_to_ground_type
     end
+    table.insert(belts, {math.floor(b.position.x - storage.offx) + LX0,
+                         math.floor(b.position.y - storage.offy) + LY0, n, det,
+                         b.name, b.direction, ug_type})
   end
   -- Pipe/fluid section (#364): every pipe-class entity with name,
   -- direction, and fluid contents — fluids were invisible in the dump,
@@ -1178,10 +1202,14 @@ local function dump_sim_state(s)
     table.insert(chests, {math.floor(c.position.x - storage.offx) + LX0,
                           math.floor(c.position.y - storage.offy) + LY0, contents})
   end
-  helpers.write_file("sim-state.json", helpers.table_to_json{
+  local sim_state_json = helpers.table_to_json{
     offx = storage.offx, offy = storage.offy, fed = storage.fed_total,
     belts = belts, machines = machines, inserters = inserters, pipes = pipes,
-    ugs = ugs, splitters = splitters, chests = chests}, false)
+    ugs = ugs, splitters = splitters, chests = chests}
+  -- Convert the belts' ug_type sentinel (see SIM_STATE_NULL above) to a
+  -- real JSON null now that the whole structure has been serialized.
+  sim_state_json = sim_state_json:gsub('"' .. SIM_STATE_NULL .. '"', "null")
+  helpers.write_file("sim-state.json", sim_state_json, false)
 end
 
 local function finalize(s, converged)

--- a/crates/sim-harness/src/scenario.rs
+++ b/crates/sim-harness/src/scenario.rs
@@ -1208,7 +1208,9 @@ local function dump_sim_state(s)
     ugs = ugs, splitters = splitters, chests = chests}
   -- Convert the belts' ug_type sentinel (see SIM_STATE_NULL above) to a
   -- real JSON null now that the whole structure has been serialized.
-  sim_state_json = sim_state_json:gsub('"' .. SIM_STATE_NULL .. '"', "null")
+  -- Anchored to an array tail (`,"<sentinel>"]`) so only the ug_type slot
+  -- can ever match, whatever item or entity names a mod might introduce.
+  sim_state_json = sim_state_json:gsub(',%s*"' .. SIM_STATE_NULL .. '"%s*%]', ",null]")
   helpers.write_file("sim-state.json", sim_state_json, false)
 end
 

--- a/docs/sim-harness-forensics.md
+++ b/docs/sim-harness-forensics.md
@@ -69,12 +69,15 @@ production per stage" panel on `/d/spaghettio-sim`.
   whole run *including warmup*. This is the trajectory record — bin it
   to see transients, plateaus, and oscillations. Whole-run averages and
   first-divergence ordering both come from here.
-- **`sim_state`** (frame at finalize): per-belt per-line item contents,
-  machine statuses + input/output inventories, inserter statuses, UG
-  pairing as the game resolved it, splitter priority/filter state, kit
-  chest census. A *single frame* — statuses are instantaneous (a
-  demand-limited machine flickers `working`/`full_output`; do not read
-  one frame's status as a time-average).
+- **`sim_state`** (frame at finalize): per-belt per-line item contents
+  (belts now also carry entity name, direction, and underground pairing
+  type, and empty belts are included rather than skipped — see
+  `docs/sim-harness.md`), machine statuses + input/output inventories,
+  inserter statuses, UG pairing as the game resolved it, splitter
+  priority/filter state, kit chest census. A *single frame* — statuses
+  are instantaneous (a demand-limited machine flickers
+  `working`/`full_output`; do not read one frame's status as a
+  time-average).
 - **`kit_errors`**: the boundary kit's self-audit. Non-empty ⇒ the run
   is invalid and the verdict is forced NO DATA. Never interpret rates
   from a run with kit errors.

--- a/docs/sim-harness-forensics.md
+++ b/docs/sim-harness-forensics.md
@@ -223,8 +223,8 @@ instrument that was true when written and false when read.
 **Step 0, before any of the below: `scripts/sim-localize.py <report.json>`.**
 It renders the "where" in one command instead of an improvised read (which
 has gotten the belt-count semantics wrong before — see the `n` warning
-above): a kit-error banner if the run is invalid, the item table with a
-same-target-shortfall hint, a starved/backpressured machine ranking (from
+above): a kit-error banner if the run is invalid, the item table with its
+below-plan intermediates listed (a listing, not a causal order), a starved/backpressured machine ranking (from
 `timeseries` when present, falling back to the final `sim_state` frame with
 an explicit "can't distinguish transient from persistent" caveat), an ASCII
 map of machines/inserters/belts by status and direction, and per-lane belt

--- a/docs/sim-harness-forensics.md
+++ b/docs/sim-harness-forensics.md
@@ -220,6 +220,17 @@ instrument that was true when written and false when read.
 
 ## Forensic playbook (in escalation order)
 
+**Step 0, before any of the below: `scripts/sim-localize.py <report.json>`.**
+It renders the "where" in one command instead of an improvised read (which
+has gotten the belt-count semantics wrong before — see the `n` warning
+above): a kit-error banner if the run is invalid, the item table with a
+same-target-shortfall hint, a starved/backpressured machine ranking (from
+`timeseries` when present, falling back to the final `sim_state` frame with
+an explicit "can't distinguish transient from persistent" caveat), an ASCII
+map of machines/inserters/belts by status and direction, and per-lane belt
+contents around the worst machines. It renders and ranks; it does not
+diagnose — steps 1-4 below are still where the reasoning happens.
+
 1. **Trajectory first** (`samples`, and now `timeseries` for a
    per-machine breakdown on the SAME checkpoint-window cadence the
    reported rates use — see "Reading time-series decay shapes" above):

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -416,6 +416,18 @@ a final census (`fluid_ingredient_shortage: 2, item_ingredient_shortage:
 fine for an hour then jammed". A rate-vs-time series distinguishes those
 at a glance; the final aggregate cannot.
 
+`sim_state.belts` entries are `[x, y, n, det, name, direction, ug_type]`:
+layout-space tile coordinate, total item count across all transport
+lines, per-line `{name, count}` detail, the entity name (e.g.
+`"transport-belt"`, `"fast-underground-belt"`, `"express-splitter"`),
+the raw Factorio 2.0 16-way `defines.direction` integer (unremapped —
+0=north, 4=east, 8=south, 12=west), and — for underground belts only —
+`"input"`/`"output"`, `null` otherwise. Empty belts (`n == 0`) are
+included: a dried-up lane is the primary localization signal for belt
+forensics, so the dump no longer skips them. Older reports carry the
+3-tuple `[x, y, n]` with nonempty belts only; both shapes load fine
+since the trailing fields are additive.
+
 Every report now carries `timeseries`, one entry per checkpoint window
 (the same item-driven windows the target/intermediate rates are computed
 over — see "How a measurement window is chosen" above):

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -399,7 +399,11 @@ tells you which check fired and how often; `warnings: 3` would not.
 **Web overlay (RFC-050 Phase 4):** load the `--out` file via the sim
 report panel in the web app to get the verdict banner plus a `sim-state`
 entity overlay tinting machines/belts/inserters by their simulated state
-— the fastest way to see *where* a FAIL is starving.
+— the fastest way to see *where* a FAIL is starving. Without a browser
+(or for a scriptable/agent-facing equivalent), `scripts/sim-localize.py
+<report.json>` renders the same "where" as a starved-machine ranking plus
+an ASCII map — see [`sim-harness-forensics.md`](sim-harness-forensics.md)'s
+forensic playbook, step 0.
 
 ## Reading the time-series
 

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -424,7 +424,12 @@ the raw Factorio 2.0 16-way `defines.direction` integer (unremapped —
 0=north, 4=east, 8=south, 12=west), and — for underground belts only —
 `"input"`/`"output"`, `null` otherwise. Empty belts (`n == 0`) are
 included: a dried-up lane is the primary localization signal for belt
-forensics, so the dump no longer skips them. Older reports carry the
+forensics, so the dump no longer skips them. `scripts/sim-localize.py`
+is what renders them (`.` on its map, `L1: —  L2: —` in lane detail);
+the web overlay deliberately draws nothing for an empty belt, so in the
+browser this change is invisible. Cost: `sim-state.json` grows by the
+empty-belt share of the layout — 12% and 10.5% of belt entries on the
+two dogfood fixtures (gear@10, EC@10). Older reports carry the
 3-tuple `[x, y, n]` with nonempty belts only; both shapes load fine
 since the trailing fields are additive.
 

--- a/docs/sim-harness.md
+++ b/docs/sim-harness.md
@@ -429,9 +429,9 @@ is what renders them (`.` on its map, `L1: —  L2: —` in lane detail);
 the web overlay deliberately draws nothing for an empty belt, so in the
 browser this change is invisible. Cost: `sim-state.json` grows by the
 empty-belt share of the layout — 12% and 10.5% of belt entries on the
-two dogfood fixtures (gear@10, EC@10). Older reports carry the
-3-tuple `[x, y, n]` with nonempty belts only; both shapes load fine
-since the trailing fields are additive.
+two dogfood fixtures (gear@10, EC@10). Older reports carry `[x, y, n]`
+(pre-#357) or `[x, y, n, det]`, nonempty belts only; all shapes load
+fine since the trailing fields are additive.
 
 Every report now carries `timeseries`, one entry per checkpoint window
 (the same item-driven windows the target/intermediate rates are computed

--- a/scripts/sim-localize.py
+++ b/scripts/sim-localize.py
@@ -14,7 +14,9 @@ Usage: python3 scripts/sim-localize.py <report.json> [--top N]
             the map is the full extent (the first look usually wants
             the whole factory). --around overrides either.
 --radius N  lane-detail radius per worst machine (default 3).
---around X,Y[,R]  window the map on this tile (default R=15).
+--around X,Y[,R]  window the map on this tile (default R=15) AND anchor
+            the lane detail there (radius --radius) instead of on the
+            worst machines.
 
 Belt `n` — LOAD-BEARING: a transport LINE spans several tiles, and
 `get_item_count()` returns the WHOLE LINE's count, so `n` repeats across
@@ -50,7 +52,9 @@ BACKPRESSURE = {"full_output", "full_burnt_result_output", "fluid_production_ove
 
 def rank_key(r):
     """One sort key for both ranking paths: worst first, then stable by tile."""
-    return (-r["frac_shortage"], -r["frac_backpressure"], -r.get("frac_other", 0.0), r["x"] or 0, r["y"] or 0)
+    x = r["x"] if r["x"] is not None else 0  # missing ≠ coordinate 0, but both sort after nothing
+    y = r["y"] if r["y"] is not None else 0
+    return (-r["frac_shortage"], -r["frac_backpressure"], -r.get("frac_other", 0.0), x, y)
 MACHINE_GLYPH = {"working": "W", "full_output": "F", "no_power": "P"}
 INSERTER_GLYPH = {
     "working": "i",
@@ -58,7 +62,7 @@ INSERTER_GLYPH = {
     "waiting_for_space_in_destination": "d",
     "waiting_for_more_items": "m",
 }
-ARROWS = ["^", ">", "v", "<"]  # indexed by round(direction / 4) % 4
+ARROWS = ["^", ">", "v", "<"]  # indexed by direction // 4 % 4 (real belts are only ever 0/4/8/12)
 
 def machine_glyph(status):
     if status in MACHINE_GLYPH:
@@ -172,29 +176,35 @@ def print_header(top):
 def classify_shape(deltas, statuses):
     """Coarse decay-shape classifier over one machine's crafts_delta series.
     See docs/sim-harness-forensics.md "Reading time-series decay shapes"
-    for the real vocabulary this approximates. Rules:
+    for the real vocabulary this approximates. Rules, in order:
       flat-zero:       every window's crafts_delta is ~0.
-      ramp-then-decay: series peaks strictly before the final window, and
-                       the final window is under half that peak.
-      stable-below:    low relative variation (stdev/mean < 20%) AND at
-                       least one window sat in a shortage/full_output status.
-      healthy:         everything else.
+      ramp-then-decay: a rise to a peak strictly before the final window,
+                       then the final window under half that peak.
+      decaying:        peak in the FIRST window, final window under half it
+                       (winding down, never ramped — not a jam signature).
+      stable-below:    low relative variation (stdev/mean < 20%) with at
+                       least one window in a non-`working` status.
+      unsteady:        any other series with a non-`working` status somewhere.
+      healthy:         never left `working`, and none of the above.
+    `healthy` is never returned for a machine that sat in an impaired
+    status: an alternating starving machine is `unsteady`, not healthy.
     """
     if not deltas:
         return "unknown"
     if all(abs(d) < 1e-9 for d in deltas):
         return "flat-zero"
+    impaired = any(s != "working" for s in statuses)
     peak = max(deltas)
     peak_idx = deltas.index(peak)
     if peak > 0 and peak_idx < len(deltas) - 1 and deltas[-1] < 0.5 * peak:
-        return "ramp-then-decay"
+        return "ramp-then-decay" if peak_idx > 0 else "decaying"
     mean = sum(deltas) / len(deltas)
-    if mean > 0:
-        cv = (sum((d - mean) ** 2 for d in deltas) / len(deltas)) ** 0.5 / mean
-        impaired = any(s in SHORTAGE or s in BACKPRESSURE for s in statuses)
-        if cv < 0.2:
-            return "stable-below" if impaired else "healthy"
-    return "healthy" if mean > 0 else "flat-zero"
+    if mean <= 0:
+        return "unknown"
+    cv = (sum((d - mean) ** 2 for d in deltas) / len(deltas)) ** 0.5 / mean
+    if cv < 0.2:
+        return "stable-below" if impaired else "healthy"
+    return "unsteady" if impaired else "healthy"
 
 def rank_from_timeseries(timeseries):
     by_unit = {}
@@ -259,7 +269,7 @@ def print_ranking(top, top_n):
         return [], rows
     print(f"{'unit':>6} {'name':<26} {'pos':>10} {'shortage%':>10} {'backpressure%':>14} {'mean crafts':>12} {'shape':<16}")
     for r in rows[:20]:
-        pos = f"({r['x']:.0f},{r['y']:.0f})"
+        pos = f"({r['x']:.0f},{r['y']:.0f})" if r["x"] is not None and r["y"] is not None else "(?,?)"
         mean = "-" if r["mean_crafts_delta"] is None else f"{r['mean_crafts_delta']:.2f}"
         print(f"{str(r['unit'] or '-'):>6} {str(r['name'] or '?'):<26} {pos:>10} "
               f"{r['frac_shortage']*100:>9.0f}% {r['frac_backpressure']*100:>13.0f}% {mean:>12} {r['shape']:<16}")
@@ -344,16 +354,19 @@ def render_map(grid, all_xy, window):
         row_label = f"{y:>5} " if y % 10 == 0 else " " * 6
         print(row_label + "".join(grid.get((x, y), " ") for x in range(xmin, xmax + 1)))
 
-def resolve_window(args, worst_rows):
-    if args.around:
-        try:
-            parts = [int(p) for p in args.around.split(",")]
-            x, y = parts[0], parts[1]
-            r = parts[2] if len(parts) > 2 else 15
-            return (x - r, x + r, y - r, y + r)
-        except (ValueError, IndexError):
-            print(f"note: --around expects X,Y[,R] (got {args.around!r}) — rendering the full extent instead",
-                  file=sys.stderr)
+def parse_around(s):
+    """`X,Y[,R]` → (x, y, r) or None (with a stderr note) on malformed input."""
+    try:
+        parts = [int(p) for p in s.split(",")]
+        return parts[0], parts[1], (parts[2] if len(parts) > 2 else 15)
+    except (ValueError, IndexError):
+        print(f"note: --around expects X,Y[,R] (got {s!r}) — rendering the full extent instead", file=sys.stderr)
+        return None
+
+def resolve_window(args, worst_rows, around=None):
+    if around is not None:
+        x, y, r = around
+        return (x - r, x + r, y - r, y + r)
     if args.top_explicit and worst_rows:
         xs = [r["x"] for r in worst_rows if r["x"] is not None]
         ys = [r["y"] for r in worst_rows if r["y"] is not None]
@@ -367,7 +380,7 @@ LEGEND = """legend:
   inserters: i working  s waiting_for_source  d waiting_for_space  m waiting_for_more  ? other
   belts (direction known): ^ > v < = nonempty, moving that way; . = empty
   belts (old format, no direction): # nonempty, . empty
-  underground: U/u input mouth (nonempty/empty)  O/o output mouth (nonempty/empty) — direction not encoded
+  underground: U/u input mouth (nonempty/empty)  O/o output mouth (nonempty/empty) — direction not shown here (lane detail prints it)
   splitters: Y nonempty, y empty     pipes: ~ has fluid, - empty
   NOTE: belt `n` is a whole TRANSPORT LINE's count (repeats across a straight run) — treated as
   empty-vs-nonempty only, never per-tile.
@@ -378,19 +391,29 @@ LEGEND = """legend:
 def lane_str(det, idx):
     if not det or len(det) <= idx or not det[idx]:
         return "—"
-    return "  ".join(f"{item}×{count}" for item, count in det[idx])
+    parts = []
+    for entry in det[idx]:
+        if isinstance(entry, (list, tuple)) and len(entry) == 2:
+            parts.append(f"{entry[0]}×{entry[1]}")
+        else:
+            parts.append(f"?{entry!r}")  # unexpected lane entry shape: show it, don't crash
+    return "  ".join(parts)
 
-def print_lane_detail(sim_state, worst_rows, radius):
-    print(f"--- lane detail (worst {len(worst_rows)}, radius {radius}) ---")
-    if not worst_rows:
+def print_lane_detail(sim_state, anchors, radius, label=None):
+    """`anchors` are ranking rows (machines) or a `{"kind": "tile", ...}` from --around."""
+    print(f"--- lane detail ({label or f'worst {len(anchors)}'}, radius {radius}) ---")
+    if not anchors:
         print("(nothing to detail)")
         return
     belts = [parse_belt(b) for b in sim_state.get("belts") or []]
-    for r in worst_rows:
+    for r in anchors:
         x0, y0 = r["x"], r["y"]
         if x0 is None or y0 is None:
             continue
-        print(f"machine {r.get('unit') or '-'} {r.get('name') or '?'} at ({x0:.0f},{y0:.0f}):")
+        if r.get("kind") == "tile":
+            print(f"tile ({x0:.0f},{y0:.0f}):")
+        else:
+            print(f"machine {r.get('unit') or '-'} {r.get('name') or '?'} at ({x0:.0f},{y0:.0f}):")
         nearby = sorted(
             (b for b in belts if abs(b["x"] - x0) <= radius and abs(b["y"] - y0) <= radius),
             key=lambda b: (abs(b["x"] - x0) + abs(b["y"] - y0), b["x"], b["y"]),
@@ -401,7 +424,7 @@ def print_lane_detail(sim_state, worst_rows, radius):
         for b in nearby:
             arrow = arrow_for(b["direction"]) if b["direction"] is not None else "?"
             name = b["name"] or "belt"
-            if b["det"]:
+            if b["det"] is not None:  # `[]`/`[{}, {}]` is a real, empty new-format belt — the headline case
                 print(f"  ({b['x']:.0f},{b['y']:.0f}) {name} {arrow} L1: {lane_str(b['det'], 0)}  L2: {lane_str(b['det'], 1)}")
             else:
                 fill = "nonempty" if (b["n"] or 0) > 0 else "empty"
@@ -430,14 +453,19 @@ def main():
     worst_rows, _all_rows = print_ranking(top, top_n)
 
     sim_state = top.get("sim_state") or {}
-    window = resolve_window(args, worst_rows)
+    around = parse_around(args.around) if args.around else None
+    window = resolve_window(args, worst_rows, around)
     print("--- map ---")
     print(LEGEND)
     grid, all_xy = build_grid(sim_state, window)
     render_map(grid, all_xy, window)
     print()
 
-    print_lane_detail(sim_state, worst_rows, args.radius)
+    if around is not None:
+        x, y, _r = around
+        print_lane_detail(sim_state, [{"kind": "tile", "x": x, "y": y}], args.radius, label=f"around ({x},{y})")
+    else:
+        print_lane_detail(sim_state, worst_rows, args.radius)
     return 0
 
 if __name__ == "__main__":

--- a/scripts/sim-localize.py
+++ b/scripts/sim-localize.py
@@ -314,7 +314,7 @@ def render_map(grid, all_xy, window):
     xmin, xmax, ymin, ymax = int(xmin), int(xmax), int(ymin), int(ymax)
     margin, width = 6, xmax - xmin + 1
 
-    header = [" "] * (margin + width)
+    header = [" "] * (margin + width + 6)  # slack so a label at the right edge isn't truncated
     for x in range(xmin, xmax + 1):
         if x % 10 == 0:
             start = margin + (x - xmin)

--- a/scripts/sim-localize.py
+++ b/scripts/sim-localize.py
@@ -9,14 +9,14 @@ tile, no validator cross-referencing.
 
 Usage: python3 scripts/sim-localize.py <report.json> [--top N]
        [--radius N] [--around X,Y[,R]]
---top N     rank/detail the worst N machines (default 3). Given
-            explicitly, also windows the map on their bbox; by default
-            the map is the full extent (the first look usually wants
-            the whole factory). --around overrides either.
---radius N  lane-detail radius per worst machine (default 3).
+--top N     table and lane-detail the worst N machines (default: table
+            20, detail 3). Given explicitly, also windows the map on
+            their bbox; by default the map is the full extent (the first
+            look usually wants the whole factory). --around overrides.
+--radius N  lane-detail radius (default 3, or --around's R when given).
 --around X,Y[,R]  window the map on this tile (default R=15) AND anchor
-            the lane detail there (radius --radius) instead of on the
-            worst machines.
+            the lane detail there instead of on the worst machines.
+            Negative coordinates: --around=-5,-3 (or bare; both work).
 
 Belt `n` — LOAD-BEARING: a transport LINE spans several tiles, and
 `get_item_count()` returns the WHOLE LINE's count, so `n` repeats across
@@ -25,7 +25,8 @@ empty-vs-nonempty only, never summed along a run or printed as
 items-per-tile (yesterday's improvised read made exactly that mistake).
 
 Formats: OLD dumps (web/src/ui/testdata/sim-report-*.json) lack
-timeseries/validator_standing/kit_errors, and belts are bare [x, y, n].
+timeseries/validator_standing/kit_errors, and belts are [x, y, n] or
+[x, y, n, det] (nonempty belts only).
 NEW dumps add those fields and extend belts to [x, y, n, det, name,
 direction, ug_type] (det: per-line [[item, count], ...], index 0=left/
 1=right lane; direction: raw Factorio 2.0 defines.direction, 16-way,
@@ -55,7 +56,6 @@ def rank_key(r):
     x = r["x"] if r["x"] is not None else 0  # missing ≠ coordinate 0, but both sort after nothing
     y = r["y"] if r["y"] is not None else 0
     return (-r["frac_shortage"], -r["frac_backpressure"], -r.get("frac_other", 0.0), x, y)
-MACHINE_GLYPH = {"working": "W", "full_output": "F", "no_power": "P"}
 INSERTER_GLYPH = {
     "working": "i",
     "waiting_for_source_items": "s",
@@ -64,11 +64,19 @@ INSERTER_GLYPH = {
 }
 ARROWS = ["^", ">", "v", "<"]  # indexed by direction // 4 % 4 (real belts are only ever 0/4/8/12)
 
+POWER = {"no_power", "low_power", "no_fuel"}
+
 def machine_glyph(status):
-    if status in MACHINE_GLYPH:
-        return MACHINE_GLYPH[status]
-    if status in ("item_ingredient_shortage", "fluid_ingredient_shortage"):
+    """Derived from the same status sets the ranking uses, so the map never
+    draws a top-ranked shortage as the catch-all `?`."""
+    if status == "working":
+        return "W"
+    if status in POWER:
+        return "P"
+    if status in SHORTAGE:
         return "S"
+    if status in BACKPRESSURE:
+        return "F"
     return "?"
 
 def arrow_for(direction):
@@ -250,7 +258,7 @@ def rank_from_final_frame(sim_state):
     rows.sort(key=rank_key)
     return rows
 
-def print_ranking(top, top_n):
+def print_ranking(top, top_n, table_n=20):
     report = top.get("report", {})
     timeseries = report.get("timeseries") or []
     print("--- machine ranking ---")
@@ -268,13 +276,13 @@ def print_ranking(top, top_n):
         print("no starved/backpressured machines found.\n")
         return [], rows
     print(f"{'unit':>6} {'name':<26} {'pos':>10} {'shortage%':>10} {'backpressure%':>14} {'mean crafts':>12} {'shape':<16}")
-    for r in rows[:20]:
+    for r in rows[:table_n]:
         pos = f"({r['x']:.0f},{r['y']:.0f})" if r["x"] is not None and r["y"] is not None else "(?,?)"
         mean = "-" if r["mean_crafts_delta"] is None else f"{r['mean_crafts_delta']:.2f}"
         print(f"{str(r['unit'] or '-'):>6} {str(r['name'] or '?'):<26} {pos:>10} "
               f"{r['frac_shortage']*100:>9.0f}% {r['frac_backpressure']*100:>13.0f}% {mean:>12} {r['shape']:<16}")
-    if len(rows) > 20:
-        print(f"... and {len(rows) - 20} more")
+    if len(rows) > table_n:
+        print(f"... and {len(rows) - table_n} more (raise --top to see them)")
     print()
     return rows[:top_n], rows
 
@@ -349,7 +357,7 @@ def render_map(grid, all_xy, window):
             for k, ch in enumerate(str(x)):
                 if start + k < len(header):
                     header[start + k] = ch
-    print("".join(header))
+    print("".join(header).rstrip())
     for y in range(ymin, ymax + 1):
         row_label = f"{y:>5} " if y % 10 == 0 else " " * 6
         print(row_label + "".join(grid.get((x, y), " ") for x in range(xmin, xmax + 1)))
@@ -358,6 +366,8 @@ def parse_around(s):
     """`X,Y[,R]` → (x, y, r) or None (with a stderr note) on malformed input."""
     try:
         parts = [int(p) for p in s.split(",")]
+        if len(parts) not in (2, 3):
+            raise ValueError(len(parts))
         return parts[0], parts[1], (parts[2] if len(parts) > 2 else 15)
     except (ValueError, IndexError):
         print(f"note: --around expects X,Y[,R] (got {s!r}) — rendering the full extent instead", file=sys.stderr)
@@ -433,15 +443,29 @@ def print_lane_detail(sim_state, anchors, radius, label=None):
 
 # --- main -----------------------------------------------------------------
 
-def main():
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # argparse reads `--around -5,-3` as an unknown option `-5,-3`. Layout
+    # coordinates are routinely negative, so glue a leading-minus value onto
+    # the flag (`--around=-5,-3`), which argparse accepts.
+    for i in range(len(argv) - 1):
+        if argv[i] == "--around" and argv[i + 1].startswith("-"):
+            argv[i:i + 2] = [f"--around={argv[i + 1]}"]
+            break
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("report", help="path to a sim-harness `run --out` JSON file")
-    ap.add_argument("--top", type=int, default=None, help="worst-N machines to detail (default 3)")
-    ap.add_argument("--radius", type=int, default=3, help="lane-detail radius (default 3)")
-    ap.add_argument("--around", default=None, help="X,Y[,R] — window the map instead of full extent")
-    args = ap.parse_args()
+    ap.add_argument("--top", type=int, default=None, help="worst-N machines to table/detail (default: table 20, detail 3)")
+    ap.add_argument("--radius", type=int, default=None, help="lane-detail radius (default 3, or --around's R)")
+    ap.add_argument("--around", default=None, help="X,Y[,R] — window map + lane detail on this tile (negative: --around=-5,-3)")
+    args = ap.parse_args(argv)
     args.top_explicit = args.top is not None
     top_n = args.top if args.top is not None else 3
+    table_n = args.top if args.top is not None else 20
+    around = parse_around(args.around) if args.around is not None else None
+    radius = args.radius if args.radius is not None else (around[2] if around is not None else 3)
+    if radius < 0:
+        print(f"note: --radius {radius} is negative — using 0", file=sys.stderr)
+        radius = 0
 
     try:
         top = load_report(args.report)
@@ -450,10 +474,9 @@ def main():
         return 1
 
     print_header(top)
-    worst_rows, _all_rows = print_ranking(top, top_n)
+    worst_rows, _all_rows = print_ranking(top, top_n, table_n)
 
     sim_state = top.get("sim_state") or {}
-    around = parse_around(args.around) if args.around else None
     window = resolve_window(args, worst_rows, around)
     print("--- map ---")
     print(LEGEND)
@@ -463,9 +486,9 @@ def main():
 
     if around is not None:
         x, y, _r = around
-        print_lane_detail(sim_state, [{"kind": "tile", "x": x, "y": y}], args.radius, label=f"around ({x},{y})")
+        print_lane_detail(sim_state, [{"kind": "tile", "x": x, "y": y}], radius, label=f"around ({x},{y})")
     else:
-        print_lane_detail(sim_state, worst_rows, args.radius)
+        print_lane_detail(sim_state, worst_rows, radius)
     return 0
 
 if __name__ == "__main__":

--- a/scripts/sim-localize.py
+++ b/scripts/sim-localize.py
@@ -8,7 +8,7 @@ belts. Renders and ranks; no root-cause, no belt-walking to first-empty-
 tile, no validator cross-referencing.
 
 Usage: python3 scripts/sim-localize.py <report.json> [--top N]
-       [--radius N] [--around X,Y[,R]] [--color]
+       [--radius N] [--around X,Y[,R]]
 --top N     rank/detail the worst N machines (default 3); also windows
             the map on their bbox unless --around is given.
 --radius N  lane-detail radius per worst machine (default 3).
@@ -132,24 +132,24 @@ def print_header(top):
     print()
 
     if target is not None and target_ratio is not None and target_ratio < 1.0:
-        # Only worth localizing when the target actually falls short — an
-        # at-or-above-plan target has no shortfall for a hint to explain.
-        # "Planned dependency order" isn't derivable from this report (no
-        # recipe graph carried) — table order (target-first, then
-        # alphabetical, per report.rs) is used instead.
-        hint = next(
-            (it for it in items if not it.get("is_target") and it.get("planned_rate")
-             and it.get("measured_produced_rate") is not None
-             and it["measured_produced_rate"] / it["planned_rate"] < target_ratio),
-            None,
+        # Only when the target actually falls short. The report carries no
+        # recipe graph, so "upstream" is not verifiable from it — this is a
+        # plain sorted listing, and the caveat printed with it is load-bearing.
+        short = sorted(
+            (it["measured_produced_rate"] / it["planned_rate"], it["item"])
+            for it in items
+            if not it.get("is_target") and it.get("planned_rate")
+            and it.get("measured_produced_rate") is not None
         )
-        if hint:
-            r = hint["measured_produced_rate"] / hint["planned_rate"] * 100
-            print(f"hint: {hint['item']} runs at {r:.0f}% of plan, below the target's own "
-                  f"{target_ratio * 100:.0f}% — a plausible upstream stage (table order, not verified dependency order).")
+        short = [(r, name) for r, name in short if r < 0.98]
+        if short:
+            print("below-plan intermediates, most short first: "
+                  + ", ".join(f"{name} {r * 100:.0f}%" for r, name in short))
+            print("  (a listing, not a causal order — a BACKED-UP stage reads below plan just like a "
+                  "starved one; cross-check the ranking's backpressure% column)")
         else:
-            print("hint: no upstream item measures below the target's own shortfall ratio — the "
-                  "bottleneck may be structural (machine count, capacity) rather than a starved input.")
+            print("no intermediate below 98% of plan — the shortfall sits at the target stage itself "
+                  "(machine count, inserter/belt capacity, or its own feed).")
     print()
 
 # --- machine ranking ---------------------------------------------------------
@@ -229,7 +229,9 @@ def print_ranking(top, top_n):
     print("--- machine ranking ---")
     if timeseries:
         rows = rank_from_timeseries(timeseries)
-        print(f"({len(timeseries)} checkpoint window(s))")
+        total = len(rows)
+        rows = [r for r in rows if r["frac_shortage"] > 0 or r["frac_backpressure"] > 0 or r["shape"] != "healthy"]
+        print(f"({len(timeseries)} checkpoint window(s); {total - len(rows)} healthy machine(s) omitted)")
     else:
         print("timeseries: absent — falling back to final frame (cannot distinguish transient from persistent)")
         rows = rank_from_final_frame(top.get("sim_state") or {})
@@ -366,7 +368,7 @@ def print_lane_detail(sim_state, worst_rows, radius):
         x0, y0 = r["x"], r["y"]
         if x0 is None or y0 is None:
             continue
-        print(f"machine {r.get('unit', '-')} {r.get('name', '?')} at ({x0:.0f},{y0:.0f}):")
+        print(f"machine {r.get('unit') or '-'} {r.get('name') or '?'} at ({x0:.0f},{y0:.0f}):")
         nearby = sorted(
             (b for b in belts if abs(b["x"] - x0) <= radius and abs(b["y"] - y0) <= radius),
             key=lambda b: (abs(b["x"] - x0) + abs(b["y"] - y0), b["x"], b["y"]),
@@ -392,7 +394,6 @@ def main():
     ap.add_argument("--top", type=int, default=None, help="worst-N machines to detail (default 3)")
     ap.add_argument("--radius", type=int, default=3, help="lane-detail radius (default 3)")
     ap.add_argument("--around", default=None, help="X,Y[,R] — window the map instead of full extent")
-    ap.add_argument("--color", action="store_true", help="cheap ANSI tinting (off by default; unused for now)")
     args = ap.parse_args()
     args.top_explicit = args.top is not None
     top_n = args.top if args.top is not None else 3

--- a/scripts/sim-localize.py
+++ b/scripts/sim-localize.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Localize WHERE a sim-harness run is failing: starved machines + a map.
+
+Read-only forensics over a `spaghettio-sim run --out report.json` (see
+docs/sim-harness.md, docs/sim-harness-forensics.md). Answers "where" —
+which machines are starved of what, since when, and the surrounding
+belts. Renders and ranks; no root-cause, no belt-walking to first-empty-
+tile, no validator cross-referencing.
+
+Usage: python3 scripts/sim-localize.py <report.json> [--top N]
+       [--radius N] [--around X,Y[,R]] [--color]
+--top N     rank/detail the worst N machines (default 3); also windows
+            the map on their bbox unless --around is given.
+--radius N  lane-detail radius per worst machine (default 3).
+--around X,Y[,R]  window the map on this tile (default R=15).
+
+Belt `n` — LOAD-BEARING: a transport LINE spans several tiles, and
+`get_item_count()` returns the WHOLE LINE's count, so `n` repeats across
+every tile of one straight run. Never per-tile: treated here as
+empty-vs-nonempty only, never summed along a run or printed as
+items-per-tile (yesterday's improvised read made exactly that mistake).
+
+Formats: OLD dumps (web/src/ui/testdata/sim-report-*.json) lack
+timeseries/validator_standing/kit_errors, and belts are bare [x, y, n].
+NEW dumps add those fields and extend belts to [x, y, n, det, name,
+direction, ug_type] (det: per-line [[item, count], ...], index 0=left/
+1=right lane; direction: raw Factorio 2.0 defines.direction, 16-way,
+0/4/8/12=N/E/S/W; ug_type: "input"/"output"/null). Every tuple here
+tolerates extra trailing elements; every access degrades to a one-line
+note, never a crash.
+"""
+import argparse
+import json
+import sys
+
+def load_report(path):
+    with open(path) as f:
+        return json.load(f)
+
+SHORTAGE = {"item_ingredient_shortage", "fluid_ingredient_shortage", "no_power", "no_fuel"}
+BACKPRESSURE = {"full_output"}
+MACHINE_GLYPH = {"working": "W", "full_output": "F", "no_power": "P"}
+INSERTER_GLYPH = {
+    "working": "i",
+    "waiting_for_source_items": "s",
+    "waiting_for_space_in_destination": "d",
+    "waiting_for_more_items": "m",
+}
+ARROWS = ["^", ">", "v", "<"]  # indexed by round(direction / 4) % 4
+
+def machine_glyph(status):
+    if status in MACHINE_GLYPH:
+        return MACHINE_GLYPH[status]
+    if status in ("item_ingredient_shortage", "fluid_ingredient_shortage"):
+        return "S"
+    return "?"
+
+def arrow_for(direction):
+    return None if direction is None else ARROWS[round(direction / 4.0) % 4]
+
+def g(d, *path, default=None):
+    """Nested .get() that never raises on a missing key or wrong shape."""
+    cur = d
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return default
+        cur = cur[key]
+    return cur if cur is not None else default
+
+def fmt(v):
+    return "-" if v is None else f"{v:.2f}"
+
+def fmt_pct(v):
+    return "-" if v is None else f"{v:+.1f}%"
+
+# --- header: kit check, verdict, validator line, item table -----------------
+
+def validator_line(top):
+    """Mirror crates/sim-harness/src/report.rs's validator_line()."""
+    report = top.get("report", {})
+    if "validator_standing" not in report:
+        return "unknown (pre-field report)"
+    v = report.get("validator")
+    if v is None:
+        return "? (manifest predates the validator field — state unknown, NOT clean)"
+    errors, warnings, layout_w = v.get("errors", 0), v.get("warnings", 0), v.get("layout_warnings", 0)
+    if errors == 0 and warnings == 0 and layout_w == 0:
+        return "clean (no issues reported — validator silence is not proof of correctness)"
+    badge = "/".join(f"{n}{c}" for n, c in ((errors, "E"), (warnings, "W"), (layout_w, "L")) if n)
+    by_cat = v.get("by_category", {}) or {}
+    ranked = sorted(by_cat.items(), key=lambda kv: (kv[1].get("errors", 0), kv[1].get("warnings", 0)), reverse=True)
+    cats = [f"{k}×{c.get('errors', 0) + c.get('warnings', 0)}" for k, c in ranked[:4]]
+    return f"{badge} — {', '.join(cats)}" if cats else badge
+
+def kit_errors_of(top):
+    return g(top, "report", "kit_errors", default=None) or g(top, "raw_result", "kit_errors", default=[])
+
+def print_header(top):
+    report = top.get("report", {})
+    kit_errors = kit_errors_of(top)
+    if kit_errors:
+        print("!! KIT ERRORS — run is invalid, rates below are not interpretable")
+        for e in kit_errors:
+            print(f"   {e}")
+        print()
+
+    label = report.get("label") or g(top, "run_params", "scenario_name", default="?")
+    print(f"=== sim-localize: {label} ===")
+    print(f"verdict: {report.get('overall_verdict', '?')}   converged: {report.get('converged')}")
+    print(f"validator: {validator_line(top)}")
+    print()
+
+    items = report.get("items") or []
+    if not items:
+        print("(no per-item table — report.items absent)\n")
+        return
+    print(f"{'item':<28} {'planned/s':>10} {'produced/s':>11} {'delivered/s':>12} {'d%':>8}")
+    target, target_ratio = None, None
+    for it in items:
+        mark = "*" if it.get("is_target") else " "
+        planned, produced, delivered = it.get("planned_rate"), it.get("measured_produced_rate"), it.get("measured_delivered_rate")
+        dpct = it.get("delta_pct_delivered")
+        if dpct is None:
+            dpct = it.get("delta_pct_produced")
+        print(f"{mark + it.get('item', '?'):<28} {fmt(planned):>10} {fmt(produced):>11} {fmt(delivered):>12} {fmt_pct(dpct):>8}")
+        if it.get("is_target"):
+            target = it
+            if delivered is not None and planned:
+                target_ratio = delivered / planned
+            elif produced is not None and planned:
+                target_ratio = produced / planned
+    print()
+
+    if target is not None and target_ratio is not None and target_ratio < 1.0:
+        # Only worth localizing when the target actually falls short — an
+        # at-or-above-plan target has no shortfall for a hint to explain.
+        # "Planned dependency order" isn't derivable from this report (no
+        # recipe graph carried) — table order (target-first, then
+        # alphabetical, per report.rs) is used instead.
+        hint = next(
+            (it for it in items if not it.get("is_target") and it.get("planned_rate")
+             and it.get("measured_produced_rate") is not None
+             and it["measured_produced_rate"] / it["planned_rate"] < target_ratio),
+            None,
+        )
+        if hint:
+            r = hint["measured_produced_rate"] / hint["planned_rate"] * 100
+            print(f"hint: {hint['item']} runs at {r:.0f}% of plan, below the target's own "
+                  f"{target_ratio * 100:.0f}% — a plausible upstream stage (table order, not verified dependency order).")
+        else:
+            print("hint: no upstream item measures below the target's own shortfall ratio — the "
+                  "bottleneck may be structural (machine count, capacity) rather than a starved input.")
+    print()
+
+# --- machine ranking ---------------------------------------------------------
+
+def classify_shape(deltas, statuses):
+    """Coarse decay-shape classifier over one machine's crafts_delta series.
+    See docs/sim-harness-forensics.md "Reading time-series decay shapes"
+    for the real vocabulary this approximates. Rules:
+      flat-zero:       every window's crafts_delta is ~0.
+      ramp-then-decay: series peaks strictly before the final window, and
+                       the final window is under half that peak.
+      stable-below:    low relative variation (stdev/mean < 20%) AND at
+                       least one window sat in a shortage/full_output status.
+      healthy:         everything else.
+    """
+    if not deltas:
+        return "unknown"
+    if all(abs(d) < 1e-9 for d in deltas):
+        return "flat-zero"
+    peak = max(deltas)
+    peak_idx = deltas.index(peak)
+    if peak > 0 and peak_idx < len(deltas) - 1 and deltas[-1] < 0.5 * peak:
+        return "ramp-then-decay"
+    mean = sum(deltas) / len(deltas)
+    if mean > 0:
+        cv = (sum((d - mean) ** 2 for d in deltas) / len(deltas)) ** 0.5 / mean
+        impaired = any(s in SHORTAGE or s in BACKPRESSURE for s in statuses)
+        if cv < 0.2:
+            return "stable-below" if impaired else "healthy"
+    return "healthy" if mean > 0 else "flat-zero"
+
+def rank_from_timeseries(timeseries):
+    by_unit = {}
+    for point in timeseries:
+        for m in point.get("machines", []):
+            unit = m.get("unit")
+            if unit is None:
+                continue
+            rec = by_unit.setdefault(unit, {"name": m.get("name"), "x": None, "y": None, "deltas": [], "statuses": []})
+            rec["x"], rec["y"] = m.get("x", rec["x"]), m.get("y", rec["y"])
+            rec["deltas"].append(m.get("crafts_delta", 0.0))
+            rec["statuses"].append(m.get("status", "?"))
+    rows = []
+    for unit, rec in by_unit.items():
+        n = len(rec["statuses"]) or 1
+        frac_s = sum(1 for s in rec["statuses"] if s in SHORTAGE) / n
+        frac_b = sum(1 for s in rec["statuses"] if s in BACKPRESSURE) / n
+        mean_delta = sum(rec["deltas"]) / len(rec["deltas"]) if rec["deltas"] else 0.0
+        rows.append({
+            "unit": unit, "name": rec["name"], "x": rec["x"], "y": rec["y"],
+            "frac_shortage": frac_s, "frac_backpressure": frac_b,
+            "mean_crafts_delta": mean_delta, "shape": classify_shape(rec["deltas"], rec["statuses"]),
+        })
+    rows.sort(key=lambda r: (-r["frac_shortage"], -r["frac_backpressure"]))
+    return rows
+
+def rank_from_final_frame(sim_state):
+    """Fallback when no timeseries: a single frame can't distinguish
+    transient from persistent — the caller prints that caveat."""
+    rows = []
+    for m in sim_state.get("machines", []):
+        x, y, name, status = m[0], m[1], m[2], m[3]
+        if status == "working":
+            continue
+        rows.append({
+            "unit": None, "name": name, "x": x, "y": y,
+            "frac_shortage": 1.0 if status in SHORTAGE else 0.0,
+            "frac_backpressure": 1.0 if status in BACKPRESSURE else 0.0,
+            "mean_crafts_delta": None, "shape": "unknown (single frame)", "status": status,
+        })
+    rows.sort(key=lambda r: (-r["frac_shortage"], -r["frac_backpressure"], r["x"], r["y"]))
+    return rows
+
+def print_ranking(top, top_n):
+    report = top.get("report", {})
+    timeseries = report.get("timeseries") or []
+    print("--- machine ranking ---")
+    if timeseries:
+        rows = rank_from_timeseries(timeseries)
+        print(f"({len(timeseries)} checkpoint window(s))")
+    else:
+        print("timeseries: absent — falling back to final frame (cannot distinguish transient from persistent)")
+        rows = rank_from_final_frame(top.get("sim_state") or {})
+
+    if not rows:
+        print("no starved/backpressured machines found.\n")
+        return [], rows
+    print(f"{'unit':>6} {'name':<26} {'pos':>10} {'shortage%':>10} {'backpressure%':>14} {'mean crafts':>12} {'shape':<16}")
+    for r in rows[:20]:
+        pos = f"({r['x']:.0f},{r['y']:.0f})"
+        mean = "-" if r["mean_crafts_delta"] is None else f"{r['mean_crafts_delta']:.2f}"
+        print(f"{str(r['unit'] or '-'):>6} {str(r['name'] or '?'):<26} {pos:>10} "
+              f"{r['frac_shortage']*100:>9.0f}% {r['frac_backpressure']*100:>13.0f}% {mean:>12} {r['shape']:<16}")
+    if len(rows) > 20:
+        print(f"... and {len(rows) - 20} more")
+    print()
+    return rows[:top_n], rows
+
+# --- map ----------------------------------------------------------------
+
+def parse_belt(b):
+    det = b[3] if len(b) > 3 and isinstance(b[3], list) else None
+    return {
+        "x": b[0], "y": b[1], "n": b[2] if len(b) > 2 else None, "det": det,
+        "name": b[4] if len(b) > 4 else None, "direction": b[5] if len(b) > 5 else None,
+        "ug_type": b[6] if len(b) > 6 else None,
+    }
+
+def belt_glyph(belt):
+    nonempty = (belt["n"] or 0) > 0
+    if belt["direction"] is None:
+        return "#" if nonempty else "."  # old-format dump: no name/direction at all
+    if belt["ug_type"] == "input":
+        return "U" if nonempty else "u"
+    if belt["ug_type"] == "output":
+        return "O" if nonempty else "o"
+    if "splitter" in (belt["name"] or ""):
+        return "Y" if nonempty else "y"
+    return (arrow_for(belt["direction"]) or "#") if nonempty else "."
+
+def build_grid(sim_state, window):
+    def in_window(x, y):
+        if window is None:
+            return True
+        xmin, xmax, ymin, ymax = window
+        return xmin <= x <= xmax and ymin <= y <= ymax
+
+    grid, all_xy = {}, []
+    for p in sim_state.get("pipes") or []:
+        x, y = p[0], p[1]
+        if in_window(x, y):
+            grid[(x, y)] = "~" if (len(p) > 4 and p[4]) else "-"
+            all_xy.append((x, y))
+    for b in sim_state.get("belts") or []:
+        belt = parse_belt(b)
+        if in_window(belt["x"], belt["y"]):
+            grid[(belt["x"], belt["y"])] = belt_glyph(belt)
+            all_xy.append((belt["x"], belt["y"]))
+    for i in sim_state.get("inserters") or []:
+        x, y, status = i[0], i[1], i[2]
+        if in_window(x, y):
+            grid[(x, y)] = INSERTER_GLYPH.get(status, "?")
+            all_xy.append((x, y))
+    for m in sim_state.get("machines") or []:  # drawn last: highest priority
+        x, y, status = m[0], m[1], m[3]
+        if in_window(x, y):
+            grid[(x, y)] = machine_glyph(status)
+            all_xy.append((x, y))
+    return grid, all_xy
+
+def render_map(grid, all_xy, window):
+    if window is not None:
+        xmin, xmax, ymin, ymax = window
+    elif all_xy:
+        xs, ys = [p[0] for p in all_xy], [p[1] for p in all_xy]
+        xmin, xmax, ymin, ymax = min(xs), max(xs), min(ys), max(ys)
+    else:
+        print("(nothing to render in this window)")
+        return
+    xmin, xmax, ymin, ymax = int(xmin), int(xmax), int(ymin), int(ymax)
+    margin, width = 6, xmax - xmin + 1
+
+    header = [" "] * (margin + width)
+    for x in range(xmin, xmax + 1):
+        if x % 10 == 0:
+            start = margin + (x - xmin)
+            for k, ch in enumerate(str(x)):
+                if start + k < len(header):
+                    header[start + k] = ch
+    print("".join(header))
+    for y in range(ymin, ymax + 1):
+        row_label = f"{y:>5} " if y % 10 == 0 else " " * 6
+        print(row_label + "".join(grid.get((x, y), " ") for x in range(xmin, xmax + 1)))
+
+def resolve_window(args, worst_rows):
+    if args.around:
+        parts = args.around.split(",")
+        x, y = int(parts[0]), int(parts[1])
+        r = int(parts[2]) if len(parts) > 2 else 15
+        return (x - r, x + r, y - r, y + r)
+    if args.top_explicit and worst_rows:
+        xs = [r["x"] for r in worst_rows if r["x"] is not None]
+        ys = [r["y"] for r in worst_rows if r["y"] is not None]
+        if xs and ys:
+            pad = 10
+            return (min(xs) - pad, max(xs) + pad, min(ys) - pad, max(ys) + pad)
+    return None
+
+LEGEND = """legend:
+  machines (anchor tile only, entity is 3x3): W working  S ingredient shortage  F full_output  P no power  ? other
+  inserters: i working  s waiting_for_source  d waiting_for_space  m waiting_for_more  ? other
+  belts (direction known): ^ > v < = nonempty, moving that way; . = empty
+  belts (old format, no direction): # nonempty, . empty
+  underground: U/u input mouth (nonempty/empty)  O/o output mouth (nonempty/empty) — direction not encoded
+  splitters: Y nonempty, y empty     pipes: ~ has fluid, - empty
+  NOTE: belt `n` is a whole TRANSPORT LINE's count (repeats across a straight run) — treated as
+  empty-vs-nonempty only, never per-tile.
+"""
+
+# --- lane detail --------------------------------------------------------
+
+def lane_str(det, idx):
+    if not det or len(det) <= idx or not det[idx]:
+        return "—"
+    return "  ".join(f"{item}×{count}" for item, count in det[idx])
+
+def print_lane_detail(sim_state, worst_rows, radius):
+    print(f"--- lane detail (worst {len(worst_rows)}, radius {radius}) ---")
+    if not worst_rows:
+        print("(nothing to detail)")
+        return
+    belts = [parse_belt(b) for b in sim_state.get("belts") or []]
+    for r in worst_rows:
+        x0, y0 = r["x"], r["y"]
+        if x0 is None or y0 is None:
+            continue
+        print(f"machine {r.get('unit', '-')} {r.get('name', '?')} at ({x0:.0f},{y0:.0f}):")
+        nearby = sorted(
+            (b for b in belts if abs(b["x"] - x0) <= radius and abs(b["y"] - y0) <= radius),
+            key=lambda b: (abs(b["x"] - x0) + abs(b["y"] - y0), b["x"], b["y"]),
+        )
+        if not nearby:
+            print("  (no belts within radius)")
+            continue
+        for b in nearby:
+            arrow = arrow_for(b["direction"]) if b["direction"] is not None else "?"
+            name = b["name"] or "belt"
+            if b["det"]:
+                print(f"  ({b['x']:.0f},{b['y']:.0f}) {name} {arrow} L1: {lane_str(b['det'], 0)}  L2: {lane_str(b['det'], 1)}")
+            else:
+                fill = "nonempty" if (b["n"] or 0) > 0 else "empty"
+                print(f"  ({b['x']:.0f},{b['y']:.0f}) {name} {arrow} n={b['n']} ({fill}, no per-lane detail)")
+        print()
+
+# --- main -----------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("report", help="path to a sim-harness `run --out` JSON file")
+    ap.add_argument("--top", type=int, default=None, help="worst-N machines to detail (default 3)")
+    ap.add_argument("--radius", type=int, default=3, help="lane-detail radius (default 3)")
+    ap.add_argument("--around", default=None, help="X,Y[,R] — window the map instead of full extent")
+    ap.add_argument("--color", action="store_true", help="cheap ANSI tinting (off by default; unused for now)")
+    args = ap.parse_args()
+    args.top_explicit = args.top is not None
+    top_n = args.top if args.top is not None else 3
+
+    try:
+        top = load_report(args.report)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"error: could not load {args.report}: {e}", file=sys.stderr)
+        return 1
+
+    print_header(top)
+    worst_rows, _all_rows = print_ranking(top, top_n)
+
+    sim_state = top.get("sim_state") or {}
+    window = resolve_window(args, worst_rows)
+    print("--- map ---")
+    print(LEGEND)
+    grid, all_xy = build_grid(sim_state, window)
+    render_map(grid, all_xy, window)
+    print()
+
+    print_lane_detail(sim_state, worst_rows, args.radius)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sim-localize.py
+++ b/scripts/sim-localize.py
@@ -9,8 +9,10 @@ tile, no validator cross-referencing.
 
 Usage: python3 scripts/sim-localize.py <report.json> [--top N]
        [--radius N] [--around X,Y[,R]]
---top N     rank/detail the worst N machines (default 3); also windows
-            the map on their bbox unless --around is given.
+--top N     rank/detail the worst N machines (default 3). Given
+            explicitly, also windows the map on their bbox; by default
+            the map is the full extent (the first look usually wants
+            the whole factory). --around overrides either.
 --radius N  lane-detail radius per worst machine (default 3).
 --around X,Y[,R]  window the map on this tile (default R=15).
 
@@ -37,8 +39,18 @@ def load_report(path):
     with open(path) as f:
         return json.load(f)
 
-SHORTAGE = {"item_ingredient_shortage", "fluid_ingredient_shortage", "no_power", "no_fuel"}
-BACKPRESSURE = {"full_output"}
+# Factorio `defines.entity_status` names, grouped the way the forensics doc
+# reads them. Anything not `working` and in neither set still counts as
+# impaired (`frac_other`) so an unfamiliar status is surfaced, not hidden.
+SHORTAGE = {
+    "item_ingredient_shortage", "fluid_ingredient_shortage", "no_ingredients",
+    "no_input_fluid", "low_input_fluid", "no_power", "low_power", "no_fuel",
+}
+BACKPRESSURE = {"full_output", "full_burnt_result_output", "fluid_production_overload"}
+
+def rank_key(r):
+    """One sort key for both ranking paths: worst first, then stable by tile."""
+    return (-r["frac_shortage"], -r["frac_backpressure"], -r.get("frac_other", 0.0), r["x"] or 0, r["y"] or 0)
 MACHINE_GLYPH = {"working": "W", "full_output": "F", "no_power": "P"}
 INSERTER_GLYPH = {
     "working": "i",
@@ -56,7 +68,7 @@ def machine_glyph(status):
     return "?"
 
 def arrow_for(direction):
-    return None if direction is None else ARROWS[round(direction / 4.0) % 4]
+    return None if direction is None else ARROWS[int(direction // 4) % 4]
 
 def g(d, *path, default=None):
     """Nested .get() that never raises on a missing key or wrong shape."""
@@ -85,7 +97,7 @@ def validator_line(top):
         return "? (manifest predates the validator field — state unknown, NOT clean)"
     errors, warnings, layout_w = v.get("errors", 0), v.get("warnings", 0), v.get("layout_warnings", 0)
     if errors == 0 and warnings == 0 and layout_w == 0:
-        return "clean (no issues reported — validator silence is not proof of correctness)"
+        return "clean (no issues reported — note validator silence is not proof of correctness)"
     badge = "/".join(f"{n}{c}" for n, c in ((errors, "E"), (warnings, "W"), (layout_w, "L")) if n)
     by_cat = v.get("by_category", {}) or {}
     ranked = sorted(by_cat.items(), key=lambda kv: (kv[1].get("errors", 0), kv[1].get("warnings", 0)), reverse=True)
@@ -125,10 +137,13 @@ def print_header(top):
         print(f"{mark + it.get('item', '?'):<28} {fmt(planned):>10} {fmt(produced):>11} {fmt(delivered):>12} {fmt_pct(dpct):>8}")
         if it.get("is_target"):
             target = it
+            ratio = None
             if delivered is not None and planned:
-                target_ratio = delivered / planned
+                ratio = delivered / planned
             elif produced is not None and planned:
-                target_ratio = produced / planned
+                ratio = produced / planned
+            if ratio is not None and (target_ratio is None or ratio < target_ratio):
+                target_ratio = ratio  # with several targets the worst one governs
     print()
 
     if target is not None and target_ratio is not None and target_ratio < 1.0:
@@ -197,13 +212,14 @@ def rank_from_timeseries(timeseries):
         n = len(rec["statuses"]) or 1
         frac_s = sum(1 for s in rec["statuses"] if s in SHORTAGE) / n
         frac_b = sum(1 for s in rec["statuses"] if s in BACKPRESSURE) / n
+        frac_o = sum(1 for s in rec["statuses"] if s != "working" and s not in SHORTAGE and s not in BACKPRESSURE) / n
         mean_delta = sum(rec["deltas"]) / len(rec["deltas"]) if rec["deltas"] else 0.0
         rows.append({
             "unit": unit, "name": rec["name"], "x": rec["x"], "y": rec["y"],
-            "frac_shortage": frac_s, "frac_backpressure": frac_b,
+            "frac_shortage": frac_s, "frac_backpressure": frac_b, "frac_other": frac_o,
             "mean_crafts_delta": mean_delta, "shape": classify_shape(rec["deltas"], rec["statuses"]),
         })
-    rows.sort(key=lambda r: (-r["frac_shortage"], -r["frac_backpressure"]))
+    rows.sort(key=rank_key)
     return rows
 
 def rank_from_final_frame(sim_state):
@@ -218,9 +234,10 @@ def rank_from_final_frame(sim_state):
             "unit": None, "name": name, "x": x, "y": y,
             "frac_shortage": 1.0 if status in SHORTAGE else 0.0,
             "frac_backpressure": 1.0 if status in BACKPRESSURE else 0.0,
+            "frac_other": 1.0 if (status not in SHORTAGE and status not in BACKPRESSURE) else 0.0,
             "mean_crafts_delta": None, "shape": "unknown (single frame)", "status": status,
         })
-    rows.sort(key=lambda r: (-r["frac_shortage"], -r["frac_backpressure"], r["x"], r["y"]))
+    rows.sort(key=rank_key)
     return rows
 
 def print_ranking(top, top_n):
@@ -230,7 +247,8 @@ def print_ranking(top, top_n):
     if timeseries:
         rows = rank_from_timeseries(timeseries)
         total = len(rows)
-        rows = [r for r in rows if r["frac_shortage"] > 0 or r["frac_backpressure"] > 0 or r["shape"] != "healthy"]
+        rows = [r for r in rows if r["frac_shortage"] > 0 or r["frac_backpressure"] > 0
+                or r["frac_other"] > 0 or r["shape"] != "healthy"]
         print(f"({len(timeseries)} checkpoint window(s); {total - len(rows)} healthy machine(s) omitted)")
     else:
         print("timeseries: absent — falling back to final frame (cannot distinguish transient from persistent)")
@@ -328,10 +346,14 @@ def render_map(grid, all_xy, window):
 
 def resolve_window(args, worst_rows):
     if args.around:
-        parts = args.around.split(",")
-        x, y = int(parts[0]), int(parts[1])
-        r = int(parts[2]) if len(parts) > 2 else 15
-        return (x - r, x + r, y - r, y + r)
+        try:
+            parts = [int(p) for p in args.around.split(",")]
+            x, y = parts[0], parts[1]
+            r = parts[2] if len(parts) > 2 else 15
+            return (x - r, x + r, y - r, y + r)
+        except (ValueError, IndexError):
+            print(f"note: --around expects X,Y[,R] (got {args.around!r}) — rendering the full extent instead",
+                  file=sys.stderr)
     if args.top_explicit and worst_rows:
         xs = [r["x"] for r in worst_rows if r["x"] is not None]
         ys = [r["y"] for r in worst_rows if r["y"] is not None]

--- a/scripts/test_sim_localize.py
+++ b/scripts/test_sim_localize.py
@@ -239,5 +239,57 @@ def test_validator_line_variants():
     assert warned == "3W — input-rate-delivery×3"
 
 
+# --- review-bot findings on #697 -------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["10", "a,b", "1,2,x", ""])
+def test_malformed_around_degrades_to_full_extent(tmp_path, capsys, bad):
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(make_new_format_report()))
+    rc = run(path, ["--around", bad] if bad else [])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "--- map ---" in captured.out
+    if bad:
+        assert "--around expects X,Y[,R]" in captured.err
+
+
+def test_below_plan_gate_uses_the_worst_of_several_targets(tmp_path, capsys):
+    report = make_new_format_report()
+    # a starved primary target followed (in table order) by a healthy secondary
+    report["report"]["items"].append(
+        {"item": "iron-gear-wheel", "planned_rate": 5.0, "measured_produced_rate": 5.1,
+         "measured_delivered_rate": 5.05, "delta_pct_produced": 2.0, "delta_pct_delivered": 1.0,
+         "is_target": True, "verdict": "PASS"})
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(report))
+    run(path)
+    out = capsys.readouterr().out
+    assert "below-plan intermediates" in out or "no intermediate below 98%" in out
+
+
+def test_no_ingredients_and_unknown_statuses_are_not_hidden():
+    ts = [{"tick": 1200 * (i + 1), "machines": [
+        {"unit": 1, "name": "assembling-machine-2", "x": 0, "y": 0, "crafts_delta": 0.0, "status": "no_ingredients"},
+        {"unit": 2, "name": "assembling-machine-2", "x": 5, "y": 0, "crafts_delta": 10.0, "status": "some_new_status"},
+        {"unit": 3, "name": "assembling-machine-2", "x": 9, "y": 0, "crafts_delta": 10.0, "status": "working"},
+    ], "items": {}} for i in range(3)]
+    rows = sim_localize.rank_from_timeseries(ts)
+    by_unit = {r["unit"]: r for r in rows}
+    assert by_unit[1]["frac_shortage"] == 1.0  # no_ingredients counts as a shortage, as the overlay does
+    assert by_unit[2]["frac_other"] == 1.0  # unfamiliar status surfaces rather than reading as healthy
+    assert rows[0]["unit"] == 1 and rows[1]["unit"] == 2
+
+
+def test_both_ranking_paths_share_the_tie_break():
+    frame = {"machines": [[9, 0, "m", "full_output"], [3, 0, "m", "full_output"], [3, -1, "m", "full_output"]]}
+    frame_rows = sim_localize.rank_from_final_frame(frame)
+    ts = [{"tick": 1, "machines": [
+        {"unit": u, "name": "m", "x": x, "y": y, "crafts_delta": 0.0, "status": "full_output"}
+        for u, (x, y) in enumerate([(9, 0), (3, 0), (3, -1)])], "items": {}}]
+    ts_rows = sim_localize.rank_from_timeseries(ts)
+    assert [(r["x"], r["y"]) for r in frame_rows] == [(r["x"], r["y"]) for r in ts_rows] == [(3, -1), (3, 0), (9, 0)]
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/scripts/test_sim_localize.py
+++ b/scripts/test_sim_localize.py
@@ -242,16 +242,15 @@ def test_validator_line_variants():
 # --- review-bot findings on #697 -------------------------------------------
 
 
-@pytest.mark.parametrize("bad", ["10", "a,b", "1,2,x", ""])
+@pytest.mark.parametrize("bad", ["10", "a,b", "1,2,x", "", "1,2,3,4"])
 def test_malformed_around_degrades_to_full_extent(tmp_path, capsys, bad):
     path = tmp_path / "report.json"
     path.write_text(json.dumps(make_new_format_report()))
-    rc = run(path, ["--around", bad] if bad else [])
+    rc = run(path, ["--around", bad])
     captured = capsys.readouterr()
     assert rc == 0
     assert "--- map ---" in captured.out
-    if bad:
-        assert "--around expects X,Y[,R]" in captured.err
+    assert "--around expects X,Y[,R]" in captured.err
 
 
 def test_below_plan_gate_uses_the_worst_of_several_targets(tmp_path, capsys):
@@ -265,7 +264,10 @@ def test_below_plan_gate_uses_the_worst_of_several_targets(tmp_path, capsys):
     path.write_text(json.dumps(report))
     run(path)
     out = capsys.readouterr().out
-    assert "below-plan intermediates" in out or "no intermediate below 98%" in out
+    # the primary target is at 20% of plan, so the gate must open even though
+    # the LAST target in table order is healthy; copper-plate (99%) is the only
+    # intermediate and sits above the 98% bar, so this exact branch prints.
+    assert "no intermediate below 98%" in out
 
 
 def test_no_ingredients_and_unknown_statuses_are_not_hidden():
@@ -328,6 +330,44 @@ def test_around_pivots_lane_detail_to_that_tile(tmp_path, capsys):
     assert "tile (12,10):" in out
     assert "(12,10) fast-underground-belt > L1: copper-plate×2  L2: —" in out
     assert "machine 1 assembling-machine-2" not in out  # worst-machine detail replaced, not appended
+
+
+# --- third-round findings on #697 ---------------------------------------------
+
+
+@pytest.mark.parametrize("form", [["--around", "-5,-3,2"], ["--around=-5,-3,2"]])
+def test_negative_coordinates_parse_in_both_forms(tmp_path, capsys, form):
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(make_new_format_report()))
+    rc = run(path, form)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "--- lane detail (around (-5,-3), radius 2) ---" in out  # R doubles as lane radius
+
+
+def test_map_glyphs_follow_the_ranking_status_sets():
+    mg = sim_localize.machine_glyph
+    assert mg("no_ingredients") == "S" and mg("fluid_ingredient_shortage") == "S"
+    assert mg("no_fuel") == "P" and mg("low_power") == "P"
+    assert mg("fluid_production_overload") == "F"
+    assert mg("disabled") == "?"
+
+
+def test_top_governs_the_ranking_table(capsys):
+    frame = {"machines": [[x, 0, "m", "full_output"] for x in range(6)]}
+    sim_localize.print_ranking({"report": {}, "sim_state": frame}, 1, 2)
+    out = capsys.readouterr().out
+    assert out.count("full_output") == 0 and "... and 4 more" in out
+
+
+def test_negative_radius_is_clamped_with_a_note(tmp_path, capsys):
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(make_new_format_report()))
+    rc = run(path, ["--radius", "-2"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "--radius -2 is negative" in captured.err
+    assert "radius 0)" in captured.out
 
 
 if __name__ == "__main__":

--- a/scripts/test_sim_localize.py
+++ b/scripts/test_sim_localize.py
@@ -49,12 +49,15 @@ def test_ec10_fail_ranks_both_shortage_assemblers_first(capsys):
     assert rows[2]["frac_backpressure"] == 1.0
 
 
-def test_ec10_fail_prints_verdict_and_hint(capsys):
+def test_ec10_fail_prints_verdict_and_below_plan_listing(capsys):
     run(TESTDATA / "sim-report-ec10-fail.json")
     out = capsys.readouterr().out
     assert "verdict: FAIL" in out
     assert "*electronic-circuit" in out
-    assert "hint:" in out
+    # cable (52%) sorts before iron (56%); copper-plate (100%) is not listed
+    line = next(l for l in out.splitlines() if l.startswith("below-plan intermediates"))
+    assert line.index("copper-cable 52%") < line.index("iron-plate 5")
+    assert "copper-plate" not in line
 
 
 def test_gear10_pass_has_no_starved_machines(capsys):
@@ -169,7 +172,8 @@ def test_synthetic_new_format_ranking_and_shapes(tmp_path, capsys):
     assert rc == 0
     assert "checkpoint window(s)" in out  # timeseries path taken, not the frame fallback
     assert "flat-zero" in out
-    assert "healthy" in out
+    assert "1 healthy machine(s) omitted" in out  # unit 2 is healthy: not listed, not lane-detailed
+    assert "machine 2 assembling-machine-2" not in out
 
     rows = sim_localize.rank_from_timeseries(report["report"]["timeseries"])
     assert rows[0]["unit"] == 1  # flat-zero shortage machine outranks the healthy one

--- a/scripts/test_sim_localize.py
+++ b/scripts/test_sim_localize.py
@@ -291,5 +291,44 @@ def test_both_ranking_paths_share_the_tie_break():
     assert [(r["x"], r["y"]) for r in frame_rows] == [(r["x"], r["y"]) for r in ts_rows] == [(3, -1), (3, 0), (9, 0)]
 
 
+# --- second-round findings on #697 -------------------------------------------
+
+
+def test_classify_shape_never_calls_an_impaired_machine_healthy():
+    cs = sim_localize.classify_shape
+    assert cs([10, 50, 10, 50], ["item_ingredient_shortage"] * 4) == "unsteady"
+    assert cs([10, 50, 10, 50], ["working"] * 4) == "healthy"
+    assert cs([15, 5, 3, 2], ["working"] * 4) == "decaying"  # peak-first: winding down, not a jam
+    assert cs([2, 15, 5, 3], ["working"] * 4) == "ramp-then-decay"
+    assert cs([-1, -1], ["working"] * 2) == "unknown"  # can't occur; must not read as flat-zero
+
+
+def test_empty_new_format_belt_gets_lane_detail_not_the_old_format_fallback(capsys):
+    sim_state = {"belts": [[10, 10, 0, [], "transport-belt", 4, None],
+                           [11, 10, 0, [{}, {}], "transport-belt", 4, None]]}
+    sim_localize.print_lane_detail(sim_state, [{"unit": 7, "name": "m", "x": 10, "y": 11}], 2)
+    out = capsys.readouterr().out
+    assert "no per-lane detail" not in out
+    assert out.count("L1: —  L2: —") == 2
+
+
+def test_ranking_and_lane_detail_tolerate_missing_fields(capsys):
+    ts = [{"tick": 1, "machines": [{"unit": 1, "name": "m", "crafts_delta": 0.0, "status": "no_power"}], "items": {}}]
+    sim_localize.print_ranking({"report": {"timeseries": ts}, "sim_state": {}}, 3)  # packet lacks x/y
+    assert "(?,?)" in capsys.readouterr().out
+    assert sim_localize.lane_str([[["iron-plate", 4, "extra"]]], 0).startswith("?")
+
+
+def test_around_pivots_lane_detail_to_that_tile(tmp_path, capsys):
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(make_new_format_report()))
+    run(path, ["--around", "12,10,2"])
+    out = capsys.readouterr().out
+    assert "--- lane detail (around (12,10)" in out
+    assert "tile (12,10):" in out
+    assert "(12,10) fast-underground-belt > L1: copper-plate×2  L2: —" in out
+    assert "machine 1 assembling-machine-2" not in out  # worst-machine detail replaced, not appended
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/scripts/test_sim_localize.py
+++ b/scripts/test_sim_localize.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Tests for scripts/sim-localize.py.
+
+Run: python3 -m pytest scripts/test_sim_localize.py -q
+"""
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+HERE = pathlib.Path(__file__).parent
+REPO_ROOT = HERE.parent
+TESTDATA = REPO_ROOT / "web" / "src" / "ui" / "testdata"
+
+spec = importlib.util.spec_from_file_location("_sim_localize", HERE / "sim-localize.py")
+sim_localize = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sim_localize)
+
+
+def run(report_path, argv=()):
+    """Run main() with the given report path + extra args, capturing stdout
+    via capsys is done by the caller; this just builds sys.argv."""
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = ["sim-localize.py", str(report_path), *argv]
+    try:
+        return sim_localize.main()
+    finally:
+        sys.argv = old_argv
+
+
+# --- old-format testdata --------------------------------------------------
+
+
+def test_ec10_fail_ranks_both_shortage_assemblers_first(capsys):
+    rc = run(TESTDATA / "sim-report-ec10-fail.json")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "timeseries: absent — falling back to final frame" in out
+
+    top = json.loads((TESTDATA / "sim-report-ec10-fail.json").read_text())
+    rows = sim_localize.rank_from_final_frame(top["sim_state"])
+    top2 = {(r["x"], r["y"]) for r in rows[:2]}
+    assert top2 == {(15, 64), (15, 72)}
+    assert all(r["frac_shortage"] == 1.0 for r in rows[:2])
+    # both are item_ingredient_shortage, ranked above the full_output ones
+    assert rows[2]["frac_backpressure"] == 1.0
+
+
+def test_ec10_fail_prints_verdict_and_hint(capsys):
+    run(TESTDATA / "sim-report-ec10-fail.json")
+    out = capsys.readouterr().out
+    assert "verdict: FAIL" in out
+    assert "*electronic-circuit" in out
+    assert "hint:" in out
+
+
+def test_gear10_pass_has_no_starved_machines(capsys):
+    rc = run(TESTDATA / "sim-report-gear10-pass.json")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no starved/backpressured machines found." in out
+    top = json.loads((TESTDATA / "sim-report-gear10-pass.json").read_text())
+    assert sim_localize.rank_from_final_frame(top["sim_state"]) == []
+
+
+def test_old_format_map_uses_hash_and_dot(capsys):
+    run(TESTDATA / "sim-report-ec10-fail.json")
+    out = capsys.readouterr().out
+    map_section = out.split("--- map ---")[1]
+    assert "#" in map_section  # nonempty old-format belt
+
+
+# --- kit_errors location (report.kit_errors preferred, raw_result fallback) --
+
+
+def test_kit_errors_of_prefers_report_then_falls_back_to_raw_result():
+    assert sim_localize.kit_errors_of({"report": {"kit_errors": ["a"]}, "raw_result": {}}) == ["a"]
+    assert sim_localize.kit_errors_of({"report": {}, "raw_result": {"kit_errors": ["b"]}}) == ["b"]
+    assert sim_localize.kit_errors_of({"report": {}, "raw_result": {}}) == []
+
+
+# --- shape classifier ------------------------------------------------------
+
+
+def test_classify_shape_flat_zero():
+    assert sim_localize.classify_shape([0, 0, 0, 0], ["item_ingredient_shortage"] * 4) == "flat-zero"
+
+
+def test_classify_shape_ramp_then_decay():
+    assert sim_localize.classify_shape([2, 10, 15, 3], ["working", "working", "working", "full_output"]) == "ramp-then-decay"
+
+
+def test_classify_shape_healthy():
+    assert sim_localize.classify_shape([10, 10.5, 9.8, 10.1], ["working"] * 4) == "healthy"
+
+
+def test_classify_shape_stable_below():
+    deltas = [5, 5.1, 4.9, 5.0]
+    statuses = ["item_ingredient_shortage", "working", "item_ingredient_shortage", "working"]
+    assert sim_localize.classify_shape(deltas, statuses) == "stable-below"
+
+
+# --- synthetic new-format report -------------------------------------------
+
+
+def make_new_format_report():
+    belts = [
+        # nonempty regular belt, direction=east(4)
+        [10, 10, 4, [[["iron-plate", 4]], [["iron-plate", 4]]], "transport-belt", 4, None],
+        # empty regular belt
+        [11, 10, 0, [], "transport-belt", 4, None],
+        # UG pair: input then output, direction=east(4)
+        [12, 10, 8, [[["copper-plate", 2]], []], "fast-underground-belt", 4, "input"],
+        [15, 10, 8, [[["copper-plate", 2]], []], "fast-underground-belt", 4, "output"],
+    ]
+    machines = [
+        [10, 12, "assembling-machine-2", "item_ingredient_shortage", {"iron-plate": 0}],
+        [20, 12, "assembling-machine-2", "working", {"iron-plate": 10}],
+    ]
+    inserters = [[10, 11, "waiting_for_source_items", 0]]
+    timeseries = []
+    for i in range(4):
+        timeseries.append({
+            "tick": 1200 * (i + 1),
+            "machines": [
+                {"unit": 1, "name": "assembling-machine-2", "x": 10, "y": 12,
+                 "crafts_delta": 0.0, "status": "item_ingredient_shortage"},
+                {"unit": 2, "name": "assembling-machine-2", "x": 20, "y": 12,
+                 "crafts_delta": 15.0 + i * 0.1, "status": "working"},
+            ],
+            "items": {"iron-plate": 0.0, "copper-plate": 30.0},
+        })
+    return {
+        "game_version": "2.0.77",
+        "raw_result": {"kit_errors": []},
+        "report": {
+            "label": "synthetic",
+            "overall_verdict": "FAIL",
+            "converged": True,
+            "kit_errors": [],
+            "validator_standing": "warned",
+            "validator": {"errors": 0, "warnings": 2, "layout_warnings": 0,
+                          "by_category": {"input-rate-delivery": {"errors": 0, "warnings": 2}}},
+            "items": [
+                {"item": "iron-plate", "planned_rate": 10.0, "measured_produced_rate": 2.0,
+                 "measured_delivered_rate": 1.8, "delta_pct_produced": -80.0, "delta_pct_delivered": -82.0,
+                 "is_target": True, "verdict": "FAIL"},
+                {"item": "copper-plate", "planned_rate": 10.0, "measured_produced_rate": 9.9,
+                 "measured_delivered_rate": None, "delta_pct_produced": -1.0, "delta_pct_delivered": None,
+                 "is_target": False, "verdict": None},
+            ],
+            "timeseries": timeseries,
+        },
+        "run_params": {"scenario_name": "synthetic-scenario"},
+        "sim_state": {"offx": 0, "offy": 0, "belts": belts, "machines": machines, "inserters": inserters},
+    }
+
+
+def test_synthetic_new_format_ranking_and_shapes(tmp_path, capsys):
+    report = make_new_format_report()
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(report))
+
+    rc = run(path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "checkpoint window(s)" in out  # timeseries path taken, not the frame fallback
+    assert "flat-zero" in out
+    assert "healthy" in out
+
+    rows = sim_localize.rank_from_timeseries(report["report"]["timeseries"])
+    assert rows[0]["unit"] == 1  # flat-zero shortage machine outranks the healthy one
+    assert rows[0]["shape"] == "flat-zero"
+    assert rows[0]["frac_shortage"] == 1.0
+    unit2 = next(r for r in rows if r["unit"] == 2)
+    assert unit2["shape"] == "healthy"
+    assert unit2["frac_shortage"] == 0.0
+
+
+def test_synthetic_new_format_map_has_direction_arrows_and_ug_glyphs(capsys):
+    report = make_new_format_report()
+    grid, all_xy = sim_localize.build_grid(report["sim_state"], window=None)
+    assert grid[(10, 10)] == ">"  # nonempty, direction=east
+    assert grid[(11, 10)] == "."  # empty regular belt
+    assert grid[(12, 10)] == "U"  # UG input, nonempty
+    assert grid[(15, 10)] == "O"  # UG output, nonempty
+    assert grid[(10, 12)] == "S"  # machine anchor wins over nothing else here
+    assert grid[(20, 12)] == "W"
+
+
+def test_synthetic_new_format_lane_detail_shows_per_lane_contents():
+    report = make_new_format_report()
+    worst_rows = [{"unit": 1, "name": "assembling-machine-2", "x": 10, "y": 12}]
+    belts = [sim_localize.parse_belt(b) for b in report["sim_state"]["belts"]]
+    b = next(b for b in belts if b["x"] == 10 and b["y"] == 10)
+    assert sim_localize.lane_str(b["det"], 0) == "iron-plate×4"
+    assert sim_localize.lane_str(b["det"], 1) == "iron-plate×4"
+    empty = next(b for b in belts if b["x"] == 11 and b["y"] == 10)
+    assert sim_localize.lane_str(empty["det"], 0) == "—"
+
+
+def test_kit_errors_case_prints_loud_banner(tmp_path, capsys):
+    report = make_new_format_report()
+    report["report"]["kit_errors"] = ["overlapping bank chests at (3,4)"]
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(report))
+
+    rc = run(path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "!! KIT ERRORS" in out
+    assert "overlapping bank chests at (3,4)" in out
+    # the map still renders despite kit errors (may show the kit fault)
+    assert "--- map ---" in out
+
+
+def test_validator_line_variants():
+    assert sim_localize.validator_line({"report": {}}) == "unknown (pre-field report)"
+    assert sim_localize.validator_line(
+        {"report": {"validator_standing": "unknown", "validator": None}}
+    ).startswith("? (manifest predates")
+    clean = sim_localize.validator_line(
+        {"report": {"validator_standing": "unflagged",
+                     "validator": {"errors": 0, "warnings": 0, "layout_warnings": 0, "by_category": {}}}}
+    )
+    assert clean.startswith("clean")
+    warned = sim_localize.validator_line(
+        {"report": {"validator_standing": "warned",
+                     "validator": {"errors": 0, "warnings": 3, "layout_warnings": 0,
+                                    "by_category": {"input-rate-delivery": {"errors": 0, "warnings": 3}}}}}
+    )
+    assert warned == "3W — input-rate-delivery×3"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/web/src/renderer/simStateOverlay.ts
+++ b/web/src/renderer/simStateOverlay.ts
@@ -39,7 +39,10 @@ function machineColor(status: string): number {
  *  count (observed values run well past a single tile's ~8-item physical
  *  max on the dogfood fixtures — a whole-line sum, not per-tile), so
  *  anything at/above `BELT_HEAT_CAP` just clamps to full red rather than
- *  needing an exact denominator. Empty belts (count 0) draw nothing. */
+ *  needing an exact denominator. Empty belts (count 0) draw nothing —
+ *  the harness now emits every belt including empty ones (the primary
+ *  localization signal for a dried-up lane), so this guard is what
+ *  keeps a factory's worth of idle belts from painting solid yellow. */
 const BELT_HEAT_CAP = 8;
 const BELT_HEAT_ALPHA = 0.5;
 const HEAT_LOW = { r: 0xf5, g: 0xc5, b: 0x18 }; // yellow

--- a/web/src/ui/simReportLoader.test.ts
+++ b/web/src/ui/simReportLoader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSimReport } from "./simReportLoader.js";
+import { parseSimReport, type SimBeltEntry } from "./simReportLoader.js";
 import ec10Fail from "./testdata/sim-report-ec10-fail.json";
 import gear10Pass from "./testdata/sim-report-gear10-pass.json";
 
@@ -60,5 +60,55 @@ describe("parseSimReport — defensive parsing", () => {
     const partial: any = JSON.parse(JSON.stringify(gear10Pass));
     partial.report.items = [{ item: "no-rate" }];
     expect(() => parseSimReport(JSON.stringify(partial))).toThrowError(/report\.items/);
+  });
+});
+
+// New belt-entry format: `[x, y, n, det, name, direction, ug_type]` (belt
+// name/direction + underground pairing type, and empty belts now included
+// rather than skipped). The loader must accept both this 7-tuple and the
+// old 3-tuple (`isTupleArray` only enforces a minimum length).
+describe("parseSimReport — new-format belt entries", () => {
+  it("parses a report whose belts carry name/direction/ug_type, including an empty belt and a UG entry", () => {
+    const withNewBelts: any = JSON.parse(JSON.stringify(gear10Pass));
+    const emptyBelt: SimBeltEntry = [12, 4, 0, [], "transport-belt", 4, null];
+    const fullBelt: SimBeltEntry = [
+      13,
+      4,
+      6,
+      [[["iron-gear-wheel", 6]]],
+      "fast-transport-belt",
+      8,
+      null,
+    ];
+    const ugBelt: SimBeltEntry = [
+      14,
+      4,
+      3,
+      [[["iron-gear-wheel", 3]]],
+      "underground-belt",
+      0,
+      "input",
+    ];
+    withNewBelts.sim_state.belts = [emptyBelt, fullBelt, ugBelt];
+
+    const report = parseSimReport(JSON.stringify(withNewBelts));
+    expect(report.sim_state.belts).toHaveLength(3);
+
+    const [x, y, count, , name, direction, ugType] = report.sim_state.belts[0];
+    expect([x, y, count, name, direction, ugType]).toEqual([12, 4, 0, "transport-belt", 4, null]);
+
+    const ug = report.sim_state.belts[2];
+    expect(ug[4]).toBe("underground-belt");
+    expect(ug[6]).toBe("input");
+  });
+
+  it("still accepts old-format belt entries with only [x, y, count]", () => {
+    // The two real fixtures above already exercise this path (dumps
+    // predating name/direction/ug_type), but assert it directly against
+    // a minimal hand-built entry too.
+    const withOldBelts: any = JSON.parse(JSON.stringify(gear10Pass));
+    withOldBelts.sim_state.belts = [[1, 2, 5]];
+    const report = parseSimReport(JSON.stringify(withOldBelts));
+    expect(report.sim_state.belts).toEqual([[1, 2, 5]]);
   });
 });

--- a/web/src/ui/simReportLoader.ts
+++ b/web/src/ui/simReportLoader.ts
@@ -57,9 +57,24 @@ export interface SimRunParams {
   end_tick: number;
 }
 
-/** `[x, y, count]` — layout-space tile coordinate + item tally. Not
- *  strictly per-tile-capacity bounded (see `simStateOverlay.ts`). */
-export type SimBeltEntry = [x: number, y: number, count: number];
+/** `[x, y, count, det?, name?, direction?, ug_type?]` — layout-space tile
+ *  coordinate + item tally, plus per-line item detail and (new format
+ *  only) the entity name, raw 16-way `defines.direction` integer
+ *  (0=north, 4=east, 8=south, 12=west; unremapped), and — for
+ *  underground belts only — `"input"`/`"output"`, `null` for everything
+ *  else. The trailing four fields are optional so older reports (plain
+ *  `[x, y, count]`, nonempty belts only) still load; `count` can be `0`
+ *  in new-format reports since empty belts are now included (the
+ *  localization signal for a dried-up lane, not previously visible). */
+export type SimBeltEntry = [
+  x: number,
+  y: number,
+  count: number,
+  det?: unknown,
+  name?: string,
+  direction?: number,
+  ug_type?: "input" | "output" | null,
+];
 /** `[x, y, name, status]` — `status` is the raw in-game `LuaEntity.status`
  *  name (`working`, `item_ingredient_shortage`, `no_power`, ...). */
 export type SimMachineEntry = [x: number, y: number, name: string, status: string];


### PR DESCRIPTION
## Intent

Make sim results *readable for localization* without a browser. Reading a FAIL report cold today gets you "which stage / which machine" in minutes, but "which tile, and why" stalls on two gaps in the `sim_state` dump (no belt direction/name, empty belts omitted) and on every session improvising its own render — and getting it subtly wrong (an improvised read this week treated per-transport-line belt counts as per-tile). Pipes got name+direction for exactly this reason in #364; belts never did.

## Scope

- **In:**
  - `sim_state.belts` entries become `[x, y, n, det, name, direction, ug_type]` — entity name, raw 16-way `defines.direction` (0/4/8/12 = N/E/S/W, unremapped), and `"input"`/`"output"` for undergrounds (`null` otherwise). **Every belt is now emitted, including `n == 0`** — an empty tile is the primary "lane ran dry here" signal and the old `if n > 0` guard hid exactly those. Trailing `null` needs a sentinel→`gsub` rewrite because `table_to_json` has no null sentinel (comment in `scenario.rs` explains).
  - Web loader type widened (trailing fields optional; old 3-tuple reports still load); overlay already skipped `count == 0`, comment updated to say why that now matters.
  - `scripts/sim-localize.py <report.json>`: kit-error banner first; header + per-item table + below-plan intermediates (a listing, explicitly *not* a causal order); machines ranked by windows-in-shortage / backpressure from `timeseries` (frame fallback for old reports, with the "single frame can't distinguish transient from persistent" caveat printed); ASCII map with direction arrows, UG mouths, inserter/machine status; per-lane belt contents around the worst N machines. Handles old and new dump formats. 14 pytest cases in `scripts/test_sim_localize.py`.
  - Docs: `sim-harness.md` (entry shape + encoding; pointer to the script), `sim-harness-forensics.md` (step 0 of the playbook; `sim_state` bullet).
- **Out:** automatic root-cause, belt-walking to first-empty-tile, validator cross-referencing. The playbook's later steps (micro-fixture, served world) stay where the reasoning happens — this renders and ranks.
- **Size:** 808 added (243 of it tests). The two halves are independent and *could* be split; they're in one PR because that was the ask, and the script (422 lines) is one self-contained file with nothing downstream of it to disagree with. The dump change is 38 lines of Lua + 26 of TS types/tests.

## Verification

- `cargo clippy -p spaghettio_sim_harness -- -D warnings` clean; `cargo test -p spaghettio_sim_harness` 86/86.
- `python3 -m pytest scripts/test_sim_localize.py -q` 14/14.
- `cd web && npx tsc --noEmit` clean; `npx vitest run src/ui/simReportLoader.test.ts` 10/10 (2 new: 7-tuple incl. zero-count + UG; old-format back-compat).
- **Two real Factorio 2.0.77 runs** on the new dump (both PASS/converged/validator-clean): `iron-gear-wheel@10` — 258 belt entries, all 7-tuples, 31 with `n == 0`, directions ⊂ {0,4,8,12}; `electronic-circuit@10` from ore — 456 entries, 48 empty, 4 underground entries split 2 `input` / 2 `output` matching the dump's existing `ugs` count, every non-UG `ug_type` a real JSON `null`.
- **End-to-end:** `sim-localize.py` run on the real EC@10 new-format report — direction arrows render, the UG pair at (2,10)→(4,10) shows as `U`…`O` with the belt passing beneath, all 50 machines accounted for as healthy. On the checked-in old-format `sim-report-ec10-fail.json` it ranks the two `item_ingredient_shortage` assemblers at (15,64)/(15,72) above the `full_output` furnaces.
- Not exercised: no fixture in either run contained a splitter, so the `*-splitter` name path (identical code to the four names observed) is unobserved.
- [ ] `cargo test --manifest-path crates/core/Cargo.toml` — not run; `crates/core` is untouched.
- WASM rebuild: done (needed for `tsc`), no browser eyeball — no rendering logic changed.

## Deviations from intent

- **Emitting empty belts** was not in the original "add direction + name" ask; added because direction alone doesn't close the gap (you can follow a belt but not see where it runs dry). Web overlay unaffected (already skipped zero).
- The localizer's original "causal hint" line (first upstream item below the target's ratio) was dropped in review: it printed "structural" on the one real fixture tried, which is iron-limited. Replaced with a plain sorted listing and a printed caveat that a backed-up stage reads below plan too.
- With `timeseries` present the ranking now omits healthy machines (and counts them) rather than listing every unit.

## Models / contracts touched

`sim_state` dump schema (additive; old reports load everywhere). No engine, validator, or blueprint contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
