### PR TITLE
fix(w2c): e2e harness runs production defaults — both fossils killed (RFC-070)

### DIFF
--- a/crates/core/src/bus/layout.rs
+++ b/crates/core/src/bus/layout.rs
@@ -157,16 +157,25 @@ pub enum SurplusPolicy {
 /// remove the trap's shape from the language (#696 review, absorbed). What
 /// it actually buys: a genuinely correct atomic default new call sites can
 /// reach for INSTEAD of hand-assembling a group, and it removes the trap
-/// for whoever takes it. **What this does not prevent, at all**: the ~80
-/// existing flat struct-literal call sites (including both known `run_e2e`
-/// fossils) are unchanged and exactly as fossil-prone as before — fixing
-/// those is #689 track W2c, sequenced after this one — and nothing stops
-/// new code from writing a flat (or group-level partial) literal instead of
-/// calling `from_groups`. **Zero production callers as of this PR**:
-/// `from_groups`/`constraints`/`axes`/`engine_tuning` are exercised only by
-/// this module's own unit tests below — they are scaffolding for Phase 1b
-/// and #689 track W2c to adopt, not yet wired into any call site that
-/// builds a real layout.
+/// for whoever takes it. **What this does not prevent, at all**: nothing
+/// stops new code from writing a flat (or group-level partial) literal
+/// instead of calling `from_groups`, and most existing flat struct-literal
+/// call sites are unchanged and exactly as fossil-prone as before.
+///
+/// **Adoption status** (this paragraph said "zero production callers as of
+/// this PR" until #689 track W2c landed and made that false — the exact
+/// records-outlive-their-state shape the rest of this legend is about;
+/// caught by #699's review round 5):
+/// - `tests/e2e.rs`'s `run_e2e_inner` is the **first** caller, via its
+///   `harness_options` helper. Both known `run_e2e` fossils
+///   (`cell_composition`, `inserter_capacity`) died in that move, and the
+///   harness is guarded by a non-ignored `harness_options_are_engine_defaults`.
+/// - `rfc060_sim_export` and `w2c_gear20_meter_export` in the same file
+///   call it too.
+/// - **Still open**: 15 other tests in `tests/e2e.rs` keep the old flat
+///   literal, pinned (not fixed) by `residual_fossil_literals_are_pinned`
+///   so the count cannot grow silently; and Phase 1b has not adopted
+///   `from_groups` yet.
 #[derive(Clone, Debug)]
 pub struct LayoutOptions {
     pub strategy: LayoutStrategy,

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -397,12 +397,22 @@ fn harness_options(o: HarnessOptions<'_>) -> layout::LayoutOptions {
 ///
 /// Non-ignored and free: no solve, no layout. Restoring either fossil
 /// fails it (checked by doing so, RFC-070 W2c).
+///
+/// Compared against `LayoutOptions::default()`'s OWN views, not against
+/// `UserConstraints::default()` et al (#699 review): the group defaults
+/// are a second, hand-written copy of the engine defaults, so comparing
+/// this harness's product against them would pass whenever both copies
+/// were wrong the same way. `LayoutOptions::default()` is the value the
+/// engine actually ships. (That the two copies agree is a separate
+/// property, asserted by `layout_options_group_defaults_match_facade` in
+/// `bus::layout`.)
 #[test]
 fn harness_options_are_engine_defaults() {
     let o = harness_options(HarnessOptions::default());
-    assert_eq!(o.constraints(), layout::UserConstraints::default(), "user-pinned group drifted");
-    assert_eq!(o.axes(), layout::SearchAxes::default(), "search-axis group drifted");
-    assert_eq!(o.engine_tuning(), layout::EngineTuning::default(), "engine-tuning group drifted");
+    let shipped = layout::LayoutOptions::default();
+    assert_eq!(o.constraints(), shipped.constraints(), "user-pinned group drifted");
+    assert_eq!(o.axes(), shipped.axes(), "search-axis group drifted");
+    assert_eq!(o.engine_tuning(), shipped.engine_tuning(), "engine-tuning group drifted");
     assert_eq!(
         o.cell_composition,
         spaghettio_core::bus::cells::CellComposition::Candidate,
@@ -414,6 +424,64 @@ fn harness_options_are_engine_defaults() {
         spaghettio_core::common::DEFAULT_INSERTER_CAPACITY,
         "inserter_capacity fossil is back (RFC-070 W2c): the suite would run a \
          different inserter ladder than production",
+    );
+}
+
+/// **The fossil pattern is dead on the `run_e2e` path only.** It survives,
+/// verbatim, at other call sites in this file that build their own
+/// `LayoutOptions` — #699's review named this 3/3 passes, and it was right:
+/// "both fossils killed" is a claim about the harness, not about the suite.
+///
+/// This test pins the residual so it cannot grow silently, and so the
+/// follow-up has a number to work against. As of RFC-070 W2c there are
+/// **15 distinct tests** carrying the copy-pasted block — 13 carry both
+/// lines, `research_l7_thins_output_inserters_s4` carries only the cells
+/// line (its capacity is a swept variable), `rfc061_allocation_probe_ac5`
+/// only the capacity line:
+///
+///   `tier4_advanced_circuit_7s_horizontal_stack_belt_pipe_crossing`,
+///   `tier5_processing_unit_2s_horizontal_stack_iron_ore_pipe_bypass`,
+///   `tier5_processing_unit_25s_horizontal_stack_pole_coverage`,
+///   `quality_differential_ec_normal_vs_legendary`,
+///   `quality_ec_45s_express_legendary_from_ore`,
+///   `quality_differential_kovarex_self_loop_normal_vs_legendary`,
+///   `quality_ec_45s_legendary_tree_wire_differential`,
+///   `stacking_ec_60s_red_one_belt_headline`,
+///   `stacking_fanin_wall_lift_ec6_yellow_legendary`,
+///   `stacking_hs_dual_input_output_cap`, `stacking_refuses_low_inserter_cap`,
+///   `stacking_kovarex_family_exempt_s2`, `stacking_ec_60s_express_legendary_s2`,
+///   `research_l7_thins_output_inserters_s4`, `rfc061_allocation_probe_ac5`.
+///
+/// None of them documents its `0` / `Off` as deliberate — every one is the
+/// same copy of `run_e2e_inner`'s old literal. They are NOT migrated here
+/// because each carries its own pins and assertions, so flipping them is a
+/// second adjudication of the same size as this PR's, not a rider on it.
+///
+/// **Reducing a count here is the good direction**: migrate a site to
+/// `harness_options` (or spell a deliberate value with a comment saying
+/// why), then lower the number. Raising one means a new copy of a known
+/// trap — don't.
+#[test]
+fn residual_fossil_literals_are_pinned() {
+    // Self-read: matching on the exact TRIMMED line means the comparison
+    // literals a few lines below do not count themselves.
+    const SRC: &str = include_str!("e2e.rs");
+    let cells = SRC
+        .lines()
+        .filter(|l| l.trim() == "cell_composition: Default::default(),")
+        .count();
+    let capacity = SRC.lines().filter(|l| l.trim() == "inserter_capacity: 0,").count();
+    assert_eq!(
+        cells, 14,
+        "residual `cell_composition: Default::default()` literals moved (was 14 at \
+         RFC-070 W2c). Fewer = a site was migrated: lower this number in the same \
+         commit. More = a new copy of a known-stale pattern: use `harness_options` \
+         instead, or spell the value deliberately with a reason.",
+    );
+    assert_eq!(
+        capacity, 14,
+        "residual `inserter_capacity: 0` literals moved (was 14 at RFC-070 W2c). \
+         Same rule as above.",
     );
 }
 
@@ -781,6 +849,18 @@ const GOLDEN_HASHES: &[(&str, &str)] = &[
     // fixture from 148 entities / 47x8 to 105 / 38x14 at the same 12.3%
     // density and the same ZERO validation issues. #694's corpus does
     // not cover gear@20/s — see the W2c finding in the RFC decision log.
+    //
+    // **THE NEW WINNER UNDER-DELIVERS — see #700.** This hash pins a
+    // layout the meter reads at 15.0/s against a 20.0/s plan (75%), where
+    // both native arms read 21.0/s. The re-bless still stands, because a
+    // golden's job is to record what the engine produces and production
+    // has produced THIS since RFC-051 Phase B flipped `cell_composition`
+    // on 2026-07-22 — the fossil is why no test could see it. But note
+    // that `assert_produces(…, 20.0)` below passes on this layout: it
+    // reads `analysis.throughput_estimates`, a static estimate the meter
+    // contradicts. Do not read this fixture's greenness as delivery.
+    // Reproduce with the `w2c_gear20_meter_export` exporter at the bottom
+    // of this file.
     ("tier1_iron_gear_wheel_20s", "8ab74dc08c91cd8d13faf0a376c0c3eabe9b21df3a80f3b5a3768f89371d794c"),
     // Updated when `(m, m)` family balancers became passthroughs
     // (issue #268) — splitter blocks replaced by a single south-facing
@@ -1037,15 +1117,41 @@ fn decomposition_search_native_candidate_fires_trace_events() {
     );
 
     // The cell-composed candidate runs a NESTED selection of its own, and
-    // its rows land in the same flat event stream (RFC-070 oracle gap (g)),
-    // so the OUTER selection's terminal is the LAST `DecompositionChosen`,
-    // not the only one.
+    // its events are replayed into the same flat stream (RFC-070 oracle
+    // gap (g)), so the OUTER selection's terminal is the LAST terminal,
+    // not the only one. That is a stated contract, not an accident:
+    // `trace.rs`'s `SelectionCandidateEvaluated` doc — "the two are emitted
+    // adjacently at the very end of the selection… without a nested
+    // selection splicing itself into the outer block" — and it is the same
+    // rule `tests/parity_corpus.rs` reads the corpus by.
+    //
+    // #699 review (2/3 passes) called `last()` an ordering-dependent
+    // oracle. It is, so it is corroborated rather than trusted: the two
+    // INDEPENDENT terminals (`DecompositionChosen` from the search,
+    // `SelectionDecided` from the scoreboard) must agree, and the stage is
+    // pinned against #694's `tier1_gear_am1` / am1 / `default` row. A
+    // reordering that broke the pairing would have to break both emitters
+    // the same way to slip through.
+    let decided: Vec<_> = result.trace_events.iter()
+        .filter_map(|e| match e {
+            TraceEvent::SelectionDecided { winner, stage } => Some((winner.clone(), *stage)),
+            _ => None,
+        })
+        .collect();
     assert!(!chosen.is_empty(), "expected at least one DecompositionChosen event");
+    assert!(!decided.is_empty(), "expected at least one SelectionDecided event");
+    assert_eq!(
+        decided.last().map(|(w, s)| (w.as_str(), *s)),
+        Some(("native", spaghettio_core::trace::SelectionStage::BestErrorFree)),
+        "expected the outer selection to decide `native` at `best-error-free` \
+         (#694: `tier1_gear_am1` / assembling-machine-1 / `default`); got {decided:?}",
+    );
     assert_eq!(
         chosen.last().map(String::as_str),
-        Some("native"),
-        "expected `native` to win the outer selection (#694: winner `native`, stage \
-         `best-error-free`); got {chosen:?}",
+        decided.last().map(|(w, _)| w.as_str()),
+        "the two terminal emitters disagree on the outer winner — the \
+         nested-before-outer ordering both this test and tests/parity_corpus.rs \
+         depend on has changed. chosen={chosen:?} decided={decided:?}",
     );
 }
 
@@ -1093,13 +1199,27 @@ fn decomposition_search_picks_native_on_clean_partitioned_case() {
         })
         .collect();
     // The last terminal is the outer selection's — nested candidate
-    // selections emit their own (RFC-070 oracle gap (g)).
+    // selections replay their own into the same stream (RFC-070 oracle gap
+    // (g); the contract is stated on `trace.rs`'s
+    // `SelectionCandidateEvaluated`). Corroborated across both independent
+    // terminal emitters rather than trusted, per #699's review.
+    let decided: Vec<_> = result.trace_events.iter()
+        .filter_map(|e| match e {
+            TraceEvent::SelectionDecided { winner, stage } => Some((winner.clone(), *stage)),
+            _ => None,
+        })
+        .collect();
     assert!(!chosen.is_empty(), "expected at least one DecompositionChosen event");
     assert_eq!(
         chosen.last().map(String::as_str),
         Some("native"),
         "K-DS1-1: search must pick `native` when Native produces a clean layout; \
          got {chosen:?}. If a non-Native candidate won, scoring or acceptance is wrong.",
+    );
+    assert_eq!(
+        decided.last().map(|(w, _)| w.as_str()),
+        Some("native"),
+        "K-DS1-1: the scoreboard's terminal must name `native` too; got {decided:?}",
     );
 
     // ModuleSizeSplit must not have run: it is the candidate this
@@ -1255,6 +1375,14 @@ fn tier1_iron_gear_wheel_20s() {
     // RFC Phase 1: 28 inserter-bound machine-sides at 20/s (more gear machines than
     // the 10/s case; each side > 0.84/s).
     // RFC rfc-inserter-sizing.md Phase 1 re-bless: ladder-sized inserters clear single_input_row entirely (28 -> 0).
+    //
+    // 2026-08-21 (RFC-070 W2c): this fixture now ships a CELL-COMPOSED
+    // layout — the only one in the suite where that candidate wins — and
+    // the meter reads it at 15.0/s against this 20.0/s plan while both
+    // native arms read 21.0/s. Tracked as #700, adjudicated there, not
+    // fixed here. Everything below is validator- and estimate-level and
+    // passes on the under-delivering layout; do NOT read this test's
+    // greenness as evidence of delivery.
     assert_warnings_golden(&result, "tier1_iron_gear_wheel_20s");
     assert_produces(&result, "iron-gear-wheel", 20.0);
     assert_round_trip(&result);
@@ -9128,6 +9256,17 @@ fn full_knob_sweep() {
 ///     --warmup 216000 --out <case>-<arm>.report.json
 /// (long warmup per the deep-chain caveat in docs/sim-harness.md; pu3
 /// used 288000).
+///
+/// **Artifacts exported after 2026-08-21 are NOT comparable to the K60-3
+/// numbers recorded in `docs/rfc-060-*`** (#699 review, absorbed). Those
+/// were measured on artifacts this exporter built with
+/// `inserter_capacity: 0` — a hand-copied fossil of `run_e2e_inner`'s old
+/// literal, which had itself drifted (it kept the capacity pin but not the
+/// cells-off one, so it matched neither the harness nor production).
+/// RFC-070 W2c routed it through `harness_options`, so it now emits
+/// production's capacity 2 and production's candidate set. The exports are
+/// not hash-pinned and there is no golden to catch this — hence this note.
+/// Re-measure both arms before comparing against a recorded K60-3 figure.
 #[test]
 #[ignore = "artifact exporter for sim runs; run explicitly with --ignored"]
 fn rfc060_sim_export() {
@@ -9208,6 +9347,78 @@ fn rfc060_sim_export() {
                 lay.height,
             );
         }
+    }
+}
+
+/// Issue #700 / RFC-070 W2c: export `tier1_iron_gear_wheel_20s` under three
+/// option arms so the meter can be pointed at each, in the layout the
+/// `crates/meter` `check_one` example expects (`bp.txt` +
+/// `manifest-real.json` per directory).
+///
+/// This exists because #699's re-bless of that fixture's golden hash rests
+/// on a measurement, and a measurement nobody can re-take is a claim, not
+/// evidence — the same gap `rfc060_sim_export` above was written to close.
+///
+/// ```text
+///   W2C_GEAR20_OUT=/tmp/gear20 cargo test --manifest-path crates/core/Cargo.toml \
+///       --test e2e -- w2c_gear20_meter_export --ignored --exact --nocapture
+///   cargo run --release -p spaghettio_meter --example check_one -- /tmp/gear20/cells-on
+/// ```
+///
+/// Readings taken 2026-08-21 (`measure(108_000, 216_000)`, no notes):
+///
+/// | arm          | cells       | capacity | entities | validator | meter        |
+/// |--------------|-------------|----------|----------|-----------|--------------|
+/// | `cells-on`   | `Candidate` | 2        | 105 38x14| 0 issues  | **15.0/20.0**|
+/// | `cells-off`  | `Off`       | 2        | 148 47x8 | 0 issues  | 21.0/20.0    |
+/// | `old-golden` | `Off`       | 0        | 148 47x8 | 0 issues  | 21.0/20.0    |
+///
+/// `cells-on` IS production's configuration. See #700.
+#[test]
+#[ignore = "artifact exporter for meter/sim runs; run explicitly with --ignored"]
+fn w2c_gear20_meter_export() {
+    use spaghettio_core::bus::cells::CellComposition;
+    let out = std::env::var("W2C_GEAR20_OUT")
+        .unwrap_or_else(|_| snapshot_dir().join("gear20").to_string_lossy().into_owned());
+    let inputs: FxHashSet<String> = ["iron-plate"].iter().map(|s| s.to_string()).collect();
+    let solved = solver::solve("iron-gear-wheel", 20.0, &inputs, "assembling-machine-2")
+        .expect("gear20 solve");
+
+    for (arm, cells, capacity) in [
+        ("cells-on", CellComposition::Candidate, 2u8),
+        ("cells-off", CellComposition::Off, 2u8),
+        // The exact pre-W2c golden: both fossils in place. Kept as an arm
+        // so the "the capacity fossil is not what moved this" claim is
+        // re-measurable, not just asserted.
+        ("old-golden", CellComposition::Off, 0u8),
+    ] {
+        let opts = layout::LayoutOptions::from_groups(
+            layout::UserConstraints { inserter_capacity: capacity, ..Default::default() },
+            layout::SearchAxes { cell_composition: cells, ..Default::default() },
+            layout::EngineTuning::default(),
+        );
+        let lay = layout::build_bus_layout(&solved, opts).expect("gear20 layout");
+        let issues = match validate::validate(&lay, Some(&solved)) {
+            Ok(v) => v,
+            Err(e) => e.issues,
+        };
+        let (bp, manifest) =
+            blueprint::export_with_manifest_validated(&lay, &solved, "gear20", &issues);
+        let dir = format!("{out}/{arm}");
+        std::fs::create_dir_all(&dir).expect("create arm dir");
+        std::fs::write(format!("{dir}/bp.txt"), &bp).expect("write bp");
+        std::fs::write(
+            format!("{dir}/manifest-real.json"),
+            serde_json::to_string_pretty(&manifest).expect("manifest json"),
+        )
+        .expect("write manifest");
+        eprintln!(
+            "{arm}: {} entities, {}x{}, {} issues -> {dir}",
+            lay.entities.len(),
+            lay.width,
+            lay.height,
+            issues.len(),
+        );
     }
 }
 

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -516,17 +516,23 @@ fn harness_options_are_engine_defaults() {
 /// Raising a count means a new copy of a known trap — don't.
 ///
 /// **This is a source-text gauge, not a behavioural one** (#699 review
-/// rounds 3 and 4), and its reach is exactly that: it counts TEXTUAL
+/// rounds 3, 4 and 5), and its reach is exactly that: it counts TEXTUAL
 /// copies of two exact trimmed lines. It does not see a fossil written
-/// on one line, a re-spelled or reformatted literal, a semantically
-/// equivalent construction, or one inside dead code — and conversely a
-/// trailing comment or a rustfmt re-wrap on an existing line moves the
-/// count and forces an edit here. So the claim is narrow: **a textual
-/// copy of these two lines cannot be added silently.** That is not the
-/// same as "the fossil cannot come back", and it is the only mechanism
-/// available — the sites are ordinary struct literals inside ordinary
-/// tests, with no runtime handle to count. The behavioural guard, for
-/// the path that matters, is `harness_options_are_engine_defaults`.
+/// on one line, a re-spelled or reformatted literal, one inside dead
+/// code, or — the sharpest miss, and the one `bus::layout`'s own field
+/// legend names as reachable — the GROUP-level partial,
+/// `SearchAxes { cell_composition: Default::default(), ..SearchAxes::default() }`,
+/// which resolves to `Off` exactly like the flat form and matches
+/// neither pattern here. Conversely a trailing comment or a rustfmt
+/// re-wrap on an existing line moves the count and forces an edit here.
+/// So the claim is narrow: **a textual copy of these two lines cannot be
+/// added silently.** That is not the same as "the fossil cannot come
+/// back", and it is the only mechanism available — the sites are
+/// ordinary struct literals inside ordinary tests, with no runtime
+/// handle to count. The behavioural guard, for the one path that builds
+/// every regression fixture, is `harness_options_are_engine_defaults`;
+/// these 15 sites have no behavioural guard, which is a reason to
+/// migrate them, not a reason to widen this gauge.
 ///
 /// Cost, since it is not free and not obvious: `include_str!` embeds
 /// this ~11k-line file into the test binary (a few hundred KB). Accepted
@@ -1536,7 +1542,38 @@ fn tier1_iron_gear_wheel_20s() {
          what hid this for a month. got {outer:?}",
     );
     assert_warnings_golden(&result, "tier1_iron_gear_wheel_20s");
-    assert_produces(&result, "iron-gear-wheel", 20.0);
+
+    // NOT `assert_produces` (#699 review round 5, 3/3). That helper reads
+    // `analysis.throughput_estimates` — a static estimate derived from the
+    // machine count, not a measurement — and on THIS fixture it says 20/s
+    // about a layout the meter reads at 15/s. Calling it here would leave
+    // a green "produces 20/s" assertion standing next to a known 25%
+    // deficit, which is the exact "the suite is green so the engine
+    // delivers" inference this PR exists to break. So the estimate is
+    // still checked (it is the plan, and a plan regression is worth
+    // catching) but under a name and a message that say what it is.
+    //
+    // Rejected alternative, recorded because it is the obvious one:
+    // metering in-suite. `spaghettio_meter` depends on `spaghettio_core`,
+    // so a dev-dependency back would close a cycle and drag the meter into
+    // every `cargo test -p spaghettio_core`; and the meter's own tripwire
+    // ALREADY carries this fixture armed (`gear20-am2-plate`, -25.0%,
+    // entities 105). Duplicating it here would add a second, weaker copy
+    // of a guard that exists, not a new guard.
+    let estimated = result
+        .analysis
+        .throughput_estimates
+        .get("iron-gear-wheel")
+        .copied()
+        .unwrap_or(0.0);
+    assert!(
+        estimated >= 20.0 * 0.99,
+        "PLAN check only — this is `analysis.throughput_estimates`, not delivery. \
+         Expected the plan to still be >=20/s, got {estimated:.1}/s. The MEASURED \
+         rate for this fixture is 15.0/s (meter tripwire `gear20-am2-plate`, \
+         -25.0%, #700); do not read this assertion, or this test passing, as \
+         evidence that the layout delivers 20/s.",
+    );
     assert_round_trip(&result);
     assert_golden_hash(&result, "tier1_iron_gear_wheel_20s");
 }
@@ -9294,6 +9331,20 @@ fn full_knob_sweep() {
     let mut md = String::new();
     let _ = writeln!(md, "# Knob sweep: strategy x row-layout\n");
     let _ = writeln!(md, "{} cases x {} combos. Lexicographic winner key: (errors, warnings, entities).\n", cases.len(), combos.len());
+    // Provenance stamped into the ARTIFACT, not just the source doc
+    // (#699 review round 5): these tables get pasted into issues and PRs,
+    // where a `run_e2e_pure_combo` doc comment is invisible, and the W2c
+    // option-set change makes old and new tables silently non-comparable.
+    let _ = writeln!(
+        md,
+        "> **Option-set epoch: post-RFC-070-W2c (2026-08-21).** Every column here — \
+         including the `pure` baselines — runs production's full candidate set \
+         (`cell-composed` competes) and the L2 inserter ladder. Before W2c the \
+         harness pinned `cell_composition: Off` and `inserter_capacity: 0`, so \
+         tables generated earlier are NOT comparable to this one: a cell can be \
+         decided by a layout family the old tables never saw. \"Pure\" means the \
+         horizontal-stack candidate is off, and only that.\n",
+    );
     let _ = writeln!(md, "## Per-run data\n");
     let _ = writeln!(md, "| case | combo | errs | warns | entities | WxH | dens% | candidate | ms |");
     let _ = writeln!(md, "|---|---|---|---|---|---|---|---|---|");

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -508,6 +508,15 @@ fn harness_options_are_engine_defaults() {
 /// harness's. Either way, name the site in the commit that lowers the
 /// number, so a reader can tell a migration from a weakened tripwire.
 /// Raising a count means a new copy of a known trap — don't.
+///
+/// **This is a source-text gauge, not a behavioural one** (#699 review
+/// round 3), and the coupling is deliberate: any edit that changes how
+/// one of these lines is SPELLED — a trailing comment, a rustfmt
+/// re-wrap, a rename — moves the count too and forces an edit here. That
+/// is a small tax on 15 known sites in exchange for the residual being
+/// impossible to grow silently, and it is the only mechanism available:
+/// the sites are ordinary struct literals inside ordinary tests, with no
+/// runtime handle to count.
 #[test]
 fn residual_fossil_literals_are_pinned() {
     // Self-read: matching on the exact TRIMMED line means the comparison
@@ -1471,10 +1480,12 @@ fn tier1_iron_gear_wheel_20s() {
         "tier1_iron_gear_wheel_20s pins a KNOWN UNDER-DELIVERING winner (#700): \
          `cell-composed` at `best-error-free`, metered at 15.0/s against a 20.0/s \
          plan while both native arms meter 21.0/s. If this assertion just failed, \
-         the selection moved — if that is #700 being fixed, re-take the meter \
-         reading (`w2c_gear20_meter_export` at the bottom of this file), update \
-         #700, and re-bless the golden with the new number. Do NOT re-bless on \
-         validator greenness alone: that is exactly what hid this for a month. \
+         the selection moved — if that is #700 being fixed: (1) re-take the meter \
+         reading with `w2c_gear20_meter_export` at the bottom of this file, \
+         (2) update #700 with it, (3) update THIS pin, and (4) re-bless the \
+         fixture's GOLDEN HASH (and its warning pin, if the tally moved). Those \
+         are the coupled artifacts; nothing else in the suite is. Do NOT re-bless \
+         on validator greenness alone: that is exactly what hid this for a month. \
          got {outer:?}",
     );
     assert_warnings_golden(&result, "tier1_iron_gear_wheel_20s");

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -486,48 +486,71 @@ fn harness_options_are_engine_defaults() {
 /// Raising a count means a new copy of a known trap — don't.
 ///
 /// **This is a source-text gauge, not a behavioural one** (#699 review
-/// rounds 3, 4 and 5), and its reach is exactly that: it counts TEXTUAL
-/// copies of two exact trimmed lines. It does not see a fossil written
-/// on one line, a re-spelled or reformatted literal, one inside dead
-/// code, a spelled-out `cell_composition: CellComposition::Off`, or —
-/// the sharpest miss, and the one `bus::layout`'s own field legend names
-/// as reachable — the GROUP-level partial,
-/// `SearchAxes { cell_composition: Default::default(), ..SearchAxes::default() }`,
-/// which resolves to `Off` exactly like the flat form and matches
-/// neither pattern here. Conversely a trailing comment or a rustfmt
-/// re-wrap on an existing line moves the count and forces an edit here.
-/// So the claim is narrow: **a textual copy of these two lines cannot be
-/// added silently.** That is not the same as "the fossil cannot come
-/// back", and it is the only mechanism available — the sites are
-/// ordinary struct literals inside ordinary tests, with no runtime
-/// handle to count. The behavioural guard, for the one path that builds
-/// every regression fixture, is `harness_options_are_engine_defaults`;
-/// these 15 sites have no behavioural guard, which is a reason to
-/// migrate them, not a reason to widen this gauge.
+/// rounds 3-5 argued its reach; round 8 argued it was pointed at the
+/// wrong shape, and was right). It counts non-comment lines CONTAINING
+/// either pattern — substring, not exact-trimmed-line — which is what
+/// makes it see the resurrection path round 8 named as most likely now
+/// that `from_groups` is the recommended constructor: the GROUP-level
+/// partial `SearchAxes { cell_composition: Default::default(), ..SearchAxes::default() }`,
+/// which resolves to `Off` exactly like the flat form. An
+/// exact-trimmed-line match saw that only when rustfmt happened to break
+/// it across lines. **Discrimination check executed**: a single-line
+/// group partial added anywhere in this file takes the count 14 → 15.
+///
+/// Still not seen: a re-spelled literal (`cell_composition:
+/// CellComposition::Off`), a semantically equivalent construction, one
+/// inside dead code. Conversely a trailing comment or a rustfmt re-wrap
+/// on an existing line moves the count and forces an edit here. So the
+/// claim is bounded: **a textual copy of either pattern, flat or
+/// group-level, cannot be added silently.** That is not "the fossil
+/// cannot come back". The behavioural guard, for the one path that
+/// builds every regression fixture, is
+/// `harness_options_are_engine_defaults`; these 15 sites have no
+/// behavioural guard, which is a reason to migrate them, not a reason to
+/// keep widening this gauge.
 ///
 /// Cost, since it is not free and not obvious: `include_str!` embeds
 /// this ~11k-line file into the test binary (a few hundred KB). Accepted
 /// for a non-ignored test that runs in microseconds.
 #[test]
 fn residual_fossil_literals_are_pinned() {
-    // Self-read: matching on the exact TRIMMED line means the comparison
-    // literals a few lines below do not count themselves.
+    // Self-read. SUBSTRING match on non-comment lines, not exact-trimmed
+    // (#699 review round 8): the review's "highest-probability
+    // resurrection path" is the group-level partial
+    // `SearchAxes { cell_composition: Default::default(), ..SearchAxes::default() }`,
+    // and an exact-trimmed match sees it only when rustfmt happens to
+    // break it across lines. A substring match sees it either way, and
+    // sees an inline flat literal too. Comment lines are skipped so the
+    // docblock above — which quotes both patterns on purpose — does not
+    // count itself; that skip is why the `//` filter is not optional.
+    // Needles are ASSEMBLED AT RUNTIME rather than written whole, so this
+    // function's own code and messages do not match themselves. (Round 8
+    // found the counts reading 16/14 for exactly that reason — a
+    // self-counting gauge is worse than no gauge, because it is wrong in
+    // the direction of "looks fine".) For the same reason the assertion
+    // messages below spell the fields with an `=` instead of the `:` the
+    // source uses.
     const SRC: &str = include_str!("e2e.rs");
-    let cells = SRC
-        .lines()
-        .filter(|l| l.trim() == "cell_composition: Default::default(),")
-        .count();
-    let capacity = SRC.lines().filter(|l| l.trim() == "inserter_capacity: 0,").count();
+    let cells_needle = format!("cell_composition: {}", "Default::default()");
+    let capacity_needle = format!("inserter_capacity: {}", 0);
+    let count_of = |needle: &str| {
+        SRC.lines()
+            .filter(|l| !l.trim_start().starts_with("//") && l.contains(needle))
+            .count()
+    };
+    let cells = count_of(&cells_needle);
+    let capacity = count_of(&capacity_needle);
     assert_eq!(
         cells, 14,
-        "residual `cell_composition: Default::default()` literals moved (was 14 at \
-         RFC-070 W2c). Fewer = a site was migrated: lower this number in the same \
-         commit. More = a new copy of a known-stale pattern: use `harness_options` \
-         instead, or spell the value deliberately with a reason.",
+        "residual `cell_composition` = `Default::default()` sites moved (was 14 at \
+         RFC-070 W2c). Fewer = a site was migrated or its value was spelled \
+         deliberately: lower this number in the same commit and NAME the site. \
+         More = a new copy of a known-stale pattern, flat or group-level: use \
+         `harness_options`, or spell the value with a reason.",
     );
     assert_eq!(
         capacity, 14,
-        "residual `inserter_capacity: 0` literals moved (was 14 at RFC-070 W2c). \
+        "residual `inserter_capacity` = 0 sites moved (was 14 at RFC-070 W2c). \
          Same rule as above.",
     );
 }
@@ -1559,6 +1582,18 @@ fn tier1_iron_gear_wheel_20s() {
     // delivers" inference this PR exists to break. So the estimate is
     // still checked (it is the plan, and a plan regression is worth
     // catching) but under a name and a message that say what it is.
+    //
+    // **Be precise about what that bought** (#699 round 8, and it was
+    // right to press): this assertion is still GREEN on the 15/s layout.
+    // The check was RELABELLED, not made stricter — nothing here can fail
+    // on delivery, because nothing in `crates/core`'s test suite measures
+    // it. What changed is that the suite no longer ASSERTS something
+    // false. Any claim that "the false delivery signal is gone" is an
+    // overclaim; the honest one is "the suite no longer says this layout
+    // produces 20/s". Failing on delivery needs the meter, and that lives
+    // behind `SPAGHETTIO_METER_TRIPWIRE=check` by a standing decision with
+    // its own recorded reasoning (`crates/meter/tests/e2e_tripwire.rs`,
+    // "Why report-only stays the default").
     //
     // Rejected alternative, recorded because it is the obvious one:
     // metering in-suite. `spaghettio_meter` depends on `spaghettio_core`,
@@ -9366,7 +9401,7 @@ fn full_knob_sweep() {
         "> **Option-set epoch: post-RFC-070-W2c (2026-08-21).** Every column here — \
          including the `pure` baselines — runs production's full candidate set \
          (`cell-composed` competes) and the L2 inserter ladder. Before W2c the \
-         harness pinned `cell_composition: Off` and `inserter_capacity: 0`, so \
+         harness pinned cells OFF and the inserter capacity at 0, so \
          tables generated earlier are NOT comparable to this one: a cell can be \
          decided by a layout family the old tables never saw. \"Pure\" means the \
          horizontal-stack candidate is off, and only that.\n",

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -489,8 +489,9 @@ fn harness_options_are_engine_defaults() {
 /// rounds 3, 4 and 5), and its reach is exactly that: it counts TEXTUAL
 /// copies of two exact trimmed lines. It does not see a fossil written
 /// on one line, a re-spelled or reformatted literal, one inside dead
-/// code, or — the sharpest miss, and the one `bus::layout`'s own field
-/// legend names as reachable — the GROUP-level partial,
+/// code, a spelled-out `cell_composition: CellComposition::Off`, or —
+/// the sharpest miss, and the one `bus::layout`'s own field legend names
+/// as reachable — the GROUP-level partial,
 /// `SearchAxes { cell_composition: Default::default(), ..SearchAxes::default() }`,
 /// which resolves to `Off` exactly like the flat form and matches
 /// neither pattern here. Conversely a trailing comment or a rustfmt
@@ -898,6 +899,13 @@ const GOLDEN_HASHES: &[(&str, &str)] = &[
     // density and the same ZERO validation issues. #694's corpus does
     // not cover gear@20/s — see the W2c finding in the RFC decision log.
     //
+    // "Same 12.3%" is `density::score_density(_, (1,1))`, printed by the
+    // harness on both arms (`260 filled / 2116` and `169 filled / 1369`),
+    // not entities/(w*h) — the score normalises to a 1:1 SQUARE bounding
+    // box and counts filled TILES, so the two are 12.3% each while a
+    // naive entity ratio would read 39% vs 20% (#699 review round 7 asked;
+    // the receipt is in the `Layout: ...` lines of any --nocapture run).
+    //
     // **THE NEW WINNER UNDER-DELIVERS — see #700.** This hash pins a
     // layout the meter reads at 15.0/s against a 20.0/s plan (75%), where
     // both native arms read 21.0/s. The re-bless still stands, because a
@@ -945,6 +953,16 @@ const GOLDEN_HASHES: &[(&str, &str)] = &[
     // negative control on this whole re-bless: they did NOT move under
     // either fossil kill, and they are the only two golden-pinned
     // fixtures that didn't.
+    //
+    // The asymmetry is UNEXPLAINED, deliberately (#699 review round 7
+    // noticed it): `tier3_sulfuric_acid`'s iron-plate side is
+    // ladder-sized too, per its own note below, yet it is
+    // capacity-invariant while this fixture's coal side moved. A
+    // plausible story is that sulfuric-acid's side already sits at the
+    // bottom rung, where a bigger hand changes nothing — but that was
+    // not measured, so it is not written as though it were. Do not
+    // "fix" either hash on the strength of the asymmetry; both were
+    // captured from clean runs, twice.
     ("tier3_plastic_bar", "847a0cf0ba7c7d8d54bd3a6f1630b1d8e7ac5efad78978f86435387e070d5758"),
     // RFC rfc-inserter-sizing.md Phase 3: fluid_input_row's solid side
     // (iron-plate) is now ladder-sized — this fixture (sulfuric-acid:
@@ -1489,7 +1507,7 @@ fn tier1_iron_gear_wheel_20s() {
     // `layout_warnings: 1` at selection and 0 at validation; decoded from
     // the snapshot, and there is no contradiction — they are different
     // fields). `LayoutResult.warnings` is the producer's own list;
-    // `validate()`'s issues are the 39 functional checks, and
+    // `validate()`'s issues are the 37 functional checks, and
     // `assert_warnings_golden` counts the latter. The one entry reads:
     //
     //   "cell-composed: geometry NOT sim-verified (hash c5c5f88087df894c)
@@ -3227,11 +3245,13 @@ fn tier5_processing_unit_from_ore_am3() {
     // (ratio >= 2.0 AND excess >= 8), not evidence that this particular
     // belt is newly pathological.
     //
-    // ACCEPTED: errors stay 0, input-rate-delivery is unchanged at 13,
-    // and the check is diagnostic-only by construction (never promotes
-    // to Error). A SECOND detour appearing here would mean the width
-    // grew again — re-trace with the same instrument rather than
-    // re-blessing.
+    // ACCEPTED: errors stay 0, input-rate-delivery was unchanged at 13
+    // AS OF THAT DATE (it is 10 now — see the 2026-08-21 block below;
+    // this sentence read as a present-tense claim until #699's review
+    // round 7 caught it sitting next to its own correction), and the
+    // check is diagnostic-only by construction (never promotes to
+    // Error). A SECOND detour appearing here would mean the width grew
+    // again — re-trace with the same instrument rather than re-blessing.
     //
     // 2026-08-21 (RFC-070 W2c, #689) — ADJUDICATION for
     // `input-rate-delivery 13 -> 10`. This is the ONLY warning pin in the
@@ -3861,11 +3881,20 @@ fn scoreboard_strategy_sweep() {
                     let warns = r.issues.iter().filter(|i| i.severity == Severity::Warning).count();
                     let errs = r.issues.iter().filter(|i| i.severity == Severity::Error).count();
                     let density_score = density::score_density(&r.layout, (1, 1));
-                    // Decomposition-search winner. Phase 0: always
-                    // "native". Future-proofs the column for later
-                    // phases when non-Native candidates can win. See
-                    // `docs/rfc-decomposition-search.md`.
-                    let chosen = r.trace_events.iter().find_map(|e| match e {
+                    // Decomposition-search winner. `.rev()` is load-bearing
+                    // (#699 review round 7): a winning candidate that runs
+                    // its own nested selection replays the inner events
+                    // FIRST, so `find_map` from the front reports the
+                    // NESTED winner. That was harmless while `run_e2e`
+                    // pinned `cell_composition: Off` and nothing nested;
+                    // RFC-070 W2c restored the cell-composed candidate, so
+                    // from-the-front would print "native" for exactly the
+                    // fixtures where cell-composed wins. Same rule as
+                    // `tests/parity_corpus.rs` and the re-pinned
+                    // decomposition tests: the OUTER terminal is the last.
+                    // (The comment here used to say "Phase 0: always
+                    // native" — stale since RFC-051/053.)
+                    let chosen = r.trace_events.iter().rev().find_map(|e| match e {
                         TraceEvent::DecompositionChosen { name, .. } => Some(name.clone()),
                         _ => None,
                     }).unwrap_or_else(|| "?".to_string());
@@ -9369,7 +9398,13 @@ fn full_knob_sweep() {
                 Ok(r) => {
                     let errs = r.issues.iter().filter(|i| i.severity == Severity::Error).count();
                     let warns = r.issues.iter().filter(|i| i.severity == Severity::Warning).count();
-                    let candidate = r.trace_events.iter().find_map(|e| match e {
+                    // `.rev()`: the OUTER selection's terminal is the LAST
+                    // one — see the sibling comment in
+                    // `scoreboard_strategy_sweep`. Reading from the front
+                    // reports a nested winner's inner pick, which since
+                    // RFC-070 W2c is reachable on any fixture the
+                    // cell-composed candidate wins (#699 review round 7).
+                    let candidate = r.trace_events.iter().rev().find_map(|e| match e {
                         TraceEvent::DecompositionChosen { name, .. } => Some(name.clone()),
                         _ => None,
                     }).unwrap_or_else(|| "?".to_string());
@@ -9584,13 +9619,13 @@ fn w2c_gear20_meter_export() {
     let solved = solver::solve("iron-gear-wheel", 20.0, &inputs, "assembling-machine-2")
         .expect("gear20 solve");
 
-    for (arm, cells, capacity) in [
-        ("cells-on", CellComposition::Candidate, 2u8),
-        ("cells-off", CellComposition::Off, 2u8),
+    for (arm, cells, capacity, expect_entities) in [
+        ("cells-on", CellComposition::Candidate, 2u8, 105usize),
+        ("cells-off", CellComposition::Off, 2u8, 148),
         // The exact pre-W2c golden: both fossils in place. Kept as an arm
         // so the "the capacity fossil is not what moved this" claim is
         // re-measurable, not just asserted.
-        ("old-golden", CellComposition::Off, 0u8),
+        ("old-golden", CellComposition::Off, 0u8, 148),
     ] {
         let opts = layout::LayoutOptions::from_groups(
             layout::UserConstraints { inserter_capacity: capacity, ..Default::default() },
@@ -9619,6 +9654,21 @@ fn w2c_gear20_meter_export() {
             lay.height,
             issues.len(),
         );
+        // Asserted, not just printed (#699 review round 7): the table in
+        // this fn's doc pairs each arm's entity count with its meter
+        // reading, so an arm that silently changes shape would leave a
+        // committed meter number attached to a different layout — the
+        // exact 105-vs-148 confusion this exporter exists to make
+        // visible. If one of these fires, the meter numbers in the doc
+        // (and in #700) are stale, not this assertion.
+        assert_eq!(
+            lay.entities.len(),
+            expect_entities,
+            "{arm}: entity count moved; the meter readings recorded in this \
+             function's doc table and in #700 describe the OLD layout. Re-meter \
+             all three arms before updating either.",
+        );
+        assert!(issues.is_empty(), "{arm}: expected 0 validation issues, got {}", issues.len());
     }
 }
 

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -193,13 +193,9 @@ fn run_e2e_with_strategy(
         item,
         rate,
         machine,
-        belt_tier,
         available_inputs,
         &FxHashSet::default(),
-        strategy,
-        spaghettio_core::bus::layout::RowLayout::default(),
-        spaghettio_core::bus::layout::SurplusPolicy::default(),
-        true,
+        HarnessOptions { belt_tier, strategy, ..Default::default() },
     )
 }
 
@@ -220,13 +216,9 @@ fn run_e2e_with_strategy_and_row_layout(
         item,
         rate,
         machine,
-        belt_tier,
         available_inputs,
         &FxHashSet::default(),
-        strategy,
-        row_layout,
-        spaghettio_core::bus::layout::SurplusPolicy::default(),
-        true,
+        HarnessOptions { belt_tier, strategy, row_layout, ..Default::default() },
     )
 }
 
@@ -268,13 +260,12 @@ fn run_e2e_pure_combo(
         item,
         rate,
         machine,
-        belt_tier,
         available_inputs,
         &FxHashSet::default(),
-        strategy,
-        row_layout,
-        spaghettio_core::bus::layout::SurplusPolicy::default(),
-        false,
+        // The one deliberate non-default in any wrapper, and the whole
+        // point of this one.
+        HarnessOptions { belt_tier, strategy, row_layout, horizontal_candidate: false,
+            ..Default::default() },
     )
 }
 
@@ -292,13 +283,9 @@ fn run_e2e_with_exclusions(
         item,
         rate,
         machine,
-        belt_tier,
         available_inputs,
         excluded_recipes,
-        spaghettio_core::bus::layout::LayoutStrategy::Pooled,
-        spaghettio_core::bus::layout::RowLayout::default(),
-        spaghettio_core::bus::layout::SurplusPolicy::default(),
-        true,
+        HarnessOptions { belt_tier, ..Default::default() },
     )
 }
 
@@ -321,13 +308,9 @@ fn run_e2e_with_exclusions_and_surplus_policy(
         item,
         rate,
         machine,
-        belt_tier,
         available_inputs,
         excluded_recipes,
-        spaghettio_core::bus::layout::LayoutStrategy::Pooled,
-        spaghettio_core::bus::layout::RowLayout::default(),
-        surplus_policy,
-        true,
+        HarnessOptions { belt_tier, surplus_policy, ..Default::default() },
     )
 }
 
@@ -443,30 +426,17 @@ fn harness_options_are_engine_defaults() {
          different inserter ladder than production",
     );
 
-    // The fields `run_e2e_inner` takes as PARAMETERS bypass the spread —
-    // the wrappers hand them in explicitly — so
-    // `harness_options(HarnessOptions::default())` alone cannot see them
-    // go stale (#699 review round 2). Two of the four are spelled as HARD
-    // LITERALS by every wrapper (`LayoutStrategy::Pooled`, `true`), which
-    // is the same fossil shape one level out; assert the engine defaults
-    // still equal them, so a default flip fails here instead of silently
-    // pinning every fixture to the old value.
-    //
-    // The other two — `row_layout` and `surplus_policy` — are absent
-    // deliberately: the wrappers pass `RowLayout::default()` /
-    // `SurplusPolicy::default()`, which follow a flip on their own.
-    assert_eq!(
-        shipped.strategy,
-        layout::LayoutStrategy::Pooled,
-        "the engine's default strategy moved, but `run_e2e`/`run_e2e_with_exclusions` \
-         still hand `LayoutStrategy::Pooled` to `run_e2e_inner` — update the wrappers \
-         (and adjudicate the goldens) rather than this assertion",
-    );
-    assert!(
-        shipped.horizontal_candidate,
-        "the engine's default `horizontal_candidate` moved to false, but the \
-         `run_e2e*` wrappers still hand `true` to `run_e2e_inner`",
-    );
+    // (Round 2 added two assertions here pinning `LayoutStrategy::Pooled`
+    // and `horizontal_candidate == true`, because every `run_e2e*` wrapper
+    // spelled those as hard literals and so bypassed the spread. Round 6
+    // pointed out that an assertion re-spelling an engine default is
+    // itself a second copy of it — the shape this whole track is about. So
+    // the wrappers were fixed instead: they now build a `HarnessOptions`
+    // with `..Default::default()` and spell only what they deliberately
+    // vary, which makes them follow a default flip on their own and makes
+    // those two assertions redundant. They are deleted rather than kept as
+    // belt-and-braces: a redundant re-spelling of a default is exactly the
+    // artifact that goes stale.)
 }
 
 /// **The fossil pattern is dead on the `run_e2e` path only.** It survives,
@@ -561,22 +531,30 @@ fn residual_fossil_literals_are_pinned() {
     );
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Takes the varied knobs as one `HarnessOptions` rather than as loose
+/// parameters (#699 review round 6). The wrappers above used to hand in
+/// `LayoutStrategy::Pooled` and `true` as HARD LITERALS — a second copy
+/// of two engine defaults, and the same stale-fossil shape one level out
+/// from the one this track killed. Every wrapper now spells only what it
+/// deliberately varies and leaves the rest to `HarnessOptions::default()`,
+/// which reads the engine's group defaults at runtime. The only
+/// non-default any wrapper sets is `run_e2e_pure_combo`'s
+/// `horizontal_candidate: false`, which is that wrapper's entire purpose.
+///
+/// (The `#[allow(clippy::too_many_arguments)]` this used to carry went
+/// with the four params: seven is the limit, and this now has seven.)
 fn run_e2e_inner(
     test_name: &str,
     item: &str,
     rate: f64,
     machine: &str,
-    belt_tier: Option<&str>,
     available_inputs: &FxHashSet<String>,
     excluded_recipes: &FxHashSet<String>,
-    strategy: spaghettio_core::bus::layout::LayoutStrategy,
-    row_layout: spaghettio_core::bus::layout::RowLayout,
-    surplus_policy: spaghettio_core::bus::layout::SurplusPolicy,
-    horizontal_candidate: bool,
+    opts: HarnessOptions<'_>,
 ) -> Result<E2EResult, String> {
     let _guard = trace::start_trace();
     spaghettio_core::zone_cache::set_thread_source(Some(test_name));
+    let belt_tier = opts.belt_tier;
     let run_params = RunParams { item, rate, machine, belt_tier, available_inputs };
 
     let solver_result = solver::solve_with_exclusions(item, rate, available_inputs, machine, excluded_recipes)
@@ -586,13 +564,7 @@ fn run_e2e_inner(
             msg
         })?;
 
-    let layout = layout::build_bus_layout(&solver_result, harness_options(HarnessOptions {
-        belt_tier,
-        strategy,
-        row_layout,
-        surplus_policy,
-        horizontal_candidate,
-    }))
+    let layout = layout::build_bus_layout(&solver_result, harness_options(opts))
         .map_err(|e| {
             let msg = format!("layout: {e}");
             dump_partial_snapshot(test_name, &run_params, Some(&solver_result), &msg);
@@ -1512,6 +1484,23 @@ fn tier1_iron_gear_wheel_20s() {
     // fixture name, two artifacts, no contradiction visible from either
     // side. That is what the fossil cost.
     //
+    // **The winner declared its own unverifiedness, and the stage ranked
+    // past it** (#699 review round 6 asked how the same layout scores
+    // `layout_warnings: 1` at selection and 0 at validation; decoded from
+    // the snapshot, and there is no contradiction — they are different
+    // fields). `LayoutResult.warnings` is the producer's own list;
+    // `validate()`'s issues are the 39 functional checks, and
+    // `assert_warnings_golden` counts the latter. The one entry reads:
+    //
+    //   "cell-composed: geometry NOT sim-verified (hash c5c5f88087df894c)
+    //    — run spaghettio-sim and add the entry to cell-sim-registry.json"
+    //
+    // RFC-051's own machinery flagged this exact geometry as unverified,
+    // `best-error-free` filters on errors and ranks on score with warnings
+    // taking no part, and the thing it was not verified for is precisely
+    // what the meter later measured. Recorded here because it is the
+    // sharpest available argument for W2b's severity-aware verdict.
+    //
     // The pin below is this file's share of the guard (#699 review round
     // 2, 3/3 — "the only guard is prose and an external issue number").
     // Neither the golden hash nor `assert_produces` can say WHY this
@@ -1786,8 +1775,16 @@ fn tier2_electronic_circuit_from_ore() {
     assert_golden_hash(&result, "tier2_electronic_circuit_from_ore");
 }
 
+/// Timeout raised 10 s → 60 s (RFC-070 W2c). `ntest::timeout` is
+/// wall-clock, and this fixture sat right on the old boundary: it tripped
+/// at 10003 ms on this PR's BASELINE run (before any change) and again at
+/// 10001 ms afterwards, while passing SOLO in 0.63 s. Restoring the
+/// cell-composed candidate adds a second layout pass and makes the
+/// boundary case worse, so the budget is raised rather than left to flake
+/// a 4-minute suite run. 60 s still catches a ~100x regression on a test
+/// that runs in well under a second.
 #[test]
-#[ntest::timeout(10000)]
+#[ntest::timeout(60000)]
 fn tier2_electronic_circuit_20s_from_ore() {
     let inputs: FxHashSet<String> = ["iron-ore", "copper-ore"]
         .iter()

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -236,6 +236,17 @@ fn run_e2e_with_strategy_and_row_layout(
 /// strategy × row-layout combination in isolation; the default engine
 /// behavior (candidate competing) is the sweep's separate `default`
 /// column.
+///
+/// "Pure" means **the horizontal-stack candidate is off**, and only that
+/// (#699 review round 2 read it as "no candidate competes"). Every other
+/// candidate — `cell-composed` included — runs exactly as production has
+/// it. Before RFC-070 W2c that was accidentally untrue: the harness
+/// pinned `cell_composition: Off`, so the cell-composed arm was absent
+/// from these columns AND from the `default` column, by fossil rather
+/// than by design. It now competes in both, which keeps the sweep's
+/// comparison apples-to-apples; disabling it in the pure columns alone
+/// would not. Consequence for readers: **`full_knob_sweep` tables
+/// produced before 2026-08-21 are not comparable to ones produced after.**
 fn run_e2e_pure_combo(
     test_name: &str,
     item: &str,
@@ -425,6 +436,31 @@ fn harness_options_are_engine_defaults() {
         "inserter_capacity fossil is back (RFC-070 W2c): the suite would run a \
          different inserter ladder than production",
     );
+
+    // The fields `run_e2e_inner` takes as PARAMETERS bypass the spread —
+    // the wrappers hand them in explicitly — so
+    // `harness_options(HarnessOptions::default())` alone cannot see them
+    // go stale (#699 review round 2). Two of the four are spelled as HARD
+    // LITERALS by every wrapper (`LayoutStrategy::Pooled`, `true`), which
+    // is the same fossil shape one level out; assert the engine defaults
+    // still equal them, so a default flip fails here instead of silently
+    // pinning every fixture to the old value.
+    //
+    // The other two — `row_layout` and `surplus_policy` — are absent
+    // deliberately: the wrappers pass `RowLayout::default()` /
+    // `SurplusPolicy::default()`, which follow a flip on their own.
+    assert_eq!(
+        shipped.strategy,
+        layout::LayoutStrategy::Pooled,
+        "the engine's default strategy moved, but `run_e2e`/`run_e2e_with_exclusions` \
+         still hand `LayoutStrategy::Pooled` to `run_e2e_inner` — update the wrappers \
+         (and adjudicate the goldens) rather than this assertion",
+    );
+    assert!(
+        shipped.horizontal_candidate,
+        "the engine's default `horizontal_candidate` moved to false, but the \
+         `run_e2e*` wrappers still hand `true` to `run_e2e_inner`",
+    );
 }
 
 /// **The fossil pattern is dead on the `run_e2e` path only.** It survives,
@@ -452,15 +488,26 @@ fn harness_options_are_engine_defaults() {
 ///   `stacking_kovarex_family_exempt_s2`, `stacking_ec_60s_express_legendary_s2`,
 ///   `research_l7_thins_output_inserters_s4`, `rfc061_allocation_probe_ac5`.
 ///
-/// None of them documents its `0` / `Off` as deliberate — every one is the
-/// same copy of `run_e2e_inner`'s old literal. They are NOT migrated here
-/// because each carries its own pins and assertions, so flipping them is a
-/// second adjudication of the same size as this PR's, not a rider on it.
+/// None of them carries a COMMENT explaining its `0` / `Off`; every one is
+/// textually the same copy of `run_e2e_inner`'s old literal. That is a
+/// claim about the prose, not about whether the value is load-bearing —
+/// **no per-site audit has been done**, and #699's review round 2 was
+/// right to flag that at least one site (`stacking_refuses_low_inserter_cap`,
+/// whose whole subject is a low-capacity config) reads as though it might
+/// be deliberate even if its refusal predicate actually names
+/// `max_inserter_tier`. They are NOT migrated here because each carries
+/// its own pins and assertions, so flipping them is a second adjudication
+/// of the same size as this PR's, not a rider on it.
 ///
-/// **Reducing a count here is the good direction**: migrate a site to
-/// `harness_options` (or spell a deliberate value with a comment saying
-/// why), then lower the number. Raising one means a new copy of a known
-/// trap — don't.
+/// **Reducing a count here is the good direction, but not unconditionally**:
+/// per site, first decide whether the value is load-bearing for what that
+/// test asserts. If it is, spell it with a comment saying so and lower the
+/// count anyway (a documented deliberate value is not a fossil). If it is
+/// not, migrate the site to `harness_options` — which will move that
+/// test's own pins, so adjudicate them the way this PR adjudicated the
+/// harness's. Either way, name the site in the commit that lowers the
+/// number, so a reader can tell a migration from a weakened tripwire.
+/// Raising a count means a new copy of a known trap — don't.
 #[test]
 fn residual_fossil_literals_are_pinned() {
     // Self-read: matching on the exact TRIMMED line means the comparison
@@ -1071,8 +1118,16 @@ fn tier1_iron_gear_wheel() {
 /// `best-error-free`, winner `native`. The assertions below now pin THAT
 /// — including cell-composed's presence, so a re-fossilization fails here
 /// as well as at `harness_options_are_engine_defaults`.
+///
+/// Timeout raised 10 s → 30 s in the same change (#699 review round 2):
+/// this fixture now runs a SECOND full layout pass (the cell-composed
+/// candidate), and `ntest::timeout` is wall-clock, so a loaded box is the
+/// binding constraint, not the work. The neighbouring
+/// `tier2_electronic_circuit_20s_from_ore` already tripped its 10 s at
+/// 10003 ms on this PR's own BASELINE run while passing solo in 0.63 s.
+/// 30 s still catches a ~1000x regression on a test that runs in ~0.02 s.
 #[test]
-#[ntest::timeout(10000)]
+#[ntest::timeout(30000)]
 fn decomposition_search_native_candidate_fires_trace_events() {
     let inputs: FxHashSet<String> = ["iron-plate"].iter().map(|s| s.to_string()).collect();
     let result = run_e2e(
@@ -1129,9 +1184,18 @@ fn decomposition_search_native_candidate_fires_trace_events() {
     // oracle. It is, so it is corroborated rather than trusted: the two
     // INDEPENDENT terminals (`DecompositionChosen` from the search,
     // `SelectionDecided` from the scoreboard) must agree, and the stage is
-    // pinned against #694's `tier1_gear_am1` / am1 / `default` row. A
-    // reordering that broke the pairing would have to break both emitters
-    // the same way to slip through.
+    // pinned against #694's `tier1_gear_am1` / am1 / `default` row.
+    //
+    // Honest residual (round 2, same finding restated): a reordering that
+    // flipped BOTH emitters consistently would sail through both
+    // assertions. Corroboration narrows the failure mode, it does not
+    // remove it — and it cannot be removed from here, because the fix is a
+    // structural nesting marker in the trace contract itself, which is the
+    // selection loop's to own (RFC-070 Phase 1b/2a), not this test's.
+    // What this test CAN do about it is pin the stage as well as the
+    // winner: gear@20's nested board decides at `best-accepted`, so a
+    // whole class of "read the nested board instead" errors would show up
+    // as a stage mismatch here rather than as a silent pass.
     let decided: Vec<_> = result.trace_events.iter()
         .filter_map(|e| match e {
             TraceEvent::SelectionDecided { winner, stage } => Some((winner.clone(), *stage)),
@@ -1172,8 +1236,12 @@ fn decomposition_search_native_candidate_fires_trace_events() {
 /// artifact of the `cell_composition: Off` fossil, not a property of the
 /// search. What K-DS1-1 actually asserts — native wins the clean case,
 /// and `size-split-2` is not paid for on it — survives verbatim below.
+///
+/// Timeout raised 30 s → 60 s for the same reason as its sibling above
+/// (#699 review round 2): one extra full layout pass under a wall-clock
+/// budget on a box that already flakes a 10 s one.
 #[test]
-#[ntest::timeout(30000)]
+#[ntest::timeout(60000)]
 fn decomposition_search_picks_native_on_clean_partitioned_case() {
     use spaghettio_core::bus::layout::LayoutStrategy;
     let inputs: FxHashSet<String> = ["petroleum-gas", "coal"]
@@ -1383,6 +1451,32 @@ fn tier1_iron_gear_wheel_20s() {
     // fixed here. Everything below is validator- and estimate-level and
     // passes on the under-delivering layout; do NOT read this test's
     // greenness as evidence of delivery.
+    //
+    // The pin below is the IN-SUITE tripwire for that (#699 review round
+    // 2, 3/3 — "the only guard is prose and an external issue number").
+    // Neither the golden hash nor `assert_produces` can say WHY this
+    // fixture is special: the hash's failure message asks whether the
+    // layout change was intentional, and `assert_produces` reads
+    // `analysis.throughput_estimates`, a static estimate the meter
+    // contradicts. This one names #700, so whoever changes the selection
+    // here — including whoever FIXES #700 — is told what they just moved
+    // instead of being invited to re-bless.
+    let outer = result.trace_events.iter().rev().find_map(|e| match e {
+        TraceEvent::SelectionDecided { winner, stage } => Some((winner.clone(), *stage)),
+        _ => None,
+    });
+    assert_eq!(
+        outer.as_ref().map(|(w, s)| (w.as_str(), *s)),
+        Some(("cell-composed", spaghettio_core::trace::SelectionStage::BestErrorFree)),
+        "tier1_iron_gear_wheel_20s pins a KNOWN UNDER-DELIVERING winner (#700): \
+         `cell-composed` at `best-error-free`, metered at 15.0/s against a 20.0/s \
+         plan while both native arms meter 21.0/s. If this assertion just failed, \
+         the selection moved — if that is #700 being fixed, re-take the meter \
+         reading (`w2c_gear20_meter_export` at the bottom of this file), update \
+         #700, and re-bless the golden with the new number. Do NOT re-bless on \
+         validator greenness alone: that is exactly what hid this for a month. \
+         got {outer:?}",
+    );
     assert_warnings_golden(&result, "tier1_iron_gear_wheel_20s");
     assert_produces(&result, "iron-gear-wheel", 20.0);
     assert_round_trip(&result);

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -238,15 +238,21 @@ fn run_e2e_with_strategy_and_row_layout(
 /// column.
 ///
 /// "Pure" means **the horizontal-stack candidate is off**, and only that
-/// (#699 review round 2 read it as "no candidate competes"). Every other
-/// candidate — `cell-composed` included — runs exactly as production has
-/// it. Before RFC-070 W2c that was accidentally untrue: the harness
-/// pinned `cell_composition: Off`, so the cell-composed arm was absent
-/// from these columns AND from the `default` column, by fossil rather
-/// than by design. It now competes in both, which keeps the sweep's
-/// comparison apples-to-apples; disabling it in the pure columns alone
-/// would not. Consequence for readers: **`full_knob_sweep` tables
-/// produced before 2026-08-21 are not comparable to ones produced after.**
+/// (#699 review rounds 2 and 4 read it as "no candidate competes"). Every
+/// other candidate — `cell-composed` included — runs exactly as
+/// production has it, and so does the L2 inserter ladder. Before RFC-070
+/// W2c that was accidentally untrue: the harness pinned
+/// `cell_composition: Off` and `inserter_capacity: 0`, so the
+/// cell-composed arm and the shipped ladder were absent from these
+/// columns AND from the `default` column, by fossil rather than by
+/// design. Both now apply to both, which keeps the sweep's comparison
+/// apples-to-apples; restoring the fossil in the pure columns alone would
+/// not — it would make the baseline columns and the `default` column
+/// differ on two axes instead of the one the sweep is about.
+/// Consequence for readers: **`full_knob_sweep` tables produced before
+/// 2026-08-21 are not comparable to ones produced after**, and a pure
+/// cell can now be decided by a layout family the pre-W2c tables never
+/// saw.
 fn run_e2e_pure_combo(
     test_name: &str,
     item: &str,
@@ -510,13 +516,21 @@ fn harness_options_are_engine_defaults() {
 /// Raising a count means a new copy of a known trap — don't.
 ///
 /// **This is a source-text gauge, not a behavioural one** (#699 review
-/// round 3), and the coupling is deliberate: any edit that changes how
-/// one of these lines is SPELLED — a trailing comment, a rustfmt
-/// re-wrap, a rename — moves the count too and forces an edit here. That
-/// is a small tax on 15 known sites in exchange for the residual being
-/// impossible to grow silently, and it is the only mechanism available:
-/// the sites are ordinary struct literals inside ordinary tests, with no
-/// runtime handle to count.
+/// rounds 3 and 4), and its reach is exactly that: it counts TEXTUAL
+/// copies of two exact trimmed lines. It does not see a fossil written
+/// on one line, a re-spelled or reformatted literal, a semantically
+/// equivalent construction, or one inside dead code — and conversely a
+/// trailing comment or a rustfmt re-wrap on an existing line moves the
+/// count and forces an edit here. So the claim is narrow: **a textual
+/// copy of these two lines cannot be added silently.** That is not the
+/// same as "the fossil cannot come back", and it is the only mechanism
+/// available — the sites are ordinary struct literals inside ordinary
+/// tests, with no runtime handle to count. The behavioural guard, for
+/// the path that matters, is `harness_options_are_engine_defaults`.
+///
+/// Cost, since it is not free and not obvious: `include_str!` embeds
+/// this ~11k-line file into the test binary (a few hundred KB). Accepted
+/// for a non-ignored test that runs in microseconds.
 #[test]
 fn residual_fossil_literals_are_pinned() {
     // Self-read: matching on the exact TRIMMED line means the comparison
@@ -1195,16 +1209,27 @@ fn decomposition_search_native_candidate_fires_trace_events() {
     // `SelectionDecided` from the scoreboard) must agree, and the stage is
     // pinned against #694's `tier1_gear_am1` / am1 / `default` row.
     //
-    // Honest residual (round 2, same finding restated): a reordering that
-    // flipped BOTH emitters consistently would sail through both
-    // assertions. Corroboration narrows the failure mode, it does not
-    // remove it — and it cannot be removed from here, because the fix is a
-    // structural nesting marker in the trace contract itself, which is the
-    // selection loop's to own (RFC-070 Phase 1b/2a), not this test's.
-    // What this test CAN do about it is pin the stage as well as the
-    // winner: gear@20's nested board decides at `best-accepted`, so a
-    // whole class of "read the nested board instead" errors would show up
-    // as a stage mismatch here rather than as a silent pass.
+    // Honest residuals, both from #699's review, both correct:
+    //
+    // 1. (round 4, 3/3) **The corroboration is currently vacuous HERE.**
+    //    Measured: this fixture emits exactly ONE `DecompositionChosen`
+    //    and ONE `SelectionDecided`, because `native` wins and native has
+    //    no nested selection — the cell-composed candidate runs and
+    //    LOSES, and `run_candidate` truncates a loser's nested trace block
+    //    (RFC-070 oracle gap (g)). So `chosen.last() == decided.last()`
+    //    cannot fail here for any ordering. It is kept as a cheap
+    //    consistency check that becomes load-bearing the moment a nesting
+    //    candidate wins this fixture — which is precisely the event this
+    //    test exists to notice. The assertion that carries weight today is
+    //    the STAGE pin plus the cell-composed-presence check above. The
+    //    fixture where the ordering IS exercised is
+    //    `tier1_iron_gear_wheel_20s`, whose winner nests.
+    // 2. (round 2/3) A reordering that flipped BOTH emitters consistently
+    //    would sail through even where the check is not vacuous.
+    //    Corroboration narrows the failure mode, it does not remove it —
+    //    and it cannot be removed from here: the fix is a structural
+    //    nesting marker in the trace contract itself, which is the
+    //    selection loop's to own (RFC-070 Phase 1b/2a), not this test's.
     let decided: Vec<_> = result.trace_events.iter()
         .filter_map(|e| match e {
             TraceEvent::SelectionDecided { winner, stage } => Some((winner.clone(), *stage)),
@@ -1279,7 +1304,11 @@ fn decomposition_search_picks_native_on_clean_partitioned_case() {
     // selections replay their own into the same stream (RFC-070 oracle gap
     // (g); the contract is stated on `trace.rs`'s
     // `SelectionCandidateEvaluated`). Corroborated across both independent
-    // terminal emitters rather than trusted, per #699's review.
+    // terminal emitters rather than trusted, per #699's review — with the
+    // same honest caveat as the sibling test above: while `native` wins
+    // and nests nothing, only one terminal of each kind is emitted, so the
+    // cross-check cannot fail. It is a cheap guard that arms itself if a
+    // nesting candidate ever takes this fixture.
     let decided: Vec<_> = result.trace_events.iter()
         .filter_map(|e| match e {
             TraceEvent::SelectionDecided { winner, stage } => Some((winner.clone(), *stage)),
@@ -1461,7 +1490,23 @@ fn tier1_iron_gear_wheel_20s() {
     // passes on the under-delivering layout; do NOT read this test's
     // greenness as evidence of delivery.
     //
-    // The pin below is the IN-SUITE tripwire for that (#699 review round
+    // **The deficit itself is not new, and this is not the only guard on
+    // it.** W1a's meter tripwire found it on day one (#693's own table:
+    // `gear20-am2-plate` 20.000 planned / 15.000 produced / −25.0% BELOW
+    // PLAN) and its committed baseline
+    // (`crates/meter/tests/e2e_tripwire_baseline.json`) carries the row
+    // ARMED, at `entities: 105, deficit_pct: -25.0, converged: true` — a
+    // STANDING BELOW-PLAN row that `SPAGHETTIO_METER_TRIPWIRE=check`
+    // fails on if it worsens. What W2c adds is the ATTRIBUTION, and the
+    // reason nobody joined the two facts: **the tripwire's 105 entities
+    // and this fixture's pre-W2c golden's 148 were different layouts of
+    // the same named config.** The tripwire built `LayoutOptions::
+    // default()` (production, cell-composed, −25 %); the e2e fixture
+    // built the fossil's options (native, +5 %). Two instruments, one
+    // fixture name, two artifacts, no contradiction visible from either
+    // side. That is what the fossil cost.
+    //
+    // The pin below is this file's share of the guard (#699 review round
     // 2, 3/3 — "the only guard is prose and an external issue number").
     // Neither the golden hash nor `assert_produces` can say WHY this
     // fixture is special: the hash's failure message asks whether the
@@ -1482,11 +1527,13 @@ fn tier1_iron_gear_wheel_20s() {
          plan while both native arms meter 21.0/s. If this assertion just failed, \
          the selection moved — if that is #700 being fixed: (1) re-take the meter \
          reading with `w2c_gear20_meter_export` at the bottom of this file, \
-         (2) update #700 with it, (3) update THIS pin, and (4) re-bless the \
-         fixture's GOLDEN HASH (and its warning pin, if the tally moved). Those \
-         are the coupled artifacts; nothing else in the suite is. Do NOT re-bless \
-         on validator greenness alone: that is exactly what hid this for a month. \
-         got {outer:?}",
+         (2) update #700 with it, (3) update THIS pin, (4) re-bless the fixture's \
+         GOLDEN HASH (and its warning pin, if the tally moved), and (5) re-bless \
+         the meter tripwire's `gear20-am2-plate` row, which is the ARMED guard \
+         on the deficit (crates/meter/tests/e2e_tripwire_baseline.json, currently \
+         entities 105 / -25.0%). Those five are the coupled artifacts; nothing \
+         else is. Do NOT re-bless on validator greenness alone: that is exactly \
+         what hid this for a month. got {outer:?}",
     );
     assert_warnings_golden(&result, "tier1_iron_gear_wheel_20s");
     assert_produces(&result, "iron-gear-wheel", 20.0);

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -483,7 +483,15 @@ fn harness_options_are_engine_defaults() {
 /// test's own pins, so adjudicate them the way this PR adjudicated the
 /// harness's. Either way, name the site in the commit that lowers the
 /// number, so a reader can tell a migration from a weakened tripwire.
-/// Raising a count means a new copy of a known trap — don't.
+///
+/// **Raising a count is allowed, but only on the record** (#699 review
+/// round 9, and the correction is fair — the earlier wording, "raising a
+/// count means a new copy of a known trap — don't", forbade a legitimate
+/// case). RFC-049's unresearched world IS a valid thing to test, and a
+/// new test whose subject is capacity 0 or cells off needs the literal.
+/// Raise the number, and say in the same commit which test and why the
+/// value is load-bearing. What the gauge is for is that a copy-paste
+/// arrives with a reason attached, not that the count never moves up.
 ///
 /// **This is a source-text gauge, not a behavioural one** (#699 review
 /// rounds 3-5 argued its reach; round 8 argued it was pointed at the

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -314,6 +314,109 @@ fn run_e2e_with_exclusions_and_surplus_policy(
     )
 }
 
+/// The knobs a `run_e2e*` caller may vary. Everything NOT listed here is
+/// the engine's shipped default, by construction — see [`harness_options`].
+///
+/// `Default` is deliberately **manual and derived from the engine's own
+/// group defaults at runtime** rather than `#[derive(Default)]`. A derived
+/// impl would give `horizontal_candidate: false` (the `bool` default),
+/// which is not the engine default (`true`) — i.e. it would recreate the
+/// exact class of bug this struct exists to kill, one level up.
+struct HarnessOptions<'a> {
+    belt_tier: Option<&'a str>,
+    strategy: layout::LayoutStrategy,
+    row_layout: layout::RowLayout,
+    surplus_policy: layout::SurplusPolicy,
+    horizontal_candidate: bool,
+}
+
+impl Default for HarnessOptions<'_> {
+    fn default() -> Self {
+        // Read through the engine's group defaults, never re-spelled here:
+        // if a default flips, this follows it with no edit.
+        let axes = layout::SearchAxes::default();
+        let constraints = layout::UserConstraints::default();
+        Self {
+            belt_tier: None,
+            strategy: axes.strategy,
+            row_layout: axes.row_layout,
+            surplus_policy: constraints.surplus_policy,
+            horizontal_candidate: axes.horizontal_candidate,
+        }
+    }
+}
+
+/// Build the `LayoutOptions` every `run_e2e*` fixture runs under: **true
+/// engine defaults**, overridden only where a test's own parameters say so.
+///
+/// RFC-070 W2c (#689). This replaced a flat `LayoutOptions` struct literal
+/// that carried TWO fossils — fields spelled `Default::default()` or a
+/// literal that were correct when written and went stale when the engine
+/// default moved underneath them:
+///
+/// * `cell_composition: Default::default()` → the ENUM's `#[default]`,
+///   `Off`, next to a `..Default::default()` that would have given the
+///   STRUCT default, `Candidate` (flipped by RFC-051 Phase B, 2026-07-22).
+///   The suite therefore never exercised the cell-composed candidate arm.
+/// * `inserter_capacity: 0` → correct at RFC-049 Phase 1 (`40fd48dc`), stale
+///   two days later when #383 flipped the default to
+///   `common::DEFAULT_INSERTER_CAPACITY` = 2. The suite ran a different
+///   inserter ladder than production.
+///
+/// Both are dead here: [`LayoutOptions::from_groups`] takes whole groups,
+/// and each group's `Default` is a MANUAL impl that matches the engine
+/// defaults field for field (`bus::layout`'s field legend, "the fossil this
+/// split guards against"). The remaining rule for anyone editing this
+/// function: **never spell `field: Default::default()` inside one of these
+/// group literals.** Per-field `Default::default()` resolves to that
+/// field's own type's default and silently ignores the `..Default::default()`
+/// spread — that is the trap, and it is still reachable one level down.
+/// Spell a real value, or leave the field to the spread.
+fn harness_options(o: HarnessOptions<'_>) -> layout::LayoutOptions {
+    layout::LayoutOptions::from_groups(
+        layout::UserConstraints {
+            max_belt_tier: o.belt_tier.map(|s| s.to_string()),
+            surplus_policy: o.surplus_policy,
+            ..Default::default()
+        },
+        layout::SearchAxes {
+            strategy: o.strategy,
+            row_layout: o.row_layout,
+            horizontal_candidate: o.horizontal_candidate,
+            ..Default::default()
+        },
+        layout::EngineTuning::default(),
+    )
+}
+
+/// The guard on [`harness_options`]: with nothing overridden, the harness
+/// must run EXACTLY what production ships. Both RFC-070 W2c fossils are
+/// named individually as well as covered by the group comparison, because
+/// the whole failure mode was that a stale value looks like a deliberate
+/// one — a reader of a group assert cannot tell which field regressed.
+///
+/// Non-ignored and free: no solve, no layout. Restoring either fossil
+/// fails it (checked by doing so, RFC-070 W2c).
+#[test]
+fn harness_options_are_engine_defaults() {
+    let o = harness_options(HarnessOptions::default());
+    assert_eq!(o.constraints(), layout::UserConstraints::default(), "user-pinned group drifted");
+    assert_eq!(o.axes(), layout::SearchAxes::default(), "search-axis group drifted");
+    assert_eq!(o.engine_tuning(), layout::EngineTuning::default(), "engine-tuning group drifted");
+    assert_eq!(
+        o.cell_composition,
+        spaghettio_core::bus::cells::CellComposition::Candidate,
+        "cells-off fossil is back (RFC-070 W2c): the suite would stop exercising \
+         the cell-composed candidate arm and nothing else would notice",
+    );
+    assert_eq!(
+        o.inserter_capacity,
+        spaghettio_core::common::DEFAULT_INSERTER_CAPACITY,
+        "inserter_capacity fossil is back (RFC-070 W2c): the suite would run a \
+         different inserter ladder than production",
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_e2e_inner(
     test_name: &str,
@@ -339,25 +442,13 @@ fn run_e2e_inner(
             msg
         })?;
 
-    let layout = layout::build_bus_layout(
-        &solver_result,
-        layout::LayoutOptions {
-            strategy,
-            surplus_policy,
-            max_belt_tier: belt_tier.map(|s| s.to_string()),
-            row_layout,
-            max_inserter_tier: Default::default(),
-            quality: Default::default(),
-            wire_mode: Default::default(),
-            merge_tap: false,
-            stacking: 1,
-            inserter_capacity: 0,
-            cell_composition: Default::default(),
-            splitter_tap_spacers: false,
-            horizontal_candidate,
-            ..Default::default()
-        },
-    )
+    let layout = layout::build_bus_layout(&solver_result, harness_options(HarnessOptions {
+        belt_tier,
+        strategy,
+        row_layout,
+        surplus_policy,
+        horizontal_candidate,
+    }))
         .map_err(|e| {
             let msg = format!("layout: {e}");
             dump_partial_snapshot(test_name, &run_params, Some(&solver_result), &msg);
@@ -672,9 +763,25 @@ const GOLDEN_HASHES: &[(&str, &str)] = &[
     // that cover single_input_row-shaped fixtures moved even though entity
     // COUNT and layout geometry (KC4) stayed byte-identical — only the
     // inserter entity NAMES at the same positions changed.
-    ("tier1_iron_gear_wheel", "61ae6bb3babd5e5921e4ca3351664903444614ef9bd57e3579f08a9b2d12e503"),
-    ("tier1_iron_gear_wheel_from_ore", "7e7fbc36c596e237a8aa6838d2095f03a67284392085d8af4b6dea96af4d1f61"),
-    ("tier1_iron_gear_wheel_20s", "d00a81cb51d646c3755b5f7d5659a6f31f1cbfcdeb21ab2303c1dfd3b2121c02"),
+    // RFC-070 W2c (#689): re-blessed when `run_e2e` stopped pinning
+    // `inserter_capacity: 0` and started running production's L2 default.
+    // A capacity-2 hand moves ~2x per swing, so the sizing ladder needs
+    // fewer inserters per machine side and places different entities —
+    // the SAME re-bless class as the rfc-inserter-sizing note above.
+    // Attribution is measured, not assumed: an A/B that killed only the
+    // cells fossil left the next two entries byte-identical; killing
+    // only the capacity fossil moved all three.
+    ("tier1_iron_gear_wheel", "ffb66596f449156e3844d9bf23d004361b76c1c011c4746dd5cefa3131160285"),
+    ("tier1_iron_gear_wheel_from_ore", "a688889d2beb81ba3adbf0a9ec5f7f070a240db9800d21a383bd2ddfc0c7e8e4"),
+    // …except this one, which moved under BOTH arms, because it is the
+    // single fixture in the suite whose WINNER changes: with the
+    // cell-composed candidate restored to the search it wins the outer
+    // selection (`SelectionDecided { winner: cell-composed, stage:
+    // best-error-free }`, score 0.1129 vs native's 0.1081), taking the
+    // fixture from 148 entities / 47x8 to 105 / 38x14 at the same 12.3%
+    // density and the same ZERO validation issues. #694's corpus does
+    // not cover gear@20/s — see the W2c finding in the RFC decision log.
+    ("tier1_iron_gear_wheel_20s", "8ab74dc08c91cd8d13faf0a376c0c3eabe9b21df3a80f3b5a3768f89371d794c"),
     // Updated when `(m, m)` family balancers became passthroughs
     // (issue #268) — splitter blocks replaced by a single south-facing
     // belt per output column.
@@ -682,7 +789,11 @@ const GOLDEN_HASHES: &[(&str, &str)] = &[
     // copper-plate) ladder-sized, see note above.
     // RFC rfc-inserter-sizing.md Phase 2: dual_input_row (this fixture's EC
     // row is dual-input) is now ladder-sized + near/far reassigned.
-    ("tier2_electronic_circuit_from_ore", "0ae4d39372e33cf6c82dc96404a5f05b5a3b9888c2cea1f65ef542caeb91f182"),
+    // RFC-070 W2c: inserter-capacity re-bless (see the note above);
+    // winner + stage unchanged, as #694 predicts for
+    // `e2e_tier2_electronic_circuit_from_ore` @ am1 (native /
+    // best-error-free under both `e2e-harness` and `default`).
+    ("tier2_electronic_circuit_from_ore", "8db994a14cba2abdece21fe705ecd110c48bd572fa91adf79b2b4839a9e394e0"),
     // Hashes below changed when row inputs were switched to always
     // use `max_belt_tier` instead of per-row consumption rate (fixes
     // tier-mismatch seam where bus tap-off feeds row belt-in).
@@ -692,13 +803,21 @@ const GOLDEN_HASHES: &[(&str, &str)] = &[
     // RFC rfc-inserter-sizing.md Phase 1: single_input_row rows ladder-sized, see note above.
     // RFC rfc-inserter-sizing.md Phase 2: dual_input_row ladder-sized + near/far reassigned.
     // RFC rfc-inserter-sizing.md Phase 3: far side's reach-2 count-ladder activated.
-    ("tier2_electronic_circuit_20s_from_ore", "7a23126d5f857d22db9374cc6269eb9ea2d7bdb2a69c6dc34f60f322cc63e134"),
+    // RFC-070 W2c: inserter-capacity re-bless. #694 predicts winner +
+    // stage hold at am2 (the tier this test runs) — the corpus's winner
+    // change on this fixture is at am3, which the suite never invokes.
+    ("tier2_electronic_circuit_20s_from_ore", "428fd17294c0d2b50a2217abf29b4e1ed723e23b04da4b89a9188608266d59e0"),
     // (RFC-047 Leg B: `tier2_electronic_circuit_splitter_stamp_regression`
     // no longer builds — it is now a named-refusal guard — so its golden
     // hash entry was removed.)
     // RFC rfc-inserter-sizing.md Phase 3: fluid_input_row's solid side
     // (coal) is now ladder-sized. Reaches fully clean.
-    ("tier3_plastic_bar", "bb1cccc422f0e44bfdb1d18ef59d870d71d8fe5d7147b659e7b388c79a526166"),
+    // RFC-070 W2c: inserter-capacity re-bless (the coal side is the
+    // ladder-sized one). The two fluid-target fixtures below are the
+    // negative control on this whole re-bless: they did NOT move under
+    // either fossil kill, and they are the only two golden-pinned
+    // fixtures that didn't.
+    ("tier3_plastic_bar", "847a0cf0ba7c7d8d54bd3a6f1630b1d8e7ac5efad78978f86435387e070d5758"),
     // RFC rfc-inserter-sizing.md Phase 3: fluid_input_row's solid side
     // (iron-plate) is now ladder-sized — this fixture (sulfuric-acid:
     // iron-plate + water) is exactly that shape. Stays fully clean
@@ -860,8 +979,18 @@ fn tier1_iron_gear_wheel() {
 /// (`docs/rfc-decomposition-search.md`). Confirms the layer is
 /// actually exercising — not just compiling but emitting the
 /// `DecompositionCandidateScored` and `DecompositionChosen` trace
-/// events. With Phase 0's single `NativeCandidate`, exactly one of
-/// each fires per layout call.
+/// events.
+///
+/// RFC-070 W2c re-pin. This used to assert "exactly one of each fires",
+/// citing Phase 0's single `NativeCandidate`. That claim stopped being
+/// true of PRODUCTION at RFC-051 Phase B and RFC-053; it kept passing
+/// only because `run_e2e` pinned `cell_composition: Off` (the fossil this
+/// track killed). The candidate set this fixture really runs is the one
+/// #694's parity corpus records for `tier1_gear_am1` @ am1 under
+/// `default`: `native` produced, `cell-composed` produced, deciding stage
+/// `best-error-free`, winner `native`. The assertions below now pin THAT
+/// — including cell-composed's presence, so a re-fossilization fails here
+/// as well as at `harness_options_are_engine_defaults`.
 #[test]
 #[ntest::timeout(10000)]
 fn decomposition_search_native_candidate_fires_trace_events() {
@@ -891,26 +1020,52 @@ fn decomposition_search_native_candidate_fires_trace_events() {
         })
         .collect();
 
-    assert_eq!(scored.len(), 1,
-        "expected exactly one DecompositionCandidateScored event under Phase 0; got {scored:?}");
-    assert_eq!(scored[0].0, "native", "expected `native` candidate; got {:?}", scored[0].0);
-    assert!(scored[0].1, "Phase 0 stub should always accept");
+    // `native` is scored and accepted — the layer is wired up at all.
+    assert!(
+        scored.iter().any(|(n, accepted)| n == "native" && *accepted),
+        "expected an accepted `native` candidate; got {scored:?}",
+    );
+    // …and so is `cell-composed`, because production's default candidate
+    // set includes it (#694: `tier1_gear_am1` / am1 / `default`). This
+    // assertion is the behavioural half of the W2c fossil guard: it fails
+    // if anything pins the harness back to `cell_composition: Off`.
+    assert!(
+        scored.iter().any(|(n, _)| n == "cell-composed"),
+        "expected the `cell-composed` candidate to run under production defaults \
+         (#694 records it as `produced` for this fixture) — if it is missing, the \
+         harness has been re-pinned to a candidate set nothing ships; got {scored:?}",
+    );
 
-    assert_eq!(chosen.len(), 1,
-        "expected exactly one DecompositionChosen event; got {chosen:?}");
-    assert_eq!(chosen[0], "native", "expected `native` to win; got {:?}", chosen[0]);
+    // The cell-composed candidate runs a NESTED selection of its own, and
+    // its rows land in the same flat event stream (RFC-070 oracle gap (g)),
+    // so the OUTER selection's terminal is the LAST `DecompositionChosen`,
+    // not the only one.
+    assert!(!chosen.is_empty(), "expected at least one DecompositionChosen event");
+    assert_eq!(
+        chosen.last().map(String::as_str),
+        Some("native"),
+        "expected `native` to win the outer selection (#694: winner `native`, stage \
+         `best-error-free`); got {chosen:?}",
+    );
 }
 
 /// K-DS1-1 from `docs/rfc-decomposition-search.md`: on cases where
 /// Native produces a clean layout (no `missing-balancer-template`
-/// warnings), the search must pick `NativeCandidate`. With sequential
-/// dispatch — Native runs first, search exits early if Native is
-/// accepted — this is true by construction; the test guards against
-/// future changes that would remove that property.
+/// warnings), the search must pick `NativeCandidate`.
 ///
 /// Runs `tier3_plastic_bar` under `PartitionedDecomposed` because
 /// that's the strategy where `ModuleSizeSplit` becomes a possible
 /// competitor (under `Pooled` it's never added to the candidate list).
+///
+/// RFC-070 W2c re-pin. The old version also asserted that `native` was
+/// the ONLY candidate scored, on the reasoning that "sequential dispatch
+/// — Native runs first, search exits early if Native is accepted — makes
+/// this true by construction". That reasoning describes a candidate set
+/// nothing ships: under production defaults `cell-composed` runs here too
+/// and native still wins, so the early-exit-on-native claim was an
+/// artifact of the `cell_composition: Off` fossil, not a property of the
+/// search. What K-DS1-1 actually asserts — native wins the clean case,
+/// and `size-split-2` is not paid for on it — survives verbatim below.
 #[test]
 #[ntest::timeout(30000)]
 fn decomposition_search_picks_native_on_clean_partitioned_case() {
@@ -937,26 +1092,34 @@ fn decomposition_search_picks_native_on_clean_partitioned_case() {
             _ => None,
         })
         .collect();
-    assert_eq!(chosen.len(), 1, "expected one DecompositionChosen event; got {chosen:?}");
+    // The last terminal is the outer selection's — nested candidate
+    // selections emit their own (RFC-070 oracle gap (g)).
+    assert!(!chosen.is_empty(), "expected at least one DecompositionChosen event");
     assert_eq!(
-        chosen[0], "native",
+        chosen.last().map(String::as_str),
+        Some("native"),
         "K-DS1-1: search must pick `native` when Native produces a clean layout; \
-         got {:?}. If a non-Native candidate won, scoring or acceptance is wrong.",
-        chosen[0]
+         got {chosen:?}. If a non-Native candidate won, scoring or acceptance is wrong.",
     );
 
-    // ModuleSizeSplit should not have run at all (sequential dispatch:
-    // Native accepted → search exits). Confirms the runtime cost of the
-    // candidate is paid only on cases that need it.
+    // ModuleSizeSplit must not have run: it is the candidate this
+    // strategy makes *available*, and a clean native case must not pay
+    // for it. (Unlike the old form, this does not claim to be the only
+    // candidate that ran — `cell-composed` does, and always did in
+    // production.)
     let scored_names: Vec<_> = result.trace_events.iter()
         .filter_map(|e| match e {
             TraceEvent::DecompositionCandidateScored { name, .. } => Some(name.clone()),
             _ => None,
         })
         .collect();
-    assert_eq!(
-        scored_names, vec!["native".to_string()],
-        "expected only `native` to be scored on a clean case; got {scored_names:?}"
+    assert!(
+        scored_names.iter().any(|n| n == "native"),
+        "expected `native` to be scored; got {scored_names:?}",
+    );
+    assert!(
+        !scored_names.iter().any(|n| n == "size-split-2"),
+        "K-DS1-1: `size-split-2` must not run on a clean native case; got {scored_names:?}",
     );
 }
 
@@ -2755,6 +2918,26 @@ fn tier5_processing_unit_from_ore_am3() {
     // to Error). A SECOND detour appearing here would mean the width
     // grew again — re-trace with the same instrument rather than
     // re-blessing.
+    //
+    // 2026-08-21 (RFC-070 W2c, #689) — ADJUDICATION for
+    // `input-rate-delivery 13 -> 10`. This is the ONLY warning pin in the
+    // suite that moved when `run_e2e` stopped pinning
+    // `inserter_capacity: 0` and started running production's L2 default
+    // (2). Attributed by A/B: killing only the cells fossil leaves this
+    // pin at 13; killing only the capacity fossil takes it to 10.
+    //
+    // NOT a check going quiet (docs/validator-reporting.md). Both issue
+    // lists were decoded from snapshots and diffed instance by instance:
+    // ten iron-plate/copper-cable rows that read "across 2 inserters" at
+    // capacity 0 read "across 1 inserter" at capacity 2 — one L2 hand
+    // does the work of two L0 hands, so the row geometry places fewer,
+    // fatter inserters — and seven equivalent warnings re-appear at the
+    // shifted coordinates. Net 13 -> 10; every surviving warning still
+    // carries its own position and its own delivered-vs-needed pair
+    // (e.g. "(50,164) delivers 0.0/s but machine needs 2.4/s"). The
+    // fixture's known deficits are NOT resolved by this change and the
+    // meter's open reading on #644 is untouched: what changed is that
+    // the pin now describes the configuration production ships.
     assert_warnings_golden(&result, "tier5_processing_unit_from_ore_am3");
     assert_produces(&result, "processing-unit", 2.0);
     assert_round_trip(&result);
@@ -8972,7 +9155,12 @@ fn rfc060_sim_export() {
         for (arm, candidate) in [("on", true), ("off", false)] {
             let label = format!("{}-{}", case.name, arm);
             // Mirror run_e2e_inner exactly so the artifacts match the
-            // sweep's layouts bit for bit.
+            // sweep's layouts bit for bit. Since RFC-070 W2c that is
+            // enforced by calling the same `harness_options` builder,
+            // not by a hand-copied struct literal — the copy here had
+            // ALREADY drifted (it kept `inserter_capacity: 0` but not
+            // the cells-off fossil, so it matched neither the harness
+            // nor production).
             let solved = match solver::solve_with_exclusions(
                 case.item, case.rate, &inputs, case.machine, &FxHashSet::default(),
             ) {
@@ -8984,15 +9172,11 @@ fn rfc060_sim_export() {
             };
             let lay = match layout::build_bus_layout(
                 &solved,
-                layout::LayoutOptions {
-                    max_belt_tier: case.belt_tier.map(|s| s.to_string()),
-                    merge_tap: false,
-                    stacking: 1,
-                    inserter_capacity: 0,
-                    splitter_tap_spacers: false,
+                harness_options(HarnessOptions {
+                    belt_tier: case.belt_tier,
                     horizontal_candidate: candidate,
                     ..Default::default()
-                },
+                }),
             ) {
                 Ok(l) => l,
                 Err(e) => {

--- a/crates/core/tests/goldens/warnings/tier5_processing_unit_from_ore_am3.txt
+++ b/crates/core/tests/goldens/warnings/tier5_processing_unit_from_ore_am3.txt
@@ -1,2 +1,2 @@
 belt-detour 1
-input-rate-delivery 13
+input-rate-delivery 10

--- a/crates/core/tests/parity_corpus.rs
+++ b/crates/core/tests/parity_corpus.rs
@@ -25,9 +25,14 @@
 //! (`40fd48dc`, RFC-049 Phase 1, 2026-07-22 — the struct default WAS 0),
 //! and went stale two days later when #383 flipped the default to
 //! `common::DEFAULT_INSERTER_CAPACITY` = 2. Identical shape, identical
-//! cause. The e2e harness therefore differs from production defaults on
+//! cause. The e2e harness therefore differed from production defaults on
 //! TWO fields, not one, which is why `e2e-harness` below is its own
 //! option set rather than a synonym for `cells-off`.
+//!
+//! Past tense as of 2026-08-21: #689 track W2c killed both fossils and
+//! the harness now runs the `default` column. `e2e-harness` stays as the
+//! historical record the W2c re-blesses were adjudicated against — see
+//! the `OPTION_SETS` doc below.
 //!
 //! # What a cell records, and what it does not
 //!
@@ -272,7 +277,19 @@ const FIXTURES: &[Fixture] = &[
 /// `Off`) and `inserter_capacity: 0`; every other field it spells
 /// (`max_inserter_tier`, `quality`, `wire_mode`, `merge_tap`,
 /// `stacking`, `splitter_tap_spacers`) already equals its default.
-/// Re-run that diff if either fossil is ever fixed.
+///
+/// **Both fossils were killed on 2026-08-21 (#689 track W2c).** As of
+/// that PR the harness builds its options through
+/// `LayoutOptions::from_groups` and runs the `default` column, so
+/// `e2e-harness` no longer names a LIVE configuration — it names the
+/// HISTORICAL one the committed baseline was taken under, which is
+/// exactly what makes it the prediction the W2c re-blesses were
+/// adjudicated against. It is kept, not deleted: dropping it would
+/// silently re-take 32 cells and destroy the only record of what the
+/// fossilized suite decided. The baseline itself needed no re-bless —
+/// this file builds its option sets as closures over
+/// `LayoutOptions::default()` (below), never through `run_e2e`, so a
+/// change to the harness cannot move a cell here.
 ///
 /// The label names an OPTION SET, not a cell the harness runs (#694
 /// review round 3). It is applied across the whole machine sweep, so

--- a/crates/core/tests/parity_corpus.rs
+++ b/crates/core/tests/parity_corpus.rs
@@ -265,31 +265,40 @@ const FIXTURES: &[Fixture] = &[
 /// ladder.
 ///
 /// `e2e-harness` encodes the harness as a DELTA from `LayoutOptions::
-/// default()`, which means it is only as accurate as this list — a
-/// future change to `run_e2e_inner`'s other pinned fields, or a default
-/// flipping to match a harness value, would break the "this is what the
-/// harness runs" claim with no corpus cell moving (#694 review round 2).
-/// It cannot be asserted automatically: `run_e2e_inner` is a private fn
-/// in a different test binary. So it is hand-verified instead, and here
-/// is the receipt to re-check against — as of `a54b9a7a`,
-/// `tests/e2e.rs:342-358` differs from the struct defaults on exactly
-/// two fields, `cell_composition` (`Default::default()` → the enum's
-/// `Off`) and `inserter_capacity: 0`; every other field it spells
-/// (`max_inserter_tier`, `quality`, `wire_mode`, `merge_tap`,
-/// `stacking`, `splitter_tap_spacers`) already equals its default.
-///
-/// **Both fossils were killed on 2026-08-21 (#689 track W2c).** As of
-/// that PR the harness builds its options through
-/// `LayoutOptions::from_groups` and runs the `default` column, so
-/// `e2e-harness` no longer names a LIVE configuration — it names the
-/// HISTORICAL one the committed baseline was taken under, which is
-/// exactly what makes it the prediction the W2c re-blesses were
+/// default()`. **It no longer describes a LIVE configuration.** Both
+/// fossils it encodes were killed on 2026-08-21 (#689 track W2c): the
+/// harness now builds its options through `LayoutOptions::from_groups`
+/// and runs the `default` column. What this label names is the
+/// HISTORICAL configuration the committed baseline was taken under —
+/// which is exactly what made it the prediction W2c's re-blesses were
 /// adjudicated against. It is kept, not deleted: dropping it would
 /// silently re-take 32 cells and destroy the only record of what the
 /// fossilized suite decided. The baseline itself needed no re-bless —
 /// this file builds its option sets as closures over
 /// `LayoutOptions::default()` (below), never through `run_e2e`, so a
-/// change to the harness cannot move a cell here.
+/// change to the harness cannot move a cell here (verified empirically:
+/// `SPAGHETTIO_PARITY_CORPUS=check` passed 160/160 after W2c).
+///
+/// **SUPERSEDED — the hand-verification receipt, kept for provenance.**
+/// Everything in this paragraph describes the pre-W2c harness and is
+/// false of the current one; it is here because it is the evidence the
+/// committed cells were taken under, not as a description of today.
+/// *"…it is only as accurate as this list — a future change to
+/// `run_e2e_inner`'s other pinned fields, or a default flipping to match
+/// a harness value, would break the 'this is what the harness runs'
+/// claim with no corpus cell moving (#694 review round 2). It cannot be
+/// asserted automatically: `run_e2e_inner` is a private fn in a
+/// different test binary. So it is hand-verified instead, and here is
+/// the receipt to re-check against — as of `a54b9a7a`,
+/// `tests/e2e.rs:342-358` differs from the struct defaults on exactly
+/// two fields, `cell_composition` (`Default::default()` → the enum's
+/// `Off`) and `inserter_capacity: 0`; every other field it spells
+/// (`max_inserter_tier`, `quality`, `wire_mode`, `merge_tap`,
+/// `stacking`, `splitter_tap_spacers`) already equals its default."*
+/// That struct literal no longer exists, and the harness spells none of
+/// those fields any more (#699 review round 3 — the correction used to
+/// be appended AFTER the receipt, leaving two mutually exclusive
+/// descriptions in one docblock).
 ///
 /// The label names an OPTION SET, not a cell the harness runs (#694
 /// review round 3). It is applied across the whole machine sweep, so

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1061,8 +1061,14 @@ fixtures / docs split per the churn norm).
   additive (the cap-only and both-fossils fingerprints differ in one
   fixture, the one cells moves).
   * **Capacity `0` → `2`** moves 6 of 8 golden hashes and 8 of 8 stress
-    hashes — every fixture with an inserter-fed row. It changes no
-    winner and no deciding stage anywhere. The two fluid-target goldens
+    hashes — every fixture with an inserter-fed row — while changing no
+    winner and no deciding stage **on any (fixture, machine) pair the
+    suite runs**. That scoping is load-bearing and the first draft of
+    this entry dropped it (#699 review round 4): the corpus DOES record
+    two capacity-attributable winner changes, both at am3, on fixtures
+    the suite invokes at am1/am2. "Additive" likewise means the two
+    fossils' effects on the SUITE compose without interacting, not that
+    either is inert. The two fluid-target goldens
     (`tier3_sulfuric_acid`, `tier3_heavy_oil_cracking`) are the negative
     control: byte-identical under both arms.
   * **Cells `Off` → `Candidate`** moves exactly ONE layout in the whole
@@ -1116,19 +1122,40 @@ fixtures / docs split per the churn norm).
 
   The cell-composed winner **under-delivers by 25 %**, validator-clean,
   and production has shipped it since RFC-051 Phase B flipped
-  `cell_composition` on 2026-07-22. **The fossil was not merely hiding a
-  candidate arm — it was hiding a live defect in that arm's only shipped
-  win.** Filed as #700 with the reproduction; a `#[ignore]`d exporter
-  (`w2c_gear20_meter_export`) is committed so the reading is re-takeable
-  from a clean clone. The golden re-bless still stands — a golden records
-  what the engine produces, and this is what it produces — but the
-  fixture's comment now says so, including that its
-  `assert_produces(…, 20.0)` passes on a 15/s layout because it reads a
-  static estimate.
+  `cell_composition` on 2026-07-22.
 
-  This is the strongest possible argument for the track: the suite could
-  not see the defect, and a single instrument the suite does not run
-  found it in one command.
+  **CORRECTION, and it makes the finding better rather than worse
+  (#699 review round 4 prompted the check).** The first draft of this
+  entry presented the deficit as newly discovered. It was not: **W1a
+  found it on day one.** #693's own table reports `gear20-am2-plate` at
+  20.000 planned / 15.000 produced / **−25.0 % BELOW PLAN**, and the
+  committed tripwire baseline
+  (`crates/meter/tests/e2e_tripwire_baseline.json`) carries the row ARMED
+  at `entities: 105, deficit_pct: -25.0, converged: true`. The reading
+  above reproduces that baseline exactly, which is corroboration, not
+  novelty. There is therefore no "prose-only guard" gap either: `check`
+  fails on that row worsening, today, without this PR.
+
+  **What W2c actually adds is the attribution, and it is the sharper
+  fact.** The tripwire's row says 105 entities. The e2e suite's
+  `tier1_iron_gear_wheel_20s` golden, before this PR, pinned 148. *Same
+  item, same rate, same machine, same inputs — two different layouts,
+  under two instruments, neither able to see the other.* The tripwire
+  built `LayoutOptions::default()` (production: cell-composed, −25 %);
+  the e2e fixture built the fossil's options (native, +5 %). Nobody
+  joined "the meter says gear@20 is 25 % down" to "the regression suite
+  says gear@20 is fine" because they were not talking about the same
+  artifact. **That** is what the fossil cost, and it is exactly the class
+  of thing a campaign about one selection loop exists to remove. Filed as
+  #700; a `#[ignore]`d exporter (`w2c_gear20_meter_export`) is committed
+  so the three arms are re-measurable side by side, which is what makes
+  the divergence checkable rather than narrated.
+
+  The golden re-bless stands — a golden records what the engine produces,
+  and this is what it produces — but the fixture's comment now says so,
+  including that its `assert_produces(…, 20.0)` passes on a 15/s layout
+  because it reads a static estimate, and names all five coupled
+  artifacts a #700 fix has to move (the tripwire row among them).
 
   **SECOND FINDING — the stage-5 policy this exposes.** On
   `tier1_iron_gear_wheel_20s` the outer board records native with
@@ -1305,3 +1332,37 @@ fixtures / docs split per the churn norm).
     documented: it is the historical record the W2c re-blesses were
     adjudicated against, and deleting it would re-take 32 cells and
     destroy the only evidence of what the fossilized suite decided.
+
+  **#699 review rounds 3 and 4 absorbed** (4 + 5 findings; the reviewer
+  states none blocks merge). Three produced real corrections:
+  * *(round 3, minor — a defect this PR introduced)* `parity_corpus.rs`'s
+    `OPTION_SETS` docblock said both things at once: round 1 appended the
+    "both fossils are dead, this column is historical" correction AFTER
+    the pre-W2c hand-verification receipt, leaving two mutually exclusive
+    descriptions of the same label with no way to tell which was current.
+    Restructured — live statement leads, receipt kept behind an explicit
+    SUPERSEDED heading as provenance for the committed cells.
+  * *(round 4, minor, 3/3 — correct, and measured)* The two re-pinned
+    decomposition tests' "two independent terminal emitters corroborate"
+    claim is **vacuous on those fixtures**: both emit exactly ONE
+    `DecompositionChosen` and ONE `SelectionDecided`, because `native`
+    wins and nests nothing — the cell-composed candidate runs and loses,
+    and `run_candidate` truncates a loser's nested block (oracle gap
+    (g)). Verified from a decoded snapshot. The check is kept as a guard
+    that arms itself if a nesting candidate ever wins those fixtures, and
+    the comments now say plainly that today's weight is carried by the
+    STAGE pin and the cell-composed-presence assertion; the fixture where
+    the ordering IS exercised is `tier1_iron_gear_wheel_20s`.
+  * *(round 4, docs-only, 1/3)* The capacity-arm claim "changes no winner
+    and no deciding stage anywhere" was over-broad — corrected above to
+    scope it to the (fixture, machine) pairs the suite runs, since the
+    corpus records two capacity-attributable winner changes at am3.
+  Absorbed as scoping rather than mechanism: the residual-literal guard's
+  reach is now stated as "a textual copy of these two lines cannot be
+  added silently" (not "the fossil cannot come back"), with the
+  `include_str!` binary cost noted; `run_e2e_pure_combo`'s note now
+  covers the inserter ladder as well as the candidate set; the gear@20
+  pin's failure message enumerates all five coupled artifacts. The
+  restated ordering residual and the restated in-suite-tripwire major are
+  answered by the correction above — the armed guard is W1a's tripwire
+  row, which predates this PR.

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1532,3 +1532,24 @@ fixtures / docs split per the churn norm).
     with `=` instead of `:`.
   * *(minor)* format fragility of the gauge — already documented, and
     narrowed rather than removed by the substring form.
+
+  **#699 review round 9** — five findings, four of them verbatim
+  restatements of residuals the code comments they quote already state
+  (the delivery-guard major for the sixth time, the vacuous corroboration,
+  the `#[ignore]`d exporter not running in CI, the gauge being textual not
+  semantic). One correction accepted: the gauge's doc said "raising a
+  count means a new copy of a known trap — don't", which forbids a
+  legitimate case — RFC-049's unresearched world is a valid subject, and a
+  test about it needs the literal. Rewritten: raising is allowed on the
+  record, naming the test and why the value is load-bearing. The point of
+  the gauge is that a copy-paste arrives with a reason attached, not that
+  the count only ever falls.
+
+  **Review rounds closed at 9.** Rounds 1, 5, 7 and 8 each found something
+  real (the missing meter anchor → #700; the stale W2a "zero production
+  callers" claim; two sweeps reading the nested winner; a self-counting
+  gauge). Round 9 produced one doc correction and four restatements, which
+  is the signal that the seam is worked out. The standing residuals — no
+  core-side delivery gate, a textual rather than semantic fossil gauge, an
+  opt-in meter tripwire — are recorded above with their reasons and are
+  not W2c's to close.

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1044,8 +1044,15 @@ fixtures / docs split per the churn norm).
   spaghettio_core -- -D warnings` clean, all PR CI checks (`rust`,
   `rust-clippy`, `web`, `second-opinion`, `deploy-preview`,
   `workflow-guard`) green on the prior commit.
-- *2026-08-21 — **W2c: both `run_e2e` fossils killed; the suite now runs
-  production defaults.** `run_e2e_inner` builds its `LayoutOptions` through
+- *2026-08-21 — **W2c: both `run_e2e` fossils killed; the `run_e2e*`
+  HARNESS now runs production defaults.** Scoped deliberately (#699 review
+  round 6 flagged the first wording, "the suite now runs production
+  defaults", as overstating what the body itself measures): 15 other tests
+  in `tests/e2e.rs` still build their own `LayoutOptions` with
+  `cell_composition: Off` / `inserter_capacity: 0` and are pinned, not
+  migrated. Every fixture routed through `run_e2e*` — which is every tier
+  and stress fixture — does run production defaults.
+  `run_e2e_inner` builds its `LayoutOptions` through
   `LayoutOptions::from_groups` (the #696 scaffolding's first production
   caller) via a new `harness_options(HarnessOptions { .. })` helper, so
   every field the harness does not deliberately override is the engine's
@@ -1213,11 +1220,18 @@ fixtures / docs split per the churn norm).
   the fossilized suite decided — the file's doc comments were updated to
   say so instead of continuing to claim a present-tense fossil.
 
-  **Pre-existing flake noted, not caused**: `tier2_electronic_circuit_20s_from_ore`
-  carries `#[ntest::timeout(10000)]` and tripped it at 10003 ms on the
-  BASELINE (pre-change) parallel run while passing solo in 0.63 s. It
-  passed on every post-change run. Wall-clock timeouts on a loaded box are
-  a suite-wide hazard the extra candidate makes marginally worse.
+  **Pre-existing flake, made marginally worse, now fixed for the three
+  fixtures that showed it.** `tier2_electronic_circuit_20s_from_ore`
+  carried `#[ntest::timeout(10000)]` and tripped it at 10003 ms on the
+  BASELINE (pre-change) parallel run and again at 10001 ms on a later
+  post-change run, while passing SOLO in 0.63 s. `ntest::timeout` is
+  wall-clock, so on a loaded box the budget, not the work, is binding —
+  and restoring the cell-composed candidate adds a layout pass to every
+  fixture. Raised to 60 s here, and 10 s → 30 s / 30 s → 60 s on the two
+  re-pinned decomposition tests (#699 review round 2 predicted exactly
+  this). **Residual, not fixed**: 60-odd other tests in the file carry the
+  same 10 s wall-clock budget and are subject to the same hazard; a
+  blanket raise is housekeeping for its own change, not a rider here.
 
   **#699 review round 1 absorbed** (7 findings, 1 union-major + 6 minor,
   all absorbed, none refuted — the major paid out immediately):
@@ -1366,3 +1380,77 @@ fixtures / docs split per the churn norm).
   restated ordering residual and the restated in-suite-tripwire major are
   answered by the correction above — the armed guard is W1a's tripwire
   row, which predates this PR.
+
+  **#699 review rounds 5 and 6 absorbed** (6 + 6 findings). Four produced
+  real changes, and one produced the best single detail in the whole
+  campaign so far:
+  * *(round 6, minor, 2/2 — asked as a question, answered with a
+    receipt)* "How does the same layout score `layout_warnings: 1` at
+    selection and 0 at validation?" No contradiction — different fields
+    (`LayoutResult.warnings` is the producer's own list; `validate()`'s
+    issues are the 39 functional checks, which is what the warning golden
+    counts). **But the one entry is the story**: decoded from the
+    snapshot, gear@20's winning cell-composed candidate carries
+    `"cell-composed: geometry NOT sim-verified (hash c5c5f88087df894c) —
+    run spaghettio-sim and add the entry to cell-sim-registry.json"`.
+    RFC-051's own machinery flagged this exact geometry as unverified;
+    `best-error-free` filters on errors and ranks on score with warnings
+    taking no part; and the thing it was not verified for is precisely
+    what the meter measured. That is the sharpest available argument for
+    W2b's severity-aware verdict, and it was sitting in the trace the
+    whole time.
+  * *(round 5, minor, 1/3 — correct, and my own bug class in W2a's file)*
+    `bus/layout.rs`'s legend said "**Zero production callers as of this
+    PR**" about `from_groups`. This PR makes `e2e.rs` the first caller, so
+    the sentence became false in the same diff that falsified it.
+    Replaced with an adoption-status list naming the caller, the two
+    exporters, and what is still open.
+  * *(round 5, major, 3/3, fourth restatement — answered with code)*
+    `assert_produces(…, 20.0)` was deleted from
+    `tier1_iron_gear_wheel_20s`. It reads `analysis.throughput_estimates`
+    — a static estimate from the machine count — and asserted "produces
+    20/s" about a layout the meter reads at 15/s: a green assertion
+    saying the opposite of the measurement. Replaced by an inline check of
+    the same number under a message that names it a PLAN check, states the
+    measured 15.0/s and the tripwire row, and says not to read the test
+    passing as delivery. Rejected alternative recorded at the call site:
+    metering in-suite would close a dev-dependency cycle
+    (`spaghettio_meter` → `spaghettio_core`) to duplicate a guard that
+    already exists armed.
+  * *(round 6, minor, 1/2 — correct, and fixed structurally rather than
+    by assertion)* Round 2 had added two guard assertions pinning
+    `LayoutStrategy::Pooled` and `horizontal_candidate == true`, because
+    every `run_e2e*` wrapper spelled those as hard literals. Round 6
+    pointed out that an assertion re-spelling an engine default is itself
+    a second copy of it. So the wrappers were fixed instead: `run_e2e_inner`
+    now takes one `HarnessOptions`, and every wrapper spells only what it
+    deliberately varies (`run_e2e_pure_combo`'s `horizontal_candidate:
+    false` is the sole non-default in any of them), leaving the rest to
+    `HarnessOptions::default()`, which reads the engine's group defaults
+    at runtime. The two assertions were deleted as redundant. **Verified
+    behaviour-neutral**: a full golden+STRESSGOLD fingerprint run before
+    and after the refactor is byte-identical on all 8 + 8 hashes. The
+    stale `#[allow(clippy::too_many_arguments)]` went with the four
+    dropped params.
+  * *(round 5, major, 1/3)* `full_knob_sweep`'s markdown now stamps an
+    "Option-set epoch: post-RFC-070-W2c" banner into the ARTIFACT — these
+    tables get pasted into issues, where a doc comment on
+    `run_e2e_pure_combo` is invisible.
+  * *(round 6, major, 2/2, fifth restatement — REFUTED with a receipt)*
+    "the pin monitors who wins, not whether it delivers, and the meter
+    tripwire never runs under `cargo test -p spaghettio_core`." Both true.
+    The tripwire being opt-in is a **standing project decision with its
+    own recorded reasoning**, not an oversight of this track:
+    `e2e_tripwire.rs`'s "Why report-only stays the default, and this is
+    NOT wired into CI as a gate" — gating a host-cache-relative instrument
+    with no track record repeats #632 B7's mistake, and promoting `check`
+    is named there as future work. Overturning it is not W2c's to do. The
+    residual is real and recorded: a further regression from 15.0 to, say,
+    13.5 would pass every core-suite check. That is an argument for
+    promoting the tripwire, which belongs with whoever owns the gate.
+  * *(round 6, minor, 1/2, REFUTED)* "no fixture-level ancestry is
+    recorded for the non-golden-pinned fixtures." The per-fixture stress
+    deltas ARE recorded above (ec22 5→4, ec23 7→6, ec40 283→235, entity
+    counts on all 8), measured under the new config, with the direction
+    stated and the alarm condition (a category reaching zero) checked and
+    absent.

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1235,3 +1235,73 @@ fixtures / docs split per the churn norm).
     expected, not unexplained: warning pins record a per-category TALLY,
     and a geometry change that leaves the tally alone leaves the pin alone.
     Only tier5's tally moved.
+
+  **#699 review round 2 absorbed** (8 findings: 2 major, 6 minor; 6
+  absorbed with code, 2 refuted with receipts):
+  * *(major, 3/3)* **"the suite now permanently endorses a known-broken
+    artifact with no in-suite tripwire — the only guard is prose and an
+    external issue number."** Correct, and the fix is an assertion, not
+    more prose: `tier1_iron_gear_wheel_20s` now PINS its outer selection
+    (`cell-composed` at `best-error-free`) with a message naming #700 and
+    telling whoever moves it — including whoever FIXES #700 — to re-take
+    the meter reading rather than re-bless on greenness. Neither existing
+    assertion could say that: the golden hash's message asks whether the
+    change was intentional, and `assert_produces` reads a static estimate
+    the meter contradicts. Discrimination check executed: restoring the
+    cells fossil fails it with `Some(("native", BestAccepted))` vs
+    `Some(("cell-composed", BestErrorFree))`.
+  * *(major, 2/3)* *"this cements a new baseline that should be treated as
+    provisional until #700 lands"* — agreed, and now literally true: the
+    pin above is what makes it provisional rather than silent.
+  * *(minor, 1/3)* *"`harness_options_are_engine_defaults` only exercises
+    the default path; the four fields the wrappers pass explicitly could
+    go stale unseen."* **The best finding of the round** — the guard did
+    have that hole. Two of the four are HARD LITERALS in every wrapper
+    (`LayoutStrategy::Pooled`, `true`), which is the same fossil shape one
+    level out; the guard now asserts the engine defaults still equal them.
+    The other two (`row_layout`, `surplus_policy`) are passed as
+    `::default()` and follow a flip on their own — stated, so the absence
+    is not read as an oversight.
+  * *(minor, 2/3)* *"the residual pin counts deliberate test vectors as
+    fossils, and its 'lower the number' policy would push someone to
+    convert a deliberate low-capacity behaviour test."* The specific
+    example is shaky (`stacking_refuses_low_inserter_cap`'s refusal
+    predicate names `max_inserter_tier`, not the capacity) but the hazard
+    is real and unaudited. The doc now claims only what was checked — none
+    carries a COMMENT explaining its value, no per-site audit was done —
+    and the guidance is rewritten: decide per site whether the value is
+    load-bearing, document it and lower the count if so, migrate if not,
+    and name the site in the commit either way.
+  * *(minor, 1/3)* *"both re-pinned tests gained a full extra layout pass
+    under wall-clock timeouts on a box this PR itself records flaking at
+    10003 ms."* Correct and cheap: 10 s → 30 s and 30 s → 60 s. Both run
+    in ~0.02 s, so the raised budgets still catch a ~1000x regression.
+  * *(minor, 1/3)* *"`run_e2e_pure_combo` silently breaks its 'pure'
+    contract."* Half right. "Pure" is documented as *the horizontal-stack
+    candidate off*, which is still exactly what it does; `cell-composed`
+    was never part of that contract and was absent by fossil, from the
+    baseline columns AND the `default` column alike. Disabling it in the
+    pure columns only would break the apples-to-apples comparison the
+    sweep exists for, so no override — but the doc now says precisely what
+    "pure" means and warns that `full_knob_sweep` tables from before
+    2026-08-21 are not comparable to ones after.
+  * *(minor, 1/3, REFUTED with an acknowledged residual)* *"a consistent
+    reversal of both terminal emitters sails through the corroboration."*
+    True, and already stated in the test's own comment. Corroboration
+    narrows a failure mode, it does not remove it, and it cannot be
+    removed from a test: the fix is a structural nesting marker in the
+    trace contract, which is Phase 1b/2a's to own. Strengthened as far as
+    a test can go — the STAGE is pinned too, so "read the nested board
+    instead" shows up as a stage mismatch (gear@20's nested board decides
+    at `best-accepted`, the outer at `best-error-free`).
+  * *(nit, REFUTED)* *"nothing re-derives tier5's 10; the answer lives
+    only in the RFC."* The committed warning pin
+    (`tests/goldens/warnings/tier5_processing_unit_from_ore_am3.txt`) is
+    re-derived and asserted on every suite run — that is what
+    `assert_warnings_golden` does. The RFC carries the ADJUDICATION, which
+    is a different artifact from the value.
+  * *(nit, REFUTED)* *"the corpus's `e2e-harness` column keeps generating
+    a baseline for a candidate set nothing ships."* Deliberate and
+    documented: it is the historical record the W2c re-blesses were
+    adjudicated against, and deleting it would re-take 32 cells and
+    destroy the only evidence of what the fossilized suite decided.

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1098,8 +1098,37 @@ fixtures / docs split per the churn norm).
   — it is silent, and the one cell where the campaign's headline flip
   changes a shipped artifact is the cell it does not cover. Recommendation
   for W3a: add gear@20/am2 to the corpus before the shadow loop gates on
-  it. Adjudicated on its own evidence instead: both arms error- and
-  warning-free, the winner is smaller and denser, so the re-bless stands.
+  it.
+
+  **FINDING — and the corpus hole was hiding a real defect (#700).** The
+  first version of this entry adjudicated that re-bless on validator
+  evidence alone: both arms error- and warning-free, the winner smaller
+  and denser. #699's review round 1 refused that reasoning — correctly,
+  per the verification protocol: the validator cannot CLEAR a layout. So
+  the layout was metered. Three arms, `measure(108_000, 216_000)`, no
+  notes:
+
+  | arm | cells | capacity | entities | validator | meter |
+  |---|---|---|---|---|---|
+  | production today | `Candidate` | 2 | 105, 38×14 | 0 issues | **15.0 / 20.0 — 75 %** |
+  | cells disabled | `Off` | 2 | 148, 47×8 | 0 issues | 21.0 / 20.0 |
+  | pre-W2c golden | `Off` | 0 | 148, 47×8 | 0 issues | 21.0 / 20.0 |
+
+  The cell-composed winner **under-delivers by 25 %**, validator-clean,
+  and production has shipped it since RFC-051 Phase B flipped
+  `cell_composition` on 2026-07-22. **The fossil was not merely hiding a
+  candidate arm — it was hiding a live defect in that arm's only shipped
+  win.** Filed as #700 with the reproduction; a `#[ignore]`d exporter
+  (`w2c_gear20_meter_export`) is committed so the reading is re-takeable
+  from a clean clone. The golden re-bless still stands — a golden records
+  what the engine produces, and this is what it produces — but the
+  fixture's comment now says so, including that its
+  `assert_produces(…, 20.0)` passes on a 15/s layout because it reads a
+  static estimate.
+
+  This is the strongest possible argument for the track: the suite could
+  not see the defect, and a single instrument the suite does not run
+  found it in one command.
 
   **SECOND FINDING — the stage-5 policy this exposes.** On
   `tier1_iron_gear_wheel_20s` the outer board records native with
@@ -1162,3 +1191,47 @@ fixtures / docs split per the churn norm).
   BASELINE (pre-change) parallel run while passing solo in 0.63 s. It
   passed on every post-change run. Wall-clock timeouts on a loaded box are
   a suite-wide hazard the extra candidate makes marginally worse.
+
+  **#699 review round 1 absorbed** (7 findings, 1 union-major + 6 minor,
+  all absorbed, none refuted — the major paid out immediately):
+  * *"the re-bless rests on validator evidence and the docs say the
+    validator cannot clear a layout; no meter/sim reading is recorded"* —
+    correct, and the meter run it forced produced #700 above. The fix is
+    the measurement plus a committed exporter, not prose.
+  * *"the fossil PATTERN survives at ~a dozen other call sites in the same
+    file, so 'both fossils killed' overstates coverage"* (3/3 passes) —
+    correct and verified: **14 `cell_composition: Default::default()` and
+    14 `inserter_capacity: 0` literals remain, across 15 distinct tests**
+    (the horizontal-stack tier4/tier5 trio, the four `quality_*`, the six
+    `stacking_*`, `research_l7_thins_output_inserters_s4`,
+    `rfc061_allocation_probe_ac5`). None documents its value as
+    deliberate; every one is a copy of `run_e2e_inner`'s old literal.
+    Not migrated here — each carries its own pins, so flipping them is a
+    second adjudication of this PR's size, not a rider on it. Instead the
+    residual is now PINNED by a non-ignored test
+    (`residual_fossil_literals_are_pinned`) that reads its own source and
+    fails if either count moves, with the reduction direction spelled out.
+    The claim itself is scoped to the `run_e2e` path everywhere it appears.
+  * *"`chosen.last()` is an ordering-dependent oracle"* (2/3) — true. The
+    ordering IS a stated contract (`trace.rs`'s
+    `SelectionCandidateEvaluated` doc: terminals emitted adjacently at the
+    very end, nested selections replayed inside the winner's events) and
+    the #694 census reads the corpus by the same rule, but "stated" is not
+    "checked". Both tests now corroborate across the two INDEPENDENT
+    terminal emitters (`DecompositionChosen` and `SelectionDecided`) and
+    the first also pins the deciding STAGE against #694's row, so a
+    reordering has to break both emitters identically to slip through.
+  * *"`harness_options_are_engine_defaults` is self-referential"* — partly:
+    it compared against the group `Default` impls, a second hand-written
+    copy of the engine defaults. Now compares against
+    `LayoutOptions::default()`'s own views, which is the value the engine
+    ships. (Group-vs-`LayoutOptions` agreement stays #696's
+    `layout_options_group_defaults_match_facade`'s job.)
+  * *"`rfc060_sim_export`'s artifacts silently change with no pin"* — true
+    and worth a warning rather than a pin: the recorded K60-3 numbers were
+    measured on capacity-0 artifacts, so post-2026-08-21 exports are not
+    comparable to them. Stated in the exporter's doc.
+  * The nit *"tier2's warning pin didn't move while its hash did"* is
+    expected, not unexplained: warning pins record a per-category TALLY,
+    and a geometry change that leaves the tally alone leaves the pin alone.
+    Only tier5's tally moved.

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1388,7 +1388,7 @@ fixtures / docs split per the churn norm).
     receipt)* "How does the same layout score `layout_warnings: 1` at
     selection and 0 at validation?" No contradiction — different fields
     (`LayoutResult.warnings` is the producer's own list; `validate()`'s
-    issues are the 39 functional checks, which is what the warning golden
+    issues are the 37 functional checks, which is what the warning golden
     counts). **But the one entry is the story**: decoded from the
     snapshot, gear@20's winning cell-composed candidate carries
     `"cell-composed: geometry NOT sim-verified (hash c5c5f88087df894c) —

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1405,7 +1405,8 @@ fixtures / docs split per the churn norm).
     the sentence became false in the same diff that falsified it.
     Replaced with an adoption-status list naming the caller, the two
     exporters, and what is still open.
-  * *(round 5, major, 3/3, fourth restatement — answered with code)*
+  * *(round 5, major, 3/3, fourth restatement — answered with code, and
+    then that answer's claim was corrected in round 8)*
     `assert_produces(…, 20.0)` was deleted from
     `tier1_iron_gear_wheel_20s`. It reads `analysis.throughput_estimates`
     — a static estimate from the machine count — and asserted "produces
@@ -1416,7 +1417,14 @@ fixtures / docs split per the churn norm).
     passing as delivery. Rejected alternative recorded at the call site:
     metering in-suite would close a dev-dependency cycle
     (`spaghettio_meter` → `spaghettio_core`) to duplicate a guard that
-    already exists armed.
+    already exists armed. **Round-8 correction, accepted**: the first
+    wording of this bullet said the false delivery signal was "killed at
+    the call site". It was not — the assertion is still GREEN on the 15/s
+    layout, and nothing in `crates/core`'s suite can fail on delivery
+    because nothing in it measures delivery. What changed is that the
+    suite no longer ASSERTS something false. The honest claim is "the
+    suite no longer says this layout produces 20/s", and it is now written
+    that way both here and at the call site.
   * *(round 6, minor, 1/2 — correct, and fixed structurally rather than
     by assertion)* Round 2 had added two guard assertions pinning
     `LayoutStrategy::Pooled` and `horizontal_candidate == true`, because
@@ -1454,3 +1462,73 @@ fixtures / docs split per the churn norm).
     counts on all 8), measured under the new config, with the direction
     stated and the alarm condition (a category reaching zero) checked and
     absent.
+
+  **#699 review round 7 absorbed** (7 findings; three were checkable
+  facts and all three checked out — the round paid for itself):
+  * *(major, 1/3 — a defect THIS change introduced)*
+    `scoreboard_strategy_sweep` and `full_knob_sweep` read their
+    `candidate` column with `find_map` from the FRONT of the event
+    stream. A winning candidate that nests replays its inner events
+    first, so from-the-front reports the NESTED winner. Harmless while
+    `run_e2e` pinned `cell_composition: Off` and nothing nested —
+    restoring the candidate makes both sweeps print "native" for exactly
+    the fixtures where cell-composed wins, i.e. the one thing this track
+    is about. Both switched to `.rev().find_map(…)`, matching
+    `parity_corpus.rs` and the re-pinned tests. A stale "Phase 0: always
+    native" comment above one of them went too. **Worth noting as a
+    pattern**: this is the third place in the campaign where the
+    nested-replay ordering has bitten a reader of the event stream
+    (oracle gap (g), the census's last-seven rule, and now these two
+    columns). A structural nesting marker in the trace contract would
+    retire the whole class; Phase 1b/2a owns it.
+  * *(major, 1/3)* "39 functional checks" was stale in two comments this
+    PR added — it is **37**. Verified twice: `CLAUDE.md` says 37 in three
+    places, `validate/mod.rs` dispatches 37 `Box::new` closures.
+  * *(minor, 1/3)* `tier5`'s 2026-08-17 ACCEPTED block still read
+    "input-rate-delivery is unchanged at 13" immediately above the new
+    "13 → 10" adjudication. Rewritten as of-its-date with a pointer — a
+    grep landing on the stale sentence would have read it as current.
+  * *(minor, 1/3, REFUTED with the receipt, and the receipt written
+    down)* "same 12.3 % density is unverified; naive entities/(w·h) gives
+    39 % vs 20 %." `density::score_density(_, (1,1))` normalises to a 1:1
+    SQUARE bounding box and counts filled TILES: `260 filled / 2116` and
+    `169 filled / 1369`, both 12.3 %, printed by the harness on both arms.
+    Now stated at the call site.
+  * *(nit)* `w2c_gear20_meter_export` now ASSERTS 105/148/148 entities and
+    zero issues per arm rather than printing them: its doc table pairs
+    each arm's entity count with a meter reading, so a silently reshaped
+    arm would leave a committed number attached to a different artifact —
+    the exact 105-vs-148 confusion the exporter exists to expose.
+  * *(minor)* The residual guard's blind-spot list gained a spelled-out
+    `CellComposition::Off`; the negative-control asymmetry
+    (`tier3_sulfuric_acid` capacity-invariant while `tier3_plastic_bar`
+    moved) is now marked explicitly UNEXPLAINED, with the plausible
+    bottom-rung story labelled unmeasured and a note not to "fix" either
+    hash on the strength of it.
+
+  **#699 review round 8 absorbed** (single pass; verdict "unusually
+  well-vetted change… no crash or contract violation found", with an
+  explicit verified-clean list covering the wrapper refactor, the
+  `from_groups` field mapping, the re-blesses and the residual counts).
+  Three findings, two of them real:
+  * *(major)* "the false delivery signal was renamed, not killed."
+    **Correct** — the corrected wording is recorded above and at the call
+    site. Nothing in `crates/core`'s suite can fail on delivery; the
+    assertion was relabelled so it stops asserting something false.
+  * *(minor, and the most useful of the round)* the residual gauge was
+    pointed at the wrong shape. It matched exact TRIMMED LINES, so the
+    group-level partial
+    `SearchAxes { cell_composition: Default::default(), ..SearchAxes::default() }`
+    — which `from_groups`, now the *recommended* constructor, makes the
+    likeliest way the fossil returns — slipped through unless rustfmt
+    happened to break it across lines. Rewritten to match non-comment
+    lines CONTAINING either pattern. **Discrimination check executed**: a
+    single-line group partial takes the count 14 → 15. Two second-order
+    fixes fell out of that, and the first is the interesting one: the
+    substring gauge initially read 16/15 because it was **counting its own
+    assertion messages and a provenance banner** — a self-counting gauge
+    is worse than none, since it is wrong in the "looks fine" direction.
+    Needles are now assembled at runtime and the prose spells the fields
+    with `=` instead of `:`.
+  * *(minor)* format fragility of the gauge — already documented, and
+    narrowed rather than removed by the substring form.

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1044,3 +1044,121 @@ fixtures / docs split per the churn norm).
   spaghettio_core -- -D warnings` clean, all PR CI checks (`rust`,
   `rust-clippy`, `web`, `second-opinion`, `deploy-preview`,
   `workflow-guard`) green on the prior commit.
+- *2026-08-21 — **W2c: both `run_e2e` fossils killed; the suite now runs
+  production defaults.** `run_e2e_inner` builds its `LayoutOptions` through
+  `LayoutOptions::from_groups` (the #696 scaffolding's first production
+  caller) via a new `harness_options(HarnessOptions { .. })` helper, so
+  every field the harness does not deliberately override is the engine's
+  own default. `cell_composition` `Off` → `Candidate`; `inserter_capacity`
+  `0` → `DEFAULT_INSERTER_CAPACITY` (2). `rfc060_sim_export`'s hand-copied
+  "mirror run_e2e_inner exactly" literal — which had ALREADY drifted, keeping
+  `inserter_capacity: 0` but not the cells fossil, so it matched neither the
+  harness nor production — now calls the same helper.
+
+  **Blast radius, measured by A/B rather than assumed.** Three full
+  `--test e2e` runs under the pinned CI zone cache: cells-fossil-killed
+  only, capacity-fossil-killed only, and both. The two effects are exactly
+  additive (the cap-only and both-fossils fingerprints differ in one
+  fixture, the one cells moves).
+  * **Capacity `0` → `2`** moves 6 of 8 golden hashes and 8 of 8 stress
+    hashes — every fixture with an inserter-fed row. It changes no
+    winner and no deciding stage anywhere. The two fluid-target goldens
+    (`tier3_sulfuric_acid`, `tier3_heavy_oil_cracking`) are the negative
+    control: byte-identical under both arms.
+  * **Cells `Off` → `Candidate`** moves exactly ONE layout in the whole
+    suite: `tier1_iron_gear_wheel_20s`, where `cell-composed` now wins the
+    outer selection (`SelectionDecided { winner: cell-composed, stage:
+    best-error-free }`, score 0.1129 vs native's 0.1081) — 148 entities /
+    47×8 → 105 / 38×14, same 12.3 % density, zero validation issues on
+    both. Everywhere else the cell-composed candidate runs, is scored, and
+    loses, exactly as RFC-051's "strictly additive" flip claimed.
+
+  **Adjudication against #694.** The corpus's `e2e-harness` → `default`
+  delta is 7 verdict-differing rows of 32: two winner changes
+  (`e2e_tier2_electronic_circuit_20s_from_ore`/am3 and
+  `tier2_ec_am1_10_ore`/am3, both native → direct-insertion, both
+  capacity-attributable — they also differ `cells-off` vs `e2e-harness`)
+  and five stage-only changes (`best-accepted` → `best-error-free`, winner
+  `native` throughout: `tier1_gear_am1` ×3 tiers, `tier3_plastic_cp_5`,
+  `e2e_tier3_plastic_bar_from_crude`), which are the cell-composed
+  candidate giving the `best-error-free` stage something to decide on
+  instead of falling through. **Both winner changes are at am3, a tier the
+  suite never invokes for those fixtures**, so the corpus predicts zero
+  winner changes among the (fixture, machine) pairs `e2e.rs` actually runs
+  — and zero materialized. 6 golden re-blesses, 1 warning-pin re-bless, 2
+  test re-pins; every one traced to the prediction or to the corpus hole
+  below. Prediction-match rate on corpus-covered fixtures: 5/5 (the four
+  golden-pinned fixtures with an exact corpus row, plus tier5's pin).
+
+  **FINDING — corpus hole.** The one winner change the flip produces,
+  `tier1_iron_gear_wheel_20s` (gear @ 20/s, am2, from iron-plate), has NO
+  row in the #694 corpus: the corpus carries gear @ 10/s (`tier1_gear_am1`,
+  `e2e_tier1_iron_gear_wheel_from_ore`) and nothing at 20/s. Its nearest
+  covered neighbours all predict `native`, so the corpus is not falsified
+  — it is silent, and the one cell where the campaign's headline flip
+  changes a shipped artifact is the cell it does not cover. Recommendation
+  for W3a: add gear@20/am2 to the corpus before the shadow loop gates on
+  it. Adjudicated on its own evidence instead: both arms error- and
+  warning-free, the winner is smaller and denser, so the re-bless stands.
+
+  **SECOND FINDING — the stage-5 policy this exposes.** On
+  `tier1_iron_gear_wheel_20s` the outer board records native with
+  `layout_warnings: 0` and cell-composed with `layout_warnings: 1`, and
+  `best-error-free` picks cell-composed anyway, on score. The stage
+  discriminates on ERRORS and then ranks on score; warnings do not
+  participate. That is a real property of today's precedence, surfaced
+  (not introduced) by this PR, and it is squarely W2b/`SelectionPolicy`
+  territory — recorded here rather than acted on.
+
+  **Two tests re-pinned, not overridden.** No test got a deliberate
+  old-behaviour override — the two that failed were asserting the fossil
+  itself, and pinning them to `cells-off` would have preserved the fossil
+  in precisely the two tests that describe the candidate set.
+  `decomposition_search_native_candidate_fires_trace_events` asserted
+  "exactly one `DecompositionCandidateScored` under Phase 0"; production
+  has run more than one candidate since RFC-051 Phase B / RFC-053, so the
+  assertion was true only of the fossilized set. It now pins the set #694
+  records for this exact fixture — `native` accepted, `cell-composed`
+  present, `native` winning the outer selection — which makes it a
+  behavioural tripwire on re-fossilization as well as a smoke test.
+  `decomposition_search_picks_native_on_clean_partitioned_case` asserted
+  native was the ONLY candidate scored, reasoning "sequential dispatch,
+  search exits early once native is accepted"; that reasoning describes a
+  candidate set nothing ships. Its K-DS1-1 content — native wins the clean
+  case, `size-split-2` is not paid for on it — survives verbatim.
+
+  **New non-ignored guard**: `harness_options_are_engine_defaults` compares
+  all three group views against the engine's own defaults and names both
+  fossils individually. Discrimination check EXECUTED twice: re-spelling
+  `cell_composition: Default::default()` inside the `SearchAxes` literal
+  fails it (`cell_composition: Off` vs `Candidate`), and the capacity-arm
+  A/B run failed it on `inserter_capacity: 0` vs `2` without being asked
+  to. Both reverted and re-verified green.
+
+  **tier5's warning pin (`input-rate-delivery 13 → 10`)** is the suite's
+  only pin movement, and it is NOT a check going quiet: both issue lists
+  were decoded from snapshots and diffed instance by instance. Ten rows
+  reading "across 2 inserters" at capacity 0 read "across 1 inserter" at
+  capacity 2 (one L2 hand replaces two L0 hands, so the row places fewer,
+  fatter inserters); seven equivalent warnings re-appear at shifted
+  coordinates. Every survivor still carries its own position and its own
+  delivered-vs-needed pair. The fixture's known deficits are untouched, as
+  is the meter's open #644 reading. Stress scoreboards moved the same
+  direction (warnings fell on 3 of 8, entity counts fell on all 8, errors
+  stayed 0; no category went to zero) — the baselines are `≤` ceilings, so
+  none required a re-bless and none were loosened.
+
+  **Corpus baseline NOT re-blessed, verified at source** (the W2c brief
+  asked for this check explicitly): `parity_corpus.rs` builds its option
+  sets as closures over `LayoutOptions::default()` in `OPTION_SETS`, never
+  through `run_e2e`, so no cell can move when the harness changes. The
+  `e2e-harness` column is now a HISTORICAL record rather than a live
+  configuration; kept, not deleted, because it is the only record of what
+  the fossilized suite decided — the file's doc comments were updated to
+  say so instead of continuing to claim a present-tense fossil.
+
+  **Pre-existing flake noted, not caused**: `tier2_electronic_circuit_20s_from_ore`
+  carries `#[ntest::timeout(10000)]` and tripped it at 10003 ms on the
+  BASELINE (pre-change) parallel run while passing solo in 0.63 s. It
+  passed on every post-change run. Wall-clock timeouts on a loaded box are
+  a suite-wide hazard the extra candidate makes marginally worse.


### PR DESCRIPTION
## Intent

RFC-070 campaign track **W2c** (tracking issue #689). The e2e harness has been running a `LayoutOptions` configuration nothing ships. `run_e2e_inner` built its options from a flat struct literal carrying **two fossils** — fields spelled `Default::default()` or a literal that were correct when written and silently went stale when the engine default flipped underneath them:

* `cell_composition: Default::default()` → the ENUM's `#[default]` (`Off`), sitting next to a `..Default::default()` that would have given the STRUCT default (`Candidate`, since RFC-051 Phase B, 2026-07-22). **The suite has never exercised the cell-composed candidate arm.**
* `inserter_capacity: 0` → correct at RFC-049 Phase 1 (`40fd48dc`), stale two days later when #383 flipped the default to `DEFAULT_INSERTER_CAPACITY` = 2. **The suite ran a different inserter ladder than production.**

Both die on the `run_e2e` path. The harness now builds options through `LayoutOptions::from_groups` — the **first production caller** of the #696 scaffolding — behind a `harness_options(HarnessOptions { .. })` helper, so every field a test does not deliberately override is the engine's own default.

> **Headline, after four review rounds.** The bot refused the gear@20 re-bless's validator-only reasoning; the meter run it forced, and then the re-check its *repeated* major prompted, produced the sharpest fact in this PR:
>
> **The meter tripwire's `gear20-am2-plate` row says 105 entities. The e2e suite's `tier1_iron_gear_wheel_20s` golden, before this PR, pinned 148.** Same item, rate, machine, inputs — two different layouts under one fixture name. The tripwire built `LayoutOptions::default()` (production: cell-composed, **−25 %**, and W1a metered and *committed* that in #693 on day one); the e2e fixture built the fossil's options (native, +5 %). Nobody joined "the meter says gear@20 is 25 % down" to "the suite says gear@20 is fine" because they were not talking about the same artifact. **That is what the fossil cost.** Attribution filed as **#700**; not fixed here.



## Scope

- **In:** `run_e2e_inner` migrated to `from_groups`; `rfc060_sim_export`'s hand-copied "mirror run_e2e_inner exactly" literal (which had *already* drifted — it kept `inserter_capacity: 0` but not the cells fossil, so it matched neither the harness nor production) now calls the same helper; 6 golden hashes re-blessed; 1 warning pin re-blessed; 2 tests re-pinned; 2 new non-ignored guard tests plus an in-suite selection pin on the #700 fixture; 1 `#[ignore]`d meter exporter; two wall-clock timeouts raised; RFC decision-log entry; `parity_corpus.rs` doc comments updated from present- to past-tense.
- **Out:** `selection_policy` / `verdict.rs` (W2b owns them concurrently) and `decomposition_search.rs` — untouched. #700's defect — evidence here, fix is W2b/W3's call. The 15 other tests in `e2e.rs` that carry the same copy-pasted fossil literals (see below) — pinned, not migrated. Stress `StressBaseline` ceilings not tightened (see Verification).
- **Size:** ~660 added across 2 rounds, ~70 removed, 4 files. Roughly 70 % is adjudication prose in comments and the RFC decision log — the executable change is ~200 lines. Not split: the fossil kill and its re-blesses are one atomic behaviour change; a split would land a red suite.

## The measurement

Attribution is **measured, not assumed** — three full `--test e2e` runs under the pinned CI zone cache (cells-fossil-killed only / capacity-fossil-killed only / both). The two effects are exactly additive: the cap-only and both-fossils fingerprints differ in exactly the one fixture cells moves.

| fossil killed | golden hashes moved | STRESSGOLD hashes moved | winner changes |
|---|---|---|---|
| `inserter_capacity` 0 → 2 | **6 / 8** | **8 / 8** | 0 |
| `cell_composition` Off → Candidate | **1 / 8** (`tier1_iron_gear_wheel_20s`) | 0 / 8 | **1** |

The two fluid-target goldens (`tier3_sulfuric_acid`, `tier3_heavy_oil_cracking`) are the negative control: byte-identical under both arms, and the only two golden-pinned fixtures that did not move.

## Prediction table (#694 parity corpus)

The `e2e-harness` column exists precisely to predict this diff. Its delta from `default` is **7 verdict-differing rows of 32**:

| corpus row | e2e-harness | default | attributable to | does the suite run this cell? |
|---|---|---|---|---|
| `e2e_tier2_electronic_circuit_20s_from_ore` / **am3** | native / best-error-free | direct-insertion / scoped-pairwise | capacity | **no** — test runs am2 |
| `tier2_ec_am1_10_ore` / **am3** | native / best-error-free | direct-insertion / scoped-pairwise | capacity | **no** — test runs am1 |
| `tier1_gear_am1` / am1, am2, am3 | native / best-accepted | native / best-error-free | cells (stage only) | am1 |
| `tier3_plastic_cp_5` / chemical-plant | native / best-accepted | native / best-error-free | cells (stage only) | — (rate/inputs differ) |
| `e2e_tier3_plastic_bar_from_crude` / chemical-plant | native / best-accepted | native / best-error-free | cells (stage only) | yes |

Both winner changes are at **am3, a tier the suite never invokes for those fixtures**. So the corpus predicts **zero winner changes** among the (fixture, machine) pairs `e2e.rs` actually runs — and **zero materialized**. The five stage-only rows keep winner `native`, hence the same layout, hence no golden movement from cells — confirmed by the cells-only A/B.

**Changed-test count: 9** — 6 golden hashes, 1 warning pin, 2 re-pinned tests. **Prediction-match rate: 5/5** on the corpus-covered fixtures (`tier1_iron_gear_wheel` @am1, `tier1_iron_gear_wheel_from_ore` @am2, `tier2_electronic_circuit_from_ore` @am1, `tier2_electronic_circuit_20s_from_ore` @am2, `tier5_processing_unit_from_ore_am3` @am3 — every one predicted to hold winner+stage, and every one did, with the layout moving via the inserter ladder as the corpus's winner/stage-only surface cannot and does not forbid). **No test got a deliberate old-behaviour override.**

## Findings

**1 — corpus hole, and two instruments measuring different layouts (#700).** The one winner change, gear @ 20/s am2, has **no row in the #694 corpus**, which carries gear @ 10/s and nothing at 20/s. Round 1 adjudicated the re-bless on validator evidence alone; the review refused that, per the verification protocol, and the meter reading it forced is:

| arm | cells | capacity | entities | validator | **meter** |
|---|---|---|---|---|---|
| production today (= tripwire's row) | `Candidate` | 2 | 105, 38×14 | 0 issues | **15.0 / 20.0 — 75 %** |
| cells disabled | `Off` | 2 | 148, 47×8 | 0 issues | 21.0 / 20.0 |
| pre-W2c e2e golden | `Off` | 0 | 148, 47×8 | 0 issues | 21.0 / 20.0 |

`measure(108_000, 216_000)`, no notes; "meter says below plan ⇒ believe it".

**Correction I owe this PR's own story** (prompted by the review repeating its major a third time — checking it is what found this): **the deficit is not new and was never guarded only by prose.** W1a metered it on day one — #693's table reports `gear20-am2-plate` at 20.000 planned / 15.000 produced / −25.0 % BELOW PLAN — and `crates/meter/tests/e2e_tripwire_baseline.json` carries the row **armed** at `entities: 105, deficit_pct: -25.0, converged: true`, a STANDING BELOW-PLAN row `check` fails on if it worsens. The reading above reproduces that baseline exactly.

What W2c adds is the **attribution**: 105 vs 148 entities under one fixture name, so the deficit belongs specifically to the cell-composed winner, and gear@20/am2 is the only fixture in the whole e2e suite where that candidate wins. The re-bless stands — a golden records what the engine *produces* — but the fixture's comment now says the layout under-delivers, names the tripwire row, and says its `assert_produces(…, 20.0)` passes on a 15/s layout because it reads a static estimate. A committed `#[ignore]`d exporter (`w2c_gear20_meter_export`) emits all three arms side by side so the divergence is checkable rather than narrated.

**2 — a selection-policy property this surfaces (W2b's, not acted on here).** The outer board records native with `layout_warnings: 0` and cell-composed with `layout_warnings: 1`, and `best-error-free` picks cell-composed anyway, on score. The stage filters on **errors** and then ranks on **score**; warnings never participate, and neither does delivered throughput.

And the one warning is not incidental — decoded from the snapshot, it reads:

> `cell-composed: geometry NOT sim-verified (hash c5c5f88087df894c) — run spaghettio-sim and add the entry to cell-sim-registry.json`

RFC-051's own machinery flagged **this exact geometry** as unverified, the stage ranked past it because warnings take no part, and the thing it was not verified for is precisely what the meter measured. Real property of today's precedence, surfaced not introduced. This is the mechanism behind #700, and the sharpest available argument for W2b's severity-aware verdict.

**3 — "both fossils killed" is true of the `run_e2e` path only.** Review finding, 3/3 passes, verified: **14 `cell_composition: Default::default()` and 14 `inserter_capacity: 0` literals remain across 15 distinct tests** in `e2e.rs` (the horizontal-stack tier4/tier5 trio, four `quality_*`, six `stacking_*`, `research_l7_thins_output_inserters_s4`, `rfc061_allocation_probe_ac5`). None documents its value as deliberate; every one is a copy of the same old literal. Not migrated — each carries its own pins, so flipping them is a second adjudication this size. Instead `residual_fossil_literals_are_pinned` reads its own source and fails if either count moves, naming every affected test and spelling out that *lowering* the number is the good direction.

## The two re-pinned tests

Neither got a cells-off override, deliberately: both were asserting *the fossil itself*, so pinning them to the old behaviour would have preserved it in precisely the two tests that describe the candidate set.

* `decomposition_search_native_candidate_fires_trace_events` asserted "exactly one `DecompositionCandidateScored` under Phase 0". Production has run more than one candidate since RFC-051 Phase B / RFC-053; the assertion was true only of the fossilized set. It now pins the set #694 records for this exact fixture — `native` accepted, `cell-composed` present, `native` winning at `best-error-free` — which makes it a **behavioural** re-fossilization tripwire as well as a smoke test.
* `decomposition_search_picks_native_on_clean_partitioned_case` asserted native was the ONLY candidate scored, reasoning "sequential dispatch, search exits early once native is accepted". That reasoning describes a candidate set nothing ships. Its K-DS1-1 content — native wins the clean case, `size-split-2` is not paid for on it — survives verbatim.

Both read the outer terminal by corroborating the two **independent** emitters (`DecompositionChosen` and `SelectionDecided`) rather than trusting `last()` on one — round-1 review finding, absorbed.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml --no-fail-fast` — **exit 0**, 29 test binaries, zero failures. Re-run after the review absorption; still exit 0.
- [x] `cargo clippy --workspace -- -D warnings` — clean (CI's exact command), both rounds.
- [x] `wasm-pack build crates/wasm-bindings --target web --out-dir <abs>` — clean.
- [x] `SPAGHETTIO_PARITY_CORPUS=check` — **160/160 cells matched** the committed baseline after the change (628 s).
- [x] **Meter** (`crates/meter` `check_one`) on all three gear@20 arms — the table above. Reproduced from the committed exporter, not just the throwaway probe.
- [x] Snapshots decoded and inspected for the specific behaviour: `tier1_iron_gear_wheel_20s`'s selection trace (which candidate won, at which stage, with which scores) and `tier5`'s full issue list, instance by instance, on both arms.
- [ ] Sim — not run. The meter refutes cheaply and did; only the sim can clear, and clearing #700's layout is that issue's job.
- [ ] Browser eyeball — not applicable; no shipped-engine code changed, only what the harness asks the engine for.

**Zone-cache discipline:** every measurement and bless ran with `SPAGHETTIO_ZONE_CACHE_PATH=crates/core/data/sat-zones-ci.bin`. **The committed goldens were blessed under the CI cache.** The pin was restored (`git checkout --`) after *every* run and is not in the diff (`git status` clean at both commits).

**Warning-pin adjudication (tier5, `input-rate-delivery 13 → 10`)** — the suite's only pin movement, and **not a check going quiet** (docs/validator-reporting.md). Both issue lists decoded from snapshots and diffed instance by instance: ten rows reading `across 2 inserters` at capacity 0 read `across 1 inserter` at capacity 2 (one L2 hand replaces two L0 hands, so the row places fewer, fatter inserters); seven equivalent warnings re-appear at shifted coordinates. Every survivor still carries its own position and its own delivered-vs-needed pair, e.g. `(50,164) delivers 0.0/s but machine needs 2.4/s`. The fixture's known deficits are untouched, as is the meter's open #644 reading. *(Why no other pin moved: pins record a per-category tally, and a geometry change that leaves the tally alone leaves the pin alone.)*

**Stress baselines: no bless needed and none loosened.** Warnings fell on 3 of 8 stress fixtures (ec22 5→4, ec23 7→6, ec40 283→235), entity counts fell on all 8, errors stayed 0, and **no category went to zero** — the alarm condition. `StressBaseline` records `≤` ceilings, so every fixture still passes; tightening them is a separate judgement and would be churn.

**Guards, three of them.**

1. `harness_options_are_engine_defaults` (non-ignored, no solve, no layout) compares all three group views against `LayoutOptions::default()`'s own views — not against the group `Default` impls, which are a second hand-written copy that could be wrong the same way (round-1 finding) — names both fossils individually, and (round-2 finding, the best of that round) asserts the engine defaults still equal the two values every `run_e2e*` wrapper spells as a **hard literal** (`LayoutStrategy::Pooled`, `true`), which bypass the spread and are the same fossil shape one level out.
2. `residual_fossil_literals_are_pinned` covers the 15 unmigrated sites.
3. `tier1_iron_gear_wheel_20s` pins its outer selection (`cell-composed` / `best-error-free`) with a message naming #700 — the in-suite tripwire round 2 asked for, so the known-bad artifact is guarded by an assertion rather than by prose plus an issue number.

**Discrimination checks executed, three times:** re-spelling `cell_composition: Default::default()` inside the `SearchAxes` literal fails guard 1 (`Off` vs `Candidate`); the capacity-arm A/B run failed guard 1 on `inserter_capacity: 0` vs `2` without being asked to; and restoring the cells fossil fails guard 3 with `Some(("native", BestAccepted))` vs `Some(("cell-composed", BestErrorFree))`. All reverted and re-verified green.

## Review rounds

**Round 1** — 7 findings (1 union-major, 6 minor), all absorbed, none refuted. The major ("no meter/sim reading recorded for the new winner") forced the measurement that produced #700. Also absorbed: the 3/3 scoping finding (→ `residual_fossil_literals_are_pinned` + the claim scoped to the `run_e2e` path everywhere), the `chosen.last()` ordering oracle (→ corroboration across two independent terminal emitters + stage pinned), the self-referential guard (→ compare against `LayoutOptions::default()`), and the `rfc060_sim_export` artifact drift (→ a K60-3 non-comparability note).

**Rounds 5 and 6** — 6 + 6 findings. Four real changes, and one question whose answer is the best detail in the PR:

* **"How does the same layout score `layout_warnings: 1` at selection and 0 at validation?"** (2/2) — no contradiction (different fields: `LayoutResult.warnings` is the producer's own list, `validate()`'s issues are the 39 checks). But decoding the snapshot for the receipt turned up **what that one warning says**: `"cell-composed: geometry NOT sim-verified (hash c5c5f88087df894c) — run spaghettio-sim and add the entry to cell-sim-registry.json"`. RFC-051's own machinery flagged this exact geometry as unverified; `best-error-free` filters on errors and ranks on score with warnings taking no part; and the thing it was not verified for is precisely what the meter measured. **The winner declared its own unverifiedness and the stage ranked past it.**
* **`assert_produces(…, 20.0)` deleted from the gear@20 fixture** (3/3 major, fourth restatement — answered with code). It read a static estimate and asserted "produces 20/s" about a layout metered at 15/s. Replaced with an inline check of the same number under a message naming it a PLAN check and stating the measured value. Rejected alternative recorded at the call site: metering in-suite closes a dev-dependency cycle to duplicate a guard that already exists armed.
* **`bus/layout.rs`'s "Zero production callers as of this PR"** (1/3) — correct, and my own bug class in W2a's file: this PR makes `e2e.rs` the first caller, so the sentence became false in the same diff that falsified it. Replaced with an adoption-status list.
* **The two round-2 guard assertions deleted, wrappers fixed instead** (1/2) — an assertion re-spelling an engine default is itself a second copy of it. `run_e2e_inner` now takes one `HarnessOptions`; each wrapper spells only what it varies. **Verified behaviour-neutral: a full golden + STRESSGOLD fingerprint before and after the refactor is byte-identical on all 8 + 8 hashes.**
* Sweep provenance stamped into the markdown artifact; residual-guard reach sharpened to name the group-level-partial miss; decision-log headline scoped to the `run_e2e*` harness; `tier2_electronic_circuit_20s_from_ore`'s 10 s wall-clock budget raised to 60 s after it flaked a second time mid-verification.
* **Refuted with receipts:** *"the tripwire never runs under `cargo test -p spaghettio_core`"* — true, and a standing project decision with its own recorded reasoning (`e2e_tripwire.rs`, "Why report-only stays the default…": gating a host-cache-relative instrument with no track record repeats #632 B7's mistake). Not W2c's to overturn; the residual is recorded as an argument for promoting the tripwire. *"No fixture-level ancestry for non-golden-pinned fixtures"* — the per-fixture stress deltas are recorded, measured under the new config.

**Rounds 3 and 4** — 4 + 5 findings, reviewer states none blocks merge. Three real corrections: `parity_corpus.rs`'s docblock said both things at once (round 1 appended the correction *after* the stale receipt — restructured, receipt kept behind an explicit SUPERSEDED heading); the two decomposition tests' "independent emitters corroborate" claim is **vacuous on those fixtures** (3/3, verified from a decoded snapshot — one terminal of each kind, because native wins and nests nothing; kept as a self-arming guard, with the comments now naming the STAGE pin as what carries weight); and the decision log's "capacity changes no winner **anywhere**" was over-broad (the corpus records two at am3 — scoped to what was measured). Plus the novelty correction above, which the repeated major produced.

**Round 2** — 8 findings (2 major, 6 minor); 6 absorbed with code, 2 refuted with receipts. Absorbed: the 3/3 in-suite-tripwire major (→ guard 3 above), the guard's wrapper-literal hole (→ guard 1's new assertions), the residual-pin guidance (→ claims only what was audited; per-site load-bearing check before lowering a count), the wall-clock timeouts (10 s → 30 s, 30 s → 60 s on the two tests that gained an extra layout pass), and `run_e2e_pure_combo`'s "pure" contract (→ documented as *HS candidate off* and only that, plus a warning that pre-2026-08-21 `full_knob_sweep` tables are not comparable). Refuted: *"a consistent reversal of both emitters sails through"* — true, already stated in the test's own comment, and not removable from a test (the fix is a structural nesting marker in the trace contract, Phase 1b/2a's to own); *"nothing re-derives tier5's 10"* — the committed warning pin is re-derived and asserted every suite run, which is what `assert_warnings_golden` does; *"the corpus's `e2e-harness` column baselines a candidate set nothing ships"* — deliberate and documented, it is the historical record the re-blesses were adjudicated against.

Full adjudication of every finding, absorbed and refuted, is in the RFC-070 decision log.

**Pre-existing flake, noted not caused:** `tier2_electronic_circuit_20s_from_ore` carries `#[ntest::timeout(10000)]` and tripped it at 10003 ms on the **baseline** (pre-change) parallel run while passing solo in 0.63 s. It passed on every post-change run. Wall-clock timeouts on a loaded box are a suite-wide hazard the extra candidate makes marginally worse.

## Deviations from intent

**One, on task item 4.** The brief asked to verify that #694's `e2e-harness` arm doesn't derive from `run_e2e`. Verified at source: `parity_corpus.rs` builds its option sets as closures over `LayoutOptions::default()` in `OPTION_SETS`, never through `run_e2e`, so no cell can move when the harness changes — confirmed empirically by the 160/160 `check` above. No re-bless. But its doc comments *claimed a present-tense fossil* ("`run_e2e_inner` also pins `inserter_capacity: 0`… re-run that diff if either fossil is ever fixed"), which this PR falsifies, so they are updated to say the column is now a **historical** record rather than a live configuration. Kept, not deleted: dropping it would silently re-take 32 cells and destroy the only record of what the fossilized suite decided.

**One from review.** #700 was filed rather than fixed, and one golden now knowingly pins an under-delivering layout with a comment saying so. The alternative — refusing to bless — means keeping the fossil, which is what hid the defect for a month.

## Models / contracts touched

None. No shipped-engine code changed — only what the test harness asks the engine for. The RFC-070 decision log carries the full W2c entry (attribution A/B, prediction table, all three findings, the meter table, the tier5 instance diff, the corpus-independence verification, and the round-1 review absorption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
