### PR TITLE
feat(w3a): v2 selection shadow + parity gate (RFC-070 Phase 2a)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -49,11 +49,21 @@ filter = "test(stress_advanced_circuit_partitioned_7s_from_plates)"
 slow-timeout = { period = "60s", terminate-after = 10 }
 
 # RFC-070 Phase 2a (#689 W3a): the shadow parity gate runs six SAT-heavy
-# fixtures in ONE non-ignored test (~15s local warm on 16 threads), which
-# is the shape that blew a ceiling the first time parallelism was tried
-# on this 4-thread runner. `threads-required = 2` keeps it off the box
-# alongside another heavy test; the 600s kill sits above its own
-# `#[ntest::timeout(300_000)]`, which stays the real hang detector.
+# fixtures in ONE non-ignored test — the shape that blew a ceiling the
+# first time parallelism was tried on this 4-thread runner.
+# `threads-required = 2` limits concurrency to two heavy tests at a time,
+# the same frame (and the accurate one) as the heavy group above: it is a
+# slot cost, NOT a reservation, so this test still co-schedules with one
+# other 2-slot test — it just cannot be one of three (#703 review round 1
+# corrected an earlier "keeps it off the box alongside another heavy
+# test", which overclaimed). The `#[ntest::timeout(300_000)]` is the real
+# hang detector; the 600s kill sits above it.
+#
+# The ceiling is sized from a MEASURED CI run, not extrapolated: 30.9s on
+# the pinned-cache runner (PR #703 head 12b1ea87, job 97039777698) against
+# 15s local warm — a 2x host penalty, not the 8-18x the cold-cache note
+# above records, because this job pins SPAGHETTIO_ZONE_CACHE_PATH. 300s
+# is a ~10x margin over the observed number.
 [[profile.ci.overrides]]
 filter = "test(shadow_agrees_with_production_on_the_census_fixtures)"
 slow-timeout = { period = "60s", terminate-after = 10 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,6 +48,17 @@ threads-required = 2
 filter = "test(stress_advanced_circuit_partitioned_7s_from_plates)"
 slow-timeout = { period = "60s", terminate-after = 10 }
 
+# RFC-070 Phase 2a (#689 W3a): the shadow parity gate runs six SAT-heavy
+# fixtures in ONE non-ignored test (~15s local warm on 16 threads), which
+# is the shape that blew a ceiling the first time parallelism was tried
+# on this 4-thread runner. `threads-required = 2` keeps it off the box
+# alongside another heavy test; the 600s kill sits above its own
+# `#[ntest::timeout(300_000)]`, which stays the real hang detector.
+[[profile.ci.overrides]]
+filter = "test(shadow_agrees_with_production_on_the_census_fixtures)"
+slow-timeout = { period = "60s", terminate-after = 10 }
+threads-required = 2
+
 [profile.ci.junit]
 path = "junit.xml"
 store-success-output = true

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -59,14 +59,26 @@ slow-timeout = { period = "60s", terminate-after = 10 }
 # test", which overclaimed). The `#[ntest::timeout(300_000)]` is the real
 # hang detector; the 600s kill sits above it.
 #
-# The ceiling is sized from a MEASURED CI run, not extrapolated: 30.9s on
-# the pinned-cache runner (PR #703 head 12b1ea87, job 97039777698) against
-# 15s local warm — a 2x host penalty, not the 8-18x the cold-cache note
-# above records, because this job pins SPAGHETTIO_ZONE_CACHE_PATH. 300s
-# is a ~10x margin over the observed number.
+# Measured, not extrapolated: 30.9s on the pinned-cache CI runner (PR
+# #703 head 12b1ea87, job 97039777698) against 15s local warm — a 2x host
+# penalty, not the 8-18x the cold-cache note above records, because this
+# job pins SPAGHETTIO_ZONE_CACHE_PATH. The test's own
+# #[ntest::timeout(600_000)] is sized for the UNPINNED case instead (the
+# 8-18x regime puts a cold run at 120-270s, and a hang detector that
+# fires on a cold cache is a false positive on the one gate that runs
+# everywhere — #703 review round 2). This kill sits above it.
 [[profile.ci.overrides]]
 filter = "test(shadow_agrees_with_production_on_the_census_fixtures)"
-slow-timeout = { period = "60s", terminate-after = 10 }
+slow-timeout = { period = "60s", terminate-after = 12 }
+threads-required = 2
+
+# The same cap for a local `cargo nextest run` with no --profile, so a
+# developer's box gets the concurrency behaviour CI gets. Plain
+# `cargo test` reads none of this file, which is why the ntest ceiling —
+# not this entry — is the real guard (#703 review round 2).
+[[profile.default.overrides]]
+filter = "test(shadow_agrees_with_production_on_the_census_fixtures)"
+slow-timeout = { period = "60s", terminate-after = 12 }
 threads-required = 2
 
 [profile.ci.junit]

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -1338,6 +1338,33 @@ impl Scoreboard {
 ///    would show up as a changed winner with no obvious cause. #698's
 ///    standing hand-off note names this as the thing only the 2a shadow
 ///    can check.
+///
+/// # Two boundary changes this wiring makes, stated because they are
+/// easy to miss in a diff
+///
+/// **`selection_policy`'s `debug_assert`s are now on the LIVE path in
+/// debug builds** (#703 review round 2). `decide`'s profile-length
+/// check, `prior_slot`'s registration-order bound and
+/// `incumbent_index`'s exactly-one check were written for a replay
+/// harness; every one of them now runs on every solve of every
+/// `cargo test` and CI job. That is the intended tripwire — those
+/// asserts guard policy-AUTHORING mistakes, which is precisely what
+/// Phase 2b will be doing — and it is why they are `debug_assert`s
+/// rather than `assert`s: release and WASM keep their documented
+/// degradation (`decide` refuses, gates fall back to the safe scan)
+/// and a browser solve cannot be panicked by a code-level slip. The
+/// consequence to be aware of: a future producer whose gate reads a
+/// slot at or after its own index will now fail the SUITE, not just
+/// the replay.
+///
+/// **The seven-slot arrays are a latent invariant.**
+/// `Scoreboard::prior_acceptance` and `v1_ran` return `[_; 7]` because
+/// the board is `[CandidateVerdict; 7]`. The alignment check below is
+/// what corrals a registration count that stops matching: an
+/// eight-producer policy fails it, the shadow skips, and the harnesses
+/// report a named missing comparison rather than indexing off the end.
+/// So a candidate-count change is caught, but by the corral, not by an
+/// assertion at the array.
 fn emit_selection_shadow(
     board: &Scoreboard,
     solver_result: &SolverResult,
@@ -1352,13 +1379,25 @@ fn emit_selection_shadow(
     // wrong verdict — and the harnesses assert the event is PRESENT for
     // every decided cell, so a silent skip fails there rather than
     // reading as agreement.
+    // NO `debug_assert` here, deliberately, and this is a correction
+    // (#703 review round 2, 3/3): the first draft had one, which made
+    // the guard below DEAD in every debug build — i.e. in every
+    // `cargo test` run and every CI job. A misalignment would then have
+    // aborted the shipped `select_best_decomposition` path with a panic,
+    // which is the exact opposite of what this function's doc promises
+    // and of what a shadow is for. Phase 2b reorders and extends the
+    // candidate set, so this is a state the campaign will actually
+    // visit.
+    //
+    // The failure is REPORTED instead of thrown, and by the right
+    // reader: skipping emits no `SelectionShadowCompared`, and both
+    // harnesses assert the event is PRESENT for every cell whose
+    // selection ran (`ShadowReport::missing` / the smoke tier's
+    // comparison count). A misalignment therefore surfaces as a named
+    // "missing comparison" on the cells it affects, not as a panicked
+    // solve.
     let aligned = policy.producers.len() == CANDIDATE_ORDER.len()
         && policy.producers.iter().zip(CANDIDATE_ORDER).all(|(p, n)| p.name == n);
-    debug_assert!(
-        aligned,
-        "SelectionPolicy::current() does not register the seven producers in \
-         CANDIDATE_ORDER; the shadow would compare mis-keyed slots"
-    );
     if !aligned {
         return;
     }

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -1009,7 +1009,7 @@ impl CandidateRun {
 /// unchanged; the blast radius is not (#692 review round 3, 1/3, which
 /// noted the unconditional form inverted the degradation philosophy used
 /// twenty lines away, where candidates run under `catch_unwind`).
-const CANDIDATE_ORDER: [&str; 7] = [
+pub(crate) const CANDIDATE_ORDER: [&str; 7] = [
     "native",
     "k1-shape-fix",
     "size-split-2",

--- a/crates/core/src/bus/decomposition_search.rs
+++ b/crates/core/src/bus/decomposition_search.rs
@@ -25,6 +25,7 @@ use super::partitioner::{
     apply_cap_driven_split, apply_partition_plan, apply_size_split, plan_partitioning,
     ModuleAssignment, PartitionPlan,
 };
+use super::selection_policy;
 use super::shape_fix::{
     select_shape_fix, PadLanesStrategy, ShapeFix, ShapeFixStrategy, ShardStrategy,
 };
@@ -1254,6 +1255,160 @@ impl Scoreboard {
             });
         }
     }
+
+    /// The v2 profile vector: one [`IssueProfile`] per candidate slot,
+    /// derived from the rows this board already holds.
+    ///
+    /// **Nothing is re-validated, and that is the discipline, not an
+    /// optimisation.** The rows record what each verdict mechanism
+    /// computed at its own site; a shadow that ran `validate()` again
+    /// could disagree with the number the v1 decision actually used, and
+    /// then a divergence would be uninterpretable — is the PROGRAM
+    /// different, or is it being fed different inputs? Measuring once
+    /// and projecting is also what makes v1's laziness carry across
+    /// unchanged: a candidate no mechanism examined has no counts here
+    /// either, which is exactly the gap [`decide`] skips on.
+    ///
+    /// Consequence, stated so the shadow's coverage is not overread:
+    /// this path does NOT exercise [`IssueProfile::measure`], so the
+    /// produce-time `refuse_on_error` gate and the eager-measurement
+    /// question are not under test here. They are covered by the unit
+    /// tier in `bus::selection_policy`.
+    fn v2_profiles(&self) -> Vec<selection_policy::IssueProfile> {
+        self.0
+            .iter()
+            .map(|row| selection_policy::IssueProfile {
+                outcome: Some(row.outcome),
+                refusal_reason: row.reason.clone(),
+                score: row.score,
+                accepted: row.accepted,
+                accepted_reason: row.accepted_reason.clone(),
+                counts: row.counts.map(|c| selection_policy::IssueCounts {
+                    errors: c.errors,
+                    selection_warnings: c.warnings,
+                    layout_warnings: c.layout_warnings,
+                }),
+                kinds: row.kinds.map(|k| selection_policy::ErrorKindCounts {
+                    contamination: k.contamination,
+                    starvation: k.starvation,
+                    structural: k.structural,
+                }),
+            })
+            .collect()
+    }
+
+    /// Per-registration acceptance in the shape a [`ProducerGate`]
+    /// reads: `Some(accepted)` where that slot produced a layout, `None`
+    /// where it produced nothing. `accepted` is `Some` iff the candidate
+    /// produced, so the row's own field IS the predicate.
+    fn prior_acceptance(&self) -> [Option<bool>; 7] {
+        std::array::from_fn(|i| self.0[i].accepted)
+    }
+
+    /// Whether v1 actually ran each slot's `produce()`. `NotRun` is the
+    /// one outcome that means the call-site gate excluded it; `Refused`
+    /// and `Panicked` both mean it ran and cost a layout pass.
+    fn v1_ran(&self) -> [bool; 7] {
+        std::array::from_fn(|i| {
+            self.0[i].outcome != crate::trace::SelectionCandidateOutcome::NotRun
+        })
+    }
+}
+
+/// RFC-070 Phase 2a (#689 W3a): run the v2 policy loop in SHADOW over
+/// the same scoreboard v1 just decided from, and emit the comparison.
+///
+/// **Zero behaviour change by construction**: this function returns
+/// nothing, mutates nothing, and is called after the winner has already
+/// been chosen and replayed. v1's answer ships regardless of what v2
+/// says. A disagreement is DATA for the campaign's K70-1 adjudication
+/// — never a panic, never a fix-it-so-it-passes signal.
+///
+/// Two things are compared, and they fail differently:
+///
+/// 1. **The decision** — `(winner, stage)` from `selection_policy::
+///    decide` over `board.v2_profiles()`, against v1's. This is the
+///    corpus's divergence-equivalence rule, live.
+/// 2. **The producer gates** — each registration's `ProducerGate`
+///    evaluated against this call's options and solve, against whether
+///    v1 actually ran that candidate. This is the half `policy_replay`
+///    structurally cannot see (it consumes already-produced profiles
+///    and evaluates zero gates), and a mis-transcribed eligibility
+///    clause moves the candidate SET rather than the ranking — so it
+///    would show up as a changed winner with no obvious cause. #698's
+///    standing hand-off note names this as the thing only the 2a shadow
+///    can check.
+fn emit_selection_shadow(
+    board: &Scoreboard,
+    solver_result: &SolverResult,
+    opts: &LayoutOptions,
+    v1: Option<(usize, crate::trace::SelectionStage)>,
+) {
+    let policy = selection_policy::SelectionPolicy::current();
+    // The profile vector is keyed by REGISTRATION order and the board by
+    // CANDIDATE_ORDER; if those ever part company, every comparison
+    // below would rank one candidate's measurement under another's
+    // policy. Degrade to emitting NOTHING rather than to a plausible
+    // wrong verdict — and the harnesses assert the event is PRESENT for
+    // every decided cell, so a silent skip fails there rather than
+    // reading as agreement.
+    let aligned = policy.producers.len() == CANDIDATE_ORDER.len()
+        && policy.producers.iter().zip(CANDIDATE_ORDER).all(|(p, n)| p.name == n);
+    debug_assert!(
+        aligned,
+        "SelectionPolicy::current() does not register the seven producers in \
+         CANDIDATE_ORDER; the shadow would compare mis-keyed slots"
+    );
+    if !aligned {
+        return;
+    }
+
+    let profiles = board.v2_profiles();
+    let v2 = selection_policy::decide(&profiles, &policy);
+
+    let prior = board.prior_acceptance();
+    let ran = board.v1_ran();
+    let incumbent = policy.incumbent_index();
+    let mut gate_disagreements = Vec::new();
+    for (i, reg) in policy.producers.iter().enumerate() {
+        let verdict = reg.gate.evaluate(&selection_policy::GateContext {
+            solver_result,
+            opts,
+            prior: &prior,
+            incumbent,
+            registration_index: i,
+        });
+        let eligible = verdict == selection_policy::GateVerdict::Eligible;
+        if eligible != ran[i] {
+            // One named entry per disagreeing producer, with both sides
+            // and (when v2 excluded it) WHICH clause did so — a count
+            // in a message cannot tell 1 from 7, and the clause name is
+            // the whole reason gaps (c) got closed.
+            gate_disagreements.push(format!(
+                "{}: v2 {} / v1 {}",
+                reg.name,
+                match verdict {
+                    selection_policy::GateVerdict::Eligible => "eligible".to_string(),
+                    selection_policy::GateVerdict::Excluded(c) => format!("excluded[{c}]"),
+                },
+                if ran[i] { "ran" } else { "not-run" }
+            ));
+        }
+    }
+
+    let agree = match (v1, v2) {
+        (Some((i, s)), Some(d)) => i == d.winner && s == d.stage,
+        (None, None) => true,
+        _ => false,
+    };
+    crate::trace::emit(crate::trace::TraceEvent::SelectionShadowCompared {
+        v1_winner: v1.map(|(i, _)| CANDIDATE_ORDER[i].to_string()),
+        v1_stage: v1.map(|(_, s)| s),
+        v2_winner: v2.map(|d| policy.producers[d.winner].name.to_string()),
+        v2_stage: v2.map(|d| d.stage),
+        agree,
+        gate_disagreements,
+    });
 }
 
 /// Run candidates and pick the winner.
@@ -1906,6 +2061,11 @@ pub fn select_best_decomposition(
         // because there is no winner and the stage enum is deliberately
         // closed over the five ways a winner CAN be picked.
         board.emit();
+        // RFC-070 Phase 2a: the shadow runs on this path too. "v2 named
+        // a winner where v1 refused everything" is a divergence worth
+        // seeing, and it is invisible if the comparison only happens
+        // where v1 succeeded.
+        emit_selection_shadow(&board, solver_result, &opts, None);
         // Both sides keyed by `CANDIDATE_ORDER`: the names from the list
         // itself and the reasons from `run_refs`, whose slots are checked
         // against it. Nothing here is positional against a separately
@@ -1953,6 +2113,13 @@ pub fn select_best_decomposition(
         winner: name.to_string(),
         stage,
     });
+    // RFC-070 Phase 2a (#689 W3a): the SHADOW, emitted immediately after
+    // the verdict it shadows and strictly after it. Ordering matters to
+    // the readers: `parity_corpus`'s extractor pairs the last seven
+    // scoreboard rows with the last `SelectionDecided`, so the shadow
+    // must not sit between them. Nothing above this line reads its
+    // result — v1 has already chosen, replayed and returned its winner.
+    emit_selection_shadow(&board, solver_result, &opts, Some((idx, stage)));
     Ok(layout)
 }
 

--- a/crates/core/src/bus/selection_policy.rs
+++ b/crates/core/src/bus/selection_policy.rs
@@ -1428,6 +1428,17 @@ fn ranks_ahead(profiles: &[IssueProfile], a: usize, b: usize, order: RankOrder) 
             // quietly turn "unmeasured" into either "worst" or
             // "ranked on density alone". Pinned by
             // `a_missing_warning_key_abstains_rather_than_ranking_on_score`.
+            //
+            // The consequence, by design and worth naming (#703 review
+            // round 2 nit): under such a stage, an unmeasured candidate
+            // registered EARLIER becomes an immovable floor — nothing
+            // ranks ahead of it, because every comparison against it
+            // abstains. That is the correct reading of "the primary
+            // criterion is unanswerable" combined with "ties keep the
+            // earlier registration"; a stage that wants unmeasured
+            // candidates ranked must either measure them or declare a
+            // different `RankOrder`, not lean on this arm to invent an
+            // ordering.
             match (profiles[a].warning_key(), profiles[b].warning_key()) {
                 (Some(wa), Some(wb)) => match wa.cmp(&wb) {
                     std::cmp::Ordering::Less => true,

--- a/crates/core/src/bus/selection_policy.rs
+++ b/crates/core/src/bus/selection_policy.rs
@@ -230,8 +230,13 @@ impl IssueProfile {
     /// So Phase 2a must either preserve the laziness as policy (skip
     /// measuring when fewer than two candidates produced) or accept
     /// those cells as MINOR divergences and adjudicate them. It is not
-    /// a free implementer's choice. Pinned by
-    /// `eager_measurement_moves_the_deciding_stage`.
+    /// a free implementer's choice. **Settled**: [`MeasurementRule`] is
+    /// that policy and [`decide`] enforces it, so eager and lazy reach
+    /// the same stage by construction (#698 review round 3). Pinned by
+    /// `the_measurement_rule_makes_eager_and_lazy_decide_alike` — the
+    /// round-1 test this line used to name
+    /// (`eager_measurement_moves_the_deciding_stage`) was replaced by it
+    /// and no longer exists.
     pub fn measure(
         layout: &LayoutResult,
         solver_result: &SolverResult,
@@ -280,14 +285,27 @@ impl IssueProfile {
         let score = score_layout(layout, solver_result);
         let refusal = policy.acceptance_gates.iter().find_map(|g| g.refusal(layout));
 
-        // The PRODUCE-TIME gate. A flag no code path applies is a trap
-        // for whoever wires this (#698 review round 2): without it, a
-        // naive `measure -> decide` hands DI / horizontal / cell-composed
-        // an error-laden `Produced` profile that can displace a healthy
-        // incumbent, inverting the very asymmetry
+        // The PRODUCE-TIME gate, as a DEFENSIVE GUARD rather than a live
+        // path (softened in W3a, having been written in #698 review
+        // round 2 as though it were load-bearing today). All three
+        // producers that carry the flag — cell-composed, direct-insertion,
+        // horizontal-stack — already self-refuse inside their own
+        // `produce()`, so an error-laden layout from one of them never
+        // reaches this function in the first place; on the live path this
+        // branch does not fire.
+        //
+        // It is kept because the flag would otherwise be policy data no
+        // code path applies, and the failure it guards is a construction
+        // mistake rather than an input: a producer registered WITH the
+        // flag but WITHOUT the produce-side refusal (a new arm, or a
+        // future loop that stops calling `produce()`'s self-validation)
+        // would hand `decide` an error-laden `Produced` profile able to
+        // displace a healthy incumbent, inverting the asymmetry
         // `refuse_on_error_is_asymmetric_and_that_asymmetry_is_load_bearing`
-        // exists to pin — and `policy_replay` cannot catch it, because
-        // it replays rows where v1 already refused.
+        // pins. `policy_replay` cannot see that class at all, because it
+        // replays rows where v1 already refused. See
+        // [`MeasurementRule::min_produced_for_error_free_tier`], whose
+        // equality with v1's `n_layouts` rests on the same pairing.
         //
         // Unlike v1, the refusal KEEPS the measurement: v1 stringifies
         // its own validation failure as `e.to_string().lines().next()`
@@ -1390,21 +1408,33 @@ fn ranks_ahead(profiles: &[IssueProfile], a: usize, b: usize, order: RankOrder) 
         RankOrder::RegistrationOrder => false,
         RankOrder::ScoreDesc => score_ahead(),
         RankOrder::WarningsAscThenScoreDesc => {
-            // A gap ABSTAINS from this criterion rather than sorting
-            // last through the sentinel — the module's own rule, applied
-            // locally instead of relying on a non-local invariant to
-            // keep the sentinel dead (#698 review round 6). Unreachable
-            // under today's program, where the error-free tier's
-            // admission already required counts; the point is that a
-            // future `require_error_free: false` stage cannot quietly
-            // turn "unmeasured" into "worst".
+            // A missing warning key ABSTAINS — `false`, "does not rank
+            // ahead" — rather than sorting last through a sentinel OR
+            // falling through to the score. Both alternatives answer a
+            // question the module says is unanswerable: this order's
+            // PRIMARY criterion is the warning key, and a gap means no
+            // mechanism computed one, so there is nothing to compare
+            // first. Falling through to score would silently promote the
+            // SECONDARY criterion to primary for exactly the candidates
+            // least is known about, which is the `unwrap_or(0)` trap
+            // wearing a different hat (#698 review round 6 removed the
+            // sentinel; the fall-through it left behind is this
+            // carry-over, W3a).
+            //
+            // Unreachable under today's program — the error-free tier's
+            // admission already requires counts, so both keys are always
+            // present here. The point is that a future
+            // `require_error_free: false` stage using this order cannot
+            // quietly turn "unmeasured" into either "worst" or
+            // "ranked on density alone". Pinned by
+            // `a_missing_warning_key_abstains_rather_than_ranking_on_score`.
             match (profiles[a].warning_key(), profiles[b].warning_key()) {
                 (Some(wa), Some(wb)) => match wa.cmp(&wb) {
                     std::cmp::Ordering::Less => true,
                     std::cmp::Ordering::Greater => false,
                     std::cmp::Ordering::Equal => score_ahead(),
                 },
-                _ => score_ahead(),
+                _ => false,
             }
         }
     }
@@ -1475,6 +1505,85 @@ mod tests {
         let names: Vec<&str> = p.producers.iter().map(|r| r.name).collect();
         assert_eq!(names, EXPECTED_ORDER);
         assert_eq!(p.incumbent_index(), Some(NATIVE));
+    }
+
+    /// Carry-over (e) of #698 rounds 9-10: bind the THREE parallel
+    /// candidate lists — this file's `EXPECTED_ORDER`, the engine's
+    /// `decomposition_search::CANDIDATE_ORDER`, and the registration
+    /// vector — and then bind the order itself to the semantics that
+    /// depend on it.
+    ///
+    /// **Why the equality checks are not enough.** Every existing check
+    /// compares one list against another, so a COORDINATED permutation
+    /// (the same swap applied to all three) passes all of them while
+    /// genuinely reordering the candidate field: `FirstProduced` is
+    /// positional, `BestAccepted`'s ties go to the earliest index, and
+    /// v1's `ranking_len` is a SLICE BOUND, not a predicate. The
+    /// positional assertions below are the part a coordinated swap
+    /// cannot satisfy, because they are stated against what the
+    /// positions MEAN rather than against another copy of the list.
+    ///
+    /// The load-bearing one is the tail: v1 excludes the scoped
+    /// candidates from the generic ranking with `candidates[..DI_IDX]`,
+    /// and v2 excludes them with a `scoped` field test. Those two are
+    /// equivalent **only while the scoped registrations are exactly the
+    /// tail** — move DI to slot 2 with everything else consistent and
+    /// v1's slice would drop three unrelated candidates while v2's
+    /// filter drops the right two, silently. (RFC-070 decision log,
+    /// "the `ranking_len` slice becomes the AdmissionRule as a FILTER".)
+    #[test]
+    fn the_candidate_order_is_bound_to_its_positional_semantics() {
+        let p = SelectionPolicy::current();
+        let names: Vec<&str> = p.producers.iter().map(|r| r.name).collect();
+        assert_eq!(
+            super::super::decomposition_search::CANDIDATE_ORDER.to_vec(),
+            EXPECTED_ORDER.to_vec(),
+            "the engine's candidate slots and this module's expectation have diverged"
+        );
+        assert_eq!(names, EXPECTED_ORDER.to_vec());
+
+        // 1. The incumbent is slot 0. `FirstProduced` is positional and
+        //    every rank tie resolves to the earliest registration, so the
+        //    incumbent sitting anywhere else changes the degraded answer.
+        assert_eq!(
+            p.incumbent_index(),
+            Some(0),
+            "the preference order puts the incumbent first; a later slot would hand \
+             `first-produced` and every score tie to a challenger"
+        );
+
+        // 2. The scoped registrations are exactly the TAIL, contiguously
+        //    — the equivalence between v1's slice bound and v2's field
+        //    filter, asserted rather than assumed.
+        let scoped: Vec<usize> =
+            (0..p.producers.len()).filter(|&i| p.producers[i].scoped).collect();
+        assert!(!scoped.is_empty(), "the AdmissionRule needs something to admit");
+        let tail: Vec<usize> = (p.producers.len() - scoped.len()..p.producers.len()).collect();
+        assert_eq!(
+            scoped, tail,
+            "the `scoped` registrations must occupy the TAIL of the order. v1 confines \
+             them with the slice `candidates[..ranking_len]` — a POSITION — while v2 \
+             confines them with the `scoped` FIELD; the two agree only while `scoped` is \
+             a suffix. A coordinated reorder of all three name lists passes every \
+             equality check above and fails here, which is the point"
+        );
+
+        // 3. Within that tail, DI precedes horizontal: the pairwise
+        //    resolution's ties go to the earlier registration, and
+        //    RFC-060 fixed that as DI.
+        assert_eq!(
+            p.producers[scoped[0]].name, "direct-insertion",
+            "ties between two scoped winners go to the earlier registration, which \
+             RFC-060 fixed as DI"
+        );
+
+        // 4. Exactly one quality-key rival, and it is registered BEFORE
+        //    the scoped tail — its stage runs first in the program and
+        //    its gate reads only the incumbent.
+        let rivals: Vec<usize> =
+            (0..p.producers.len()).filter(|&i| p.producers[i].quality_key_rival).collect();
+        assert_eq!(rivals.len(), 1, "the quality-key stage compares exactly one rival");
+        assert!(rivals[0] < scoped[0]);
     }
 
     #[test]
@@ -1721,6 +1830,106 @@ mod tests {
         ps[HS].counts = Some(counts(0, 2, 0));
         let d = decide(&ps, &SelectionPolicy::current()).unwrap();
         assert_eq!(d.winner, DI);
+    }
+
+    /// The one overlap of the two scoped arms that neither the test above
+    /// nor the corpus reaches: **DI qualifies only by its
+    /// equal-and-denser arm while horizontal qualifies by being strictly
+    /// better than the incumbent.** The arms admit them for different
+    /// reasons, so "which is better" is not obviously the same question
+    /// in v2's single loop as in v1's two-then-one structure.
+    ///
+    /// v1 answers HORIZONTAL, and it is worth spelling out why, because
+    /// the reason is arithmetic rather than precedence: `di_choice` is
+    /// `Some(DI)` (equal counts, denser), `horizontal_choice` is
+    /// `Some(HS)` (strictly better counts), so `scoped_choice`'s
+    /// both-Some arm compares them directly with
+    /// `hs_counts.strictly_better_than(&di_counts)` — and DI's counts ARE
+    /// the incumbent's, so horizontal is strictly better than DI too.
+    /// **Density does not enter that comparison at all**: v1's pairwise
+    /// resolution has no density tiebreak, deliberately (RFC-060), so
+    /// DI's whole claim evaporates the moment a genuinely quieter rival
+    /// exists.
+    ///
+    /// v2 reaches the same answer by a different route — one fold over
+    /// the scoped registrations, where DI is admitted by
+    /// `equal_and_denser`, seated as `best`, and then displaced by
+    /// horizontal under the same `strictly_better_than`. Same answer,
+    /// and the two routes agreeing is the point of the test
+    /// (#698 rounds 9-10 carry-over (d)).
+    #[test]
+    fn a_strictly_better_horizontal_beats_a_merely_denser_di() {
+        let mut ps = blank();
+        ps[NATIVE] = produced(1.0, true);
+        ps[NATIVE].counts = Some(counts(0, 3, 1));
+        // DI: equal on every channel, strictly denser — its arm, and
+        // ONLY its arm, admits it.
+        ps[DI] = produced(9.0, true);
+        ps[DI].counts = Some(counts(0, 3, 1));
+        // Horizontal: strictly better on the warning channel, and far
+        // sparser than DI.
+        ps[HS] = produced(0.1, true);
+        ps[HS].counts = Some(counts(0, 2, 1));
+        let d = decide(&ps, &SelectionPolicy::current()).unwrap();
+        assert_eq!(
+            d,
+            Decision { winner: HS, stage: SelectionStage::ScopedPairwise },
+            "v1's both-scoped-won arm compares the two by the floor ALONE (no density \
+             tiebreak), and DI's counts are the incumbent's — so a strictly-better \
+             horizontal takes it despite DI's 90x score"
+        );
+
+        // The control: remove horizontal and DI's denser arm stands.
+        ps[HS] = not_run();
+        assert_eq!(
+            decide(&ps, &SelectionPolicy::current()).unwrap(),
+            Decision { winner: DI, stage: SelectionStage::ScopedPairwise },
+        );
+    }
+
+    /// Carry-over (a) of #698 rounds 9-10: the warnings-first order's
+    /// missing-key arm ABSTAINS instead of falling through to the score.
+    ///
+    /// Unreachable under today's program — `BestErrorFree` is the only
+    /// stage using this order and its admission already requires counts —
+    /// so it is exercised through a policy whose ranked stage drops
+    /// `require_error_free`, which is exactly the future stage the arm
+    /// exists for. Without the fix the unmeasured candidate wins on
+    /// density alone; with it, the primary criterion being unanswerable
+    /// means the challenger does not rank ahead and the earlier
+    /// registration keeps its seat.
+    #[test]
+    fn a_missing_warning_key_abstains_rather_than_ranking_on_score() {
+        let mut policy = SelectionPolicy::current();
+        policy.program.stages = vec![StageSpec {
+            tag: SelectionStage::BestAccepted,
+            kind: StageKind::TieredRank(RankSpec {
+                require_accepted: true,
+                require_error_free: false,
+                success_order: RankOrder::WarningsAscThenScoreDesc,
+                refusal_order: RankOrder::WarningsAscThenScoreDesc,
+            }),
+            on_incumbent_win: ChainBehavior::Terminate,
+        }];
+
+        let mut ps = blank();
+        ps[NATIVE] = produced(1.0, true);
+        ps[NATIVE].counts = Some(counts(0, 5, 0));
+        // No counts at all: nothing measured this candidate, so it has
+        // no warning key — and a 50x score must not smuggle it past the
+        // criterion it cannot answer.
+        ps[CELLS] = produced(50.0, true);
+        assert_eq!(
+            decide(&ps, &policy).unwrap().winner,
+            NATIVE,
+            "an unmeasured candidate must not rank ahead on the SECONDARY criterion when \
+             the primary one is a gap"
+        );
+
+        // Control, in the same policy: give it a key and the ordinary
+        // warnings-asc comparison applies.
+        ps[CELLS].counts = Some(counts(0, 4, 0));
+        assert_eq!(decide(&ps, &policy).unwrap().winner, CELLS);
     }
 
     // -----------------------------------------------------------------

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1465,6 +1465,51 @@ pub enum TraceEvent {
         stage: SelectionStage,
     },
 
+    // RFC-070 Phase 2a (#689 W3a): the SHADOW comparison. Emitted once
+    // per `select_best_decomposition` call, immediately after the
+    // scoreboard's terminal, recording what the v2 policy loop
+    // (`bus::selection_policy::decide`) would have answered on the same
+    // solve.
+    //
+    // **Observational only. v1's answer ships, always.** A disagreement
+    // is DATA for the campaign's K70-1/K70-2 adjudication, never a
+    // panic and never a behaviour change — the whole point of a shadow
+    // is that a divergence survives long enough to be read.
+    //
+    // Why this can gate CI where the parity corpus cannot: it compares
+    // two dispatches on ONE solve rather than one dispatch against a
+    // committed record, so it is independent of which zone-cache
+    // solutions the layout replayed. A cell that lands a different
+    // layout than the baseline still has a well-defined shadow verdict.
+    SelectionShadowCompared {
+        /// The winner v1 shipped, and the stage that picked it. `None`
+        /// on the all-candidates-failed path, where v1 names no winner
+        /// at all — kept comparable rather than unemitted, because "v2
+        /// found a winner where v1 refused" is exactly the kind of
+        /// divergence a shadow exists to surface.
+        v1_winner: Option<String>,
+        v1_stage: Option<SelectionStage>,
+        /// What `selection_policy::decide` answered over the SAME
+        /// scoreboard rows. Never re-validates: it consumes the
+        /// measurements the decision path already computed, so a
+        /// disagreement is about the PROGRAM, not about a second
+        /// opinion on the layout.
+        v2_winner: Option<String>,
+        v2_stage: Option<SelectionStage>,
+        /// `(winner, stage)` equal on both sides — the corpus's
+        /// divergence-equivalence rule, minus `status` (which is a
+        /// property of the build, not of the selection).
+        agree: bool,
+        /// Producers whose v2 `ProducerGate` verdict disagreed with
+        /// whether v1 actually ran them. One entry per producer, named
+        /// — never a count in a message (`docs/validator-reporting.md`).
+        /// This is the ONLY instrument that can see a mis-transcribed
+        /// eligibility clause: `policy_replay` consumes already-produced
+        /// profiles and evaluates zero gates (RFC-070 decision log,
+        /// #698's standing hand-off note).
+        gate_disagreements: Vec<String>,
+    },
+
     // `ModuleSizeSplit` candidate (see `docs/rfc-decomposition-search.md`)
     // applied a k-way split to one module of the partition plan. Fires
     // once per split module per `produce()` call. With Phase 1's k=2,

--- a/crates/core/src/verdict.rs
+++ b/crates/core/src/verdict.rs
@@ -250,7 +250,7 @@ pub struct Policy {
     /// nothing, deliberately" and "never thought about it", and the
     /// selection accessors must not answer for the second — see
     /// [`Verdict::candidate_selection_warnings`]. Set by
-    /// [`Policy::selection`], [`Policy::with_live_selection_exclusions`]
+    /// [`Policy::selection_counts`], [`Policy::with_live_selection_exclusions`]
     /// and [`Policy::with_excluded_warning_category`].
     pub selection_scoped: bool,
 }
@@ -290,18 +290,26 @@ impl Policy {
         self
     }
 
-    /// The preset for selection-scoped comparisons: gate nothing, carry
-    /// the live exclusions, and declare the scope so
+    /// The preset for selection-scoped COUNTS: gate nothing, carry the
+    /// live exclusions, and declare the scope so
     /// [`Verdict::candidate_selection_warnings`] answers. Named so the
     /// correct setup is a thing you reach for rather than a step you
     /// remember (#698 review round 3).
     ///
-    /// **Its `pass` is always `true`**, because it gates nothing — this
-    /// preset supplies COUNTS, and the pass/fail bit is not one of its
-    /// outputs. Reading both from one verdict would read a gate that was
-    /// never asked to gate; add overrides if you want it to (#698 review
-    /// round 5).
-    pub fn selection() -> Self {
+    /// **`_counts` is in the name deliberately** (renamed from
+    /// `selection` in W3a, #698 rounds 9-10 carry-over (f)). Round 5 had
+    /// settled the semantics — `pass` is always `true` here because
+    /// nothing is gated — but left them stated only in prose, on a
+    /// method whose bare name reads like "the selection policy" and
+    /// whose return type carries a `pass` field that looks like an
+    /// answer. A caller reaching for `Policy::selection()` and then
+    /// reading `verdict.pass` gets `true` for every input, which is the
+    /// most dangerous shape a wrong number can take: it is not wrong, it
+    /// is answering a question nobody asked. The name now says which
+    /// output is the real one, and
+    /// `selection_counts_never_gates_so_its_pass_bit_is_not_an_answer`
+    /// pins it. Add overrides if you want it to gate.
+    pub fn selection_counts() -> Self {
         Self::new(GatePolicy::ReportOnly).with_live_selection_exclusions()
     }
 
@@ -456,7 +464,7 @@ impl Verdict {
     ///
     /// A gap, not a zero and not a plausible wrong number, per the rule
     /// this campaign's instruments run on. Declare the scope with
-    /// [`Policy::selection`] or
+    /// [`Policy::selection_counts`] or
     /// [`Policy::with_excluded_warning_category`] to get a value —
     /// including a deliberately empty exclusion set, which is a
     /// declaration too.
@@ -931,8 +939,47 @@ mod tests {
 
         // Declaring the scope — even with an empty set — is what makes
         // it answerable.
-        let declared = never_worse(&[], &candidate, &Policy::selection(), MatchTier::Count, None);
+        let declared = never_worse(&[], &candidate, &Policy::selection_counts(), MatchTier::Count, None);
         assert_eq!(declared.candidate_selection_warnings(), Some(0));
+    }
+
+    /// The property the `_counts` suffix promises: this preset's `pass`
+    /// bit is not one of its outputs. It is `true` for a clean
+    /// comparison AND for a comparison that regresses every category,
+    /// because nothing is gated — so a caller reading it is reading a
+    /// gate that was never asked to gate (#698 rounds 9-10 carry-over
+    /// (f); the semantics were settled in round 5, the name and this pin
+    /// are what make them unmistakable).
+    #[test]
+    fn selection_counts_never_gates_so_its_pass_bit_is_not_an_answer() {
+        let policy = Policy::selection_counts();
+        let clean = never_worse(&[], &[], &policy, MatchTier::Count, None);
+        assert!(clean.pass);
+        // Five new Errors in a category that IS gated under every other
+        // preset. Still `pass`.
+        let candidate: Vec<ValidationIssue> = (0..5)
+            .map(|i| {
+                ValidationIssue::with_pos(
+                    Severity::Error,
+                    "missing-balancer-template",
+                    "test error",
+                    i,
+                    i,
+                )
+            })
+            .collect();
+        let regressed = never_worse(&[], &candidate, &policy, MatchTier::Count, None);
+        assert!(
+            regressed.pass,
+            "`pass` under this preset is a constant, not a verdict — read the COUNTS"
+        );
+        assert!(
+            regressed.regressed_categories().next().is_none(),
+            "…and nothing is recorded as regressed either, because nothing is gated"
+        );
+        assert_eq!(regressed.candidate_errors(), 5, "the numbers are what it answers");
+        // The control: the same comparison under a gating preset fails.
+        assert!(!never_worse(&[], &candidate, &Policy::decomposition(), MatchTier::Count, None).pass);
     }
 
     // -----------------------------------------------------------------

--- a/crates/core/tests/parity_corpus.rs
+++ b/crates/core/tests/parity_corpus.rs
@@ -488,6 +488,160 @@ struct OuterSelection {
     /// The seven `SelectionCandidateEvaluated` events of the outer
     /// block, in canonical slot order. Empty when no selection ran.
     rows: Vec<TraceEvent>,
+    /// RFC-070 Phase 2a: the live shadow comparison the engine emitted
+    /// for this selection. `None` when no selection ran at all — and
+    /// that is the ONLY reason it may be absent, which is why the
+    /// harnesses below assert its presence on every decided cell rather
+    /// than skipping a missing one (a skipped comparison reads as clean,
+    /// the #693 shape this campaign keeps re-closing).
+    shadow: Option<ShadowOutcome>,
+}
+
+/// One `SelectionShadowCompared` event, flattened for reporting.
+#[derive(Debug, Clone)]
+struct ShadowOutcome {
+    agree: bool,
+    v1: (Option<String>, Option<SelectionStage>),
+    v2: (Option<String>, Option<SelectionStage>),
+    gate_disagreements: Vec<String>,
+}
+
+impl ShadowOutcome {
+    /// Everything an adjudicator needs on one line: both verdicts and
+    /// any gate disagreement, NAMED. A disagreement is a campaign-level
+    /// finding, so the message has to carry enough to act on without
+    /// re-running.
+    fn describe(&self) -> String {
+        let side = |(w, s): &(Option<String>, Option<SelectionStage>)| {
+            format!(
+                "{}/{}",
+                w.as_deref().unwrap_or("<none>"),
+                s.map(stage_name).unwrap_or("<none>")
+            )
+        };
+        let gates = if self.gate_disagreements.is_empty() {
+            String::new()
+        } else {
+            format!("  gates: [{}]", self.gate_disagreements.join("; "))
+        };
+        format!("v1 {} -> v2 {}{gates}", side(&self.v1), side(&self.v2))
+    }
+    /// Agreement on BOTH surfaces the shadow compares. A gate
+    /// disagreement that happens not to move the winner on this
+    /// particular solve is still a mis-transcription, and letting it
+    /// ride on `agree` alone would hide exactly the class the gate
+    /// comparison exists to catch.
+    fn clean(&self) -> bool {
+        self.agree && self.gate_disagreements.is_empty()
+    }
+}
+
+/// The shadow-agreement tally over a sweep of cells, and the failure
+/// message it produces.
+///
+/// **Why this gate is CI-shaped where the baseline is not.** Five review
+/// rounds across #694/#698 refused "CI-gate the corpus", and correctly:
+/// a baseline gate asserts "production has not changed", which every
+/// engine PR legitimately falsifies, and the record is cache-relative
+/// besides. The shadow is neither. It compares two dispatches on ONE
+/// solve, so it says nothing about which layout was produced and
+/// everything about whether the two programs answer alike — a fixture
+/// whose winner legitimately moved still has a well-defined shadow
+/// verdict, and a host with a different zone cache computes the same
+/// one. That is what makes the smoke tier below runnable on every push
+/// (RFC-070 Verification plan item 2, whose promise the earlier
+/// refusals kept pointing at).
+#[derive(Default)]
+struct ShadowReport {
+    compared: usize,
+    disagreements: Vec<String>,
+    /// Cells that decided but emitted no shadow event at all. A missing
+    /// comparison must never read as agreement — that is the "compared
+    /// nothing reads as clean" shape (#693) this campaign has now closed
+    /// in four places.
+    missing: Vec<String>,
+}
+
+impl ShadowReport {
+    fn absorb(&mut self, key: &str, run: &CellRun) {
+        match (&run.shadow, run.cell.status.as_str()) {
+            (Some(s), _) => {
+                self.compared += 1;
+                if !s.clean() {
+                    self.disagreements.push(format!("  {key}: {}", s.describe()));
+                }
+            }
+            // `no-solve` never reaches the search, so there is nothing
+            // to shadow. Every other status means the search ran.
+            (None, "no-solve") => {}
+            (None, status) => self.missing.push(format!("  {key}: status {status}")),
+        }
+    }
+
+    fn print(&self) {
+        println!("\n=== RFC-070 Phase 2a shadow ===");
+        println!(
+            "cells compared: {}  |  disagreements: {}  |  missing comparisons: {}",
+            self.compared,
+            self.disagreements.len(),
+            self.missing.len()
+        );
+        for d in self.disagreements.iter().chain(self.missing.iter()) {
+            println!("{d}");
+        }
+    }
+
+    /// Fails the sweep on a disagreement, a missing comparison, or an
+    /// empty tally.
+    fn assert_clean(&self) {
+        assert!(
+            self.compared > 0,
+            "the shadow compared NOTHING across the whole sweep — the comparison is not \
+             running, which is not the same fact as it agreeing"
+        );
+        assert!(
+            self.missing.is_empty(),
+            "{} cell(s) ran a selection but emitted no `SelectionShadowCompared`. A \
+             missing comparison is a HOLE, not an agreement:\n{}",
+            self.missing.len(),
+            self.missing.join("\n")
+        );
+        assert!(
+            self.disagreements.is_empty(),
+            "the v2 shadow disagreed with production on {} of {} cell(s). **THIS IS A \
+             CAMPAIGN-LEVEL FINDING (RFC-070 K70-1 / K70-2), not a test bug.** Record the \
+             cell and the mechanism and take it to the campaign lead. A transcription bug \
+             may be fixed with receipts; a semantic one MUST be reported — do not tune \
+             policy data until the numbers line up.\n{}",
+            self.disagreements.len(),
+            self.compared,
+            self.disagreements.join("\n")
+        );
+    }
+}
+
+/// Pull the outer selection's shadow event out of one build's stream.
+/// Same "last one wins" rule as the rows: a nested selection's shadow is
+/// emitted inside that candidate's captured events and is replayed
+/// (winner only) BEFORE the outer board, so the last event is the outer
+/// one.
+fn outer_shadow(events: &[TraceEvent]) -> Option<ShadowOutcome> {
+    events.iter().rev().find_map(|e| match e {
+        TraceEvent::SelectionShadowCompared {
+            v1_winner,
+            v1_stage,
+            v2_winner,
+            v2_stage,
+            agree,
+            gate_disagreements,
+        } => Some(ShadowOutcome {
+            agree: *agree,
+            v1: (v1_winner.clone(), *v1_stage),
+            v2: (v2_winner.clone(), *v2_stage),
+            gate_disagreements: gate_disagreements.clone(),
+        }),
+        _ => None,
+    })
 }
 
 /// Pull the OUTER selection out of one build's event stream.
@@ -580,21 +734,38 @@ fn outer_selection(events: &[TraceEvent]) -> OuterSelection {
              different blocks. Do not bless this baseline"
         );
     }
-    OuterSelection { outcomes, decided, rows: tail.iter().map(|e| (*e).clone()).collect() }
+    OuterSelection {
+        outcomes,
+        decided,
+        rows: tail.iter().map(|e| (*e).clone()).collect(),
+        shadow: outer_shadow(events),
+    }
 }
 
-fn run_cell(f: &Fixture, machine: &str, opts_label: &str, apply: fn(&mut LayoutOptions)) -> Cell {
-    run_cell_capturing(f, machine, opts_label, apply).0
+/// One cell's result: the committed record, the scoreboard rows
+/// `policy_replay` replays, and the live shadow comparison the engine
+/// emitted alongside them.
+///
+/// `rows` and `shadow` are deliberately NOT fields of [`Cell`]: `Cell`
+/// is what gets serialised into the committed baseline, and adding to it
+/// would force a re-bless of 160 rows for data the equivalence rule does
+/// not compare. The baseline stays byte-identical across this phase,
+/// which is itself part of the evidence that nothing moved.
+struct CellRun {
+    cell: Cell,
+    rows: Vec<TraceEvent>,
+    shadow: Option<ShadowOutcome>,
 }
 
-/// `run_cell`, plus the outer selection's seven scoreboard rows. One
-/// solve, two consumers — `policy_replay`'s whole shape.
-fn run_cell_capturing(
+/// One cell: the committed record, the scoreboard rows `policy_replay`
+/// replays, and the shadow comparison. One solve, three consumers —
+/// `policy_replay`'s shape, widened by Phase 2a.
+fn run_cell(
     f: &Fixture,
     machine: &str,
     opts_label: &str,
     apply: fn(&mut LayoutOptions),
-) -> (Cell, Vec<TraceEvent>) {
+) -> CellRun {
     let base = Cell {
         fixture: f.label.to_string(),
         machine: machine.to_string(),
@@ -606,7 +777,11 @@ fn run_cell_capturing(
     };
     let inputs: FxHashSet<String> = f.inputs.iter().map(|s| s.to_string()).collect();
     let Ok(sr) = solver::solve(f.item, f.rate, &inputs, machine) else {
-        return (Cell { status: "no-solve".into(), ..base }, Vec::new());
+        return CellRun {
+            cell: Cell { status: "no-solve".into(), ..base },
+            rows: Vec::new(),
+            shadow: None,
+        };
     };
 
     let mut opts = LayoutOptions { max_belt_tier: f.belt.map(str::to_string), ..Default::default() };
@@ -617,7 +792,7 @@ fn run_cell_capturing(
     let events = trace::drain_events();
     drop(guard);
 
-    let OuterSelection { outcomes, decided, rows } = outer_selection(&events);
+    let OuterSelection { outcomes, decided, rows, shadow } = outer_selection(&events);
     let cell = match decided {
         Some((winner, stage)) => Cell {
             // A build can refuse AFTER the search picked a winner (the
@@ -633,7 +808,7 @@ fn run_cell_capturing(
         None if outcomes.is_empty() => Cell { status: "no-selection".into(), ..base },
         None => Cell { status: "no-winner".into(), outcomes, ..base },
     };
-    (cell, rows)
+    CellRun { cell, rows, shadow }
 }
 
 /// Print the corpus as the campaign's key table: rows are
@@ -908,7 +1083,7 @@ fn policy_replay() {
     for f in FIXTURES {
         for machine in f.machines {
             for (label, apply) in OPTION_SETS {
-                let (cell, rows) = run_cell_capturing(f, machine, label, *apply);
+                let CellRun { cell, rows, .. } = run_cell(f, machine, label, *apply);
                 let key = format!("{}[{machine}]/{label}", f.label);
 
                 // v1 decided this cell against the committed record.
@@ -1074,16 +1249,20 @@ fn stage_label(stage: &str) -> &'static str {
 fn parity_corpus() {
     let pin_hash = hash_zone_cache();
     let mut cells = Vec::new();
+    let mut shadow_report = ShadowReport::default();
     for f in FIXTURES {
         for machine in f.machines {
             for (label, apply) in OPTION_SETS {
-                cells.push(run_cell(f, machine, label, *apply));
+                let run = run_cell(f, machine, label, *apply);
+                shadow_report.absorb(&format!("{}[{machine}]/{label}", f.label), &run);
+                cells.push(run.cell);
             }
         }
     }
 
     print_grid(&cells);
     print_divergences(&cells);
+    shadow_report.print();
 
     match std::env::var("SPAGHETTIO_PARITY_CORPUS").as_deref() {
         Ok(mode @ ("bless" | "bless-repin")) => {
@@ -1174,6 +1353,15 @@ fn parity_corpus() {
             );
         }
         Ok(mode @ ("check" | "check-any-cache")) => {
+            // RFC-070 Phase 2a: the shadow gate, asserted BEFORE the
+            // baseline comparison and deliberately so. The two failures
+            // are independent and answer different questions, but only
+            // one of them is interpretable under a mis-pinned cache: a
+            // baseline divergence may be provenance, while a shadow
+            // disagreement is two programs answering differently about
+            // the same solve — true regardless of which layout that
+            // solve produced. So the interpretable failure leads.
+            shadow_report.assert_clean();
             let text = std::fs::read_to_string(baseline_path())
                 .expect("SPAGHETTIO_PARITY_CORPUS=check needs a committed baseline");
             let baseline: Baseline = serde_json::from_str(&text).expect("baseline parses");
@@ -1311,4 +1499,83 @@ fn parity_corpus() {
             // Report-only default: prints, asserts nothing.
         }
     }
+}
+
+// =====================================================================
+// RFC-070 Phase 2a (#689 W3a): the non-ignored shadow smoke tier
+// =====================================================================
+
+/// The six census fixtures at the machine tier their #691 labels name,
+/// under production defaults. Spelled longhand rather than sliced off
+/// `FIXTURES` — a list derived from the thing it checks cannot notice
+/// that thing changing, the same argument `EXPECTED_ORDER` rests on.
+///
+/// These are the six that `check_firing_census.rs` and the junction-seed
+/// census also describe, so a shadow finding here is readable against
+/// both of the campaign's other instruments row by row.
+const SMOKE_CELLS: &[(&str, &str)] = &[
+    ("tier1_gear_am1", "assembling-machine-1"),
+    ("tier2_ec_am1_10_ore", "assembling-machine-1"),
+    ("tier2_ec_am2_30_ore", "assembling-machine-2"),
+    ("tier3_plastic_cp_5", "chemical-plant"),
+    ("tier4_ac_am2_5_unconstrained", "assembling-machine-2"),
+    ("tier5_pu_am3_2_unconstrained", "assembling-machine-3"),
+];
+
+/// **The parity CI gate.** Not `#[ignore]`d: this is what runs on every
+/// push, and it is the first assertion in this campaign that can.
+///
+/// Its two ignored siblings are cache-relative — they compare a live run
+/// against a COMMITTED record, so a host with a different zone cache
+/// gets different layouts and a meaningless diff, and every legitimate
+/// engine change falsifies them. This test compares the v1 and v2
+/// dispatches **on the same solve**: whatever layout each fixture
+/// produces on this host with this cache, both programs see the same
+/// scoreboard and must reach the same `(winner, stage)`. Nothing about
+/// the assertion depends on WHICH layout that was, so there is no
+/// re-bless treadmill and no pin to get wrong.
+///
+/// What it therefore covers, and what it does not: six of the corpus's
+/// 160 cells, all at the `default` option set. The option-set axis
+/// carries this corpus's claim surface (RFC-070 decision log), so the
+/// full 160-cell sweep under `SPAGHETTIO_PARITY_CORPUS=check` remains
+/// the real gate for a phase boundary — this is the tripwire between
+/// them, sized so it can run unconditionally.
+#[test]
+fn shadow_agrees_with_production_on_the_census_fixtures() {
+    // The third parallel candidate list, bound in CI (#698 rounds 9-10
+    // carry-over (e) — the unit tier binds the other two). A shadow
+    // whose profile vector is keyed differently from the scoreboard
+    // would compare mis-keyed slots and could agree by luck.
+    assert_eq!(
+        SelectionPolicy::current().producers.iter().map(|p| p.name).collect::<Vec<_>>(),
+        EXPECTED_ORDER,
+        "SelectionPolicy::current() does not register the seven producers in the slot \
+         order this file expects"
+    );
+
+    let mut report = ShadowReport::default();
+    for (label, machine) in SMOKE_CELLS {
+        let f = FIXTURES
+            .iter()
+            .find(|f| f.label == *label)
+            .unwrap_or_else(|| panic!("smoke cell {label} is not a corpus fixture"));
+        assert!(
+            f.machines.contains(machine),
+            "smoke cell {label} names machine {machine}, which is not on that fixture's \
+             swept axis"
+        );
+        let run = run_cell(f, machine, "default", |_| {});
+        assert_eq!(
+            run.cell.status, "decided",
+            "smoke cell {label}[{machine}] did not decide (status {:?}) — the shadow gate \
+             needs a live selection to compare, so a fixture that stopped deciding must \
+             be replaced rather than silently skipped",
+            run.cell.status
+        );
+        report.absorb(&format!("{label}[{machine}]"), &run);
+    }
+    report.print();
+    assert_eq!(report.compared, SMOKE_CELLS.len(), "one comparison per smoke cell");
+    report.assert_clean();
 }

--- a/crates/core/tests/parity_corpus.rs
+++ b/crates/core/tests/parity_corpus.rs
@@ -526,13 +526,67 @@ impl ShadowOutcome {
         };
         format!("v1 {} -> v2 {}{gates}", side(&self.v1), side(&self.v2))
     }
-    /// Agreement on BOTH surfaces the shadow compares. A gate
-    /// disagreement that happens not to move the winner on this
-    /// particular solve is still a mis-transcription, and letting it
-    /// ride on `agree` alone would hide exactly the class the gate
-    /// comparison exists to catch.
-    fn clean(&self) -> bool {
-        self.agree && self.gate_disagreements.is_empty()
+    /// Everything wrong with this comparison, or `None`.
+    ///
+    /// **Deliberately does NOT trust the engine's `agree` bit** (#703
+    /// review round 1, the 1/3-pass finding and the most useful one):
+    /// a harness that reads a boolean the thing under test computed is
+    /// asserting "it says it agrees", not "the two programs agree". The
+    /// event carries all four sides, so the comparison is redone here
+    /// from the data — and the engine's own bit is then checked against
+    /// that recomputation, which turns the self-referential read into a
+    /// second independent surface.
+    ///
+    /// Four surfaces, each failing separately:
+    ///
+    /// 1. **The recomputed verdict.** `(v1_winner, v1_stage)` vs
+    ///    `(v2_winner, v2_stage)`, compared here.
+    /// 2. **The engine's `agree` bit** against (1) — a stuck-true bit,
+    ///    or a comparison written against the wrong pair, shows up as a
+    ///    mismatch rather than as silence.
+    /// 3. **v1's side against the cell's OWN record**, which came from
+    ///    the independent `SelectionDecided` event. This catches a
+    ///    mis-indexed winner name (`CANDIDATE_ORDER[idx]` vs the name
+    ///    the winner replay actually used) and a shadow event paired
+    ///    with the wrong block.
+    /// 4. **The producer gates.** A gate disagreement that does not
+    ///    happen to move the winner on this solve is still a
+    ///    mis-transcription, and letting it ride on the verdict alone
+    ///    hides exactly the class the gate comparison exists to catch.
+    ///
+    /// What none of this can reach, stated so the coverage is not
+    /// overread: a policy error faithfully reproduced by BOTH the
+    /// registration and v1 — the shadow's gate half checks v2's clauses
+    /// against v1's actual dispatch, so a mis-transcription is caught
+    /// wherever the corpus exercises it, but a clause that is wrong and
+    /// behaviourally identical on all 160 cells is a coverage limit, not
+    /// something an assertion can close.
+    fn faults(&self, cell: &Cell) -> Vec<String> {
+        let mut out = Vec::new();
+        let recomputed = self.v1.0 == self.v2.0 && self.v1.1 == self.v2.1;
+        if !recomputed {
+            out.push("v1 and v2 named different verdicts".to_string());
+        }
+        if self.agree != recomputed {
+            out.push(format!(
+                "the engine's own `agree` bit says {} where the four recorded fields say \
+                 {recomputed} — the shadow's comparison disagrees with its own data",
+                self.agree
+            ));
+        }
+        let cell_side = (cell.winner.clone(), cell.stage.clone());
+        let shadow_side = (self.v1.0.clone(), self.v1.1.map(|s| stage_name(s).to_string()));
+        if cell_side != shadow_side {
+            out.push(format!(
+                "the shadow's v1 side {shadow_side:?} is not what `SelectionDecided` \
+                 recorded for this cell ({cell_side:?}) — the two events are from \
+                 different selections"
+            ));
+        }
+        if !self.gate_disagreements.is_empty() {
+            out.push(format!("gates: [{}]", self.gate_disagreements.join("; ")));
+        }
+        out
     }
 }
 
@@ -551,11 +605,27 @@ impl ShadowOutcome {
 /// one. That is what makes the smoke tier below runnable on every push
 /// (RFC-070 Verification plan item 2, whose promise the earlier
 /// refusals kept pointing at).
+///
+/// **Scoped precisely** (#703 review round 1): what is cache- and
+/// layout-independent is the VERDICT COMPARISON. The fixture list is
+/// still a list — a smoke cell that stops reaching the search has
+/// nothing to shadow and fails the count check below, which is a
+/// maintenance obligation like any hand-written fixture list. The claim
+/// is "no re-bless treadmill for the DECISION", not "no fixture can
+/// ever need replacing".
 #[derive(Default)]
 struct ShadowReport {
-    compared: usize,
+    /// Cells where BOTH programs named a winner and agreed.
+    agreed_decided: usize,
+    /// Cells where both programs named NO winner. Also an agreement,
+    /// and counted apart from the one above so the headline figure
+    /// cannot quietly mean something wider than "decided cells agree"
+    /// (#703 review round 1: today's corpus has zero of these, so the
+    /// two numbers coincide — the split is what keeps that checkable
+    /// rather than assumed).
+    agreed_no_winner: usize,
     disagreements: Vec<String>,
-    /// Cells that decided but emitted no shadow event at all. A missing
+    /// Cells whose selection RAN but emitted no shadow event. A missing
     /// comparison must never read as agreement — that is the "compared
     /// nothing reads as clean" shape (#693) this campaign has now closed
     /// in four places.
@@ -563,17 +633,39 @@ struct ShadowReport {
 }
 
 impl ShadowReport {
+    fn compared(&self) -> usize {
+        self.agreed_decided + self.agreed_no_winner + self.disagreements.len()
+    }
+
     fn absorb(&mut self, key: &str, run: &CellRun) {
         match (&run.shadow, run.cell.status.as_str()) {
             (Some(s), _) => {
-                self.compared += 1;
-                if !s.clean() {
-                    self.disagreements.push(format!("  {key}: {}", s.describe()));
+                let faults = s.faults(&run.cell);
+                if faults.is_empty() {
+                    if run.cell.winner.is_some() {
+                        self.agreed_decided += 1;
+                    } else {
+                        self.agreed_no_winner += 1;
+                    }
+                } else {
+                    self.disagreements
+                        .push(format!("  {key}: {}\n      {}", s.describe(), faults.join("\n      ")));
                 }
             }
-            // `no-solve` never reaches the search, so there is nothing
-            // to shadow. Every other status means the search ran.
-            (None, "no-solve") => {}
+            // The two statuses where there is genuinely nothing to
+            // shadow, because no selection ran at all: `no-solve` (the
+            // solver refused this fixture×machine pair) and
+            // `no-selection` (`build_bus_layout` refused BEFORE reaching
+            // the search — the cell emits no scoreboard rows either).
+            //
+            // `no-selection` was hard-failing here in the first draft,
+            // on a comment claiming "every other status means the search
+            // ran" that is simply false of it (#703 review round 1). It
+            // is latent today (zero such cells) but it would have turned
+            // a legitimately-refusing cell into a campaign-finding-style
+            // failure with no divergence — a criterion the baseline
+            // comparison never had and this gate has no business adding.
+            (None, "no-solve" | "no-selection") => {}
             (None, status) => self.missing.push(format!("  {key}: status {status}")),
         }
     }
@@ -581,8 +673,11 @@ impl ShadowReport {
     fn print(&self) {
         println!("\n=== RFC-070 Phase 2a shadow ===");
         println!(
-            "cells compared: {}  |  disagreements: {}  |  missing comparisons: {}",
-            self.compared,
+            "cells compared: {}  (agreed: {} decided + {} no-winner)  |  disagreements: {}  \
+             |  missing comparisons: {}",
+            self.compared(),
+            self.agreed_decided,
+            self.agreed_no_winner,
             self.disagreements.len(),
             self.missing.len()
         );
@@ -595,7 +690,7 @@ impl ShadowReport {
     /// empty tally.
     fn assert_clean(&self) {
         assert!(
-            self.compared > 0,
+            self.compared() > 0,
             "the shadow compared NOTHING across the whole sweep — the comparison is not \
              running, which is not the same fact as it agreeing"
         );
@@ -614,7 +709,7 @@ impl ShadowReport {
              may be fixed with receipts; a semantic one MUST be reported — do not tune \
              policy data until the numbers line up.\n{}",
             self.disagreements.len(),
-            self.compared,
+            self.compared(),
             self.disagreements.join("\n")
         );
     }
@@ -1541,12 +1636,16 @@ const SMOKE_CELLS: &[(&str, &str)] = &[
 /// full 160-cell sweep under `SPAGHETTIO_PARITY_CORPUS=check` remains
 /// the real gate for a phase boundary — this is the tripwire between
 /// them, sized so it can run unconditionally.
-/// Cost: ~15s local warm (16 threads, pinned cache), which puts it in
-/// the 5–20s band `.config/nextest.toml` sizes at a 300s ceiling. It
-/// also carries a `threads-required` override there, because six SAT-
-/// heavy solves in one test on a 4-thread runner is the shape that blew
+/// Cost: ~15s local warm (16 threads, pinned cache) and **30.9s
+/// measured on the CI runner** (PR #703 head `12b1ea87`, job
+/// 97039777698) — a 2x host penalty rather than the 8-18x the cold-cache
+/// note in `.config/nextest.toml` records, because the rust job pins
+/// `SPAGHETTIO_ZONE_CACHE_PATH`. The 300s ceiling is therefore a ~10x
+/// margin over an observed number, not an extrapolation. It also carries
+/// a `threads-required` override there, because six SAT-heavy solves in
+/// one test on a 4-thread runner is the shape that blew
 /// `tier4_..._belt_pipe_crossing`'s ceiling when parallelism was first
-/// tried. The ntest ceiling is the real hang detector; nextest's kill
+/// tried. The ntest ceiling is the real hang detector; nextest'''s kill
 /// sits above it.
 #[test]
 #[ntest::timeout(300_000)]
@@ -1574,16 +1673,32 @@ fn shadow_agrees_with_production_on_the_census_fixtures() {
              swept axis"
         );
         let run = run_cell(f, machine, "default", |_| {});
-        assert_eq!(
-            run.cell.status, "decided",
-            "smoke cell {label}[{machine}] did not decide (status {:?}) — the shadow gate \
-             needs a live selection to compare, so a fixture that stopped deciding must \
-             be replaced rather than silently skipped",
-            run.cell.status
-        );
         report.absorb(&format!("{label}[{machine}]"), &run);
     }
     report.print();
-    assert_eq!(report.compared, SMOKE_CELLS.len(), "one comparison per smoke cell");
+    // The ONLY fixture-shaped requirement: each smoke cell must reach
+    // the search, so there is something to compare. Nothing here pins
+    // WHICH winner, WHICH stage, or even that the build succeeded.
+    //
+    // The first draft asserted `status == "decided"` per cell, and that
+    // was the wrong pin (#703 review round 1, the major): the shadow's
+    // verdict comparison is layout-independent, but "decided" is not —
+    // a host whose zone cache differs can legitimately land a cell in
+    // `decided-then-refused` (the search picked a winner and a LATER
+    // build step refused, which `run_cell` distinguishes on purpose),
+    // and that would red the one always-on gate with no v1/v2
+    // divergence anywhere. The shadow is emitted on that path too, so
+    // the comparison is still available and still meaningful; only the
+    // over-tight assertion had to go.
+    assert_eq!(
+        report.compared(),
+        SMOKE_CELLS.len(),
+        "every smoke cell must reach the selection and emit a comparison; {} of {} did. \
+         A cell that stopped reaching the search has nothing to shadow, so this gate \
+         would be silently measuring less than it claims — replace the fixture rather \
+         than letting the count drift",
+        report.compared(),
+        SMOKE_CELLS.len()
+    );
     report.assert_clean();
 }

--- a/crates/core/tests/parity_corpus.rs
+++ b/crates/core/tests/parity_corpus.rs
@@ -526,42 +526,48 @@ impl ShadowOutcome {
         };
         format!("v1 {} -> v2 {}{gates}", side(&self.v1), side(&self.v2))
     }
-    /// Everything wrong with this comparison, or `None`.
+    /// Everything wrong with this comparison, or an empty vec.
     ///
     /// **Deliberately does NOT trust the engine's `agree` bit** (#703
     /// review round 1, the 1/3-pass finding and the most useful one):
     /// a harness that reads a boolean the thing under test computed is
-    /// asserting "it says it agrees", not "the two programs agree". The
-    /// event carries all four sides, so the comparison is redone here
-    /// from the data — and the engine's own bit is then checked against
-    /// that recomputation, which turns the self-referential read into a
-    /// second independent surface.
+    /// asserting "it says it agrees", not "the two programs agree".
     ///
-    /// Four surfaces, each failing separately:
+    /// Four checks. **Two of them are ANCHORED OUTSIDE the shadow event
+    /// and two are not**, and the distinction is the whole point — the
+    /// first draft of this doc called all four "independent surfaces",
+    /// which overstated it (#703 review round 2, and correctly: an
+    /// internally-consistent-but-wrong event passes anything computed
+    /// only from itself).
     ///
-    /// 1. **The recomputed verdict.** `(v1_winner, v1_stage)` vs
-    ///    `(v2_winner, v2_stage)`, compared here.
-    /// 2. **The engine's `agree` bit** against (1) — a stuck-true bit,
-    ///    or a comparison written against the wrong pair, shows up as a
-    ///    mismatch rather than as silence.
-    /// 3. **v1's side against the cell's OWN record**, which came from
-    ///    the independent `SelectionDecided` event. This catches a
-    ///    mis-indexed winner name (`CANDIDATE_ORDER[idx]` vs the name
-    ///    the winner replay actually used) and a shadow event paired
-    ///    with the wrong block.
-    /// 4. **The producer gates.** A gate disagreement that does not
-    ///    happen to move the winner on this solve is still a
-    ///    mis-transcription, and letting it ride on the verdict alone
-    ///    hides exactly the class the gate comparison exists to catch.
+    /// 1. *Within the event.* The recomputed verdict:
+    ///    `(v1_winner, v1_stage)` vs `(v2_winner, v2_stage)`.
+    /// 2. *Within the event.* The engine's `agree` bit against (1) — a
+    ///    stuck-true bit, or a comparison written against the wrong
+    ///    pair, shows up as a mismatch rather than as silence.
+    /// 3. **ANCHORED: v1's side against `SelectionDecided`**, a
+    ///    different event emitted by a different code path. Catches a
+    ///    mis-indexed winner name and a shadow paired with the wrong
+    ///    block.
+    /// 4. **ANCHORED: v2's side against the harness's OWN `decide` run**
+    ///    over the same cell's recorded rows (`anchor` below). This is
+    ///    the one the event cannot fake: the harness reaches the v2
+    ///    answer independently, through `profile_from_row` — a
+    ///    different projection of the same scoreboard than
+    ///    `Scoreboard::v2_profiles`, so it also pins those two
+    ///    constructions against each other.
     ///
-    /// What none of this can reach, stated so the coverage is not
-    /// overread: a policy error faithfully reproduced by BOTH the
-    /// registration and v1 — the shadow's gate half checks v2's clauses
-    /// against v1's actual dispatch, so a mis-transcription is caught
-    /// wherever the corpus exercises it, but a clause that is wrong and
-    /// behaviourally identical on all 160 cells is a coverage limit, not
+    /// Plus the producer gates, which are anchored by construction:
+    /// they compare v2's clauses against v1's ACTUAL dispatch (did v1
+    /// run that candidate), not against a re-reading of the same source.
+    /// A gate disagreement that does not happen to move the winner on
+    /// this solve is still a mis-transcription.
+    ///
+    /// What remains out of reach, stated so the coverage is not
+    /// overread: a clause that is wrong AND behaviourally identical to
+    /// v1's on every cell the corpus runs. That is a coverage limit, not
     /// something an assertion can close.
-    fn faults(&self, cell: &Cell) -> Vec<String> {
+    fn faults(&self, cell: &Cell, anchor: Option<(String, String)>) -> Vec<String> {
         let mut out = Vec::new();
         let recomputed = self.v1.0 == self.v2.0 && self.v1.1 == self.v2.1;
         if !recomputed {
@@ -581,6 +587,16 @@ impl ShadowOutcome {
                 "the shadow's v1 side {shadow_side:?} is not what `SelectionDecided` \
                  recorded for this cell ({cell_side:?}) — the two events are from \
                  different selections"
+            ));
+        }
+        let shadow_v2 =
+            self.v2.0.clone().zip(self.v2.1.map(|s| stage_name(s).to_string()));
+        if anchor != shadow_v2 {
+            out.push(format!(
+                "the event's v2 side {shadow_v2:?} is not what this harness's own \
+                 `decide` run over the same rows produced ({anchor:?}) — either the \
+                 shadow's profile projection and `profile_from_row` disagree, or the \
+                 event does not report what `decide` actually said"
             ));
         }
         if !self.gate_disagreements.is_empty() {
@@ -637,10 +653,25 @@ impl ShadowReport {
         self.agreed_decided + self.agreed_no_winner + self.disagreements.len()
     }
 
+    /// The harness's OWN v2 answer for this cell, reached without
+    /// reading the shadow event: `decide` over the profiles built from
+    /// the recorded scoreboard rows. `None` when there are no rows to
+    /// decide from, or when `decide` names no winner.
+    fn independent_v2(rows: &[TraceEvent]) -> Option<(String, String)> {
+        if rows.len() != EXPECTED_ORDER.len() {
+            return None;
+        }
+        let policy = SelectionPolicy::current();
+        let profiles: Vec<IssueProfile> = rows.iter().map(profile_from_row).collect();
+        decide(&profiles, &policy).map(|d| {
+            (policy.producers[d.winner].name.to_string(), stage_name(d.stage).to_string())
+        })
+    }
+
     fn absorb(&mut self, key: &str, run: &CellRun) {
         match (&run.shadow, run.cell.status.as_str()) {
             (Some(s), _) => {
-                let faults = s.faults(&run.cell);
+                let faults = s.faults(&run.cell, Self::independent_v2(&run.rows));
                 if faults.is_empty() {
                     if run.cell.winner.is_some() {
                         self.agreed_decided += 1;
@@ -715,13 +746,38 @@ impl ShadowReport {
     }
 }
 
-/// Pull the outer selection's shadow event out of one build's stream.
-/// Same "last one wins" rule as the rows: a nested selection's shadow is
-/// emitted inside that candidate's captured events and is replayed
-/// (winner only) BEFORE the outer board, so the last event is the outer
-/// one.
-fn outer_shadow(events: &[TraceEvent]) -> Option<ShadowOutcome> {
-    events.iter().rev().find_map(|e| match e {
+/// Pull the outer selection's shadow event out of one build's stream,
+/// **by adjacency to its own anchor** rather than by "the last one
+/// anywhere".
+///
+/// The first draft took the last `SelectionShadowCompared` in the
+/// stream, on the argument that a nested selection's shadow is replayed
+/// before the outer board. That argument is true and it is not enough
+/// (found by an independent read of this PR's head): if the OUTER
+/// emission is ever missing — suppressed, skipped by the alignment
+/// guard, or lost to a future refactor — a WINNING nested candidate's
+/// own shadow event is then the last one, and if its verdict happens to
+/// match the outer `SelectionDecided` the cell reads as compared and
+/// agreed. The missing-comparison guard never fires, and the gate
+/// silently measures a different selection than the one it names.
+///
+/// So the outer event is identified POSITIVELY, with the same adjacency
+/// discipline the scoreboard already uses. Verified at source
+/// (`decomposition_search.rs`), both emission paths:
+///
+/// - success: `board.emit()` → `SelectionDecided` → shadow, with no
+///   intervening `emit`, so the shadow is at `terminal + 1`;
+/// - all-candidates-failed: `board.emit()` → shadow (no terminal at
+///   all), so the shadow is at `last_row + 1`.
+///
+/// A nested block cannot occupy either slot: nested events are replayed
+/// from the winner's captured buffer BEFORE the outer board is emitted.
+/// If the anchor's successor is not a shadow event, this returns `None`
+/// and the caller reports a missing comparison — which is the loud
+/// answer, not the quiet one.
+fn outer_shadow(events: &[TraceEvent], anchor: Option<usize>) -> Option<ShadowOutcome> {
+    let after = events.get(anchor? + 1)?;
+    match after {
         TraceEvent::SelectionShadowCompared {
             v1_winner,
             v1_stage,
@@ -736,7 +792,7 @@ fn outer_shadow(events: &[TraceEvent]) -> Option<ShadowOutcome> {
             gate_disagreements: gate_disagreements.clone(),
         }),
         _ => None,
-    })
+    }
 }
 
 /// Pull the OUTER selection out of one build's event stream.
@@ -829,11 +885,19 @@ fn outer_selection(events: &[TraceEvent]) -> OuterSelection {
              different blocks. Do not bless this baseline"
         );
     }
+    // The shadow's anchor: the outer terminal when there is one, else
+    // the outer block's last row (the all-candidates-failed path emits
+    // a board and no terminal). See `outer_shadow` for why the shadow
+    // is located by ADJACENCY to this rather than by "the last one in
+    // the stream".
+    let anchor = terminal.or_else(|| {
+        events.iter().rposition(|e| matches!(e, TraceEvent::SelectionCandidateEvaluated { .. }))
+    });
     OuterSelection {
         outcomes,
         decided,
         rows: tail.iter().map(|e| (*e).clone()).collect(),
-        shadow: outer_shadow(events),
+        shadow: outer_shadow(events, anchor),
     }
 }
 
@@ -1627,8 +1691,11 @@ const SMOKE_CELLS: &[(&str, &str)] = &[
 /// dispatches **on the same solve**: whatever layout each fixture
 /// produces on this host with this cache, both programs see the same
 /// scoreboard and must reach the same `(winner, stage)`. Nothing about
-/// the assertion depends on WHICH layout that was, so there is no
-/// re-bless treadmill and no pin to get wrong.
+/// the VERDICT depends on WHICH layout that was, so there is no
+/// re-bless treadmill and no pin to get wrong for the comparison — the
+/// fixture list is still a list, and a cell that stops deciding fails
+/// the liveness check at the bottom like any hand-written fixture
+/// would.
 ///
 /// What it therefore covers, and what it does not: six of the corpus's
 /// 160 cells, all at the `default` option set. The option-set axis
@@ -1636,20 +1703,50 @@ const SMOKE_CELLS: &[(&str, &str)] = &[
 /// full 160-cell sweep under `SPAGHETTIO_PARITY_CORPUS=check` remains
 /// the real gate for a phase boundary — this is the tripwire between
 /// them, sized so it can run unconditionally.
-/// Cost: ~15s local warm (16 threads, pinned cache) and **30.9s
-/// measured on the CI runner** (PR #703 head `12b1ea87`, job
-/// 97039777698) — a 2x host penalty rather than the 8-18x the cold-cache
-/// note in `.config/nextest.toml` records, because the rust job pins
-/// `SPAGHETTIO_ZONE_CACHE_PATH`. The 300s ceiling is therefore a ~10x
-/// margin over an observed number, not an extrapolation. It also carries
-/// a `threads-required` override there, because six SAT-heavy solves in
-/// one test on a 4-thread runner is the shape that blew
-/// `tier4_..._belt_pipe_crossing`'s ceiling when parallelism was first
-/// tried. The ntest ceiling is the real hang detector; nextest'''s kill
-/// sits above it.
+///
+/// # Cost, and why the ceiling is 600s for a 31-second test
+///
+/// Measured: **~15s local warm** (16 threads, pinned cache) and **30.9s
+/// on the CI runner** (PR #703 head `12b1ea87`, job 97039777698) — a 2x
+/// host penalty, not the 8-18x `.config/nextest.toml`'s cold-cache note
+/// records, because the rust job pins `SPAGHETTIO_ZONE_CACHE_PATH`
+/// (`ci.yml`'s `rust` job, `env:
+/// SPAGHETTIO_ZONE_CACHE_PATH: ${{ github.workspace }}/crates/core/data/
+/// sat-zones-ci.bin`).
+///
+/// The ceiling is sized for the case that is NOT measured: an unpinned
+/// host solving all six fixtures' zones fresh (#703 review round 2).
+/// That is the 8-18x regime, which puts a cold run in the 120-270s band
+/// — uncomfortably close to a 300s ceiling for a run that is working
+/// correctly, just slowly. **A hang detector that fires on a cold cache
+/// is a false positive on the one gate that runs everywhere**, which is
+/// the same class as the `status == "decided"` pin round 1 removed. 600s
+/// keeps the detector without that failure mode, and costs nothing in
+/// the pinned case.
+///
+/// Setting the pin from inside the test was considered and rejected:
+/// `zone_cache::lookup_table()` is a process-wide `OnceLock` seeded on
+/// first use, and `cargo test` runs this binary's tests as threads of
+/// one process, so a test that mutated the environment would be racing
+/// its siblings for a global. The test REPORTS which cache it resolved
+/// instead, so a slow run is self-diagnosing, and does not fail on an
+/// unpinned one — the verdict comparison genuinely does not care.
+///
+/// The `threads-required` override in `.config/nextest.toml` covers
+/// `cargo nextest` (both profiles); plain `cargo test` reads none of
+/// that, which is exactly why the ntest ceiling is the real guard.
 #[test]
-#[ntest::timeout(300_000)]
+#[ntest::timeout(600_000)]
 fn shadow_agrees_with_production_on_the_census_fixtures() {
+    // Self-describing rather than self-enforcing: a cold-cache run is
+    // legitimate here (the comparison is cache-independent) but is many
+    // times slower, so the one thing a slow or timed-out run needs is to
+    // say which cache it was using.
+    println!(
+        "shadow gate: zone cache = {:?} (pinned: {})",
+        resolve_zone_cache_path(),
+        std::env::var("SPAGHETTIO_ZONE_CACHE_PATH").is_ok()
+    );
     // The third parallel candidate list, bound in CI (#698 rounds 9-10
     // carry-over (e) — the unit tier binds the other two). A shadow
     // whose profile vector is keyed differently from the scoreboard
@@ -1690,15 +1787,30 @@ fn shadow_agrees_with_production_on_the_census_fixtures() {
     // divergence anywhere. The shadow is emitted on that path too, so
     // the comparison is still available and still meaningful; only the
     // over-tight assertion had to go.
-    assert_eq!(
-        report.compared(),
-        SMOKE_CELLS.len(),
-        "every smoke cell must reach the selection and emit a comparison; {} of {} did. \
-         A cell that stopped reaching the search has nothing to shadow, so this gate \
-         would be silently measuring less than it claims — replace the fixture rather \
-         than letting the count drift",
-        report.compared(),
-        SMOKE_CELLS.len()
-    );
+    //
+    // `agreed_decided`, NOT `compared()` (#703 review round 2): the
+    // count alone is satisfied by `agreed_no_winner` cells, so all six
+    // fixtures silently refusing everything — both programs naming
+    // nobody, which agrees — would have read green. That is a natural
+    // signature for the engine regression this tripwire is meant to
+    // notice, and it is the "compared nothing reads as clean" shape
+    // wearing yet another hat. All six ARE known-decided; requiring it
+    // is a fixture-liveness pin, not a verdict pin (nothing here says
+    // WHICH winner or WHICH stage).
+    //
+    // ORDER: the disagreement assertion FIRST. A shortfall in the count
+    // below is usually a CONSEQUENCE of a disagreement, and the
+    // disagreement is the campaign-level finding a reader has to act on;
+    // leading with "5 of 6 agreed" would bury it.
     report.assert_clean();
+    assert_eq!(
+        report.agreed_decided,
+        SMOKE_CELLS.len(),
+        "{} of {} smoke cells reached a selection, named a winner, and agreed. Every one \
+         must: a cell that stopped deciding has nothing (or almost nothing) to shadow, so \
+         this gate would be silently measuring less than it claims. Tally was {:?}",
+        report.agreed_decided,
+        SMOKE_CELLS.len(),
+        (report.agreed_decided, report.agreed_no_winner, report.disagreements.len())
+    );
 }

--- a/crates/core/tests/parity_corpus.rs
+++ b/crates/core/tests/parity_corpus.rs
@@ -1541,7 +1541,15 @@ const SMOKE_CELLS: &[(&str, &str)] = &[
 /// full 160-cell sweep under `SPAGHETTIO_PARITY_CORPUS=check` remains
 /// the real gate for a phase boundary — this is the tripwire between
 /// them, sized so it can run unconditionally.
+/// Cost: ~15s local warm (16 threads, pinned cache), which puts it in
+/// the 5–20s band `.config/nextest.toml` sizes at a 300s ceiling. It
+/// also carries a `threads-required` override there, because six SAT-
+/// heavy solves in one test on a 4-thread runner is the shape that blew
+/// `tier4_..._belt_pipe_crossing`'s ceiling when parallelism was first
+/// tried. The ntest ceiling is the real hang detector; nextest's kill
+/// sits above it.
 #[test]
+#[ntest::timeout(300_000)]
 fn shadow_agrees_with_production_on_the_census_fixtures() {
     // The third parallel candidate list, bound in CI (#698 rounds 9-10
     // carry-over (e) — the unit tier binds the other two). A shadow

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1985,7 +1985,12 @@ fixtures / docs split per the churn norm).
     shadow compares two dispatches on ONE solve. Whatever layout this
     host's cache produced, both programs saw the same scoreboard and
     must reach the same `(winner, stage)` — so there is no re-bless
-    treadmill and no pin to get wrong. Hence
+    treadmill and no pin to get wrong **for the VERDICT** (scoped after
+    #703 review round 1, which was right that the first wording claimed
+    more: the fixture LIST is still a list, and a smoke cell that stops
+    reaching the search fails a count check like any hand-written
+    fixture would. What is cache- and layout-independent is the
+    comparison, not fixture stability). Hence
     `shadow_agrees_with_production_on_the_census_fixtures`, NON-ignored
     (~15s local warm, six census fixtures at their #691 machine tiers,
     `threads-required = 2` and a 300s ntest ceiling for the 4-thread
@@ -2054,3 +2059,54 @@ fixtures / docs split per the churn norm).
     exactly the contiguous TAIL, which is what makes v1's
     `candidates[..ranking_len]` SLICE and v2's `scoped` FIELD filter
     the same rule.*
+- *2026-08-22 — **#703 review round 1 adjudicated** (1 major, 5 minors, 1
+  nit; 6 absorbed, 1 refuted with a receipt). **The round's real
+  contribution is the 1/3-pass finding, which is the one this campaign
+  should have caught itself**: the harness read the engine's own `agree`
+  bit, so it asserted "the shadow SAYS it agrees", not "the two programs
+  agree". A stuck-true bit, or a comparison written against the wrong
+  pair, passed. `ShadowOutcome::faults` now recomputes the verdict from
+  the four recorded fields, checks the engine's bit AGAINST that
+  recomputation, and cross-checks the shadow's v1 side against the
+  cell's own `SelectionDecided` record — three independent surfaces
+  where there was one trusted boolean. Discrimination executed on both
+  new ones: forcing `agree = true` under a real divergence still fails,
+  reporting BOTH "v1 and v2 named different verdicts" and "the engine's
+  own `agree` bit says true where the four recorded fields say false";
+  mis-indexing `v1_winner` by one slot fails all six smoke cells naming
+  the mismatch against `SelectionDecided`. Restored and re-verified
+  green. **The generalisation, and it is a sibling of the one #698's
+  close-out recorded: a harness that reads a value the thing under test
+  computed has not verified that value.** The campaign has now hit
+  "compared nothing reads as clean" four times and "compared the subject
+  to its own claim" once.*
+  - *The MAJOR was also right and was a pin I had no business making:
+    the smoke gate asserted `status == "decided"` per cell, which is
+    NOT layout-independent the way the verdict comparison is — a host
+    whose zone cache differs can legitimately land a cell in
+    `decided-then-refused` (the search picked a winner and a LATER build
+    step refused, a status `run_cell` distinguishes on purpose), reddening
+    the one always-on gate with no divergence anywhere. Dropped; the
+    comparison-count assertion carries the real requirement, which is
+    only that each cell REACHES the search. Same shape one path over:
+    `ShadowReport::absorb` hard-failed on `no-selection` under a comment
+    claiming "every other status means the search ran", which is false of
+    exactly that status — a cell whose build refuses before the search
+    has nothing to shadow and is now exempt alongside `no-solve`. Latent
+    (zero such cells today), and it would have added a failure criterion
+    the baseline comparison never had.*
+  - *Also absorbed: the tally now splits agreed-decided from
+    agreed-no-winner, so "140/140" cannot quietly widen (today the two
+    coincide, which is what the split keeps checkable); and the nextest
+    override's comment claimed `threads-required = 2` "keeps it off the
+    box alongside another heavy test", which overclaims — it is a slot
+    cost, not a reservation, so the file's own accurate frame ("limits
+    concurrency to two heavy tests at a time") replaces it.*
+  - *Refuted with a receipt: the nit extrapolated the ceiling risk from
+    this file's cold-cache note (`partition_strategy_scoreboard`, ~26s
+    local warm vs 200-480s CI) and recommended raising the 300s ntest
+    ceiling. That ratio does not apply — the rust job PINS
+    `SPAGHETTIO_ZONE_CACHE_PATH`, so the gate is not solving zones fresh.
+    **Measured on the PR's own head**: 30.9s in CI against 15s local warm,
+    a 2x host penalty, leaving a ~10x margin. The sizing is now stated
+    from that measurement rather than from a band, at both sites.*

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -1929,3 +1929,128 @@ fixtures / docs split per the churn norm).
     tier for the first three, the clause-by-clause gate tests for the
     fourth — and the 2a shadow, which runs both dispatches on the same
     solve, is the first instrument that can check them together.*
+- *2026-08-22 — **Phase 2a landed and K70-1 IS ADJUDICATED: it PASSES**
+  (#689 track W3a). The v2 policy loop now runs in SHADOW inside
+  `select_best_decomposition` on every solve, after v1 has chosen,
+  replayed and returned its winner, and emits
+  `SelectionShadowCompared`. v1 ships everywhere; nothing flipped. **On
+  the full named parity corpus: 140/140 decided cells agree on winner
+  AND deciding stage, zero disagreements, zero missing comparisons**,
+  with the baseline itself `check`-clean 160/160 and the stage
+  distribution unmoved (`best-error-free` 87, `scoped-pairwise` 26,
+  `merge-tap` 15, `best-accepted` 12). So the premise test's live
+  verdict matches its offline precursor's: **no
+  candidate-identity-conditioned logic was needed anywhere**, at
+  produce time or in the stage logic, and the K70-1 fence still holds
+  mechanically.*
+  - ***The design call, and it is the one Phase 2b inherits: the shadow
+    consumes the SCOREBOARD, it does not re-validate.***
+    `Scoreboard::v2_profiles` projects the rows each verdict mechanism
+    already computed. Re-running `validate()` would have been the
+    obvious wiring and it would have made every divergence
+    uninterpretable — a different answer could mean a different
+    PROGRAM or merely different INPUTS, and no diff can separate them
+    after the fact. Measuring once also carries v1's laziness across
+    for free: a candidate no mechanism examined has no counts in the
+    shadow either, which is exactly the gap `decide` skips on, so the
+    `MeasurementRule` question round 3 settled never re-opens on the
+    live path. The price is stated where it lives: this path does NOT
+    exercise `IssueProfile::measure`, so `refuse_on_error` and eager
+    measurement stay covered by the unit tier alone.*
+  - ***The gate half is a NEW instrument and it closes #698's standing
+    hand-off hole.*** Alongside the decision, the shadow evaluates every
+    registration's `ProducerGate` against this call's options and solve
+    and compares it to whether v1 actually ran that candidate. That is
+    the coverage `policy_replay` cannot have by construction (it
+    consumes already-produced profiles and evaluates zero gates), and
+    it is the failure mode that would have been hardest to read: a
+    mis-transcribed eligibility clause moves the candidate SET, so it
+    surfaces as a changed winner with no visible cause. **0 gate
+    disagreements across all 353 selections of the corpus sweep.**
+    Discrimination executed, not assumed: forcing horizontal-stack's
+    `solve-has-dual-input-row` clause true fails two smoke cells with
+    the WINNER UNCHANGED, naming `horizontal-stack: v2 eligible / v1
+    not-run` — i.e. the gate half catches precisely what the decision
+    half cannot see. Two other breaks were executed and restored:
+    `AdmissionRule::AdmitAll` fails naming the pu@2/am3 cell, and
+    suppressing the emission fails as "compared nothing", not as
+    agreement.*
+  - ***The shadow is CI-gateable, and that is a property of the
+    instrument rather than a change of posture.*** The
+    "why isn't the corpus CI-gated" finding was raised eight times
+    across #694/#698 and refused eight times, correctly: those
+    harnesses compare a live run against a COMMITTED, cache-relative
+    record, so every legitimate engine change falsifies them and a
+    host with a different zone cache produces a meaningless diff. The
+    shadow compares two dispatches on ONE solve. Whatever layout this
+    host's cache produced, both programs saw the same scoreboard and
+    must reach the same `(winner, stage)` — so there is no re-bless
+    treadmill and no pin to get wrong. Hence
+    `shadow_agrees_with_production_on_the_census_fixtures`, NON-ignored
+    (~15s local warm, six census fixtures at their #691 machine tiers,
+    `threads-required = 2` and a 300s ntest ceiling for the 4-thread
+    runner), running on every push — the first always-on assertion this
+    campaign has been able to make, and the thing Verification plan
+    item 2 was pointing at all along. The 160-cell sweep under
+    `SPAGHETTIO_PARITY_CORPUS=check` now asserts shadow agreement too,
+    BEFORE the baseline comparison: the two failures are independent,
+    and only the shadow one is interpretable under a mis-pinned cache.*
+  - ***K70-3: not close.*** Measured in-process, which is the only
+    reading this host can support: across 28 selections totalling
+    24.837 s of `select_best_decomposition` time, the shadow accounted
+    for **0.513 ms — 0.00207%**, at 18.3 µs mean and 83.9 µs max per
+    selection (debug build, so an upper bound on production cost). Over
+    the whole corpus sweep, 353 selections cost **4.94 ms** of shadow
+    against a ~5-minute run. **The wall-clock A/B the kill criterion
+    asks for is uninformative BY CONSTRUCTION and is reported as such
+    rather than dressed up**: three full corpus runs on this box came
+    in at 284.96 s (shadow on, check), 361.59 s (shadow on,
+    instrumented) and **525.40 s with the shadow COMPILED OUT** — the
+    slowest of the three. Run-to-run variance spans ±60% while the
+    thing being measured is 0.002%, so the A/B measures the host, and
+    the in-process ratio is the answer. No stress-corpus timeout is
+    approached: the shadow adds tens of microseconds to a selection, and
+    the one new CI test is 15 s local warm inside a 300 s ceiling.*
+  - ***What the shadow still does NOT see, recorded before anyone
+    quotes 140/140.*** (i) **Nested selections in LOSING candidates.**
+    The shadow event is emitted like any other, so `run_candidate`
+    truncates it out with the rest of that candidate's stream — Phase-0b
+    oracle gap (g) applies unchanged, and the corpus reads only the
+    OUTER comparison. A disagreement inside a losing candidate's own
+    search is invisible here. (ii) `IssueProfile::measure`, per the
+    design call above. (iii) The two comparator blind spots #698
+    measured — the corpus still cannot discriminate a lexicographic
+    floor or a shadowing stage 1, and the shadow inherits that, because
+    it agrees with v1 on the same cells v1 decides. The unit tier
+    remains the only cover for those, and the smoke tier now binds the
+    THIRD parallel candidate list (`parity_corpus`'s `EXPECTED_ORDER`)
+    against the registration vector in CI, where only the other two
+    were bound before.*
+  - *Carry-overs from #698 rounds 9-10, all six landed in the opening
+    commit; two touch behaviour on unreachable paths and are named
+    here because a future reader will meet them as unexplained diffs.
+    (a) `ranks_ahead`'s `WarningsAscThenScoreDesc` gap arm ABSTAINS on
+    a missing warning key instead of falling through to the score —
+    round 6 removed the sentinel and left the fall-through, which
+    promotes the SECONDARY criterion to primary for the candidates
+    least is known about. (f) `Policy::selection` is renamed
+    `Policy::selection_counts`: round 5 settled that its `pass` is
+    always `true` because it gates nothing, but left that in prose on a
+    method whose return type has a `pass` field that looks like an
+    answer — the most dangerous shape a wrong number takes, since it is
+    not wrong, it is answering a question nobody asked. Also: (b) a
+    stale test name in `measure`'s doc; (c) the `refuse_on_error` block
+    softened from load-bearing to defensive (the three producers
+    carrying the flag self-refuse inside `produce()`, so it does not
+    fire on the live path); (d) `a_strictly_better_horizontal_beats_a_
+    merely_denser_di`, the one overlap of the two scoped arms neither
+    the corpus nor the existing pairwise test reaches — v1 answers
+    horizontal, by arithmetic rather than precedence, because its
+    both-scoped-won arm compares the two by the floor ALONE and DI's
+    counts are the incumbent's; (e)
+    `the_candidate_order_is_bound_to_its_positional_semantics`, which
+    is what a coordinated permutation of all three name lists cannot
+    satisfy: the incumbent is slot 0 and the `scoped` registrations are
+    exactly the contiguous TAIL, which is what makes v1's
+    `candidates[..ranking_len]` SLICE and v2's `scoped` FIELD filter
+    the same rule.*

--- a/docs/rfc-070-one-selection-loop.md
+++ b/docs/rfc-070-one-selection-loop.md
@@ -2110,3 +2110,84 @@ fixtures / docs split per the churn norm).
     **Measured on the PR's own head**: 30.9s in CI against 15s local warm,
     a 2x host penalty, leaving a ~10x margin. The sizing is now stated
     from that measurement rather than from a band, at both sites.*
+- *2026-08-22 — **#703 review round 2 adjudicated and the review cycle
+  CLOSED** (no majors from the bot — six minors and two nits, plus one
+  **major-latent** from an independent read-only audit of the same head
+  that the bot missed; all absorbed, none refuted). **The audit finding
+  is the one to keep, and it is the fourth appearance of this campaign's
+  signature bug**: `outer_shadow` took the LAST `SelectionShadowCompared`
+  anywhere in the stream, on the (true) argument that a nested
+  selection's shadow is replayed before the outer board. True, and not
+  enough — if the OUTER emission is ever missing (suppressed, skipped by
+  the alignment guard, lost to a refactor), a winning nested candidate's
+  own shadow becomes the last one, and if its verdict matches the outer
+  `SelectionDecided` the cell reads as compared and agreed while the
+  missing-comparison guard stays silent. The gate would then be
+  measuring a different selection than the one it names. The outer event
+  is now identified POSITIVELY by adjacency to its own anchor — the
+  terminal on the success path, the last board row on the
+  all-candidates-failed path — which is verified at source as strictly
+  adjacent on both, and is the same discipline the scoreboard extractor
+  already uses. Discrimination executed: emitting the shadow where a
+  nested one would sit AND suppressing the outer emission fails all six
+  smoke cells as "missing comparison" (it passed under the old rule);
+  restored and re-verified green.*
+  - *Absorbed from the bot, and the 3/3 one was a real defect: the
+    `debug_assert!(aligned, …)` beside `emit_selection_shadow`'s guard
+    made that guard DEAD in every debug build, so a registration
+    misalignment would have panicked the shipped
+    `select_best_decomposition` path — the exact opposite of the
+    function's own doc and of what a shadow is for, on a state Phase 2b
+    will actually visit. Dropped; skipping emits no event and the
+    harnesses report a named missing comparison. Also: the smoke gate's
+    count check was satisfied by agreed-NO-WINNER cells, so all six
+    fixtures silently refusing everything would have read green — it now
+    requires `agreed_decided == 6`, a fixture-liveness pin that still
+    says nothing about which winner or stage; the disagreement assertion
+    runs FIRST so a count shortfall cannot bury the campaign-level
+    finding that caused it; and the "four independent surfaces" claim in
+    `ShadowOutcome::faults` was overstated, since two of them derive
+    from the same event. The doc now marks which two are ANCHORED
+    OUTSIDE it, and a fourth check was added that genuinely is: the
+    harness re-runs `decide()` over the cell's recorded rows and
+    compares to the event's v2 side. That also pins
+    `Scoreboard::v2_profiles` against `profile_from_row` — two
+    projections of the same scoreboard that nothing previously compared.
+    Discrimination executed: a v2 side faked to echo v1 passes while the
+    two agree (correctly — no false alarm) and FAILS the moment a real
+    divergence exists, naming both the anchor mismatch and the
+    inconsistent `agree` bit.*
+  - *Timing, absorbed: the 300s ntest ceiling was sized against the
+    MEASURED pinned-cache CI number (30.9s) and said nothing about an
+    unpinned host, where this file's own cold-cache note implies 8-18x
+    and a 120-270s run. **A hang detector that fires on a cold cache is
+    a false positive on the one gate that runs everywhere** — the same
+    class as the `status == "decided"` pin round 1 removed — so the
+    ceiling is 600s, which costs nothing in the pinned case. Setting the
+    pin from inside the test was rejected and the reason recorded at the
+    test: `zone_cache::lookup_table()` is a process-wide `OnceLock` and
+    `cargo test` runs the binary's tests as threads of one process, so a
+    test mutating the environment would race its siblings for a global.
+    It PRINTS the resolved cache instead, so a slow run is
+    self-diagnosing. A `profile.default` nextest override was added
+    alongside the `profile.ci` one; plain `cargo test` reads neither,
+    which is precisely why the ntest ceiling is the real guard.*
+  - *Documented rather than changed, both flagged at 1/3: `decide()`,
+    `prior_slot` and `incumbent_index`'s `debug_assert`s are now on the
+    LIVE path in debug builds — the intended tripwire, since they guard
+    policy-AUTHORING mistakes and Phase 2b is authoring policy, and they
+    stay `debug_assert`s so release and WASM keep their documented
+    degradation. The consequence to know: a future producer whose gate
+    reads a slot at or after its own index now fails the SUITE, not just
+    the replay. And the seven-slot arrays in
+    `Scoreboard::prior_acceptance` / `v1_ran` are a latent invariant
+    corralled by the alignment check rather than asserted at the array —
+    an eight-producer policy fails alignment, the shadow skips, and the
+    harnesses report a named missing comparison. Reply-only: the
+    positional `debug_assert`s in `select_best_decomposition` are
+    release-silent, but the shadow's surface-3 check compares NAMES
+    (`CANDIDATE_ORDER[idx]` against the string `SelectionDecided`
+    carries from the winner's own `CandidateRun::name`), not indices, so
+    a `run_refs`/`candidates` desync is caught in the environment the
+    oracle is designed for — debug and CI, per the #692 round-4
+    precedent.*


### PR DESCRIPTION
## Intent

RFC-070 Phase 2a (#689 track W3a): run the v2 policy loop in **shadow** beside
production under a parity gate, so **K70-1 — the campaign's premise test — is
adjudicated live, before anything flips**. v1 ships everywhere; nothing is
deleted; the WASM/web path gains only a trace event.

**Verdict: K70-1 PASSES. 140/140 decided parity cells agree on winner AND
deciding stage. Zero disagreements, zero missing comparisons, zero gate
disagreements across all 353 selections of the sweep.** No
candidate-identity-conditioned logic was needed anywhere.

RFC: [`docs/rfc-070-one-selection-loop.md`](../blob/feat/selection-shadow-2a/docs/rfc-070-one-selection-loop.md)
§Phase 1b specification, §Kill criteria. Queue: #689.

## Scope

**In:**

1. **The shadow.** Inside `select_best_decomposition`, after v1 has chosen,
   replayed and returned its winner, `emit_selection_shadow` runs
   `selection_policy::decide` over the same scoreboard and emits
   `SelectionShadowCompared`. It returns nothing and mutates nothing — zero
   behaviour change by construction. A disagreement is DATA, never a panic.
2. **The gate half — a new instrument.** The shadow also evaluates every
   registration's `ProducerGate` against this call's options and solve, against
   whether v1 actually ran that candidate. `policy_replay` cannot have this
   coverage (it consumes already-produced profiles and evaluates zero gates),
   and it is the failure that would be hardest to read: a mis-transcribed
   eligibility clause moves the candidate SET, so it surfaces as a changed
   winner with no visible cause. This is exactly the hole #698's standing
   hand-off note named.
3. **The parity gate.** `parity_corpus`'s `check` mode now asserts shadow
   agreement on every cell, before the baseline comparison. Plus a
   **non-ignored** smoke tier — the six census fixtures at their #691 machine
   tiers, ~15s local warm — that runs on every push.
4. **The six recorded #698 round 9-10 carry-overs** (opening commit, a/b/c/d/e/f
   from the W2b hand-off).

**Out:**

- **No flip, no deletion.** `build_bus_layout` still calls v1 unconditionally.
  W3b/W3c own those, and W3b carries its own owner gate.
- **`IssueProfile::measure` is not on the shadow path.** The profiles come from
  the scoreboard's own measurements. This is the design call, not an
  optimisation — see Deviations.
- **The two comparator blind spots #698 measured are not closed.** The corpus
  still cannot discriminate a lexicographic floor or a shadowing stage 1, and
  the shadow inherits that. The unit tier remains their only cover.
- **Nested selections inside LOSING candidates.** Their shadow event is
  truncated out with the rest of that candidate's stream (Phase-0b oracle gap
  (g)), so only the OUTER comparison is read.

**Size: 921 added lines, over the ~400 norm. Why it could not usefully split.**

- The reviewable claim surface is **389 non-comment Rust lines**; comments and
  docs are 51% of the Rust diff, which is this module lineage's house style
  (`selection_policy.rs` carries its transcription receipts inline), plus 125
  markdown lines of decision log.
- The one honest split is *carry-overs* (286 added) from *shadow + gate* (511)
  — and Wave 3 is a **strictly sequential single-file lineage**, so the second
  PR would stack on the first, doubling review rounds over the same
  `decomposition_search.rs` hunks for no independent verification.
- Within the shadow half there is no split: landing the instrument without its
  gate ships a comparison nobody asserts on, which is the "compared nothing
  reads as clean" shape this campaign has now closed in four places. Landing
  the gate without the instrument does not compile.

## Verification

- [x] `cargo test --manifest-path crates/core/Cargo.toml --no-fail-fast` — **all
      green, exit 0**, unpiped: 1048 lib + 29 binaries, 0 failed across every
      result line (single invocation).
- [x] `cargo clippy --workspace -- -D warnings` — clean (CI's exact invocation).
      Note: `--all-targets` reports 11 pre-existing errors in `e2e.rs`,
      `layout.rs`, `placer.rs` and gitignored `examples/`, none in files this PR
      touches, and CI does not run that form.
- [x] **Parity corpus 160/160 WITH shadow agreement** —
      `SPAGHETTIO_PARITY_CORPUS=check` under the pinned cache:
      `cells compared: 140 | disagreements: 0 | missing comparisons: 0`,
      `checked 160 cell(s) against the committed baseline`, stage distribution
      unmoved (`best-error-free` 87, `scoped-pairwise` 26, `merge-tap` 15,
      `best-accepted` 12). Zone-cache pin restored after every run; baseline
      JSON untouched (`Cell` is unchanged, so no re-bless).
- [x] WASM rebuild (absolute `--out-dir`) + `npx tsc --noEmit` in `web/` — both
      clean. The new variant is additive to the generated `TraceEvent` union;
      web code matches on `phase === "…"` strings, no exhaustive switch.
- [x] **celldb harness byte-untouched**: `git diff origin/main --` on
      `tests/celldb_template.rs`, `tests/candidate_runner.rs`,
      `src/bus/candidate_runner.rs` is empty, and all three are green in the
      suite run above.
- [x] **Discrimination EXECUTED, not assumed** — three deliberate breaks, each
      restored and re-verified green:
  - `AdmissionRule::AdmitAll` → smoke tier FAILS naming
    `tier5_pu_am3_2_unconstrained[am3]: v1 native/best-error-free -> v2
    horizontal-stack/best-error-free`.
  - horizontal-stack's `solve-has-dual-input-row` clause forced true → FAILS on
    two cells **with the winner unchanged**, naming `horizontal-stack: v2
    eligible / v1 not-run`. The gate half catches what the decision half cannot.
  - shadow emission suppressed → FAILS as "compared nothing", not as agreement.
- [x] **K70-3.** Measured **in-process**, which is the only reading this host
      supports: across 28 selections totalling 24.837 s of
      `select_best_decomposition` time, the shadow accounted for **0.513 ms —
      0.00207%** (18.3 µs mean, 83.9 µs max per selection, debug build, so an
      upper bound). Over the whole corpus sweep, 353 selections cost **4.94 ms**.
      The wall-clock A/B the criterion asks for is **uninformative by
      construction and is reported as such**: three full corpus runs came in at
      284.96 s (shadow on, check), 361.59 s (shadow on, instrumented) and
      **525.40 s with the shadow COMPILED OUT** — the slowest of the three.
      ±60% host variance against a 0.002% signal. No timeout is approached; the
      one new CI test is 15 s local warm inside a 300 s `ntest` ceiling, sized
      per `.config/nextest.toml`'s documented bands with `threads-required = 2`
      for the 4-thread runner.
- [ ] Browser eyeball — **deliberately skipped, with reason.** This PR changes
      no geometry: v1 decides and ships exactly as before, and the only
      observable delta is one extra trace event. "Measure it, don't look at it"
      applies, and the measurement is the 160-cell corpus check showing the
      winner and stage of every cell unmoved. No sim anchor either, for the same
      reason — the RFC requires them on *divergences*, and there are none.
- [ ] Snapshot inspection — n/a, no layout change.

## Deviations from intent

**One design call, and it is the one Phase 2b inherits: the shadow consumes the
SCOREBOARD; it does not re-validate.** The brief said "reuse what the scoreboard
already measured", and this is why it matters beyond cost: re-running
`validate()` would make every divergence uninterpretable — a different answer
could mean a different PROGRAM or merely different INPUTS, and no diff can
separate them after the fact. Measuring once also carries v1's laziness across
for free, so the `MeasurementRule` question #698 round 3 settled never re-opens
on the live path. The price is stated at `Scoreboard::v2_profiles`: this path
does not exercise `IssueProfile::measure`.

**Two carry-overs change behaviour, both on paths unreachable today**, named
here because a future reader will meet them as unexplained diffs:

- **(a)** `ranks_ahead`'s `WarningsAscThenScoreDesc` gap arm now ABSTAINS on a
  missing warning key instead of falling through to the score. Round 6 removed
  the sentinel and left the fall-through, which promotes the SECONDARY criterion
  to primary for exactly the candidates least is known about — the
  `unwrap_or(0)` trap in another hat. Unreachable under today's program (the
  error-free tier's admission already requires counts), so the new pin exercises
  it through a policy whose ranked stage drops `require_error_free`.
- **(f)** `Policy::selection` → `Policy::selection_counts` (test-only callers).
  Round 5 settled that its `pass` is always `true` because it gates nothing, but
  left that in prose on a method whose return type has a `pass` field that looks
  like an answer — the most dangerous shape a wrong number takes, since it is not
  wrong, it is answering a question nobody asked.

**(c)** is a comment softening with a factual correction: `measure`'s
`refuse_on_error` block was written as load-bearing, and it is not — all three
producers carrying the flag self-refuse inside their own `produce()`, so the
branch does not fire on the live path. It is kept as a defensive guard against a
producer registered with the flag but without the produce-side refusal, which is
also what `min_produced_for_error_free_tier`'s equality with v1's `n_layouts`
rests on.

**One thing I want on the record for the reviewer**, because it reverses a
position taken eight times: the shadow **is** CI-gateable, and that is a property
of the instrument, not a change of posture. The refusals of "CI-gate the corpus"
were right — those harnesses compare a live run against a COMMITTED,
cache-relative record, so every legitimate engine change falsifies them. The
shadow compares two dispatches on **one** solve: whatever layout this host's
cache produced, both programs saw the same scoreboard and must agree. No
re-bless treadmill, no pin to get wrong.

## Models / contracts touched

- **`docs/rfc-070-one-selection-loop.md`** — decision log entry for Phase 2a:
  K70-1's live verdict, the measure-once design call, the gate instrument, the
  CI-gateability argument, K70-3's numbers, and what the shadow still does not
  see.
- **`crates/core/src/trace.rs`** — one additive `TraceEvent` variant,
  `SelectionShadowCompared`. Snapshot-safe (`.fls` is a serialised enum; nothing
  deserialises a committed snapshot containing it), WASM-safe (regenerated
  `.d.ts` typechecks).
- **`.config/nextest.toml`** — one override, for the new non-ignored gate.
- Not touched: `docs/validator-trust.md` (no severity, category or selection
  participation changed), `docs/status.md` (RFC-070 is mid-campaign, not a
  close-out), `ghost-pipeline-contracts.md`, the tier ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
