### PR TITLE
feat(meter): add current-generation calibration matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ web/src/wasm-pkg/
 # there is no tracked way to produce the pair" as a known gap; this closes it
 # while keeping every other script in the directory local-only.
 !/crates/core/examples/sim_export.rs
+# ...and the matrix exporter. It materializes the shared e2e fixture corpus
+# into the immutable artifact bank that both Factorio and the meter consume.
+!/crates/core/examples/calibration_matrix_export.rs
 # ...and the four probes that generate RFC-066's headline corpus numbers. Same
 # reasoning as sim_export above: a reader who cannot regenerate a figure cannot
 # detect corpus drift, and an RFC resting on unreproducible aggregates has the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
+ "sha2",
  "spaghettio_core",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,7 +21,6 @@ rayon = "1.10"
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
 thiserror = "2"
 varisat = "0.2"
 tsify-next = { version = "0.5", features = ["js"], optional = true }
@@ -32,6 +31,10 @@ web-time = "1"
 
 [dev-dependencies]
 ntest = "0.9"
+# Hashing only in test/example targets: `parity_corpus`'s committed-prefix
+# cache pin, `e2e`, and the calibration-matrix exporter. Keep it out of
+# `[dependencies]` — the library never hashes, and WASM would carry it.
+sha2 = "0.10"
 
 # sim_export is the tracked fixture generator; its label logic decides the
 # OUTPUT DIRECTORY, so a regression there silently re-collides A/B fixtures

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,6 +21,7 @@ rayon = "1.10"
 rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 thiserror = "2"
 varisat = "0.2"
 tsify-next = { version = "0.5", features = ["js"], optional = true }
@@ -31,7 +32,6 @@ web-time = "1"
 
 [dev-dependencies]
 ntest = "0.9"
-sha2 = "0.10"
 
 # sim_export is the tracked fixture generator; its label logic decides the
 # OUTPUT DIRECTORY, so a regression there silently re-collides A/B fixtures
@@ -48,4 +48,9 @@ sha2 = "0.10"
 [[example]]
 name = "sim_export"
 path = "examples/sim_export.rs"
+test = true
+
+[[example]]
+name = "calibration_matrix_export"
+path = "examples/calibration_matrix_export.rs"
 test = true

--- a/crates/core/examples/calibration_matrix_export.rs
+++ b/crates/core/examples/calibration_matrix_export.rs
@@ -12,6 +12,11 @@
 //! means anything when its Factorio result belongs to the same blueprint, so
 //! this exporter refuses to overwrite an existing bank.  Generate a new bank
 //! after an engine change; do not replace `bp.txt` underneath an old report.
+//!
+//! A fixture that fails to build is recorded under `build_failures` in
+//! `matrix.json` and the export continues: an engine regression is exactly
+//! when the other rows' measurements are wanted, so one broken fixture must
+//! not cost the bank.  The process still exits non-zero so a script notices.
 
 use sha2::{Digest, Sha256};
 use spaghettio_core::blueprint;
@@ -23,12 +28,15 @@ fn usage() -> ! {
     std::process::exit(2);
 }
 
-fn variant_name(variant: FixtureVariant) -> &'static str {
+/// Machine-readable variant tag. A strategy row carries its discriminant —
+/// the pooled/partitioned A/B pairs in the corpus are otherwise identical
+/// rows distinguishable only by label.
+fn variant_name(variant: FixtureVariant) -> String {
     match variant {
-        FixtureVariant::Plain => "plain",
-        FixtureVariant::Strategy(_) => "strategy",
-        FixtureVariant::Excluded => "excluded",
-        FixtureVariant::ExcludedVoid => "excluded-void",
+        FixtureVariant::Plain => "plain".into(),
+        FixtureVariant::Strategy(s) => format!("strategy:{s:?}"),
+        FixtureVariant::Excluded => "excluded".into(),
+        FixtureVariant::ExcludedVoid => "excluded-void".into(),
     }
 }
 
@@ -85,9 +93,18 @@ fn main() {
         std::fs::create_dir_all(root).unwrap_or_else(|e| panic!("create {}: {e}", root.display()));
     }
 
+    let corpus = fixtures();
     let mut entries = Vec::new();
-    for fixture in fixtures() {
-        let built = build(&fixture).unwrap_or_else(|e| panic!("{}: {e}", fixture.name));
+    let mut failures = Vec::new();
+    for fixture in &corpus {
+        let built = match build(fixture) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("{:<62} FAILED: {e}", fixture.name);
+                failures.push(serde_json::json!({ "label": fixture.name, "error": e }));
+                continue;
+            }
+        };
         let (bp, manifest) = blueprint::export_with_manifest_validated(
             &built.layout,
             &built.solver_result,
@@ -110,13 +127,20 @@ fn main() {
             built.layout.width,
             built.layout.height,
         );
-        entries.push(entry(&fixture, &built, &bp));
+        entries.push(entry(fixture, &built, &bp));
     }
+    let exported = entries.len();
+    let failed = failures.len();
+    // `fixture_count` is the number of exported rows (what the sweep checks
+    // the directory set against); `corpus_size` is what the corpus declares.
+    // They differ by exactly `build_failures.len()`.
     let index = serde_json::json!({
         "schema_version": 1,
         "purpose": "current-generation meter-vs-Factorio calibration matrix",
-        "fixture_count": entries.len(),
+        "corpus_size": corpus.len(),
+        "fixture_count": exported,
         "fixtures": entries,
+        "build_failures": failures,
     });
     let index_path = root.join("matrix.json");
     std::fs::write(
@@ -125,20 +149,37 @@ fn main() {
     )
     .unwrap_or_else(|e| panic!("write {}: {e}", index_path.display()));
     println!(
-        "wrote {} fixtures and {}",
-        fixtures().len(),
+        "wrote {exported} of {} fixtures ({failed} failed to build) and {}",
+        corpus.len(),
         index_path.display()
     );
+    if failed > 0 {
+        eprintln!(
+            "{failed} fixture(s) failed to build; the bank is usable but incomplete — \
+             see `build_failures` in {}",
+            index_path.display()
+        );
+        std::process::exit(1);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spaghettio_core::bus::layout::LayoutStrategy;
 
     #[test]
     fn variants_have_stable_machine_readable_names() {
         assert_eq!(variant_name(FixtureVariant::Plain), "plain");
         assert_eq!(variant_name(FixtureVariant::Excluded), "excluded");
         assert_eq!(variant_name(FixtureVariant::ExcludedVoid), "excluded-void");
+        assert_eq!(
+            variant_name(FixtureVariant::Strategy(LayoutStrategy::Pooled)),
+            "strategy:Pooled"
+        );
+        assert_eq!(
+            variant_name(FixtureVariant::Strategy(LayoutStrategy::PartitionedDecomposed)),
+            "strategy:PartitionedDecomposed"
+        );
     }
 }

--- a/crates/core/examples/calibration_matrix_export.rs
+++ b/crates/core/examples/calibration_matrix_export.rs
@@ -17,11 +17,18 @@
 //! `matrix.json` and the export continues: an engine regression is exactly
 //! when the other rows' measurements are wanted, so one broken fixture must
 //! not cost the bank.  The process still exits non-zero so a script notices.
+//!
+//! `matrix.json` schema versions (the sweep reads both):
+//!   1 — first revision: `fixture_count`, `fixtures[]` with `blueprint_sha256`.
+//!   2 — adds `corpus_size`, `build_failures[]`, and `manifest_sha256` per
+//!       row, so the immutable bp.txt/manifest-real.json PAIR is fingerprinted.
 
 use sha2::{Digest, Sha256};
 use spaghettio_core::blueprint;
 use spaghettio_core::calibration_matrix::{build, fixtures, CalibrationFixture, FixtureVariant};
 use spaghettio_core::validate::Severity;
+
+const SCHEMA_VERSION: u64 = 2;
 
 fn usage() -> ! {
     eprintln!("usage: calibration_matrix_export <new-or-empty-bank-dir>");
@@ -40,10 +47,15 @@ fn variant_name(variant: FixtureVariant) -> String {
     }
 }
 
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
 fn entry(
     fixture: &CalibrationFixture,
     built: &spaghettio_core::calibration_matrix::BuiltFixture,
     bp: &str,
+    manifest_json: &str,
 ) -> serde_json::Value {
     let errors = built
         .issues
@@ -55,7 +67,6 @@ fn entry(
         .iter()
         .filter(|i| i.severity == Severity::Warning)
         .count();
-    let hash = format!("{:x}", Sha256::digest(bp.as_bytes()));
     serde_json::json!({
         "label": fixture.name,
         "target": fixture.item,
@@ -65,7 +76,8 @@ fn entry(
         "inputs": fixture.inputs,
         "excluded_recipes": fixture.excluded,
         "variant": variant_name(fixture.variant),
-        "blueprint_sha256": hash,
+        "blueprint_sha256": sha256_hex(bp.as_bytes()),
+        "manifest_sha256": sha256_hex(manifest_json.as_bytes()),
         "entities": built.layout.entities.len(),
         "dimensions": [built.layout.width, built.layout.height],
         "validator": { "errors": errors, "warnings": warnings },
@@ -111,15 +123,15 @@ fn main() {
             fixture.name,
             &built.issues,
         );
+        // Hashed from the same string that is written, so a reader hashing
+        // the file bytes reproduces it exactly.
+        let manifest_json = serde_json::to_string_pretty(&manifest).expect("manifest serializes");
         let dir = root.join(fixture.name);
         std::fs::create_dir(&dir).unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
         std::fs::write(dir.join("bp.txt"), &bp)
             .unwrap_or_else(|e| panic!("write {}: {e}", dir.join("bp.txt").display()));
-        std::fs::write(
-            dir.join("manifest-real.json"),
-            serde_json::to_string_pretty(&manifest).expect("manifest serializes"),
-        )
-        .unwrap_or_else(|e| panic!("write {}: {e}", dir.join("manifest-real.json").display()));
+        std::fs::write(dir.join("manifest-real.json"), &manifest_json)
+            .unwrap_or_else(|e| panic!("write {}: {e}", dir.join("manifest-real.json").display()));
         println!(
             "{:<62} {:>5} entities {:>4}x{:<4}",
             fixture.name,
@@ -127,7 +139,7 @@ fn main() {
             built.layout.width,
             built.layout.height,
         );
-        entries.push(entry(fixture, &built, &bp));
+        entries.push(entry(fixture, &built, &bp, &manifest_json));
     }
     let exported = entries.len();
     let failed = failures.len();
@@ -135,7 +147,7 @@ fn main() {
     // the directory set against); `corpus_size` is what the corpus declares.
     // They differ by exactly `build_failures.len()`.
     let index = serde_json::json!({
-        "schema_version": 1,
+        "schema_version": SCHEMA_VERSION,
         "purpose": "current-generation meter-vs-Factorio calibration matrix",
         "corpus_size": corpus.len(),
         "fixture_count": exported,
@@ -181,5 +193,12 @@ mod tests {
             variant_name(FixtureVariant::Strategy(LayoutStrategy::PartitionedDecomposed)),
             "strategy:PartitionedDecomposed"
         );
+    }
+
+    /// The sweep's reader keys its compat branch on this number; bumping it
+    /// without teaching the reader is the failure this pin makes visible.
+    #[test]
+    fn schema_version_is_the_one_the_sweep_reads() {
+        assert_eq!(SCHEMA_VERSION, 2);
     }
 }

--- a/crates/core/examples/calibration_matrix_export.rs
+++ b/crates/core/examples/calibration_matrix_export.rs
@@ -1,0 +1,144 @@
+//! Export the current-generation calibration matrix for Factorio and meter.
+//!
+//! ```text
+//! cargo run --release -p spaghettio_core --example calibration_matrix_export -- \
+//!   /path/to/new-bank
+//! scripts/run-calibration-matrix.sh /path/to/new-bank
+//! cargo run --release -p spaghettio_meter --example sweep_postlift -- \
+//!   /path/to/new-bank /tmp/meter-vs-sim.csv
+//! ```
+//!
+//! The output directory must be new or empty.  A calibration report only
+//! means anything when its Factorio result belongs to the same blueprint, so
+//! this exporter refuses to overwrite an existing bank.  Generate a new bank
+//! after an engine change; do not replace `bp.txt` underneath an old report.
+
+use sha2::{Digest, Sha256};
+use spaghettio_core::blueprint;
+use spaghettio_core::calibration_matrix::{build, fixtures, CalibrationFixture, FixtureVariant};
+use spaghettio_core::validate::Severity;
+
+fn usage() -> ! {
+    eprintln!("usage: calibration_matrix_export <new-or-empty-bank-dir>");
+    std::process::exit(2);
+}
+
+fn variant_name(variant: FixtureVariant) -> &'static str {
+    match variant {
+        FixtureVariant::Plain => "plain",
+        FixtureVariant::Strategy(_) => "strategy",
+        FixtureVariant::Excluded => "excluded",
+        FixtureVariant::ExcludedVoid => "excluded-void",
+    }
+}
+
+fn entry(
+    fixture: &CalibrationFixture,
+    built: &spaghettio_core::calibration_matrix::BuiltFixture,
+    bp: &str,
+) -> serde_json::Value {
+    let errors = built
+        .issues
+        .iter()
+        .filter(|i| i.severity == Severity::Error)
+        .count();
+    let warnings = built
+        .issues
+        .iter()
+        .filter(|i| i.severity == Severity::Warning)
+        .count();
+    let hash = format!("{:x}", Sha256::digest(bp.as_bytes()));
+    serde_json::json!({
+        "label": fixture.name,
+        "target": fixture.item,
+        "rate": fixture.rate,
+        "machine": fixture.machine,
+        "belt_tier": fixture.belt_tier,
+        "inputs": fixture.inputs,
+        "excluded_recipes": fixture.excluded,
+        "variant": variant_name(fixture.variant),
+        "blueprint_sha256": hash,
+        "entities": built.layout.entities.len(),
+        "dimensions": [built.layout.width, built.layout.height],
+        "validator": { "errors": errors, "warnings": warnings },
+    })
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        usage();
+    }
+    let root = std::path::Path::new(&args[1]);
+    if root.exists() {
+        let non_empty = std::fs::read_dir(root)
+            .unwrap_or_else(|e| panic!("read {}: {e}", root.display()))
+            .next()
+            .is_some();
+        if non_empty {
+            panic!(
+                "refusing to overwrite non-empty calibration bank {}; choose a new directory",
+                root.display()
+            );
+        }
+    } else {
+        std::fs::create_dir_all(root).unwrap_or_else(|e| panic!("create {}: {e}", root.display()));
+    }
+
+    let mut entries = Vec::new();
+    for fixture in fixtures() {
+        let built = build(&fixture).unwrap_or_else(|e| panic!("{}: {e}", fixture.name));
+        let (bp, manifest) = blueprint::export_with_manifest_validated(
+            &built.layout,
+            &built.solver_result,
+            fixture.name,
+            &built.issues,
+        );
+        let dir = root.join(fixture.name);
+        std::fs::create_dir(&dir).unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
+        std::fs::write(dir.join("bp.txt"), &bp)
+            .unwrap_or_else(|e| panic!("write {}: {e}", dir.join("bp.txt").display()));
+        std::fs::write(
+            dir.join("manifest-real.json"),
+            serde_json::to_string_pretty(&manifest).expect("manifest serializes"),
+        )
+        .unwrap_or_else(|e| panic!("write {}: {e}", dir.join("manifest-real.json").display()));
+        println!(
+            "{:<62} {:>5} entities {:>4}x{:<4}",
+            fixture.name,
+            built.layout.entities.len(),
+            built.layout.width,
+            built.layout.height,
+        );
+        entries.push(entry(&fixture, &built, &bp));
+    }
+    let index = serde_json::json!({
+        "schema_version": 1,
+        "purpose": "current-generation meter-vs-Factorio calibration matrix",
+        "fixture_count": entries.len(),
+        "fixtures": entries,
+    });
+    let index_path = root.join("matrix.json");
+    std::fs::write(
+        &index_path,
+        serde_json::to_string_pretty(&index).expect("matrix serializes"),
+    )
+    .unwrap_or_else(|e| panic!("write {}: {e}", index_path.display()));
+    println!(
+        "wrote {} fixtures and {}",
+        fixtures().len(),
+        index_path.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn variants_have_stable_machine_readable_names() {
+        assert_eq!(variant_name(FixtureVariant::Plain), "plain");
+        assert_eq!(variant_name(FixtureVariant::Excluded), "excluded");
+        assert_eq!(variant_name(FixtureVariant::ExcludedVoid), "excluded-void");
+    }
+}

--- a/crates/core/src/calibration_matrix.rs
+++ b/crates/core/src/calibration_matrix.rs
@@ -350,6 +350,13 @@ pub fn fixtures() -> Vec<CalibrationFixture> {
             excluded: &[],
             variant: Strategy(LayoutStrategy::PartitionedDecomposed),
         },
+        // `stress_processing_unit_20s_from_plates` (processing-unit at 20/s,
+        // AM3) is deliberately NOT a row: its balancer-shape SAT search ran
+        // >20 min without finishing (belt-detour survey driver run,
+        // 2026-08-01), far outside any corpus budget. Its e2e test is
+        // `#[ignore]` for the same reason. Listed here so the omission reads
+        // as a decision rather than an oversight; add it back only with a
+        // measured build time.
         CalibrationFixture {
             name: "stress_electronic_circuit_60s_red_from_ore",
             item: "electronic-circuit",

--- a/crates/core/src/calibration_matrix.rs
+++ b/crates/core/src/calibration_matrix.rs
@@ -1,0 +1,487 @@
+//! Canonical current-generation fixtures for meter-vs-Factorio calibration.
+//!
+//! The e2e suite and the Factorio calibration bank must exercise the same
+//! factories.  Keeping this list in a test-only helper previously made the
+//! latter a manually-maintained, incomplete subset.  The exporter in
+//! `examples/calibration_matrix_export.rs` consumes this module to create a
+//! fresh, immutable bank for `spaghettio-sim` and the meter sweep.
+
+use rustc_hash::FxHashSet;
+
+use crate::bus::layout::{self, LayoutOptions, LayoutStrategy, SurplusPolicy};
+use crate::models::{LayoutResult, SolverResult};
+use crate::solver;
+use crate::validate::{self, ValidationIssue};
+
+/// The one deliberate layout variation a calibration fixture may request.
+#[derive(Clone, Copy, Debug)]
+pub enum FixtureVariant {
+    /// Production defaults.
+    Plain,
+    /// A named production strategy rather than the default candidate choice.
+    Strategy(LayoutStrategy),
+    /// Exclude recipes before solving.
+    Excluded,
+    /// Exclude recipes and consume recyclable solid surplus.
+    ExcludedVoid,
+}
+
+/// A representative, current-production factory configuration.
+///
+/// This is not a claim to enumerate every possible generator input.  It is
+/// the maintained regression corpus: every row builds in e2e, and every row
+/// is eligible for an independently measured Factorio result.
+#[derive(Clone, Copy, Debug)]
+pub struct CalibrationFixture {
+    pub name: &'static str,
+    pub item: &'static str,
+    pub rate: f64,
+    pub machine: &'static str,
+    pub belt_tier: Option<&'static str>,
+    pub inputs: &'static [&'static str],
+    pub excluded: &'static [&'static str],
+    pub variant: FixtureVariant,
+}
+
+/// The shared current-generation corpus.  Add a fixture here when adding a
+/// materially new generator shape; the e2e differential and calibration
+/// exporter then gain it together.
+pub fn fixtures() -> Vec<CalibrationFixture> {
+    use FixtureVariant::*;
+
+    vec![
+        CalibrationFixture {
+            name: "tier1_iron_gear_wheel",
+            item: "iron-gear-wheel",
+            rate: 10.0,
+            machine: "assembling-machine-1",
+            belt_tier: None,
+            inputs: &["iron-plate"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier1_iron_gear_wheel_from_ore",
+            item: "iron-gear-wheel",
+            rate: 10.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier1_iron_gear_wheel_20s",
+            item: "iron-gear-wheel",
+            rate: 20.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier2_electronic_circuit",
+            item: "electronic-circuit",
+            rate: 10.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier2_electronic_circuit_from_ore",
+            item: "electronic-circuit",
+            rate: 10.0,
+            machine: "assembling-machine-1",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier2_electronic_circuit_20s_from_ore",
+            item: "electronic-circuit",
+            rate: 20.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier3_plastic_bar",
+            item: "plastic-bar",
+            rate: 10.0,
+            machine: "chemical-plant",
+            belt_tier: None,
+            inputs: &["petroleum-gas", "coal"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier3_plastic_bar_from_crude",
+            item: "plastic-bar",
+            rate: 10.0,
+            machine: "chemical-plant",
+            belt_tier: None,
+            inputs: &["crude-oil", "coal"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier3_sulfuric_acid",
+            item: "sulfuric-acid",
+            rate: 5.0,
+            machine: "chemical-plant",
+            belt_tier: None,
+            inputs: &["iron-plate", "sulfur", "water"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier3_heavy_oil_cracking",
+            item: "light-oil",
+            rate: 5.0,
+            machine: "chemical-plant",
+            belt_tier: None,
+            inputs: &["water", "heavy-oil"],
+            excluded: &["advanced-oil-processing", "coal-liquefaction"],
+            variant: Excluded,
+        },
+        CalibrationFixture {
+            name: "tier3_advanced_oil_processing_multi_machine",
+            item: "petroleum-gas",
+            rate: 12.0,
+            machine: "oil-refinery",
+            belt_tier: None,
+            inputs: &["water", "crude-oil"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier3_advanced_oil_processing_forced_multi_machine_pipe_isolation",
+            item: "petroleum-gas",
+            rate: 24.0,
+            machine: "oil-refinery",
+            belt_tier: None,
+            inputs: &["water", "crude-oil"],
+            excluded: &["basic-oil-processing", "coal-liquefaction"],
+            variant: Excluded,
+        },
+        CalibrationFixture {
+            name: "tier4_advanced_circuit_from_plates",
+            item: "advanced-circuit",
+            rate: 1.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier4_advanced_circuit_partitioned",
+            item: "advanced-circuit",
+            rate: 1.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"],
+            excluded: &[],
+            variant: Strategy(LayoutStrategy::PartitionedDecomposed),
+        },
+        CalibrationFixture {
+            name: "tier4_advanced_circuit_from_ore_am2",
+            item: "advanced-circuit",
+            rate: 5.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier5_processing_unit_from_ore_am3",
+            item: "processing-unit",
+            rate: 2.0,
+            machine: "assembling-machine-3",
+            belt_tier: Some("fast-transport-belt"),
+            inputs: &["iron-ore", "copper-ore", "coal", "water", "crude-oil"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier_kovarex_self_loop",
+            item: "uranium-235",
+            rate: 0.1,
+            machine: "assembling-machine-3",
+            belt_tier: None,
+            inputs: &["uranium-238"],
+            excluded: &["uranium-processing"],
+            variant: Excluded,
+        },
+        CalibrationFixture {
+            name: "tier_uranium_processing_surplus_export",
+            item: "uranium-235",
+            rate: 0.05,
+            machine: "assembling-machine-3",
+            belt_tier: None,
+            inputs: &["uranium-ore"],
+            excluded: &["kovarex-enrichment-process"],
+            variant: Excluded,
+        },
+        CalibrationFixture {
+            name: "tier_uranium_processing_voider",
+            item: "uranium-235",
+            rate: 0.05,
+            machine: "assembling-machine-3",
+            belt_tier: None,
+            inputs: &["uranium-ore"],
+            excluded: &["kovarex-enrichment-process"],
+            variant: ExcludedVoid,
+        },
+        CalibrationFixture {
+            name: "tier_pentapod_egg_self_loop",
+            item: "pentapod-egg",
+            rate: 0.2,
+            machine: "assembling-machine-3",
+            belt_tier: None,
+            inputs: &["nutrients", "water"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier_fish_breeding_self_loop",
+            item: "raw-fish",
+            rate: 0.15,
+            machine: "assembling-machine-3",
+            belt_tier: Some("fast-transport-belt"),
+            inputs: &["nutrients", "water"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "tier_bacteria_self_loop_regression",
+            item: "iron-bacteria",
+            rate: 1.0,
+            machine: "assembling-machine-3",
+            belt_tier: None,
+            inputs: &["bioflux"],
+            excluded: &["iron-bacteria"],
+            variant: Excluded,
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_30s_from_ore",
+            item: "electronic-circuit",
+            rate: 30.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "stress_advanced_circuit_45s_from_plates",
+            item: "advanced-circuit",
+            rate: 45.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate", "plastic-bar"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "stress_advanced_circuit_partitioned_5s_from_plates_pooled",
+            item: "advanced-circuit",
+            rate: 5.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"],
+            excluded: &[],
+            variant: Strategy(LayoutStrategy::Pooled),
+        },
+        CalibrationFixture {
+            name: "stress_advanced_circuit_partitioned_5s_from_plates_partitioned",
+            item: "advanced-circuit",
+            rate: 5.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"],
+            excluded: &[],
+            variant: Strategy(LayoutStrategy::PartitionedDecomposed),
+        },
+        CalibrationFixture {
+            name: "stress_advanced_circuit_partitioned_4s_from_plates_pooled",
+            item: "advanced-circuit",
+            rate: 4.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"],
+            excluded: &[],
+            variant: Strategy(LayoutStrategy::Pooled),
+        },
+        CalibrationFixture {
+            name: "stress_advanced_circuit_partitioned_4s_from_plates_partitioned",
+            item: "advanced-circuit",
+            rate: 4.0,
+            machine: "assembling-machine-2",
+            belt_tier: None,
+            inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"],
+            excluded: &[],
+            variant: Strategy(LayoutStrategy::PartitionedDecomposed),
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_30s_decomposed_pooled",
+            item: "electronic-circuit",
+            rate: 30.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Strategy(LayoutStrategy::Pooled),
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_30s_decomposed_partitioned",
+            item: "electronic-circuit",
+            rate: 30.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Strategy(LayoutStrategy::PartitionedDecomposed),
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_60s_red_from_ore",
+            item: "electronic-circuit",
+            rate: 60.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("fast-transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_22s_from_ore",
+            item: "electronic-circuit",
+            rate: 22.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_23s_from_ore",
+            item: "electronic-circuit",
+            rate: 23.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_35s_from_ore",
+            item: "electronic-circuit",
+            rate: 35.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+        CalibrationFixture {
+            name: "stress_electronic_circuit_40s_from_ore",
+            item: "electronic-circuit",
+            rate: 40.0,
+            machine: "assembling-machine-2",
+            belt_tier: Some("transport-belt"),
+            inputs: &["iron-ore", "copper-ore"],
+            excluded: &[],
+            variant: Plain,
+        },
+    ]
+}
+
+/// Build the exact production-default option set with only this fixture's
+/// declared axes overridden.  Group defaults avoid the historic e2e fossils
+/// where a field type's own `Default` differed from the engine default.
+pub fn layout_options(fixture: &CalibrationFixture) -> LayoutOptions {
+    let mut constraints = layout::UserConstraints {
+        max_belt_tier: fixture.belt_tier.map(str::to_owned),
+        ..Default::default()
+    };
+    let mut axes = layout::SearchAxes::default();
+    match fixture.variant {
+        FixtureVariant::Plain | FixtureVariant::Excluded => {}
+        FixtureVariant::Strategy(strategy) => axes.strategy = strategy,
+        FixtureVariant::ExcludedVoid => constraints.surplus_policy = SurplusPolicy::Void,
+    }
+    LayoutOptions::from_groups(constraints, axes, layout::EngineTuning::default())
+}
+
+/// A generated fixture ready to export and measure.
+pub struct BuiltFixture {
+    pub solver_result: SolverResult,
+    pub layout: LayoutResult,
+    pub issues: Vec<ValidationIssue>,
+}
+
+/// Solve, lay out, and validate one fixture using the same axes as e2e.
+pub fn build(fixture: &CalibrationFixture) -> Result<BuiltFixture, String> {
+    let inputs: FxHashSet<String> = fixture.inputs.iter().map(|s| (*s).to_string()).collect();
+    let excluded: FxHashSet<String> = fixture.excluded.iter().map(|s| (*s).to_string()).collect();
+    let solver_result = solver::solve_with_exclusions(
+        fixture.item,
+        fixture.rate,
+        &inputs,
+        fixture.machine,
+        &excluded,
+    )
+    .map_err(|e| format!("solver: {e}"))?;
+    let layout = layout::build_bus_layout(&solver_result, layout_options(fixture))
+        .map_err(|e| format!("layout: {e}"))?;
+    let issues = validate::validate(&layout, Some(&solver_result)).unwrap_or_else(|e| e.issues);
+    Ok(BuiltFixture {
+        solver_result,
+        layout,
+        issues,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_corpus_has_unique_fixture_labels() {
+        let fixtures = fixtures();
+        let labels: std::collections::BTreeSet<_> = fixtures.iter().map(|f| f.name).collect();
+        assert_eq!(
+            labels.len(),
+            fixtures.len(),
+            "calibration fixture labels must be unique"
+        );
+        assert_eq!(
+            fixtures.len(),
+            35,
+            "corpus changes must be deliberate and visible"
+        );
+    }
+
+    #[test]
+    fn plain_fixture_uses_shipped_defaults() {
+        let fixture = fixtures()
+            .into_iter()
+            .find(|f| matches!(f.variant, FixtureVariant::Plain) && f.belt_tier.is_none())
+            .expect("plain fixture");
+        assert_eq!(
+            layout_options(&fixture).constraints(),
+            LayoutOptions::default().constraints()
+        );
+        assert_eq!(
+            layout_options(&fixture).axes(),
+            LayoutOptions::default().axes()
+        );
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod blueprint;
 pub mod blueprint_parser;
 pub mod bus;
 pub mod celldb;
+pub mod calibration_matrix;
 pub mod classify;
 pub mod common;
 pub mod connectivity;

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -10792,15 +10792,49 @@ fn rfc061_allocation_probe_ac5() {
 //       belt_detour_survey --exact --ignored --nocapture
 
 use spaghettio_core::calibration_matrix::{
-    fixtures as calibration_fixtures, CalibrationFixture as SurveyFixture,
-    FixtureVariant as SurveyVariant,
+    self, CalibrationFixture as SurveyFixture, FixtureVariant as SurveyVariant,
 };
 
 /// The belt-detour differential and the Factorio calibration exporter use the
 /// same current-generation fixture list. A new e2e shape is therefore
 /// automatically visible as an unmeasured calibration row until it is run.
+/// The three drivers below still build through this file's `run_e2e*`
+/// helpers (the always-on differential chunks among them); the option-builder
+/// pin right after this keeps that path and the exporter's from diverging.
 fn survey_fixtures() -> Vec<SurveyFixture> {
-    calibration_fixtures()
+    calibration_matrix::fixtures()
+}
+
+/// The pin between the two option builders in play: [`harness_options`] is
+/// what every `run_e2e*` fixture in this file runs under, and
+/// `calibration_matrix::layout_options` is what the Factorio bank is exported
+/// under. Each is pinned to `LayoutOptions::default()` on its own
+/// (`harness_options_are_engine_defaults`, `plain_fixture_uses_shipped_defaults`),
+/// but that only proves each is right with NOTHING overridden — the RFC-070
+/// W2c fossils were overrides. This asserts the two agree on every declared
+/// variant in the corpus, so an axis added to one builder and not the other
+/// fails here instead of producing a bank the e2e suite never ran. Free: no
+/// solve, no layout.
+#[test]
+fn calibration_matrix_options_match_harness_options() {
+    for f in calibration_matrix::fixtures() {
+        let mut h = HarnessOptions { belt_tier: f.belt_tier, ..HarnessOptions::default() };
+        match f.variant {
+            SurveyVariant::Plain | SurveyVariant::Excluded => {}
+            SurveyVariant::Strategy(s) => h.strategy = s,
+            SurveyVariant::ExcludedVoid => h.surplus_policy = layout::SurplusPolicy::Void,
+        }
+        let harness = harness_options(h);
+        let bank = calibration_matrix::layout_options(&f);
+        assert_eq!(harness.constraints(), bank.constraints(), "{}: user-pinned group drifted", f.name);
+        assert_eq!(harness.axes(), bank.axes(), "{}: search-axis group drifted", f.name);
+        assert_eq!(
+            harness.engine_tuning(),
+            bank.engine_tuning(),
+            "{}: engine-tuning group drifted",
+            f.name
+        );
+    }
 }
 
 fn percentile(sorted_ascending: &[f64], p: f64) -> f64 {

--- a/crates/core/tests/e2e.rs
+++ b/crates/core/tests/e2e.rs
@@ -10791,70 +10791,16 @@ fn rfc061_allocation_probe_ac5() {
 //   cargo test --manifest-path crates/core/Cargo.toml --test e2e -- \
 //       belt_detour_survey --exact --ignored --nocapture
 
-#[derive(Clone, Copy)]
-enum SurveyVariant {
-    Plain,
-    Strategy(spaghettio_core::bus::layout::LayoutStrategy),
-    Excluded,
-    ExcludedVoid,
-}
+use spaghettio_core::calibration_matrix::{
+    fixtures as calibration_fixtures, CalibrationFixture as SurveyFixture,
+    FixtureVariant as SurveyVariant,
+};
 
-struct SurveyFixture {
-    name: &'static str,
-    item: &'static str,
-    rate: f64,
-    machine: &'static str,
-    belt_tier: Option<&'static str>,
-    inputs: &'static [&'static str],
-    excluded: &'static [&'static str],
-    variant: SurveyVariant,
-}
-
+/// The belt-detour differential and the Factorio calibration exporter use the
+/// same current-generation fixture list. A new e2e shape is therefore
+/// automatically visible as an unmeasured calibration row until it is run.
 fn survey_fixtures() -> Vec<SurveyFixture> {
-    use spaghettio_core::bus::layout::LayoutStrategy;
-    use SurveyVariant::*;
-
-    vec![
-        SurveyFixture { name: "tier1_iron_gear_wheel", item: "iron-gear-wheel", rate: 10.0, machine: "assembling-machine-1", belt_tier: None, inputs: &["iron-plate"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier1_iron_gear_wheel_from_ore", item: "iron-gear-wheel", rate: 10.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier1_iron_gear_wheel_20s", item: "iron-gear-wheel", rate: 20.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier2_electronic_circuit", item: "electronic-circuit", rate: 10.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier2_electronic_circuit_from_ore", item: "electronic-circuit", rate: 10.0, machine: "assembling-machine-1", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier2_electronic_circuit_20s_from_ore", item: "electronic-circuit", rate: 20.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier3_plastic_bar", item: "plastic-bar", rate: 10.0, machine: "chemical-plant", belt_tier: None, inputs: &["petroleum-gas", "coal"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier3_plastic_bar_from_crude", item: "plastic-bar", rate: 10.0, machine: "chemical-plant", belt_tier: None, inputs: &["crude-oil", "coal"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier3_sulfuric_acid", item: "sulfuric-acid", rate: 5.0, machine: "chemical-plant", belt_tier: None, inputs: &["iron-plate", "sulfur", "water"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier3_heavy_oil_cracking", item: "light-oil", rate: 5.0, machine: "chemical-plant", belt_tier: None, inputs: &["water", "heavy-oil"], excluded: &["advanced-oil-processing", "coal-liquefaction"], variant: Excluded },
-        SurveyFixture { name: "tier3_advanced_oil_processing_multi_machine", item: "petroleum-gas", rate: 12.0, machine: "oil-refinery", belt_tier: None, inputs: &["water", "crude-oil"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier3_advanced_oil_processing_forced_multi_machine_pipe_isolation", item: "petroleum-gas", rate: 24.0, machine: "oil-refinery", belt_tier: None, inputs: &["water", "crude-oil"], excluded: &["basic-oil-processing", "coal-liquefaction"], variant: Excluded },
-        SurveyFixture { name: "tier4_advanced_circuit_from_plates", item: "advanced-circuit", rate: 1.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier4_advanced_circuit_partitioned", item: "advanced-circuit", rate: 1.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"], excluded: &[], variant: Strategy(LayoutStrategy::PartitionedDecomposed) },
-        SurveyFixture { name: "tier4_advanced_circuit_from_ore_am2", item: "advanced-circuit", rate: 5.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore", "coal", "water", "crude-oil"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier5_processing_unit_from_ore_am3", item: "processing-unit", rate: 2.0, machine: "assembling-machine-3", belt_tier: Some("fast-transport-belt"), inputs: &["iron-ore", "copper-ore", "coal", "water", "crude-oil"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier_kovarex_self_loop", item: "uranium-235", rate: 0.1, machine: "assembling-machine-3", belt_tier: None, inputs: &["uranium-238"], excluded: &["uranium-processing"], variant: Excluded },
-        SurveyFixture { name: "tier_uranium_processing_surplus_export", item: "uranium-235", rate: 0.05, machine: "assembling-machine-3", belt_tier: None, inputs: &["uranium-ore"], excluded: &["kovarex-enrichment-process"], variant: Excluded },
-        SurveyFixture { name: "tier_uranium_processing_voider", item: "uranium-235", rate: 0.05, machine: "assembling-machine-3", belt_tier: None, inputs: &["uranium-ore"], excluded: &["kovarex-enrichment-process"], variant: ExcludedVoid },
-        SurveyFixture { name: "tier_pentapod_egg_self_loop", item: "pentapod-egg", rate: 0.2, machine: "assembling-machine-3", belt_tier: None, inputs: &["nutrients", "water"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier_fish_breeding_self_loop", item: "raw-fish", rate: 0.15, machine: "assembling-machine-3", belt_tier: Some("fast-transport-belt"), inputs: &["nutrients", "water"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "tier_bacteria_self_loop_regression", item: "iron-bacteria", rate: 1.0, machine: "assembling-machine-3", belt_tier: None, inputs: &["bioflux"], excluded: &["iron-bacteria"], variant: Excluded },
-        SurveyFixture { name: "stress_electronic_circuit_30s_from_ore", item: "electronic-circuit", rate: 30.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "stress_advanced_circuit_45s_from_plates", item: "advanced-circuit", rate: 45.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate", "plastic-bar"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "stress_advanced_circuit_partitioned_5s_from_plates_pooled", item: "advanced-circuit", rate: 5.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"], excluded: &[], variant: Strategy(LayoutStrategy::Pooled) },
-        SurveyFixture { name: "stress_advanced_circuit_partitioned_5s_from_plates_partitioned", item: "advanced-circuit", rate: 5.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"], excluded: &[], variant: Strategy(LayoutStrategy::PartitionedDecomposed) },
-        SurveyFixture { name: "stress_advanced_circuit_partitioned_4s_from_plates_pooled", item: "advanced-circuit", rate: 4.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"], excluded: &[], variant: Strategy(LayoutStrategy::Pooled) },
-        SurveyFixture { name: "stress_advanced_circuit_partitioned_4s_from_plates_partitioned", item: "advanced-circuit", rate: 4.0, machine: "assembling-machine-2", belt_tier: None, inputs: &["iron-plate", "copper-plate", "coal", "crude-oil", "water"], excluded: &[], variant: Strategy(LayoutStrategy::PartitionedDecomposed) },
-        SurveyFixture { name: "stress_electronic_circuit_30s_decomposed_pooled", item: "electronic-circuit", rate: 30.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Strategy(LayoutStrategy::Pooled) },
-        SurveyFixture { name: "stress_electronic_circuit_30s_decomposed_partitioned", item: "electronic-circuit", rate: 30.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Strategy(LayoutStrategy::PartitionedDecomposed) },
-        // stress_processing_unit_20s_from_plates deliberately excluded: its
-        // balancer-shape SAT search ran >20 min without finishing (survey
-        // driver run, 2026-08-01) — far outside a corpus-survey budget.
-        // Noted as a gap in the survey report rather than silently dropped.
-        SurveyFixture { name: "stress_electronic_circuit_60s_red_from_ore", item: "electronic-circuit", rate: 60.0, machine: "assembling-machine-2", belt_tier: Some("fast-transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "stress_electronic_circuit_22s_from_ore", item: "electronic-circuit", rate: 22.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "stress_electronic_circuit_23s_from_ore", item: "electronic-circuit", rate: 23.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "stress_electronic_circuit_35s_from_ore", item: "electronic-circuit", rate: 35.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-        SurveyFixture { name: "stress_electronic_circuit_40s_from_ore", item: "electronic-circuit", rate: 40.0, machine: "assembling-machine-2", belt_tier: Some("transport-belt"), inputs: &["iron-ore", "copper-ore"], excluded: &[], variant: Plain },
-    ]
+    calibration_fixtures()
 }
 
 fn percentile(sorted_ascending: &[f64], p: f64) -> f64 {

--- a/crates/meter/Cargo.toml
+++ b/crates/meter/Cargo.toml
@@ -32,3 +32,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 flate2 = "1"
+
+[dev-dependencies]
+# `examples/sweep_postlift` re-hashes each bank's bp.txt against the
+# `blueprint_sha256` that `calibration_matrix_export` recorded — the only
+# thing that binds a report.json to the blueprint it was measured from.
+# Examples see dev-dependencies; the meter library itself does not hash.
+sha2 = "0.10"

--- a/crates/meter/examples/sweep_postlift.rs
+++ b/crates/meter/examples/sweep_postlift.rs
@@ -185,6 +185,55 @@ fn main() {
         .filter(|p| p.is_dir())
         .collect();
     fixtures.sort();
+    // A bank created by `calibration_matrix_export` carries an explicit list
+    // of expected fixture labels. Validate it before measuring anything: a
+    // missing directory otherwise turns a 35-row matrix into a plausible
+    // 34-row one, which is exactly the silent coverage shrink this tool exists
+    // to expose. Older ad-hoc banks deliberately have no such contract and
+    // retain their directory-driven behavior.
+    let matrix_path = std::path::Path::new(&dir).join("matrix.json");
+    let matrix_fixture_count = if matrix_path.exists() {
+        let raw = std::fs::read_to_string(&matrix_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", matrix_path.display()));
+        let matrix: serde_json::Value = serde_json::from_str(&raw)
+            .unwrap_or_else(|e| panic!("parse {}: {e}", matrix_path.display()));
+        let expected: std::collections::BTreeSet<String> = matrix["fixtures"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{} has no fixtures array", matrix_path.display()))
+            .iter()
+            .map(|v| {
+                v["label"]
+                    .as_str()
+                    .unwrap_or_else(|| {
+                        panic!("{} has fixture without label", matrix_path.display())
+                    })
+                    .to_string()
+            })
+            .collect();
+        let declared = matrix["fixture_count"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("{} has no fixture_count", matrix_path.display()))
+            as usize;
+        assert_eq!(
+            expected.len(),
+            declared,
+            "{} declares {declared} fixtures but names {} unique labels",
+            matrix_path.display(),
+            expected.len()
+        );
+        let actual: std::collections::BTreeSet<String> = fixtures
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "matrix directory set differs from {}; regenerate a fresh bank rather than mixing artifacts",
+            matrix_path.display()
+        );
+        Some(declared)
+    } else {
+        None
+    };
 
     for fp in fixtures {
         let fixture = fp.file_name().unwrap().to_string_lossy().to_string();
@@ -475,6 +524,20 @@ fn main() {
 
     let f = |v: Option<f64>| v.map_or("n/a".into(), |x| format!("{x:.4}"));
     let p = |v: Option<f64>| v.map_or("n/a".into(), |x| format!("{x:.2}"));
+
+    if let Some(expected) = matrix_fixture_count {
+        let awaiting = excluded
+            .iter()
+            .filter(|(_, why)| why == "no sim report.json — nothing to compare")
+            .count();
+        println!("=== MATRIX COVERAGE ===");
+        println!(
+            "  {}/{} fixtures have a vetted sim report; {} awaiting measurement",
+            provenance.len(),
+            expected,
+            awaiting,
+        );
+    }
 
     // --- per-item table ---------------------------------------------------
     // `tgt` is a declared column, not a bare marker appended past the last

--- a/crates/meter/examples/sweep_postlift.rs
+++ b/crates/meter/examples/sweep_postlift.rs
@@ -167,9 +167,21 @@ impl Row {
 
 use sha2::{Digest, Sha256};
 
+/// The exclusion reason the coverage line counts as "awaiting measurement".
+/// One definition for the push site and the count, so a wording change
+/// cannot silently empty the bucket into "other".
+const AWAITING: &str = "no sim report.json — nothing to compare";
+
+/// The `matrix.json` schema versions this reader understands. 1 = the first
+/// exporter revision (blueprint hash only; declared exactly what it
+/// exported). 2 adds `manifest_sha256` per row, `corpus_size`, and
+/// `build_failures`. The branch taken is printed, not inferred by absence.
+const KNOWN_SCHEMA_VERSIONS: [u64; 2] = [1, 2];
+
 /// What a `calibration_matrix_export` bank declares about itself, read from
 /// its `matrix.json`. Absent for the older ad-hoc banks.
 struct MatrixIndex {
+    schema_version: u64,
     /// Fixtures the corpus DECLARES — exported rows plus any that failed to
     /// build at export. The honest coverage denominator.
     corpus_size: usize,
@@ -177,7 +189,13 @@ struct MatrixIndex {
     /// they have no directory and can never be measured from this bank.
     build_failures: usize,
     /// `label → blueprint_sha256` for every exported row.
-    hashes: std::collections::BTreeMap<String, String>,
+    blueprint_hashes: std::collections::BTreeMap<String, String>,
+    /// `label → manifest_sha256` for every exported row; empty for schema 1.
+    manifest_hashes: std::collections::BTreeMap<String, String>,
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
 }
 
 fn main() {
@@ -212,7 +230,17 @@ fn main() {
             .unwrap_or_else(|e| panic!("read {}: {e}", matrix_path.display()));
         let matrix: serde_json::Value = serde_json::from_str(&raw)
             .unwrap_or_else(|e| panic!("parse {}: {e}", matrix_path.display()));
-        let mut hashes = std::collections::BTreeMap::new();
+        let schema_version = matrix["schema_version"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("{} has no schema_version", matrix_path.display()));
+        assert!(
+            KNOWN_SCHEMA_VERSIONS.contains(&schema_version),
+            "{} schema_version {schema_version} is not one this reader understands {:?}",
+            matrix_path.display(),
+            KNOWN_SCHEMA_VERSIONS
+        );
+        let mut blueprint_hashes = std::collections::BTreeMap::new();
+        let mut manifest_hashes = std::collections::BTreeMap::new();
         for v in matrix["fixtures"]
             .as_array()
             .unwrap_or_else(|| panic!("{} has no fixtures array", matrix_path.display()))
@@ -223,11 +251,18 @@ fn main() {
             let hash = v["blueprint_sha256"].as_str().unwrap_or_else(|| {
                 panic!("{} row {label} has no blueprint_sha256", matrix_path.display())
             });
-            if hashes.insert(label.to_string(), hash.to_string()).is_some() {
+            if blueprint_hashes.insert(label.to_string(), hash.to_string()).is_some() {
                 panic!("{} names {label} twice", matrix_path.display());
             }
+            if schema_version >= 2 {
+                let mh = v["manifest_sha256"].as_str().unwrap_or_else(|| {
+                    panic!("{} row {label} has no manifest_sha256 (schema 2)", matrix_path.display())
+                });
+                manifest_hashes.insert(label.to_string(), mh.to_string());
+            }
         }
-        let expected: std::collections::BTreeSet<String> = hashes.keys().cloned().collect();
+        let expected: std::collections::BTreeSet<String> =
+            blueprint_hashes.keys().cloned().collect();
         let declared = matrix["fixture_count"]
             .as_u64()
             .unwrap_or_else(|| panic!("{} has no fixture_count", matrix_path.display()))
@@ -248,19 +283,45 @@ fn main() {
             "matrix directory set differs from {}; regenerate a fresh bank rather than mixing artifacts",
             matrix_path.display()
         );
-        // Additive fields (second exporter revision): a bank from the first
-        // revision has neither and declared exactly what it exported.
-        let build_failures = matrix["build_failures"].as_array().map_or(0, Vec::len);
-        let corpus_size = matrix["corpus_size"]
-            .as_u64()
-            .map_or(declared + build_failures, |n| n as usize);
-        assert_eq!(
-            corpus_size,
-            declared + build_failures,
-            "{} corpus_size must equal fixture_count + build_failures",
-            matrix_path.display()
+        let (corpus_size, build_failures) = if schema_version >= 2 {
+            let build_failures = matrix["build_failures"]
+                .as_array()
+                .unwrap_or_else(|| {
+                    panic!("{} has no build_failures (schema 2)", matrix_path.display())
+                })
+                .len();
+            let corpus_size = matrix["corpus_size"]
+                .as_u64()
+                .unwrap_or_else(|| panic!("{} has no corpus_size (schema 2)", matrix_path.display()))
+                as usize;
+            assert_eq!(
+                corpus_size,
+                declared + build_failures,
+                "{} corpus_size must equal fixture_count + build_failures",
+                matrix_path.display()
+            );
+            (corpus_size, build_failures)
+        } else {
+            // Schema 1 declared exactly what it exported and recorded no
+            // failures; the corpus it was cut from is not knowable from it.
+            (declared, 0)
+        };
+        println!(
+            "matrix.json schema_version {schema_version}: {declared} exported rows, \
+             {build_failures} build failures, corpus {corpus_size}{}",
+            if schema_version < 2 {
+                " (schema 1: blueprint hash only — manifests unverified, no failure record)"
+            } else {
+                ""
+            }
         );
-        Some(MatrixIndex { corpus_size, build_failures, hashes })
+        Some(MatrixIndex {
+            schema_version,
+            corpus_size,
+            build_failures,
+            blueprint_hashes,
+            manifest_hashes,
+        })
     } else {
         None
     };
@@ -274,41 +335,39 @@ fn main() {
             excluded.push((fixture, "no bp.txt / manifest-real.json".into()));
             continue;
         }
-        // Bank integrity before any report gate. The matrix fingerprint is
-        // the only thing that binds report.json to THIS bp.txt — the label
-        // matches whether or not someone re-exported underneath the report —
-        // and a blueprint that no longer matches is a corrupted bank whatever
-        // else is true of the row, so it is reported as that and not as the
-        // first report gate it happens to fail. A fingerprint recorded but
-        // never read lets a stale report through as vetted (#710 review).
+        // Bank integrity before any report gate. The matrix fingerprints are
+        // the only thing that binds report.json to THIS bp.txt/manifest pair
+        // — the label matches whether or not someone re-exported underneath
+        // the report — and a file that no longer matches is a corrupted bank
+        // whatever else is true of the row, so it is reported as that and not
+        // as the first report gate it happens to fail. A fingerprint recorded
+        // but never read lets a stale report through as vetted (#710 review).
         if let Some(index) = &matrix {
-            let bytes = match std::fs::read(&bp_path) {
-                Ok(b) => b,
-                Err(e) => {
-                    excluded.push((fixture, format!("bp.txt unreadable: {e}")));
-                    continue;
+            let check = |path: &std::path::Path, what: &str, recorded: Option<&String>| {
+                let bytes = std::fs::read(path).map_err(|e| format!("{what} unreadable: {e}"))?;
+                match recorded {
+                    Some(r) if *r == sha256_hex(&bytes) => Ok(()),
+                    Some(_) => Err(format!(
+                        "{what} sha256 differs from matrix.json — report.json cannot be bound \
+                         to this {what}; regenerate a fresh bank"
+                    )),
+                    None => Err(format!("label absent from matrix.json ({what} fingerprint)")),
                 }
             };
-            let actual = format!("{:x}", Sha256::digest(&bytes));
-            match index.hashes.get(&fixture) {
-                Some(recorded) if *recorded == actual => {}
-                Some(_) => {
-                    excluded.push((
-                        fixture,
-                        "bp.txt sha256 differs from matrix.json — report.json cannot be bound \
-                         to this blueprint; regenerate a fresh bank"
-                            .into(),
-                    ));
-                    continue;
-                }
-                None => {
-                    excluded.push((fixture, "label absent from matrix.json fixtures".into()));
-                    continue;
-                }
+            let mut checks = vec![("bp.txt", &bp_path, index.blueprint_hashes.get(&fixture))];
+            if index.schema_version >= 2 {
+                checks.push(("manifest-real.json", &mf_path, index.manifest_hashes.get(&fixture)));
+            }
+            if let Some(why) = checks
+                .into_iter()
+                .find_map(|(what, path, recorded)| check(path, what, recorded).err())
+            {
+                excluded.push((fixture, why));
+                continue;
             }
         }
         if !rp_path.exists() {
-            excluded.push((fixture, "no sim report.json — nothing to compare".into()));
+            excluded.push((fixture, AWAITING.into()));
             continue;
         }
 
@@ -596,7 +655,7 @@ fn main() {
         // not dropped from the denominator.
         let awaiting = excluded
             .iter()
-            .filter(|(_, why)| why == "no sim report.json — nothing to compare")
+            .filter(|(_, why)| why == AWAITING)
             .count();
         let other = excluded.len() - awaiting;
         let vetted = provenance.len();

--- a/crates/meter/examples/sweep_postlift.rs
+++ b/crates/meter/examples/sweep_postlift.rs
@@ -165,6 +165,21 @@ impl Row {
     }
 }
 
+use sha2::{Digest, Sha256};
+
+/// What a `calibration_matrix_export` bank declares about itself, read from
+/// its `matrix.json`. Absent for the older ad-hoc banks.
+struct MatrixIndex {
+    /// Fixtures the corpus DECLARES — exported rows plus any that failed to
+    /// build at export. The honest coverage denominator.
+    corpus_size: usize,
+    /// Rows recorded under `build_failures`: declared, never exported, so
+    /// they have no directory and can never be measured from this bank.
+    build_failures: usize,
+    /// `label → blueprint_sha256` for every exported row.
+    hashes: std::collections::BTreeMap<String, String>,
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let dir = args.get(1).cloned().unwrap_or_else(|| {
@@ -192,24 +207,27 @@ fn main() {
     // to expose. Older ad-hoc banks deliberately have no such contract and
     // retain their directory-driven behavior.
     let matrix_path = std::path::Path::new(&dir).join("matrix.json");
-    let matrix_fixture_count = if matrix_path.exists() {
+    let matrix = if matrix_path.exists() {
         let raw = std::fs::read_to_string(&matrix_path)
             .unwrap_or_else(|e| panic!("read {}: {e}", matrix_path.display()));
         let matrix: serde_json::Value = serde_json::from_str(&raw)
             .unwrap_or_else(|e| panic!("parse {}: {e}", matrix_path.display()));
-        let expected: std::collections::BTreeSet<String> = matrix["fixtures"]
+        let mut hashes = std::collections::BTreeMap::new();
+        for v in matrix["fixtures"]
             .as_array()
             .unwrap_or_else(|| panic!("{} has no fixtures array", matrix_path.display()))
-            .iter()
-            .map(|v| {
-                v["label"]
-                    .as_str()
-                    .unwrap_or_else(|| {
-                        panic!("{} has fixture without label", matrix_path.display())
-                    })
-                    .to_string()
-            })
-            .collect();
+        {
+            let label = v["label"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{} has fixture without label", matrix_path.display()));
+            let hash = v["blueprint_sha256"].as_str().unwrap_or_else(|| {
+                panic!("{} row {label} has no blueprint_sha256", matrix_path.display())
+            });
+            if hashes.insert(label.to_string(), hash.to_string()).is_some() {
+                panic!("{} names {label} twice", matrix_path.display());
+            }
+        }
+        let expected: std::collections::BTreeSet<String> = hashes.keys().cloned().collect();
         let declared = matrix["fixture_count"]
             .as_u64()
             .unwrap_or_else(|| panic!("{} has no fixture_count", matrix_path.display()))
@@ -230,7 +248,19 @@ fn main() {
             "matrix directory set differs from {}; regenerate a fresh bank rather than mixing artifacts",
             matrix_path.display()
         );
-        Some(declared)
+        // Additive fields (second exporter revision): a bank from the first
+        // revision has neither and declared exactly what it exported.
+        let build_failures = matrix["build_failures"].as_array().map_or(0, Vec::len);
+        let corpus_size = matrix["corpus_size"]
+            .as_u64()
+            .map_or(declared + build_failures, |n| n as usize);
+        assert_eq!(
+            corpus_size,
+            declared + build_failures,
+            "{} corpus_size must equal fixture_count + build_failures",
+            matrix_path.display()
+        );
+        Some(MatrixIndex { corpus_size, build_failures, hashes })
     } else {
         None
     };
@@ -243,6 +273,39 @@ fn main() {
         if !bp_path.exists() || !mf_path.exists() {
             excluded.push((fixture, "no bp.txt / manifest-real.json".into()));
             continue;
+        }
+        // Bank integrity before any report gate. The matrix fingerprint is
+        // the only thing that binds report.json to THIS bp.txt — the label
+        // matches whether or not someone re-exported underneath the report —
+        // and a blueprint that no longer matches is a corrupted bank whatever
+        // else is true of the row, so it is reported as that and not as the
+        // first report gate it happens to fail. A fingerprint recorded but
+        // never read lets a stale report through as vetted (#710 review).
+        if let Some(index) = &matrix {
+            let bytes = match std::fs::read(&bp_path) {
+                Ok(b) => b,
+                Err(e) => {
+                    excluded.push((fixture, format!("bp.txt unreadable: {e}")));
+                    continue;
+                }
+            };
+            let actual = format!("{:x}", Sha256::digest(&bytes));
+            match index.hashes.get(&fixture) {
+                Some(recorded) if *recorded == actual => {}
+                Some(_) => {
+                    excluded.push((
+                        fixture,
+                        "bp.txt sha256 differs from matrix.json — report.json cannot be bound \
+                         to this blueprint; regenerate a fresh bank"
+                            .into(),
+                    ));
+                    continue;
+                }
+                None => {
+                    excluded.push((fixture, "label absent from matrix.json fixtures".into()));
+                    continue;
+                }
+            }
         }
         if !rp_path.exists() {
             excluded.push((fixture, "no sim report.json — nothing to compare".into()));
@@ -525,18 +588,32 @@ fn main() {
     let f = |v: Option<f64>| v.map_or("n/a".into(), |x| format!("{x:.4}"));
     let p = |v: Option<f64>| v.map_or("n/a".into(), |x| format!("{x:.2}"));
 
-    if let Some(expected) = matrix_fixture_count {
+    if let Some(index) = &matrix {
+        // Four buckets that sum to the corpus the bank declares. A fixture
+        // excluded for any reason other than "not measured yet" (kit errors,
+        // non-convergence, short warmup, a hash mismatch above) is a coverage
+        // shortfall and is counted as one — not folded into "awaiting", and
+        // not dropped from the denominator.
         let awaiting = excluded
             .iter()
             .filter(|(_, why)| why == "no sim report.json — nothing to compare")
             .count();
+        let other = excluded.len() - awaiting;
+        let vetted = provenance.len();
         println!("=== MATRIX COVERAGE ===");
         println!(
-            "  {}/{} fixtures have a vetted sim report; {} awaiting measurement",
-            provenance.len(),
-            expected,
-            awaiting,
+            "  {vetted}/{} fixtures have a vetted sim report; {awaiting} awaiting measurement; \
+             {other} excluded for another reason (see EXCLUDED); {} failed to build at export",
+            index.corpus_size, index.build_failures,
         );
+        let accounted = vetted + awaiting + other + index.build_failures;
+        if accounted != index.corpus_size {
+            println!(
+                "  WARNING: buckets sum to {accounted}, corpus declares {} — a fixture was \
+                 neither vetted nor excluded (a fixture directory that yielded no row?)",
+                index.corpus_size
+            );
+        }
     }
 
     // --- per-item table ---------------------------------------------------

--- a/docs/meter-calibration-matrix.md
+++ b/docs/meter-calibration-matrix.md
@@ -1,0 +1,60 @@
+# Meter calibration matrix
+
+Status: active measurement workflow. The matrix is the current 35-fixture
+generator regression corpus, exported once and then measured by headless
+Factorio. It is deliberately broader than the historical Job-2 and post-lift
+banks, which remain useful evidence but are incomplete snapshots of older
+generator configurations.
+
+## What it establishes
+
+Every row starts from the same source used by the e2e belt-detour differential:
+recipe, rate, machine tier, raw inputs, belt tier, exclusions, and the one
+declared layout variant. The exporter writes the exact blueprint and manifest
+that Factorio runs; the meter reads those same files. A row is therefore a
+meter-vs-game comparison of one concrete generated factory, not a comparison
+between separately reconstructed configurations.
+
+This is a representative current-production corpus, not an exhaustive Cartesian
+product of every recipe and every engine option. A newly added e2e fixture
+automatically appears as an unmeasured row in the next bank. Broader fuzzing is
+a separate robustness concern and should not be mistaken for calibrated physics
+coverage.
+
+## Create and measure a bank
+
+Use a new directory for each engine revision or deliberate fixture change:
+
+```text
+cargo run --release -p spaghettio_core --example calibration_matrix_export -- \
+  /path/to/calibration-bank-YYYY-MM-DD
+scripts/run-calibration-matrix.sh /path/to/calibration-bank-YYYY-MM-DD
+cargo run --release -p spaghettio_meter --example sweep_postlift -- \
+  /path/to/calibration-bank-YYYY-MM-DD /tmp/meter-vs-sim.csv
+```
+
+The exporter refuses a non-empty target directory. That is intentional: do not
+replace a blueprint beneath an old `report.json`, because a label match alone
+cannot prove that the report was made from the current file. `matrix.json`
+records the fixture declaration, geometry, validator summary, and SHA-256 of
+each exported blueprint. The runner resumes a stopped campaign by skipping
+existing reports; a changed factory always requires a new bank.
+
+Each Factorio run uses a 432,000-tick warmup at speed 32, matching the
+post-lift provenance bar. Runs remain sequential because the main purpose is
+reproducibility and the largest factories are CPU-bound. Parallel campaigns
+need an explicit resource budget and independent Factorio installs.
+
+## Reading coverage honestly
+
+`sweep_postlift` prints every fixture directory without a usable report as an
+exclusion, rather than silently shrinking the denominator. It compares solid
+targets on both produced and delivered rates, reports threshold classifications,
+and keeps fluid target rows visible but unjudged until a comparable fluid
+metric is established. Its output, plus the `matrix.json` fingerprint, is the
+calibration matrix record; neither a green e2e test nor a meter-only run is a
+substitute for a Factorio measurement.
+
+Historical context and the known divergence results live in
+[`meter-divergence.md`](meter-divergence.md). This document owns the workflow
+that prevents the next result from becoming another local-only, partial bank.

--- a/docs/meter-calibration-matrix.md
+++ b/docs/meter-calibration-matrix.md
@@ -10,10 +10,16 @@ generator configurations.
 
 Every row starts from the same source used by the e2e belt-detour differential:
 recipe, rate, machine tier, raw inputs, belt tier, exclusions, and the one
-declared layout variant. The exporter writes the exact blueprint and manifest
-that Factorio runs; the meter reads those same files. A row is therefore a
-meter-vs-game comparison of one concrete generated factory, not a comparison
-between separately reconstructed configurations.
+declared layout variant. The e2e drivers build through the suite's own
+`run_e2e*` helpers and the exporter through `calibration_matrix::build`; the
+two option builders are pinned to each other on every declared variant by
+`calibration_matrix_options_match_harness_options` in `e2e.rs`, so an axis
+added to one and not the other fails a free test rather than producing a bank
+the suite never ran (the RFC-070 W2c fossil class).
+The exporter writes the exact blueprint and manifest that Factorio runs; the
+meter reads those same files. A row is therefore a meter-vs-game comparison of
+one concrete generated factory, not a comparison between separately
+reconstructed configurations.
 
 This is a representative current-production corpus, not an exhaustive Cartesian
 product of every recipe and every engine option. A newly added e2e fixture
@@ -37,8 +43,17 @@ The exporter refuses a non-empty target directory. That is intentional: do not
 replace a blueprint beneath an old `report.json`, because a label match alone
 cannot prove that the report was made from the current file. `matrix.json`
 records the fixture declaration, geometry, validator summary, and SHA-256 of
-each exported blueprint. The runner resumes a stopped campaign by skipping
-existing reports; a changed factory always requires a new bank.
+each exported blueprint, and `sweep_postlift` re-hashes every `bp.txt` it
+reads against that entry — a row whose blueprint no longer matches is excluded,
+not vetted. A fixture that fails to build at export is recorded under
+`build_failures` in `matrix.json` and the export continues (exiting non-zero):
+an engine regression is exactly when the other rows' measurements are wanted.
+
+The runner resumes a stopped campaign by skipping existing reports; a changed
+factory always requires a new bank. A fixture whose Factorio run fails
+(harness timeout, crash) is logged and the campaign moves on; the script exits
+non-zero at the end and the next invocation retries it, since no report was
+written.
 
 Each Factorio run uses a 432,000-tick warmup at speed 32, matching the
 post-lift provenance bar. Runs remain sequential because the main purpose is
@@ -48,12 +63,16 @@ need an explicit resource budget and independent Factorio installs.
 ## Reading coverage honestly
 
 `sweep_postlift` prints every fixture directory without a usable report as an
-exclusion, rather than silently shrinking the denominator. It compares solid
-targets on both produced and delivered rates, reports threshold classifications,
-and keeps fluid target rows visible but unjudged until a comparable fluid
-metric is established. Its output, plus the `matrix.json` fingerprint, is the
-calibration matrix record; neither a green e2e test nor a meter-only run is a
-substitute for a Factorio measurement.
+exclusion, rather than silently shrinking the denominator. Its
+`MATRIX COVERAGE` line reconciles to the corpus the bank declares: vetted +
+awaiting measurement + excluded for another reason + failed to build = corpus
+size, so a shortfall in any bucket is visible as a shortfall rather than
+absorbed into a smaller denominator. It compares solid targets on both produced
+and delivered rates, reports threshold classifications, and keeps fluid target
+rows visible but unjudged until a comparable fluid metric is established. Its
+output, plus the `matrix.json` fingerprint, is the calibration matrix record;
+neither a green e2e test nor a meter-only run is a substitute for a Factorio
+measurement.
 
 Historical context and the known divergence results live in
 [`meter-divergence.md`](meter-divergence.md). This document owns the workflow

--- a/docs/meter-calibration-matrix.md
+++ b/docs/meter-calibration-matrix.md
@@ -49,11 +49,21 @@ not vetted. A fixture that fails to build at export is recorded under
 `build_failures` in `matrix.json` and the export continues (exiting non-zero):
 an engine regression is exactly when the other rows' measurements are wanted.
 
-The runner resumes a stopped campaign by skipping existing reports; a changed
-factory always requires a new bank. A fixture whose Factorio run fails
-(harness timeout, crash) is logged and the campaign moves on; the script exits
-non-zero at the end and the next invocation retries it, since no report was
-written.
+The runner resumes a stopped campaign by skipping existing reports — one
+completed Factorio run per fixture; a changed factory always requires a new
+bank. A run that completed but did not converge, or reported kit errors, still
+wrote its report: that **is** the row's result (deterministic — re-running it
+reproduces it), and the sweep lists the row as excluded with the reason. To
+re-measure such a row deliberately, delete its `report.json` first. Two things
+are not results and are retried on the next invocation: a harness failure
+(timeout, crash, pre-flight — no report is written, the failure is logged, the
+script exits non-zero at the end) and a `report.json` that does not parse (a
+kill or full disk mid-write — treated as absent).
+
+`matrix.json` carries `schema_version` 2: per-row `blueprint_sha256` **and**
+`manifest_sha256` (the immutable pair, both checked by the sweep),
+`corpus_size`, and `build_failures`. The sweep still reads a version-1 bank
+(blueprint hash only, no failure record) and says which branch it took.
 
 Each Factorio run uses a 432,000-tick warmup at speed 32, matching the
 post-lift provenance bar. Runs remain sequential because the main purpose is

--- a/docs/status.md
+++ b/docs/status.md
@@ -220,6 +220,14 @@ cell-interface RFC.)
 
 ## Deferred tooling tasks
 
+- **Meter-vs-Factorio calibration matrix (active, 2026-08-22):** the current
+  35-fixture e2e corpus now has one shared definition, a tracked exporter, an
+  immutable Factorio-runner, and a meter reader that reports coverage as
+  `measured/expected` rather than silently narrowing its denominator. The
+  first full current-generation bank is being measured; its reports are not
+  yet a calibration result. Workflow and interpretation:
+  [`meter-calibration-matrix.md`](meter-calibration-matrix.md).
+
 Test-suite time recovery (audited 2026-07-19, pick-up notes per item in
 [`test-suite-followups.md`](test-suite-followups.md)): committed STRESSGOLD
 baseline goldens landed 2026-07-19 and were DELETED 2026-08-15 (#632 B7 —

--- a/scripts/run-calibration-matrix.sh
+++ b/scripts/run-calibration-matrix.sh
@@ -4,6 +4,15 @@
 # The exporter creates immutable bp.txt/manifest-real.json pairs.  This script
 # resumes safely after interruption by leaving existing report.json files
 # alone; regenerate into a new directory after changing the engine.
+#
+# One fixture's failure (harness timeout, Factorio crash, pre-flight error) is
+# logged and the campaign moves on.  Letting `set -e` abort on the harness
+# call would end the whole run at the first such fixture and, on resume, end
+# it at the same fixture again — a campaign that can never complete.  The
+# script exits non-zero at the end if anything failed; re-run it to retry
+# (a failed fixture has no report.json, so it is not skipped).  The harness
+# writes --out only after a completed run, so an absent report is the whole
+# failure signature.
 set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
@@ -17,6 +26,7 @@ if [ ! -f "$bank_dir/matrix.json" ]; then
   exit 2
 fi
 
+failed=0
 for fixture_dir in "$bank_dir"/*; do
   [ -d "$fixture_dir" ] || continue
   bp="$fixture_dir/bp.txt"
@@ -31,7 +41,15 @@ for fixture_dir in "$bank_dir"/*; do
     continue
   fi
   echo "measure $(basename "$fixture_dir")"
-  cargo run --release -p spaghettio_sim_harness -- run \
-    --bp "$bp" --manifest "$manifest" \
-    --warmup 432000 --speed 32 --out "$report"
+  if ! cargo run --release -p spaghettio_sim_harness -- run \
+      --bp "$bp" --manifest "$manifest" \
+      --warmup 432000 --speed 32 --out "$report"; then
+    echo "FAILED $(basename "$fixture_dir"): no report written; re-run this script to retry it" >&2
+    failed=$((failed + 1))
+  fi
 done
+
+if [ "$failed" -gt 0 ]; then
+  echo "$failed fixture(s) failed; re-run to retry them" >&2
+  exit 1
+fi

--- a/scripts/run-calibration-matrix.sh
+++ b/scripts/run-calibration-matrix.sh
@@ -5,14 +5,21 @@
 # resumes safely after interruption by leaving existing report.json files
 # alone; regenerate into a new directory after changing the engine.
 #
-# One fixture's failure (harness timeout, Factorio crash, pre-flight error) is
-# logged and the campaign moves on.  Letting `set -e` abort on the harness
-# call would end the whole run at the first such fixture and, on resume, end
-# it at the same fixture again — a campaign that can never complete.  The
-# script exits non-zero at the end if anything failed; re-run it to retry
-# (a failed fixture has no report.json, so it is not skipped).  The harness
-# writes --out only after a completed run, so an absent report is the whole
-# failure signature.
+# What "resume" means here: one completed Factorio run per fixture.  A run
+# that completed but did not converge, or that reported kit errors, still
+# wrote a report.json — that IS its result (deterministic; re-running it
+# reproduces it), and the sweep reports the row as excluded with the reason.
+# To re-measure such a row deliberately, delete its report.json first.
+#
+# Two things are NOT results and are retried on the next invocation:
+#   - a harness failure (timeout, crash, pre-flight error): no report is
+#     written, the failure is logged, the loop continues, and the script
+#     exits non-zero at the end.  Letting `set -e` abort on the harness call
+#     would end the campaign at the first such fixture and, on resume, end
+#     it at the same fixture again.
+#   - a report.json that does not parse (a kill or a full disk mid-write):
+#     treated as absent and re-measured, since the harness writes it with
+#     one non-atomic write.
 set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
@@ -23,6 +30,10 @@ fi
 bank_dir=$1
 if [ ! -f "$bank_dir/matrix.json" ]; then
   echo "missing $bank_dir/matrix.json; run calibration_matrix_export first" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required (used to recognise a partially written report.json)" >&2
   exit 2
 fi
 
@@ -37,8 +48,11 @@ for fixture_dir in "$bank_dir"/*; do
     continue
   fi
   if [ -f "$report" ]; then
-    echo "skip $(basename "$fixture_dir"): report.json already exists"
-    continue
+    if jq -e . "$report" >/dev/null 2>&1; then
+      echo "skip $(basename "$fixture_dir"): report.json already exists"
+      continue
+    fi
+    echo "re-measure $(basename "$fixture_dir"): report.json exists but does not parse (partial write?)" >&2
   fi
   echo "measure $(basename "$fixture_dir")"
   if ! cargo run --release -p spaghettio_sim_harness -- run \

--- a/scripts/run-calibration-matrix.sh
+++ b/scripts/run-calibration-matrix.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run Factorio over every not-yet-measured fixture in a freshly exported bank.
+#
+# The exporter creates immutable bp.txt/manifest-real.json pairs.  This script
+# resumes safely after interruption by leaving existing report.json files
+# alone; regenerate into a new directory after changing the engine.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: scripts/run-calibration-matrix.sh <bank-dir>" >&2
+  exit 2
+fi
+
+bank_dir=$1
+if [ ! -f "$bank_dir/matrix.json" ]; then
+  echo "missing $bank_dir/matrix.json; run calibration_matrix_export first" >&2
+  exit 2
+fi
+
+for fixture_dir in "$bank_dir"/*; do
+  [ -d "$fixture_dir" ] || continue
+  bp="$fixture_dir/bp.txt"
+  manifest="$fixture_dir/manifest-real.json"
+  report="$fixture_dir/report.json"
+  if [ ! -f "$bp" ] || [ ! -f "$manifest" ]; then
+    echo "skip $fixture_dir: missing bp.txt or manifest-real.json" >&2
+    continue
+  fi
+  if [ -f "$report" ]; then
+    echo "skip $(basename "$fixture_dir"): report.json already exists"
+    continue
+  fi
+  echo "measure $(basename "$fixture_dir")"
+  cargo run --release -p spaghettio_sim_harness -- run \
+    --bp "$bp" --manifest "$manifest" \
+    --warmup 432000 --speed 32 --out "$report"
+done


### PR DESCRIPTION
## Summary
- make the 35 current generated E2E fixtures a shared, reusable calibration corpus
- export each fixture into a fresh immutable bank with blueprint hashes and validated manifests
- add a resumable Factorio campaign runner and sweep coverage checks
- document the calibration workflow and its current limits

This does not claim measured agreement yet. A fresh local Factorio campaign is running against the generated bank; its reports remain uncommitted evidence until the sweep produces comparable values.

## Why this is one PR
The shared fixture source, exporter, bank validation, runner, and meter reader form one anti-drift contract. Splitting them would temporarily reintroduce the divergent fixture definitions this change removes.

## Validation
- `cargo test -p spaghettio_core calibration_matrix --lib`
- `cargo test -p spaghettio_core --example calibration_matrix_export`
- `cargo test -p spaghettio_core --test e2e --no-run`
- `bash -n scripts/run-calibration-matrix.sh`
- generated a fresh 35-fixture bank with the release exporter; the sweep correctly reports `0/35` measured before simulator reports exist

`cargo clippy -p spaghettio_core --all-targets -- -D warnings` remains blocked by pre-existing warnings in unrelated core examples/tests; it reported none in this change. Repository-wide fmt likewise has unrelated existing drift.